### PR TITLE
refactor(seller): 프론트엔드 5-Phase 리팩토링 (#CL-32)

### DIFF
--- a/apps/seller/src/app/hubs/[id]/page.tsx
+++ b/apps/seller/src/app/hubs/[id]/page.tsx
@@ -4,8 +4,10 @@ import { useState, useEffect, useCallback } from 'react';
 import { useSession } from 'next-auth/react';
 import { useParams, useRouter } from 'next/navigation';
 import { apiFetch } from '@/lib/api';
-import { ActionIcon, Badge, Box, Container, Group, Paper, Stack, Text, Title } from '@mantine/core';
-import { ChevronLeft } from 'lucide-react';
+import { Badge, Box, Container, Group, Paper, Stack, Text } from '@mantine/core';
+import { PageShell } from '@/components/PageShell';
+import { PageHeader } from '@/components/PageHeader';
+import { LoadingState } from '@/components/StateViews';
 
 interface Hub {
   id: string;
@@ -90,30 +92,8 @@ export default function HubDetailPage() {
   const orderId = (o: HubOrder) => o.id ?? o.orderId ?? '';
 
   return (
-    <Box
-      component="main"
-      style={{ minHeight: '100vh', backgroundColor: 'var(--color-surface-muted)' }}
-    >
-      <Box
-        component="header"
-        style={{
-          backgroundColor: 'var(--color-bg)',
-          borderBottom: '1px solid var(--color-border)',
-          padding: '16px',
-          position: 'sticky',
-          top: 0,
-          zIndex: 10,
-        }}
-      >
-        <Container size="sm">
-          <Group gap="sm">
-            <ActionIcon variant="subtle" color="gray" onClick={() => router.back()}>
-              <ChevronLeft size={20} />
-            </ActionIcon>
-            <Title order={3}>{hub ? hub.name : '거점 상세'}</Title>
-          </Group>
-        </Container>
-      </Box>
+    <PageShell>
+      <PageHeader title={hub ? hub.name : '거점 상세'} onBack={() => router.back()} />
 
       <Container size="sm" px="md" py="md">
         <Stack gap="md">
@@ -124,13 +104,7 @@ export default function HubDetailPage() {
           )}
 
           {loading ? (
-            <Text
-              style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-text-disabled)' }}
-              ta="center"
-              py={80}
-            >
-              불러오는 중...
-            </Text>
+            <LoadingState />
           ) : hub ? (
             <>
               {/* 거점 정보 카드 */}
@@ -292,6 +266,6 @@ export default function HubDetailPage() {
           ) : null}
         </Stack>
       </Container>
-    </Box>
+    </PageShell>
   );
 }

--- a/apps/seller/src/app/hubs/[id]/pickup/page.tsx
+++ b/apps/seller/src/app/hubs/[id]/pickup/page.tsx
@@ -4,8 +4,9 @@ import { useState, useRef, useEffect } from 'react';
 import { useSession } from 'next-auth/react';
 import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import { apiFetch } from '@/lib/api';
-import { ActionIcon, Box, Button, Container, Group, Stack, Text, Title } from '@mantine/core';
-import { ChevronLeft } from 'lucide-react';
+import { Box, Button, Container, Group, Stack, Text, Title } from '@mantine/core';
+import { PageShell } from '@/components/PageShell';
+import { PageHeader } from '@/components/PageHeader';
 
 type Step = 'input' | 'success' | 'error';
 
@@ -93,30 +94,8 @@ export default function HubPickupPage() {
   const isFilled = digits.every((d) => d !== '');
 
   return (
-    <Box
-      component="main"
-      style={{ minHeight: '100vh', backgroundColor: 'var(--color-surface-muted)' }}
-    >
-      <Box
-        component="header"
-        style={{
-          backgroundColor: 'var(--color-bg)',
-          borderBottom: '1px solid var(--color-border)',
-          padding: '16px',
-          position: 'sticky',
-          top: 0,
-          zIndex: 10,
-        }}
-      >
-        <Container size="sm">
-          <Group gap="sm">
-            <ActionIcon variant="subtle" color="gray" onClick={() => router.back()}>
-              <ChevronLeft size={20} />
-            </ActionIcon>
-            <Title order={3}>픽업 코드 확인</Title>
-          </Group>
-        </Container>
-      </Box>
+    <PageShell>
+      <PageHeader title="픽업 코드 확인" onBack={() => router.back()} />
 
       <Container size="sm" px="md" py={40}>
         <Stack align="center">
@@ -251,6 +230,6 @@ export default function HubPickupPage() {
           )}
         </Stack>
       </Container>
-    </Box>
+    </PageShell>
   );
 }

--- a/apps/seller/src/app/hubs/page.tsx
+++ b/apps/seller/src/app/hubs/page.tsx
@@ -4,18 +4,10 @@ import { useState, useEffect, useCallback } from 'react';
 import { useSession } from 'next-auth/react';
 import Link from 'next/link';
 import { apiFetch } from '@/lib/api';
-import {
-  Badge,
-  Box,
-  Button,
-  Container,
-  Group,
-  Paper,
-  Stack,
-  Text,
-  Title,
-  UnstyledButton,
-} from '@mantine/core';
+import { PageShell } from '@/components/PageShell';
+import { PageHeader } from '@/components/PageHeader';
+import { EmptyState, LoadingState } from '@/components/StateViews';
+import { Badge, Button, Container, Group, Paper, Stack, Text, UnstyledButton } from '@mantine/core';
 
 interface Hub {
   id: string;
@@ -78,36 +70,21 @@ export default function HubsPage() {
   }
 
   return (
-    <Box
-      component="main"
-      style={{ minHeight: '100vh', backgroundColor: 'var(--color-surface-muted)' }}
-    >
-      <Box
-        component="header"
-        style={{
-          backgroundColor: 'var(--color-bg)',
-          borderBottom: '1px solid var(--color-border)',
-          padding: '16px',
-          position: 'sticky',
-          top: 0,
-          zIndex: 10,
-        }}
-      >
-        <Container size="sm">
-          <Group justify="space-between">
-            <Title order={3}>거점 관리</Title>
-            <Button
-              component={Link}
-              href="/hubs/new"
-              size="xs"
-              radius="md"
-              style={{ backgroundColor: 'var(--color-primary)' }}
-            >
-              + 거점 등록
-            </Button>
-          </Group>
-        </Container>
-      </Box>
+    <PageShell>
+      <PageHeader
+        title="거점 관리"
+        right={
+          <Button
+            component={Link}
+            href="/hubs/new"
+            size="xs"
+            radius="md"
+            style={{ backgroundColor: 'var(--color-primary)' }}
+          >
+            + 거점 등록
+          </Button>
+        }
+      />
 
       <Container size="sm" px="md" py="md">
         {error && (
@@ -117,47 +94,40 @@ export default function HubsPage() {
         )}
 
         {loading ? (
-          <Text
-            style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-text-disabled)' }}
-            ta="center"
-            py={80}
-          >
-            불러오는 중...
-          </Text>
+          <LoadingState />
         ) : hubs.length === 0 ? (
-          <Stack
-            align="center"
-            justify="center"
-            py={80}
-            style={{ color: 'var(--color-text-disabled)' }}
-          >
-            <svg
-              width="48"
-              height="48"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="1.5"
-              aria-hidden="true"
-              focusable="false"
-            >
-              <path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z" />
-              <circle cx="12" cy="10" r="3" />
-            </svg>
-            <Text style={{ fontSize: 'var(--font-size-sm)' }}>등록된 거점이 없습니다</Text>
-            <Text
-              component={Link}
-              href="/hubs/new"
-              mt="xs"
-              style={{
-                fontSize: 'var(--font-size-sm)',
-                color: 'var(--color-primary)',
-                fontWeight: 500,
-              }}
-            >
-              거점 등록하기 →
-            </Text>
-          </Stack>
+          <EmptyState
+            icon={
+              <svg
+                width="48"
+                height="48"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z" />
+                <circle cx="12" cy="10" r="3" />
+              </svg>
+            }
+            text="등록된 거점이 없습니다"
+            action={
+              <Text
+                component={Link}
+                href="/hubs/new"
+                mt="xs"
+                style={{
+                  fontSize: 'var(--font-size-sm)',
+                  color: 'var(--color-primary)',
+                  fontWeight: 500,
+                }}
+              >
+                거점 등록하기 →
+              </Text>
+            }
+          />
         ) : (
           <Stack gap="sm">
             {hubs.map((hub) => (
@@ -242,6 +212,6 @@ export default function HubsPage() {
           </Stack>
         )}
       </Container>
-    </Box>
+    </PageShell>
   );
 }

--- a/apps/seller/src/app/orders/[id]/_hooks/useOrderDetailActions.ts
+++ b/apps/seller/src/app/orders/[id]/_hooks/useOrderDetailActions.ts
@@ -1,8 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { useSession } from 'next-auth/react';
-import { apiFetch } from '@/lib/api';
+import { useOrderStatusUpdate } from '@/hooks/useOrderStatusUpdate';
 
 export interface UseOrderDetailActionsResult {
   actionLoading: boolean;
@@ -20,58 +19,34 @@ export interface UseOrderDetailActionsResult {
   handleCancel: () => Promise<void>;
 }
 
+/** 주문 상세 페이지용 액션 — 프리셋 준비 폼 + 모달 취소 사유. */
 export function useOrderDetailActions(
   storeId: string | null,
   orderId: string,
 ): UseOrderDetailActionsResult {
-  const { data: session } = useSession();
-  const token = session?.user.accessToken ?? '';
-
-  const [actionLoading, setActionLoading] = useState(false);
-  const [actionError, setActionError] = useState<string | null>(null);
+  const { actionLoading, actionError, setActionError, updateStatus } = useOrderStatusUpdate(
+    storeId,
+    orderId,
+  );
   const [showPrepareForm, setShowPrepareForm] = useState(false);
   const [preparedAt, setPreparedAt] = useState<string | null>(null);
   const [showCancelModal, setShowCancelModal] = useState(false);
   const [cancelReason, setCancelReason] = useState('');
 
   async function handlePrepare() {
-    if (!storeId) return;
-    setActionLoading(true);
-    setActionError(null);
-    try {
-      const body: Record<string, string> = { status: 'PREPARING' };
-      if (preparedAt) body.preparedAt = preparedAt;
-      const res = await apiFetch(`/stores/${storeId}/orders/${orderId}/status`, token, {
-        method: 'PATCH',
-        body: JSON.stringify(body),
-      });
-      if (!res.ok) throw new Error(`서버 오류 (${res.status})`);
+    const ok = await updateStatus('PREPARING', preparedAt ? { preparedAt } : undefined);
+    if (ok) {
       setShowPrepareForm(false);
       setPreparedAt(null);
-    } catch (e) {
-      setActionError(e instanceof Error ? e.message : '오류가 발생했습니다');
-    } finally {
-      setActionLoading(false);
     }
   }
 
   async function handleCancel() {
-    if (!storeId) return;
     if (cancelReason.trim().length < 5) return;
-    setActionLoading(true);
-    setActionError(null);
-    try {
-      const res = await apiFetch(`/stores/${storeId}/orders/${orderId}/status`, token, {
-        method: 'PATCH',
-        body: JSON.stringify({ status: 'CANCELLED', reason: cancelReason.trim() }),
-      });
-      if (!res.ok) throw new Error(`서버 오류 (${res.status})`);
+    const ok = await updateStatus('CANCELLED', { reason: cancelReason.trim() });
+    if (ok) {
       setShowCancelModal(false);
       setCancelReason('');
-    } catch (e) {
-      setActionError(e instanceof Error ? e.message : '오류가 발생했습니다');
-    } finally {
-      setActionLoading(false);
     }
   }
 

--- a/apps/seller/src/app/orders/[id]/page.tsx
+++ b/apps/seller/src/app/orders/[id]/page.tsx
@@ -2,19 +2,10 @@
 
 import { useParams, useRouter } from 'next/navigation';
 import { useSession } from 'next-auth/react';
-import {
-  ActionIcon,
-  Box,
-  Button,
-  Container,
-  Group,
-  Loader,
-  Stack,
-  Text,
-  Title,
-  UnstyledButton,
-} from '@mantine/core';
-import { ChevronLeft } from 'lucide-react';
+import { Box, Button, Container, Stack, Text, UnstyledButton } from '@mantine/core';
+import { PageShell } from '@/components/PageShell';
+import { PageHeader } from '@/components/PageHeader';
+import { LoadingState } from '@/components/StateViews';
 import { CANCELLABLE_STATUSES, READONLY_STATUSES } from './_lib';
 import { useOrderDetail } from './_hooks/useOrderDetail';
 import { useOrderDetailActions } from './_hooks/useOrderDetailActions';
@@ -47,19 +38,7 @@ export default function OrderDetailPage() {
   } = useOrderDetailActions(storeId, orderId);
 
   if (loading) {
-    return (
-      <Box
-        style={{
-          minHeight: '100vh',
-          backgroundColor: 'var(--color-surface-muted)',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-        }}
-      >
-        <Loader size="sm" color="brand" />
-      </Box>
-    );
+    return <LoadingState fullPage />;
   }
 
   if (!order) {
@@ -97,34 +76,8 @@ export default function OrderDetailPage() {
       : (groupConfig?.groupDeliveryDate?.slice(0, 10) ?? null);
 
   return (
-    <Box
-      component="main"
-      style={{
-        minHeight: '100vh',
-        backgroundColor: 'var(--color-surface-muted)',
-        paddingBottom: 96,
-      }}
-    >
-      <Box
-        component="header"
-        style={{
-          backgroundColor: 'var(--color-bg)',
-          borderBottom: '1px solid var(--color-border)',
-          padding: '16px',
-          position: 'sticky',
-          top: 0,
-          zIndex: 10,
-        }}
-      >
-        <Container size="sm">
-          <Group gap="sm">
-            <ActionIcon variant="subtle" color="gray" onClick={() => router.back()}>
-              <ChevronLeft size={20} />
-            </ActionIcon>
-            <Title order={3}>주문 상세</Title>
-          </Group>
-        </Container>
-      </Box>
+    <PageShell paddingBottom={96}>
+      <PageHeader title="주문 상세" onBack={() => router.back()} />
 
       <Container size="sm" px="md" py="md">
         <Stack gap="sm">
@@ -212,6 +165,6 @@ export default function OrderDetailPage() {
         }}
         onConfirm={handleCancel}
       />
-    </Box>
+    </PageShell>
   );
 }

--- a/apps/seller/src/app/orders/page.tsx
+++ b/apps/seller/src/app/orders/page.tsx
@@ -11,17 +11,10 @@ import {
   IN_DELIVERY_SUBFILTERS,
   type OrderGroup,
 } from './_constants';
-import {
-  Badge,
-  Box,
-  Container,
-  Group,
-  Loader,
-  Stack,
-  Text,
-  Title,
-  UnstyledButton,
-} from '@mantine/core';
+import { Badge, Box, Container, Group, Stack, Text, UnstyledButton } from '@mantine/core';
+import { PageShell } from '@/components/PageShell';
+import { PageHeader } from '@/components/PageHeader';
+import { EmptyState, LoadingState } from '@/components/StateViews';
 
 const VALID_TABS = new Set<OrderGroup>(['ACTION_REQUIRED', 'WAITING', 'IN_DELIVERY', 'DONE', 'CANCELLED']);
 
@@ -47,48 +40,30 @@ export default function OrdersPage() {
   });
 
   return (
-    <Box
-      component="main"
-      style={{ minHeight: '100vh', backgroundColor: 'var(--color-surface-muted)' }}
-    >
-      {/* 헤더 */}
-      <Box
-        component="header"
-        style={{
-          backgroundColor: 'var(--color-bg)',
-          borderBottom: '1px solid var(--color-border)',
-          padding: '16px',
-          position: 'sticky',
-          top: 0,
-          zIndex: 10,
-        }}
-      >
-        <Container size="sm">
-          <Group justify="space-between">
-            <Title order={3} style={{ fontWeight: 'var(--fw-bold)' }}>
-              주문 관리
-            </Title>
-            <Group gap={6}>
-              <Box
-                style={{
-                  width: 8,
-                  height: 8,
-                  borderRadius: '50%',
-                  backgroundColor:
-                    loading || !firebaseReady
-                      ? 'var(--color-caution-border)'
-                      : error
-                        ? 'var(--color-danger)'
-                        : 'var(--color-primary)',
-                }}
-              />
-              <Text style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-text-disabled)' }}>
-                {loading || !firebaseReady ? '연결 중' : error ? '연결 오류' : '실시간 연결'}
-              </Text>
-            </Group>
+    <PageShell>
+      <PageHeader
+        title="주문 관리"
+        right={
+          <Group gap={6}>
+            <Box
+              style={{
+                width: 8,
+                height: 8,
+                borderRadius: '50%',
+                backgroundColor:
+                  loading || !firebaseReady
+                    ? 'var(--color-caution-border)'
+                    : error
+                      ? 'var(--color-danger)'
+                      : 'var(--color-primary)',
+              }}
+            />
+            <Text style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-text-disabled)' }}>
+              {loading || !firebaseReady ? '연결 중' : error ? '연결 오류' : '실시간 연결'}
+            </Text>
           </Group>
-        </Container>
-      </Box>
+        }
+      />
 
       {/* Summary Bar */}
       <Box style={{ backgroundColor: 'var(--color-bg)', borderBottom: '1px solid var(--color-border)', padding: '8px 0', position: 'sticky', top: 57, zIndex: 9 }}>
@@ -179,29 +154,27 @@ export default function OrdersPage() {
       {/* 주문 목록 */}
       <Container size="sm" px="md" py="md">
         <Stack gap="sm">
-          {(loading || !firebaseReady) && (
-            <Group justify="center" py={80}>
-              <Loader size="sm" color="brand" />
-            </Group>
-          )}
+          {(loading || !firebaseReady) && <LoadingState />}
 
           {!loading && firebaseReady && filteredOrders.length === 0 && (
-            <Stack align="center" justify="center" py={80} style={{ color: 'var(--color-text-disabled)' }}>
-              <svg
-                width="48"
-                height="48"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="1.5"
-                aria-hidden="true"
-                focusable="false"
-              >
-                <path d="M9 11l3 3L22 4" />
-                <path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11" />
-              </svg>
-              <Text style={{ fontSize: 'var(--font-size-sm)' }}>현재 해당 주문이 없습니다</Text>
-            </Stack>
+            <EmptyState
+              icon={
+                <svg
+                  width="48"
+                  height="48"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  aria-hidden="true"
+                  focusable="false"
+                >
+                  <path d="M9 11l3 3L22 4" />
+                  <path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11" />
+                </svg>
+              }
+              text="현재 해당 주문이 없습니다"
+            />
           )}
 
           {filteredOrders.map((order) => (
@@ -209,6 +182,6 @@ export default function OrdersPage() {
           ))}
         </Stack>
       </Container>
-    </Box>
+    </PageShell>
   );
 }

--- a/apps/seller/src/app/products/[id]/edit/page.tsx
+++ b/apps/seller/src/app/products/[id]/edit/page.tsx
@@ -5,7 +5,8 @@ import { useParams, useRouter } from 'next/navigation';
 import { useSession } from 'next-auth/react';
 import ProductForm from '../../_components/ProductForm';
 import type { ProductFormData } from '../../_components/ProductForm';
-import { Box, Loader, Text, UnstyledButton } from '@mantine/core';
+import { Box, Text, UnstyledButton } from '@mantine/core';
+import { LoadingState } from '@/components/StateViews';
 
 // Firestore Timestamp | ISO string → YYYY-MM-DD
 function toISODate(value: unknown): Date | null {
@@ -126,19 +127,7 @@ export default function EditProductPage() {
   }
 
   if (!initialData) {
-    return (
-      <Box
-        style={{
-          minHeight: '100vh',
-          backgroundColor: 'var(--color-surface-muted)',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-        }}
-      >
-        <Loader size="sm" color="var(--color-primary)" />
-      </Box>
-    );
+    return <LoadingState fullPage />;
   }
 
   return (

--- a/apps/seller/src/app/products/_components/FormPrimitives.tsx
+++ b/apps/seller/src/app/products/_components/FormPrimitives.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { Button, Group, Paper, Text } from '@mantine/core';
+import type { ReactNode } from 'react';
+
+const LABEL_STYLE = {
+  fontSize: 'var(--font-size-sm)',
+  fontWeight: 'var(--fw-medium)',
+  color: 'var(--color-text-disabled)',
+} as const;
+
+const SELECTED_STYLE = {
+  backgroundColor: 'var(--color-primary)',
+  borderColor: 'var(--color-primary)',
+  color: 'white',
+} as const;
+
+/** Paper 카드 + 비활성색 라벨. ProductForm 스텝 본문 전반에서 재사용. */
+export function FieldCard({
+  label,
+  labelGap = 'xs',
+  children,
+}: {
+  label: string;
+  labelGap?: 'xs' | 'sm';
+  children: ReactNode;
+}) {
+  return (
+    <Paper radius="lg" shadow="xs" p="md">
+      <Text style={LABEL_STYLE} mb={labelGap}>
+        {label}
+      </Text>
+      {children}
+    </Paper>
+  );
+}
+
+/** 단일 선택 버튼 행 (카테고리·배송 사이즈 등 동일 패턴). */
+export function ChoiceRow({
+  options,
+  value,
+  onChange,
+}: {
+  options: readonly { value: string; label: string }[];
+  value: string;
+  onChange: (value: string) => void;
+}) {
+  return (
+    <Group gap="xs">
+      {options.map(({ value: v, label }) => (
+        <Button
+          key={v}
+          onClick={() => onChange(v)}
+          flex={1}
+          size="sm"
+          radius="xl"
+          variant={value === v ? 'filled' : 'outline'}
+          color="gray"
+          style={value === v ? SELECTED_STYLE : {}}
+        >
+          {label}
+        </Button>
+      ))}
+    </Group>
+  );
+}

--- a/apps/seller/src/app/products/_components/ProductForm.tsx
+++ b/apps/seller/src/app/products/_components/ProductForm.tsx
@@ -1,671 +1,120 @@
 'use client';
 
-import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
-import ImageUpload from './ImageUpload';
-import GroupConfigSection from './GroupConfigSection';
-import VarietySelector from './VarietySelector';
-import TouchSelector, { type SelectionForm } from './TouchSelector';
+import { Button, Container, Group, Stack, Text, UnstyledButton } from '@mantine/core';
+import { PageShell } from '@/components/PageShell';
+import { PageHeader } from '@/components/PageHeader';
+import TouchSelector from './TouchSelector';
 import SellerNoteInput from './SellerNoteInput';
-import AIPreviewPanel, { type ConflictWarning } from './AIPreviewPanel';
-import {
-  ActionIcon,
-  Box,
-  Button,
-  Container,
-  Group,
-  NumberInput,
-  Paper,
-  Stack,
-  Text,
-  TextInput,
-  Title,
-  UnstyledButton,
-} from '@mantine/core';
+import AIPreviewPanel from './AIPreviewPanel';
+import { StepIndicator } from './StepIndicator';
+import { Step1Basic } from './steps/Step1Basic';
+import { Step5Pricing } from './steps/Step5Pricing';
+import { useProductForm } from './useProductForm';
+import type { ProductFormProps } from './productForm.types';
 
-const CATEGORIES = [
-  { value: 'cut_flower', label: '절화' },
-  { value: 'orchid', label: '난' },
-  { value: 'foliage', label: '관엽' },
-] as const;
+export type { ProductFormData, ProductFormProps } from './productForm.types';
 
-const DELIVERY_SIZES = [
-  { value: 'small', label: '소형' },
-  { value: 'medium', label: '중형' },
-  { value: 'large', label: '대형' },
-] as const;
-
-const STEP_LABELS = ['사진·품종', '터치 선택', '판매자 메모', 'AI 미리보기', '가격·배송'];
-
-interface GroupConfigForm {
-  minQuantity: string;
-  targetQuantity: string;
-  maxPerPerson: string;
-  recruitDeadline: string;
-  groupDeliveryDate: string;
-  groupDeliveryMethod: 'direct' | 'parcel';
-}
-
-interface ContentForm {
-  headline: string;
-  description: string;
-  isEditedByUser: boolean;
-}
-
-export interface ProductFormData {
-  name: string;
-  category: string;
-  deliverySize: string;
-  price: string;
-  saleType: 'normal' | 'group';
-  groupConfig: GroupConfigForm;
-  images: string[];
-  varietyId: string;
-  selection: SelectionForm;
-  sellerNote: string;
-  content: ContentForm;
-  sellerOverride: boolean;
-}
-
-export interface ProductFormProps {
-  mode: 'create' | 'edit';
-  productId?: string;
-  storeId: string;
-  token: string;
-  initialData?: Partial<ProductFormData>;
-  onSuccess: () => void;
-}
-
-function defaultForm(): ProductFormData {
-  return {
-    name: '',
-    category: 'cut_flower',
-    deliverySize: 'small',
-    price: '',
-    saleType: 'normal',
-    groupConfig: {
-      minQuantity: '10',
-      targetQuantity: '50',
-      maxPerPerson: '5',
-      recruitDeadline: '',
-      groupDeliveryDate: '',
-      groupDeliveryMethod: 'direct',
-    },
-    images: [],
-    varietyId: '',
-    selection: {
-      colors: [],
-      stemType: '외대',
-      fragrance: 'none',
-      bloomCondition: 'half',
-      careLevel: 'normal',
-      bundleUnit: '',
-    },
-    sellerNote: '',
-    content: { headline: '', description: '', isEditedByUser: false },
-    sellerOverride: false,
-  };
-}
-
-export default function ProductForm({
-  mode,
-  productId,
-  storeId,
-  token,
-  initialData,
-  onSuccess,
-}: ProductFormProps) {
+export default function ProductForm(props: ProductFormProps) {
+  const { mode, storeId, token } = props;
   const router = useRouter();
-  const draftKey = mode === 'create' ? 'product_draft_new' : `product_draft_${productId}`;
-
-  const [form, setForm] = useState<ProductFormData>(() =>
-    initialData ? { ...defaultForm(), ...initialData } : defaultForm(),
-  );
-
-  useEffect(() => {
-    if (initialData) return;
-    try {
-      const saved = localStorage.getItem(draftKey);
-      if (saved) {
-        const p = JSON.parse(saved);
-        const def = defaultForm();
-        setForm({
-          ...def,
-          ...p,
-          groupConfig: { ...def.groupConfig, ...(p.groupConfig ?? {}) },
-          selection: { ...def.selection, ...(p.selection ?? {}) },
-          content: { ...def.content, ...(p.content ?? {}) },
-        });
-        if (p._step) setStep(p._step);
-      }
-    } catch {}
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [draftKey, initialData]);
-
-  const [step, setStep] = useState(1);
-  const [availableStemTypes, setAvailableStemTypes] = useState<string[] | undefined>(undefined);
-  const [conflicts, setConflicts] = useState<ConflictWarning[]>([]);
-  const [aiLoading, setAiLoading] = useState(false);
-  const [submitting, setSubmitting] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [draftSaved, setDraftSaved] = useState(false);
-
-  useEffect(() => {
-    if (initialData?.name) setForm({ ...defaultForm(), ...initialData });
-  }, [initialData?.name, initialData]);
-
-  function set<K extends keyof ProductFormData>(key: K, value: ProductFormData[K]) {
-    setForm((prev) => ({ ...prev, [key]: value }));
-  }
-
-  function setGroupConfig<K extends keyof GroupConfigForm>(key: K, value: GroupConfigForm[K]) {
-    setForm((prev) => ({ ...prev, groupConfig: { ...prev.groupConfig, [key]: value } }));
-  }
-
-  function handleDraftSave() {
-    try {
-      localStorage.setItem(draftKey, JSON.stringify(form));
-      setDraftSaved(true);
-      setTimeout(() => setDraftSaved(false), 2000);
-    } catch {}
-  }
-
-  function handleDraftReset() {
-    try {
-      localStorage.removeItem(draftKey);
-    } catch {}
-    setForm(defaultForm());
-    setStep(1);
-    setError(null);
-  }
-
-  async function generateContent() {
-    setAiLoading(true);
-    setConflicts([]);
-    try {
-      const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/ai/generate-content`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
-        body: JSON.stringify({
-          varietyId: form.varietyId || undefined,
-          category: form.category || undefined,
-          selection: form.selection,
-          sellerNote: form.sellerNote,
-        }),
-      });
-      if (!res.ok) throw new Error('AI 생성 실패');
-      const data = await res.json();
-      setConflicts(data.conflicts ?? []);
-      setError(null);
-      setForm((prev) => ({
-        ...prev,
-        content: { headline: data.headline, description: data.description, isEditedByUser: false },
-      }));
-    } catch {
-      setError('AI 생성 중 오류가 발생했습니다.');
-    } finally {
-      setAiLoading(false);
-    }
-  }
-
-  function validateStep(s: number): string | null {
-    if (s === 1 && !form.name.trim()) return '상품명을 입력해주세요.';
-    if (s === 2 && form.selection.colors.length === 0) return '색상을 하나 이상 선택해주세요.';
-    return null;
-  }
-
-  async function goNext() {
-    const err = validateStep(step);
-    if (err) {
-      setError(err);
-      return;
-    }
-    setError(null);
-    const next = step + 1;
-    setStep(next);
-    localStorage.setItem(draftKey, JSON.stringify({ ...form, _step: next }));
-    if (next === 4 && !form.content.headline) {
-      await generateContent();
-    }
-  }
-
-  function goPrev() {
-    setError(null);
-    setStep((s) => Math.max(1, s - 1));
-  }
-
-  async function handleSubmit() {
-    if (!form.price || Number.isNaN(Number(form.price)) || Number(form.price) < 0) {
-      setError('올바른 가격을 입력해주세요.');
-      return;
-    }
-    if (form.saleType === 'group') {
-      const g = form.groupConfig;
-      if (!g.minQuantity || Number(g.minQuantity) < 1) {
-        setError('최소 수량을 입력해주세요.');
-        return;
-      }
-      if (!g.targetQuantity || Number(g.targetQuantity) < 1) {
-        setError('목표 수량을 입력해주세요.');
-        return;
-      }
-      if (!g.maxPerPerson || Number(g.maxPerPerson) < 1) {
-        setError('1인 최대 구매 수량을 입력해주세요.');
-        return;
-      }
-      if (!g.recruitDeadline) {
-        setError('모집 마감일시를 입력해주세요.');
-        return;
-      }
-      if (!g.groupDeliveryDate) {
-        setError('배송 예정일을 입력해주세요.');
-        return;
-      }
-      if (Number(g.minQuantity) > Number(g.targetQuantity)) {
-        setError('최소 수량은 목표 수량보다 클 수 없습니다.');
-        return;
-      }
-      if (new Date(g.recruitDeadline) <= new Date()) {
-        setError('모집 마감일시는 현재 시각 이후여야 합니다.');
-        return;
-      }
-      if (new Date(g.groupDeliveryDate) <= new Date(g.recruitDeadline)) {
-        setError('배송 예정일은 모집 마감일 이후여야 합니다.');
-        return;
-      }
-    }
-    setSubmitting(true);
-    setError(null);
-    const body: Record<string, unknown> = {
-      name: form.name.trim(),
-      images: form.images,
-      price: Number(form.price),
-      category: form.category,
-      saleType: form.saleType,
-      deliverySize: form.deliverySize,
-      varietyId: form.varietyId || undefined,
-      selection: form.selection,
-      sellerNote: form.sellerNote,
-      content: form.content,
-      sellerOverride: form.sellerOverride,
-    };
-    if (form.saleType === 'group') {
-      body.groupConfig = {
-        minQuantity: Number(form.groupConfig.minQuantity),
-        targetQuantity: Number(form.groupConfig.targetQuantity),
-        maxPerPerson: Number(form.groupConfig.maxPerPerson),
-        recruitDeadline: new Date(form.groupConfig.recruitDeadline).toISOString(),
-        groupDeliveryDate: new Date(form.groupConfig.groupDeliveryDate).toISOString(),
-        groupDeliveryMethod: form.groupConfig.groupDeliveryMethod,
-        deliveryFeeDiscount: 0,
-      };
-    }
-    try {
-      const url =
-        mode === 'create'
-          ? `/stores/${storeId}/products`
-          : `/stores/${storeId}/products/${productId}`;
-      const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}${url}`, {
-        method: mode === 'create' ? 'POST' : 'PATCH',
-        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
-        body: JSON.stringify(body),
-      });
-      if (!res.ok) {
-        const data = await res.json().catch(() => ({}));
-        throw new Error(data.message ?? `서버 오류 (${res.status})`);
-      }
-      localStorage.removeItem(draftKey);
-      onSuccess();
-    } catch (e) {
-      setError(e instanceof Error ? e.message : '오류가 발생했습니다.');
-    } finally {
-      setSubmitting(false);
-    }
-  }
+  const f = useProductForm(props);
 
   function renderStep() {
-    switch (step) {
+    switch (f.step) {
       case 1:
         return (
-          <Stack gap="sm">
-            <ImageUpload
-              storeId={storeId}
-              images={form.images}
-              onChange={(images) => set('images', images)}
-              onError={(msg) => setError(msg)}
-            />
-            <TextInput
-              placeholder="상품명"
-              value={form.name}
-              onChange={(e) => set('name', e.target.value)}
-              radius="xl"
-              size="md"
-            />
-            <Paper radius="lg" shadow="xs" p="md">
-              <Text
-                style={{
-                  fontSize: 'var(--font-size-sm)',
-                  fontWeight: 'var(--fw-medium)',
-                  color: 'var(--color-text-disabled)',
-                }}
-                mb="xs"
-              >
-                카테고리
-              </Text>
-              <Group gap="xs">
-                {CATEGORIES.map(({ value, label }) => (
-                  <Button
-                    key={value}
-                    onClick={() => set('category', value)}
-                    flex={1}
-                    size="sm"
-                    radius="xl"
-                    variant={form.category === value ? 'filled' : 'outline'}
-                    color="gray"
-                    style={
-                      form.category === value
-                        ? {
-                            backgroundColor: 'var(--color-primary)',
-                            borderColor: 'var(--color-primary)',
-                            color: 'white',
-                          }
-                        : {}
-                    }
-                  >
-                    {label}
-                  </Button>
-                ))}
-              </Group>
-            </Paper>
-            <Paper radius="lg" shadow="xs" p="md">
-              <Text
-                style={{
-                  fontSize: 'var(--font-size-sm)',
-                  fontWeight: 'var(--fw-medium)',
-                  color: 'var(--color-text-disabled)',
-                }}
-                mb="xs"
-              >
-                품종 선택
-              </Text>
-              <VarietySelector
-                category={form.category}
-                value={form.varietyId}
-                onChange={(id) => set('varietyId', id)}
-                onVarietyChange={(v) => setAvailableStemTypes(v?.availableStemTypes)}
-                token={token}
-              />
-            </Paper>
-          </Stack>
+          <Step1Basic
+            storeId={storeId}
+            token={token}
+            form={f.form}
+            set={f.set}
+            setAvailableStemTypes={f.setAvailableStemTypes}
+            setError={f.setError}
+          />
         );
       case 2:
         return (
           <TouchSelector
-            value={form.selection}
-            onChange={(s) => set('selection', s)}
-            availableStemTypes={availableStemTypes}
+            value={f.form.selection}
+            onChange={(s) => f.set('selection', s)}
+            availableStemTypes={f.availableStemTypes}
           />
         );
       case 3:
-        return <SellerNoteInput value={form.sellerNote} onChange={(v) => set('sellerNote', v)} />;
+        return (
+          <SellerNoteInput
+            value={f.form.sellerNote}
+            onChange={(v) => f.set('sellerNote', v)}
+          />
+        );
       case 4:
         return (
           <AIPreviewPanel
-            loading={aiLoading}
-            headline={form.content.headline}
-            description={form.content.description}
-            isEditedByUser={form.content.isEditedByUser}
-            conflicts={conflicts}
-            onHeadlineChange={(v) =>
-              setForm((p) => ({
-                ...p,
-                content: { ...p.content, headline: v, isEditedByUser: true },
-              }))
-            }
-            onDescriptionChange={(v) =>
-              setForm((p) => ({
-                ...p,
-                content: { ...p.content, description: v, isEditedByUser: true },
-              }))
-            }
-            onRegenerate={generateContent}
+            loading={f.aiLoading}
+            headline={f.form.content.headline}
+            description={f.form.content.description}
+            isEditedByUser={f.form.content.isEditedByUser}
+            conflicts={f.conflicts}
+            onHeadlineChange={(v) => f.setContent({ headline: v, isEditedByUser: true })}
+            onDescriptionChange={(v) => f.setContent({ description: v, isEditedByUser: true })}
+            onRegenerate={f.generateContent}
             onSellerOverride={() => {
-              set('sellerOverride', true);
-              setConflicts([]);
+              f.set('sellerOverride', true);
+              f.setConflicts([]);
             }}
           />
         );
       case 5:
-        return (
-          <Stack gap="sm">
-            <NumberInput
-              placeholder="가격"
-              leftSection={
-                <Text
-                  style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-text-disabled)' }}
-                >
-                  ₩
-                </Text>
-              }
-              thousandSeparator=","
-              min={0}
-              hideControls
-              value={form.price === '' ? '' : Number(form.price)}
-              onChange={(val) => set('price', val === '' ? '' : String(val))}
-              radius="xl"
-              size="md"
-            />
-            <Paper radius="lg" shadow="xs" p="md">
-              <Text
-                style={{
-                  fontSize: 'var(--font-size-sm)',
-                  fontWeight: 'var(--fw-medium)',
-                  color: 'var(--color-text-disabled)',
-                }}
-                mb="xs"
-              >
-                배송 사이즈
-              </Text>
-              <Group gap="xs">
-                {DELIVERY_SIZES.map(({ value, label }) => (
-                  <Button
-                    key={value}
-                    onClick={() => set('deliverySize', value)}
-                    flex={1}
-                    size="sm"
-                    radius="xl"
-                    variant="outline"
-                    color="gray"
-                    style={
-                      form.deliverySize === value
-                        ? {
-                            backgroundColor: 'var(--color-primary)',
-                            borderColor: 'var(--color-primary)',
-                            color: 'white',
-                          }
-                        : {}
-                    }
-                  >
-                    {label}
-                  </Button>
-                ))}
-              </Group>
-            </Paper>
-            <Paper radius="lg" shadow="xs" p="md">
-              <Text
-                style={{
-                  fontSize: 'var(--font-size-sm)',
-                  fontWeight: 'var(--fw-medium)',
-                  color: 'var(--color-text-disabled)',
-                }}
-                mb="sm"
-              >
-                판매 방식
-              </Text>
-              <Group gap="xl">
-                {(['normal', 'group'] as const).map((type) => (
-                  <label
-                    key={type}
-                    style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer' }}
-                  >
-                    <input
-                      type="radio"
-                      name="saleType"
-                      checked={form.saleType === type}
-                      onChange={() => set('saleType', type)}
-                      style={{ accentColor: 'var(--color-primary)', width: 16, height: 16 }}
-                    />
-                    <Text
-                      style={{
-                        fontSize: 'var(--font-size-sm)',
-                        color: 'var(--color-text-secondary)',
-                      }}
-                    >
-                      {type === 'normal' ? '일반 판매' : '공동구매'}
-                    </Text>
-                  </label>
-                ))}
-              </Group>
-              <GroupConfigSection
-                visible={form.saleType === 'group'}
-                config={form.groupConfig}
-                setGroupConfig={setGroupConfig}
-              />
-            </Paper>
-          </Stack>
-        );
+        return <Step5Pricing form={f.form} set={f.set} setGroupConfig={f.setGroupConfig} />;
     }
   }
 
   return (
-    <Box
-      component="main"
-      style={{ minHeight: '100vh', backgroundColor: 'var(--color-surface-muted)' }}
-    >
-      <Box
-        component="header"
-        style={{
-          backgroundColor: 'var(--color-bg)',
-          borderBottom: '1px solid var(--color-border)',
-          padding: '16px',
-          position: 'sticky',
-          top: 0,
-          zIndex: 10,
-        }}
-      >
-        <Container size="sm">
-          <Group justify="space-between">
-            <Group gap="sm">
-              <ActionIcon variant="subtle" color="gray" onClick={() => router.back()}>
-                <svg
-                  width="20"
-                  height="20"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  aria-hidden="true"
-                  focusable="false"
-                >
-                  <path d="M19 12H5M12 5l-7 7 7 7" />
-                </svg>
-              </ActionIcon>
-              <Title order={3}>{mode === 'create' ? '상품 등록' : '상품 수정'}</Title>
-            </Group>
-            <Group gap="xs">
-              <UnstyledButton
-                onClick={handleDraftReset}
-                style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-text-disabled)' }}
-              >
-                초기화
-              </UnstyledButton>
-              <UnstyledButton
-                onClick={handleDraftSave}
-                style={{
-                  fontSize: 'var(--font-size-sm)',
-                  fontWeight: 'var(--fw-medium)',
-                  color: draftSaved ? 'var(--color-primary)' : 'var(--color-text-secondary)',
-                }}
-              >
-                {draftSaved ? '저장됨 ✓' : '임시저장'}
-              </UnstyledButton>
-            </Group>
+    <PageShell>
+      <PageHeader
+        title={mode === 'create' ? '상품 등록' : '상품 수정'}
+        onBack={() => router.back()}
+        right={
+          <Group gap="xs">
+            <UnstyledButton
+              onClick={f.handleDraftReset}
+              style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-text-disabled)' }}
+            >
+              초기화
+            </UnstyledButton>
+            <UnstyledButton
+              onClick={f.handleDraftSave}
+              style={{
+                fontSize: 'var(--font-size-sm)',
+                fontWeight: 'var(--fw-medium)',
+                color: f.draftSaved ? 'var(--color-primary)' : 'var(--color-text-secondary)',
+              }}
+            >
+              {f.draftSaved ? '저장됨 ✓' : '임시저장'}
+            </UnstyledButton>
           </Group>
-        </Container>
-      </Box>
+        }
+      />
 
-      <Box
-        style={{
-          backgroundColor: 'var(--color-bg)',
-          borderBottom: '1px solid var(--color-border)',
-          padding: '8px 16px',
-        }}
-      >
-        <Container size="sm">
-          <Group gap={0}>
-            {STEP_LABELS.map((label, i) => {
-              const s = i + 1;
-              const active = s === step;
-              const done = s < step;
-              return (
-                <Box key={s} style={{ flex: 1, textAlign: 'center', padding: '4px 2px' }}>
-                  <Box
-                    style={{
-                      width: 24,
-                      height: 24,
-                      borderRadius: '50%',
-                      margin: '0 auto 2px',
-                      backgroundColor: active
-                        ? 'var(--color-primary)'
-                        : done
-                          ? 'var(--color-primary-surface)'
-                          : 'var(--color-border)',
-                      display: 'flex',
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                      fontSize: 'var(--font-size-sm)',
-                      fontWeight: 'var(--fw-medium)',
-                      color: active
-                        ? 'white'
-                        : done
-                          ? 'var(--color-primary)'
-                          : 'var(--color-text-disabled)',
-                    }}
-                  >
-                    {done ? '✓' : s}
-                  </Box>
-                  <Text
-                    style={{
-                      fontSize: 'var(--font-size-sm)',
-                      color: active ? 'var(--color-primary)' : 'var(--color-text-disabled)',
-                      fontWeight: active ? 'var(--fw-medium)' : 400,
-                    }}
-                  >
-                    {label}
-                  </Text>
-                </Box>
-              );
-            })}
-          </Group>
-        </Container>
-      </Box>
+      <StepIndicator step={f.step} />
 
       <Container size="sm" px="md" py="md" pb={96}>
         <Stack gap="sm">
           {renderStep()}
-          {error && (
+          {f.error && (
             <Text
               style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-danger)' }}
               ta="center"
               px="xs"
             >
-              {error}
+              {f.error}
             </Text>
           )}
           <Group gap="xs" mt="xs">
-            {step > 1 && (
+            {f.step > 1 && (
               <Button
-                onClick={goPrev}
+                onClick={f.goPrev}
                 variant="outline"
                 color="gray"
                 flex={1}
@@ -675,9 +124,9 @@ export default function ProductForm({
                 이전
               </Button>
             )}
-            {step < 5 ? (
+            {f.step < 5 ? (
               <Button
-                onClick={goNext}
+                onClick={f.goNext}
                 flex={1}
                 size="lg"
                 radius="xl"
@@ -687,19 +136,19 @@ export default function ProductForm({
               </Button>
             ) : (
               <Button
-                onClick={handleSubmit}
-                disabled={submitting}
+                onClick={f.handleSubmit}
+                disabled={f.submitting}
                 flex={1}
                 size="lg"
                 radius="xl"
                 style={{ backgroundColor: 'var(--color-primary)', fontWeight: 'var(--fw-medium)' }}
               >
-                {submitting ? '처리 중...' : mode === 'create' ? '등록하기' : '저장하기'}
+                {f.submitting ? '처리 중...' : mode === 'create' ? '등록하기' : '저장하기'}
               </Button>
             )}
           </Group>
         </Stack>
       </Container>
-    </Box>
+    </PageShell>
   );
 }

--- a/apps/seller/src/app/products/_components/StepIndicator.tsx
+++ b/apps/seller/src/app/products/_components/StepIndicator.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { Box, Container, Group, Text } from '@mantine/core';
+import { STEP_LABELS } from './productForm.types';
+
+/** ProductForm 5단계 진행 인디케이터. */
+export function StepIndicator({ step }: { step: number }) {
+  return (
+    <Box
+      style={{
+        backgroundColor: 'var(--color-bg)',
+        borderBottom: '1px solid var(--color-border)',
+        padding: '8px 16px',
+      }}
+    >
+      <Container size="sm">
+        <Group gap={0}>
+          {STEP_LABELS.map((label, i) => {
+            const s = i + 1;
+            const active = s === step;
+            const done = s < step;
+            return (
+              <Box key={s} style={{ flex: 1, textAlign: 'center', padding: '4px 2px' }}>
+                <Box
+                  style={{
+                    width: 24,
+                    height: 24,
+                    borderRadius: '50%',
+                    margin: '0 auto 2px',
+                    backgroundColor: active
+                      ? 'var(--color-primary)'
+                      : done
+                        ? 'var(--color-primary-surface)'
+                        : 'var(--color-border)',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    fontSize: 'var(--font-size-sm)',
+                    fontWeight: 'var(--fw-medium)',
+                    color: active
+                      ? 'white'
+                      : done
+                        ? 'var(--color-primary)'
+                        : 'var(--color-text-disabled)',
+                  }}
+                >
+                  {done ? '✓' : s}
+                </Box>
+                <Text
+                  style={{
+                    fontSize: 'var(--font-size-sm)',
+                    color: active ? 'var(--color-primary)' : 'var(--color-text-disabled)',
+                    fontWeight: active ? 'var(--fw-medium)' : 400,
+                  }}
+                >
+                  {label}
+                </Text>
+              </Box>
+            );
+          })}
+        </Group>
+      </Container>
+    </Box>
+  );
+}

--- a/apps/seller/src/app/products/_components/productForm.types.ts
+++ b/apps/seller/src/app/products/_components/productForm.types.ts
@@ -1,0 +1,85 @@
+import type { SelectionForm } from './TouchSelector';
+
+export const CATEGORIES = [
+  { value: 'cut_flower', label: '절화' },
+  { value: 'orchid', label: '난' },
+  { value: 'foliage', label: '관엽' },
+] as const;
+
+export const DELIVERY_SIZES = [
+  { value: 'small', label: '소형' },
+  { value: 'medium', label: '중형' },
+  { value: 'large', label: '대형' },
+] as const;
+
+export const STEP_LABELS = ['사진·품종', '터치 선택', '판매자 메모', 'AI 미리보기', '가격·배송'];
+
+export interface GroupConfigForm {
+  minQuantity: string;
+  targetQuantity: string;
+  maxPerPerson: string;
+  recruitDeadline: string;
+  groupDeliveryDate: string;
+  groupDeliveryMethod: 'direct' | 'parcel';
+}
+
+export interface ContentForm {
+  headline: string;
+  description: string;
+  isEditedByUser: boolean;
+}
+
+export interface ProductFormData {
+  name: string;
+  category: string;
+  deliverySize: string;
+  price: string;
+  saleType: 'normal' | 'group';
+  groupConfig: GroupConfigForm;
+  images: string[];
+  varietyId: string;
+  selection: SelectionForm;
+  sellerNote: string;
+  content: ContentForm;
+  sellerOverride: boolean;
+}
+
+export interface ProductFormProps {
+  mode: 'create' | 'edit';
+  productId?: string;
+  storeId: string;
+  token: string;
+  initialData?: Partial<ProductFormData>;
+  onSuccess: () => void;
+}
+
+export function defaultForm(): ProductFormData {
+  return {
+    name: '',
+    category: 'cut_flower',
+    deliverySize: 'small',
+    price: '',
+    saleType: 'normal',
+    groupConfig: {
+      minQuantity: '10',
+      targetQuantity: '50',
+      maxPerPerson: '5',
+      recruitDeadline: '',
+      groupDeliveryDate: '',
+      groupDeliveryMethod: 'direct',
+    },
+    images: [],
+    varietyId: '',
+    selection: {
+      colors: [],
+      stemType: '외대',
+      fragrance: 'none',
+      bloomCondition: 'half',
+      careLevel: 'normal',
+      bundleUnit: '',
+    },
+    sellerNote: '',
+    content: { headline: '', description: '', isEditedByUser: false },
+    sellerOverride: false,
+  };
+}

--- a/apps/seller/src/app/products/_components/steps/Step1Basic.tsx
+++ b/apps/seller/src/app/products/_components/steps/Step1Basic.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { Stack, TextInput } from '@mantine/core';
+import ImageUpload from '../ImageUpload';
+import VarietySelector from '../VarietySelector';
+import { ChoiceRow, FieldCard } from '../FormPrimitives';
+import { CATEGORIES, type ProductFormData } from '../productForm.types';
+
+interface Step1BasicProps {
+  storeId: string;
+  token: string;
+  form: ProductFormData;
+  set: <K extends keyof ProductFormData>(key: K, value: ProductFormData[K]) => void;
+  setAvailableStemTypes: (v: string[] | undefined) => void;
+  setError: (msg: string) => void;
+}
+
+export function Step1Basic({
+  storeId,
+  token,
+  form,
+  set,
+  setAvailableStemTypes,
+  setError,
+}: Step1BasicProps) {
+  return (
+    <Stack gap="sm">
+      <ImageUpload
+        storeId={storeId}
+        images={form.images}
+        onChange={(images) => set('images', images)}
+        onError={(msg) => setError(msg)}
+      />
+      <TextInput
+        placeholder="상품명"
+        value={form.name}
+        onChange={(e) => set('name', e.target.value)}
+        radius="xl"
+        size="md"
+      />
+      <FieldCard label="카테고리">
+        <ChoiceRow
+          options={CATEGORIES}
+          value={form.category}
+          onChange={(v) => set('category', v)}
+        />
+      </FieldCard>
+      <FieldCard label="품종 선택">
+        <VarietySelector
+          category={form.category}
+          value={form.varietyId}
+          onChange={(id) => set('varietyId', id)}
+          onVarietyChange={(v) => setAvailableStemTypes(v?.availableStemTypes)}
+          token={token}
+        />
+      </FieldCard>
+    </Stack>
+  );
+}

--- a/apps/seller/src/app/products/_components/steps/Step5Pricing.tsx
+++ b/apps/seller/src/app/products/_components/steps/Step5Pricing.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { Group, NumberInput, Stack, Text } from '@mantine/core';
+import GroupConfigSection from '../GroupConfigSection';
+import { ChoiceRow, FieldCard } from '../FormPrimitives';
+import {
+  DELIVERY_SIZES,
+  type GroupConfigForm,
+  type ProductFormData,
+} from '../productForm.types';
+
+interface Step5PricingProps {
+  form: ProductFormData;
+  set: <K extends keyof ProductFormData>(key: K, value: ProductFormData[K]) => void;
+  setGroupConfig: <K extends keyof GroupConfigForm>(key: K, value: GroupConfigForm[K]) => void;
+}
+
+export function Step5Pricing({ form, set, setGroupConfig }: Step5PricingProps) {
+  return (
+    <Stack gap="sm">
+      <NumberInput
+        placeholder="가격"
+        leftSection={
+          <Text style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-text-disabled)' }}>
+            ₩
+          </Text>
+        }
+        thousandSeparator=","
+        min={0}
+        hideControls
+        value={form.price === '' ? '' : Number(form.price)}
+        onChange={(val) => set('price', val === '' ? '' : String(val))}
+        radius="xl"
+        size="md"
+      />
+      <FieldCard label="배송 사이즈">
+        <ChoiceRow
+          options={DELIVERY_SIZES}
+          value={form.deliverySize}
+          onChange={(v) => set('deliverySize', v)}
+        />
+      </FieldCard>
+      <FieldCard label="판매 방식" labelGap="sm">
+        <Group gap="xl">
+          {(['normal', 'group'] as const).map((type) => (
+            <label
+              key={type}
+              style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer' }}
+            >
+              <input
+                type="radio"
+                name="saleType"
+                checked={form.saleType === type}
+                onChange={() => set('saleType', type)}
+                style={{ accentColor: 'var(--color-primary)', width: 16, height: 16 }}
+              />
+              <Text
+                style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-text-secondary)' }}
+              >
+                {type === 'normal' ? '일반 판매' : '공동구매'}
+              </Text>
+            </label>
+          ))}
+        </Group>
+        <GroupConfigSection
+          visible={form.saleType === 'group'}
+          config={form.groupConfig}
+          setGroupConfig={setGroupConfig}
+        />
+      </FieldCard>
+    </Stack>
+  );
+}

--- a/apps/seller/src/app/products/_components/useProductForm.ts
+++ b/apps/seller/src/app/products/_components/useProductForm.ts
@@ -1,0 +1,240 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { apiJson } from '@/lib/api';
+import type { ConflictWarning } from './AIPreviewPanel';
+import {
+  type GroupConfigForm,
+  type ProductFormData,
+  type ProductFormProps,
+  defaultForm,
+} from './productForm.types';
+
+/** ProductForm의 상태·검증·임시저장·제출 로직을 모두 담는 훅. */
+export function useProductForm({
+  mode,
+  productId,
+  storeId,
+  token,
+  initialData,
+  onSuccess,
+}: ProductFormProps) {
+  const draftKey = mode === 'create' ? 'product_draft_new' : `product_draft_${productId}`;
+
+  const [form, setForm] = useState<ProductFormData>(() =>
+    initialData ? { ...defaultForm(), ...initialData } : defaultForm(),
+  );
+  const [step, setStep] = useState(1);
+  const [availableStemTypes, setAvailableStemTypes] = useState<string[] | undefined>(undefined);
+  const [conflicts, setConflicts] = useState<ConflictWarning[]>([]);
+  const [aiLoading, setAiLoading] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [draftSaved, setDraftSaved] = useState(false);
+
+  // 신규 등록 시에만 localStorage 임시저장 복원
+  useEffect(() => {
+    if (initialData) return;
+    try {
+      const saved = localStorage.getItem(draftKey);
+      if (saved) {
+        const p = JSON.parse(saved);
+        const def = defaultForm();
+        setForm({
+          ...def,
+          ...p,
+          groupConfig: { ...def.groupConfig, ...(p.groupConfig ?? {}) },
+          selection: { ...def.selection, ...(p.selection ?? {}) },
+          content: { ...def.content, ...(p.content ?? {}) },
+        });
+        if (p._step) setStep(p._step);
+      }
+    } catch {}
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [draftKey, initialData]);
+
+  // 수정 모드: 비동기로 도착한 initialData 반영
+  useEffect(() => {
+    if (initialData?.name) setForm({ ...defaultForm(), ...initialData });
+  }, [initialData?.name, initialData]);
+
+  function set<K extends keyof ProductFormData>(key: K, value: ProductFormData[K]) {
+    setForm((prev) => ({ ...prev, [key]: value }));
+  }
+
+  function setGroupConfig<K extends keyof GroupConfigForm>(key: K, value: GroupConfigForm[K]) {
+    setForm((prev) => ({ ...prev, groupConfig: { ...prev.groupConfig, [key]: value } }));
+  }
+
+  function setContent(patch: Partial<ProductFormData['content']>) {
+    setForm((prev) => ({ ...prev, content: { ...prev.content, ...patch } }));
+  }
+
+  function handleDraftSave() {
+    try {
+      localStorage.setItem(draftKey, JSON.stringify(form));
+      setDraftSaved(true);
+      setTimeout(() => setDraftSaved(false), 2000);
+    } catch {}
+  }
+
+  function handleDraftReset() {
+    try {
+      localStorage.removeItem(draftKey);
+    } catch {}
+    setForm(defaultForm());
+    setStep(1);
+    setError(null);
+  }
+
+  async function generateContent() {
+    setAiLoading(true);
+    setConflicts([]);
+    try {
+      const data = await apiJson<{
+        headline: string;
+        description: string;
+        conflicts?: ConflictWarning[];
+      }>('/ai/generate-content', token, {
+        method: 'POST',
+        body: JSON.stringify({
+          varietyId: form.varietyId || undefined,
+          category: form.category || undefined,
+          selection: form.selection,
+          sellerNote: form.sellerNote,
+        }),
+      });
+      setConflicts(data.conflicts ?? []);
+      setError(null);
+      setForm((prev) => ({
+        ...prev,
+        content: { headline: data.headline, description: data.description, isEditedByUser: false },
+      }));
+    } catch {
+      setError('AI 생성 중 오류가 발생했습니다.');
+    } finally {
+      setAiLoading(false);
+    }
+  }
+
+  function validateStep(s: number): string | null {
+    if (s === 1 && !form.name.trim()) return '상품명을 입력해주세요.';
+    if (s === 2 && form.selection.colors.length === 0) return '색상을 하나 이상 선택해주세요.';
+    return null;
+  }
+
+  async function goNext() {
+    const err = validateStep(step);
+    if (err) {
+      setError(err);
+      return;
+    }
+    setError(null);
+    const next = step + 1;
+    setStep(next);
+    localStorage.setItem(draftKey, JSON.stringify({ ...form, _step: next }));
+    if (next === 4 && !form.content.headline) {
+      await generateContent();
+    }
+  }
+
+  function goPrev() {
+    setError(null);
+    setStep((s) => Math.max(1, s - 1));
+  }
+
+  function validateSubmit(): string | null {
+    if (!form.price || Number.isNaN(Number(form.price)) || Number(form.price) < 0) {
+      return '올바른 가격을 입력해주세요.';
+    }
+    if (form.saleType === 'group') {
+      const g = form.groupConfig;
+      if (!g.minQuantity || Number(g.minQuantity) < 1) return '최소 수량을 입력해주세요.';
+      if (!g.targetQuantity || Number(g.targetQuantity) < 1) return '목표 수량을 입력해주세요.';
+      if (!g.maxPerPerson || Number(g.maxPerPerson) < 1)
+        return '1인 최대 구매 수량을 입력해주세요.';
+      if (!g.recruitDeadline) return '모집 마감일시를 입력해주세요.';
+      if (!g.groupDeliveryDate) return '배송 예정일을 입력해주세요.';
+      if (Number(g.minQuantity) > Number(g.targetQuantity))
+        return '최소 수량은 목표 수량보다 클 수 없습니다.';
+      if (new Date(g.recruitDeadline) <= new Date())
+        return '모집 마감일시는 현재 시각 이후여야 합니다.';
+      if (new Date(g.groupDeliveryDate) <= new Date(g.recruitDeadline))
+        return '배송 예정일은 모집 마감일 이후여야 합니다.';
+    }
+    return null;
+  }
+
+  async function handleSubmit() {
+    const err = validateSubmit();
+    if (err) {
+      setError(err);
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    const body: Record<string, unknown> = {
+      name: form.name.trim(),
+      images: form.images,
+      price: Number(form.price),
+      category: form.category,
+      saleType: form.saleType,
+      deliverySize: form.deliverySize,
+      varietyId: form.varietyId || undefined,
+      selection: form.selection,
+      sellerNote: form.sellerNote,
+      content: form.content,
+      sellerOverride: form.sellerOverride,
+    };
+    if (form.saleType === 'group') {
+      body.groupConfig = {
+        minQuantity: Number(form.groupConfig.minQuantity),
+        targetQuantity: Number(form.groupConfig.targetQuantity),
+        maxPerPerson: Number(form.groupConfig.maxPerPerson),
+        recruitDeadline: new Date(form.groupConfig.recruitDeadline).toISOString(),
+        groupDeliveryDate: new Date(form.groupConfig.groupDeliveryDate).toISOString(),
+        groupDeliveryMethod: form.groupConfig.groupDeliveryMethod,
+        deliveryFeeDiscount: 0,
+      };
+    }
+    try {
+      const url =
+        mode === 'create'
+          ? `/stores/${storeId}/products`
+          : `/stores/${storeId}/products/${productId}`;
+      await apiJson(url, token, {
+        method: mode === 'create' ? 'POST' : 'PATCH',
+        body: JSON.stringify(body),
+      });
+      localStorage.removeItem(draftKey);
+      onSuccess();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : '오류가 발생했습니다.');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return {
+    form,
+    set,
+    setGroupConfig,
+    setContent,
+    step,
+    availableStemTypes,
+    setAvailableStemTypes,
+    conflicts,
+    setConflicts,
+    aiLoading,
+    submitting,
+    error,
+    setError,
+    draftSaved,
+    handleDraftSave,
+    handleDraftReset,
+    generateContent,
+    goNext,
+    goPrev,
+    handleSubmit,
+  };
+}

--- a/apps/seller/src/app/products/page.tsx
+++ b/apps/seller/src/app/products/page.tsx
@@ -6,6 +6,9 @@ import { useSession } from 'next-auth/react';
 import Link from 'next/link';
 import { useStoreProducts } from '@/hooks/useStoreProducts';
 import { apiFetch } from '@/lib/api';
+import { PageShell } from '@/components/PageShell';
+import { PageHeader } from '@/components/PageHeader';
+import { EmptyState, LoadingState } from '@/components/StateViews';
 import type { Product } from '@greenhub/shared';
 import {
   Badge,
@@ -13,11 +16,9 @@ import {
   Button,
   Container,
   Group,
-  Loader,
   Paper,
   Stack,
   Text,
-  Title,
   UnstyledButton,
 } from '@mantine/core';
 
@@ -42,37 +43,21 @@ export default function ProductsPage() {
   });
 
   return (
-    <Box
-      component="main"
-      style={{ minHeight: '100vh', backgroundColor: 'var(--color-surface-muted)' }}
-    >
-      {/* 헤더 */}
-      <Box
-        component="header"
-        style={{
-          backgroundColor: 'var(--color-bg)',
-          borderBottom: '1px solid var(--color-border)',
-          padding: '16px',
-          position: 'sticky',
-          top: 0,
-          zIndex: 10,
-        }}
-      >
-        <Container size="sm">
-          <Group justify="space-between">
-            <Title order={3}>상품 관리</Title>
-            <Button
-              component={Link}
-              href="/products/new"
-              size="xs"
-              radius="md"
-              style={{ backgroundColor: 'var(--color-primary)' }}
-            >
-              + 등록
-            </Button>
-          </Group>
-        </Container>
-      </Box>
+    <PageShell>
+      <PageHeader
+        title="상품 관리"
+        right={
+          <Button
+            component={Link}
+            href="/products/new"
+            size="xs"
+            radius="md"
+            style={{ backgroundColor: 'var(--color-primary)' }}
+          >
+            + 등록
+          </Button>
+        }
+      />
 
       {/* 필터 탭 */}
       <Box
@@ -111,46 +96,41 @@ export default function ProductsPage() {
       {/* 상품 목록 */}
       <Container size="sm" px="md" py="md">
         <Stack gap="sm">
-          {loading && (
-            <Group justify="center" py={80}>
-              <Loader size="sm" color="var(--color-primary)" />
-            </Group>
-          )}
+          {loading && <LoadingState />}
 
           {!loading && filtered.length === 0 && (
-            <Stack
-              align="center"
-              justify="center"
-              py={80}
-              style={{ color: 'var(--color-text-disabled)' }}
-            >
-              <svg
-                width="48"
-                height="48"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="1.5"
-                aria-hidden="true"
-                focusable="false"
-              >
-                <rect x="2" y="7" width="20" height="14" rx="2" />
-                <path d="M16 7V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v2" />
-              </svg>
-              <Text style={{ fontSize: 'var(--font-size-sm)' }}>등록된 상품이 없습니다</Text>
-              <Text
-                component={Link}
-                href="/products/new"
-                mt="xs"
-                style={{
-                  color: 'var(--color-primary)',
-                  fontWeight: 'var(--fw-medium)',
-                  fontSize: 'var(--font-size-md)',
-                }}
-              >
-                상품 등록하기 →
-              </Text>
-            </Stack>
+            <EmptyState
+              icon={
+                <svg
+                  width="48"
+                  height="48"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  aria-hidden="true"
+                  focusable="false"
+                >
+                  <rect x="2" y="7" width="20" height="14" rx="2" />
+                  <path d="M16 7V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v2" />
+                </svg>
+              }
+              text="등록된 상품이 없습니다"
+              action={
+                <Text
+                  component={Link}
+                  href="/products/new"
+                  mt="xs"
+                  style={{
+                    color: 'var(--color-primary)',
+                    fontWeight: 'var(--fw-medium)',
+                    fontSize: 'var(--font-size-md)',
+                  }}
+                >
+                  상품 등록하기 →
+                </Text>
+              }
+            />
           )}
 
           {filtered.map((product) => (
@@ -158,7 +138,7 @@ export default function ProductsPage() {
           ))}
         </Stack>
       </Container>
-    </Box>
+    </PageShell>
   );
 }
 

--- a/apps/seller/src/app/settings/page.tsx
+++ b/apps/seller/src/app/settings/page.tsx
@@ -1,30 +1,15 @@
 'use client';
 
-import { signOut, useSession } from 'next-auth/react';
+import { signOut } from 'next-auth/react';
 import Link from 'next/link';
-import { Box, Container, Group, Paper, Stack, Text, Title, UnstyledButton } from '@mantine/core';
+import { Box, Container, Group, Paper, Stack, Text, UnstyledButton } from '@mantine/core';
+import { PageShell } from '@/components/PageShell';
+import { PageHeader } from '@/components/PageHeader';
 
 export default function SettingsPage() {
-  const { data: session } = useSession();
-
   return (
-    <Box
-      component="main"
-      style={{ minHeight: '100vh', backgroundColor: 'var(--color-surface-muted)' }}
-    >
-      {/* 헤더 */}
-      <Box
-        component="header"
-        style={{
-          backgroundColor: 'var(--color-bg)',
-          borderBottom: '1px solid var(--color-border)',
-          padding: '16px',
-        }}
-      >
-        <Container size="sm">
-          <Title order={3}>설정</Title>
-        </Container>
-      </Box>
+    <PageShell>
+      <PageHeader title="설정" sticky={false} />
 
       <Container size="sm" px="md" py="md">
         <Stack gap="sm">
@@ -187,6 +172,6 @@ export default function SettingsPage() {
           </Paper>
         </Stack>
       </Container>
-    </Box>
+    </PageShell>
   );
 }

--- a/apps/seller/src/app/settlements/page.tsx
+++ b/apps/seller/src/app/settlements/page.tsx
@@ -1,7 +1,9 @@
 'use client';
 
 import { useState } from 'react';
-import { Box, Container, Group, Title, UnstyledButton } from '@mantine/core';
+import { Box, Container, Group, UnstyledButton } from '@mantine/core';
+import { PageShell } from '@/components/PageShell';
+import { PageHeader } from '@/components/PageHeader';
 import type { SettlementTab } from './_constants';
 import { TABS } from './_constants';
 import { useSettlements } from './_hooks/useSettlements';
@@ -30,25 +32,8 @@ export default function SettlementsPage() {
   } = useSettlements(activeTab);
 
   return (
-    <Box
-      component="main"
-      style={{ minHeight: '100vh', backgroundColor: 'var(--color-surface-muted)' }}
-    >
-      <Box
-        component="header"
-        style={{
-          backgroundColor: 'var(--color-bg)',
-          borderBottom: '1px solid var(--color-border)',
-          padding: '16px',
-          position: 'sticky',
-          top: 0,
-          zIndex: 10,
-        }}
-      >
-        <Container size="sm">
-          <Title order={3}>정산 관리</Title>
-        </Container>
-      </Box>
+    <PageShell>
+      <PageHeader title="정산 관리" />
 
       <Box
         style={{
@@ -111,6 +96,6 @@ export default function SettlementsPage() {
           <OrdersTab settlements={settlements} listLoading={listLoading} />
         )}
       </Container>
-    </Box>
+    </PageShell>
   );
 }

--- a/apps/seller/src/components/PageHeader.tsx
+++ b/apps/seller/src/components/PageHeader.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { ActionIcon, Box, Container, Group, Title } from '@mantine/core';
+import { ChevronLeft } from 'lucide-react';
+import type { MantineSize } from '@mantine/core';
+import type { ReactNode } from 'react';
+
+interface PageHeaderProps {
+  title: string;
+  /** 지정 시 좌측에 뒤로가기 버튼을 렌더. */
+  onBack?: () => void;
+  /** 우측 영역 (액션 버튼·상태 표시 등). */
+  right?: ReactNode;
+  containerSize?: MantineSize;
+  /** false면 sticky 해제 (기본 true). */
+  sticky?: boolean;
+}
+
+/** 페이지 헤더. 셀러앱 전 페이지가 동일 마크업을 공유. */
+export function PageHeader({
+  title,
+  onBack,
+  right,
+  containerSize = 'sm',
+  sticky = true,
+}: PageHeaderProps) {
+  return (
+    <Box
+      component="header"
+      style={{
+        backgroundColor: 'var(--color-bg)',
+        borderBottom: '1px solid var(--color-border)',
+        padding: '16px',
+        ...(sticky ? { position: 'sticky', top: 0, zIndex: 10 } : {}),
+      }}
+    >
+      <Container size={containerSize}>
+        <Group justify="space-between">
+          <Group gap="sm">
+            {onBack && (
+              <ActionIcon variant="subtle" color="gray" onClick={onBack}>
+                <ChevronLeft size={20} />
+              </ActionIcon>
+            )}
+            <Title order={3}>{title}</Title>
+          </Group>
+          {right}
+        </Group>
+      </Container>
+    </Box>
+  );
+}

--- a/apps/seller/src/components/PageShell.tsx
+++ b/apps/seller/src/components/PageShell.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { Box } from '@mantine/core';
+import type { ReactNode } from 'react';
+
+/** 셀러앱 페이지의 최상위 컨테이너 (min-height + muted 배경). */
+export function PageShell({
+  children,
+  paddingBottom,
+}: {
+  children: ReactNode;
+  paddingBottom?: number;
+}) {
+  return (
+    <Box
+      component="main"
+      style={{
+        minHeight: '100vh',
+        backgroundColor: 'var(--color-surface-muted)',
+        ...(paddingBottom ? { paddingBottom } : {}),
+      }}
+    >
+      {children}
+    </Box>
+  );
+}

--- a/apps/seller/src/components/StateViews.tsx
+++ b/apps/seller/src/components/StateViews.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { Box, Group, Loader, Stack, Text } from '@mantine/core';
+import type { ReactNode } from 'react';
+
+/** 로딩 스피너. fullPage=true면 화면 전체 중앙 정렬. */
+export function LoadingState({ fullPage = false }: { fullPage?: boolean }) {
+  if (fullPage) {
+    return (
+      <Box
+        style={{
+          minHeight: '100vh',
+          backgroundColor: 'var(--color-surface-muted)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <Loader size="sm" color="brand" />
+      </Box>
+    );
+  }
+  return (
+    <Group justify="center" py={80}>
+      <Loader size="sm" color="brand" />
+    </Group>
+  );
+}
+
+/** 빈 목록 안내 (아이콘 + 문구 + 선택 액션). */
+export function EmptyState({
+  icon,
+  text,
+  action,
+}: {
+  icon?: ReactNode;
+  text: string;
+  action?: ReactNode;
+}) {
+  return (
+    <Stack
+      align="center"
+      justify="center"
+      py={80}
+      style={{ color: 'var(--color-text-disabled)' }}
+    >
+      {icon}
+      <Text style={{ fontSize: 'var(--font-size-sm)' }}>{text}</Text>
+      {action}
+    </Stack>
+  );
+}

--- a/apps/seller/src/hooks/useAdmin.ts
+++ b/apps/seller/src/hooks/useAdmin.ts
@@ -1,8 +1,8 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { type DependencyList, useCallback, useEffect, useState } from 'react';
 import { useSession } from 'next-auth/react';
-import { apiFetch } from '@/lib/api';
+import { apiJson } from '@/lib/api';
 
 // ── Types ────────────────────────────────────────────────────────
 
@@ -55,220 +55,6 @@ export interface InviteToken {
   createdAt: string | null;
 }
 
-// ── Stores ───────────────────────────────────────────────────────
-
-export function useAdminStores() {
-  const { data: session } = useSession();
-  const [stores, setStores] = useState<AdminStore[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
-  const load = useCallback(async () => {
-    if (!session?.user.accessToken) return;
-    setLoading(true);
-    try {
-      const res = await apiFetch('/admin/stores', session.user.accessToken);
-      if (res.ok) {
-        const data = await res.json();
-        setStores(data.stores ?? []);
-      } else {
-        setError('판매자 목록 조회 실패');
-      }
-    } catch {
-      setError('판매자 목록 조회 중 오류 발생');
-    } finally {
-      setLoading(false);
-    }
-  }, [session?.user.accessToken]);
-
-  useEffect(() => {
-    load();
-  }, [load]);
-
-  const setCommission = async (storeId: string, rate: number) => {
-    if (!session?.user.accessToken) return false;
-    try {
-      const res = await apiFetch(`/admin/stores/${storeId}/commission`, session.user.accessToken, {
-        method: 'PATCH',
-        body: JSON.stringify({ rate }),
-      });
-      if (res.ok) {
-        await load();
-        return true;
-      }
-      return false;
-    } catch {
-      return false;
-    }
-  };
-
-  return { stores, loading, error, reload: load, setCommission };
-}
-
-// ── Users ────────────────────────────────────────────────────────
-
-export function useAdminUsers() {
-  const { data: session } = useSession();
-  const [users, setUsers] = useState<AdminUser[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
-  const load = useCallback(async () => {
-    if (!session?.user.accessToken) return;
-    setLoading(true);
-    try {
-      const res = await apiFetch('/admin/users', session.user.accessToken);
-      if (res.ok) {
-        const data = await res.json();
-        setUsers(data.users ?? []);
-      } else {
-        setError('사용자 목록 조회 실패');
-      }
-    } catch {
-      setError('사용자 목록 조회 중 오류 발생');
-    } finally {
-      setLoading(false);
-    }
-  }, [session?.user.accessToken]);
-
-  useEffect(() => {
-    load();
-  }, [load]);
-
-  const toggleSuspend = async (userId: string, suspended: boolean) => {
-    if (!session?.user.accessToken) return false;
-    try {
-      const res = await apiFetch(`/admin/users/${userId}/status`, session.user.accessToken, {
-        method: 'PATCH',
-        body: JSON.stringify({ suspended }),
-      });
-      if (res.ok) {
-        await load();
-        return true;
-      }
-      return false;
-    } catch {
-      return false;
-    }
-  };
-
-  return { users, loading, error, reload: load, toggleSuspend };
-}
-
-// ── Orders ───────────────────────────────────────────────────────
-
-export function useAdminOrders(filters?: { storeId?: string; status?: string }) {
-  const { data: session } = useSession();
-  const [orders, setOrders] = useState<AdminOrder[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
-  const load = useCallback(async () => {
-    if (!session?.user.accessToken) return;
-    setLoading(true);
-    try {
-      const params = new URLSearchParams();
-      if (filters?.storeId) params.set('storeId', filters.storeId);
-      if (filters?.status) params.set('status', filters.status);
-      const qs = params.toString() ? `?${params.toString()}` : '';
-      const res = await apiFetch(`/admin/orders${qs}`, session.user.accessToken);
-      if (res.ok) {
-        const data = await res.json();
-        setOrders(data.orders ?? []);
-      } else {
-        setError('주문 목록 조회 실패');
-      }
-    } catch {
-      setError('주문 목록 조회 중 오류 발생');
-    } finally {
-      setLoading(false);
-    }
-  }, [session?.user.accessToken, filters?.storeId, filters?.status]);
-
-  useEffect(() => {
-    load();
-  }, [load]);
-
-  const forceRefund = async (orderId: string, reason?: string) => {
-    if (!session?.user.accessToken) return false;
-    try {
-      const res = await apiFetch(`/admin/orders/${orderId}/refund`, session.user.accessToken, {
-        method: 'POST',
-        body: JSON.stringify({ reason }),
-      });
-      if (res.ok) {
-        await load();
-        return true;
-      }
-      return false;
-    } catch {
-      return false;
-    }
-  };
-
-  return { orders, loading, error, reload: load, forceRefund };
-}
-
-// ── Settlements ──────────────────────────────────────────────────
-
-export function useAdminSettlements(filters?: { storeId?: string; from?: string; to?: string }) {
-  const { data: session } = useSession();
-  const [settlements, setSettlements] = useState<AdminSettlement[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
-  const load = useCallback(async () => {
-    if (!session?.user.accessToken) return;
-    setLoading(true);
-    try {
-      const params = new URLSearchParams();
-      if (filters?.storeId) params.set('storeId', filters.storeId);
-      if (filters?.from) params.set('from', filters.from);
-      if (filters?.to) params.set('to', filters.to);
-      const qs = params.toString() ? `?${params.toString()}` : '';
-      const res = await apiFetch(`/admin/settlements${qs}`, session.user.accessToken);
-      if (res.ok) {
-        const data = await res.json();
-        setSettlements(data.settlements ?? []);
-      } else {
-        setError('정산 목록 조회 실패');
-      }
-    } catch {
-      setError('정산 목록 조회 중 오류 발생');
-    } finally {
-      setLoading(false);
-    }
-  }, [session?.user.accessToken, filters?.storeId, filters?.from, filters?.to]);
-
-  useEffect(() => {
-    load();
-  }, [load]);
-
-  const markAsPaid = async (settlementId: string) => {
-    if (!session?.user.accessToken) return false;
-    try {
-      const res = await apiFetch(
-        `/admin/settlements/${settlementId}/pay`,
-        session.user.accessToken,
-        {
-          method: 'PATCH',
-        },
-      );
-      if (res.ok) {
-        await load();
-        return true;
-      }
-      return false;
-    } catch {
-      return false;
-    }
-  };
-
-  return { settlements, loading, error, reload: load, markAsPaid };
-}
-
-// ── Drivers ──────────────────────────────────────────────────────
-
 export type DriverStatus = 'all' | 'pending' | 'approved' | 'suspended';
 
 export interface AdminDriver {
@@ -279,72 +65,6 @@ export interface AdminDriver {
   suspended?: boolean;
   createdAt: unknown;
 }
-
-export function useAdminDrivers() {
-  const { data: session } = useSession();
-  const [drivers, setDrivers] = useState<AdminDriver[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
-  const load = useCallback(async () => {
-    if (!session?.user.accessToken) return;
-    setLoading(true);
-    try {
-      const res = await apiFetch('/admin/drivers', session.user.accessToken);
-      if (res.ok) {
-        const data = await res.json();
-        setDrivers(data.drivers ?? []);
-      } else {
-        setError('드라이버 목록 조회 실패');
-      }
-    } catch {
-      setError('드라이버 목록 조회 중 오류 발생');
-    } finally {
-      setLoading(false);
-    }
-  }, [session?.user.accessToken]);
-
-  useEffect(() => {
-    load();
-  }, [load]);
-
-  const approve = async (userId: string) => {
-    if (!session?.user.accessToken) return false;
-    try {
-      const res = await apiFetch(`/admin/drivers/${userId}/approve`, session.user.accessToken, {
-        method: 'PATCH',
-      });
-      if (res.ok) {
-        await load();
-        return true;
-      }
-      return false;
-    } catch {
-      return false;
-    }
-  };
-
-  const toggleSuspend = async (userId: string, suspended: boolean) => {
-    if (!session?.user.accessToken) return false;
-    try {
-      const res = await apiFetch(`/admin/drivers/${userId}/suspend`, session.user.accessToken, {
-        method: 'PATCH',
-        body: JSON.stringify({ suspended }),
-      });
-      if (res.ok) {
-        await load();
-        return true;
-      }
-      return false;
-    } catch {
-      return false;
-    }
-  };
-
-  return { drivers, loading, error, reload: load, approve, toggleSuspend };
-}
-
-// ── Banner ───────────────────────────────────────────────────────
 
 export interface BannerCta {
   label: string;
@@ -361,49 +81,226 @@ export interface AdminBanner {
   isActive?: boolean;
 }
 
+// ── Core ─────────────────────────────────────────────────────────
+
+/**
+ * 관리자 목록 리소스 공통 훅 — data/loading/error 상태 + 토큰 가드 + 자동 로드.
+ * `buildPath`/`extract`는 매 렌더 재생성되므로 deps에 넣지 않는다(필터값만 deps로).
+ */
+function useAdminList<T>(
+  buildPath: () => string,
+  extract: (data: unknown) => T[],
+  errLabel: string,
+  deps: DependencyList = [],
+) {
+  const { data: session } = useSession();
+  const token = session?.user.accessToken;
+  const [items, setItems] = useState<T[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: buildPath/extract/errLabel은 매 렌더 재생성되는 안정 클로저 — reload는 token·필터(deps) 변화로만 트리거한다
+  const load = useCallback(async () => {
+    if (!token) return;
+    setLoading(true);
+    try {
+      const data = await apiJson(buildPath(), token);
+      setItems(extract(data));
+      setError(null);
+    } catch {
+      setError(`${errLabel} 조회 중 오류 발생`);
+    } finally {
+      setLoading(false);
+    }
+  }, [token, ...deps]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  return { items, loading, error, reload: load, token };
+}
+
+/** 관리자 액션(PATCH/POST/PUT) 실행 — 성공 여부만 boolean으로 반환. */
+async function runAction(
+  token: string | undefined,
+  path: string,
+  options: RequestInit,
+): Promise<boolean> {
+  if (!token) return false;
+  try {
+    await apiJson(path, token, options);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function withQuery(base: string, params: Record<string, string | undefined>): string {
+  const qs = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value) qs.set(key, value);
+  }
+  const str = qs.toString();
+  return str ? `${base}?${str}` : base;
+}
+
+function pick<T>(key: string) {
+  return (data: unknown): T[] => (data as Record<string, T[]>)?.[key] ?? [];
+}
+
+// ── Stores ───────────────────────────────────────────────────────
+
+export function useAdminStores() {
+  const { items: stores, loading, error, reload, token } = useAdminList<AdminStore>(
+    () => '/admin/stores',
+    pick<AdminStore>('stores'),
+    '판매자 목록',
+  );
+
+  const setCommission = async (storeId: string, rate: number) => {
+    const ok = await runAction(token, `/admin/stores/${storeId}/commission`, {
+      method: 'PATCH',
+      body: JSON.stringify({ rate }),
+    });
+    if (ok) await reload();
+    return ok;
+  };
+
+  return { stores, loading, error, reload, setCommission };
+}
+
+// ── Users ────────────────────────────────────────────────────────
+
+export function useAdminUsers() {
+  const { items: users, loading, error, reload, token } = useAdminList<AdminUser>(
+    () => '/admin/users',
+    pick<AdminUser>('users'),
+    '사용자 목록',
+  );
+
+  const toggleSuspend = async (userId: string, suspended: boolean) => {
+    const ok = await runAction(token, `/admin/users/${userId}/status`, {
+      method: 'PATCH',
+      body: JSON.stringify({ suspended }),
+    });
+    if (ok) await reload();
+    return ok;
+  };
+
+  return { users, loading, error, reload, toggleSuspend };
+}
+
+// ── Orders ───────────────────────────────────────────────────────
+
+export function useAdminOrders(filters?: { storeId?: string; status?: string }) {
+  const { items: orders, loading, error, reload, token } = useAdminList<AdminOrder>(
+    () => withQuery('/admin/orders', { storeId: filters?.storeId, status: filters?.status }),
+    pick<AdminOrder>('orders'),
+    '주문 목록',
+    [filters?.storeId, filters?.status],
+  );
+
+  const forceRefund = async (orderId: string, reason?: string) => {
+    const ok = await runAction(token, `/admin/orders/${orderId}/refund`, {
+      method: 'POST',
+      body: JSON.stringify({ reason }),
+    });
+    if (ok) await reload();
+    return ok;
+  };
+
+  return { orders, loading, error, reload, forceRefund };
+}
+
+// ── Settlements ──────────────────────────────────────────────────
+
+export function useAdminSettlements(filters?: { storeId?: string; from?: string; to?: string }) {
+  const { items: settlements, loading, error, reload, token } = useAdminList<AdminSettlement>(
+    () =>
+      withQuery('/admin/settlements', {
+        storeId: filters?.storeId,
+        from: filters?.from,
+        to: filters?.to,
+      }),
+    pick<AdminSettlement>('settlements'),
+    '정산 목록',
+    [filters?.storeId, filters?.from, filters?.to],
+  );
+
+  const markAsPaid = async (settlementId: string) => {
+    const ok = await runAction(token, `/admin/settlements/${settlementId}/pay`, {
+      method: 'PATCH',
+    });
+    if (ok) await reload();
+    return ok;
+  };
+
+  return { settlements, loading, error, reload, markAsPaid };
+}
+
+// ── Drivers ──────────────────────────────────────────────────────
+
+export function useAdminDrivers() {
+  const { items: drivers, loading, error, reload, token } = useAdminList<AdminDriver>(
+    () => '/admin/drivers',
+    pick<AdminDriver>('drivers'),
+    '드라이버 목록',
+  );
+
+  const approve = async (userId: string) => {
+    const ok = await runAction(token, `/admin/drivers/${userId}/approve`, { method: 'PATCH' });
+    if (ok) await reload();
+    return ok;
+  };
+
+  const toggleSuspend = async (userId: string, suspended: boolean) => {
+    const ok = await runAction(token, `/admin/drivers/${userId}/suspend`, {
+      method: 'PATCH',
+      body: JSON.stringify({ suspended }),
+    });
+    if (ok) await reload();
+    return ok;
+  };
+
+  return { drivers, loading, error, reload, approve, toggleSuspend };
+}
+
+// ── Banner ───────────────────────────────────────────────────────
+
 export function useAdminBanner() {
   const { data: session } = useSession();
+  const token = session?.user.accessToken;
   const [banner, setBanner] = useState<AdminBanner | null>(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
 
   const load = useCallback(async () => {
-    if (!session?.user.accessToken) return;
+    if (!token) return;
     setLoading(true);
     try {
-      const res = await apiFetch('/admin/banner', session.user.accessToken);
-      if (res.ok) {
-        const data = await res.json();
-        setBanner(data);
-      }
+      setBanner(await apiJson<AdminBanner>('/admin/banner', token));
+    } catch {
+      // 배너 미설정 등 — 무시
     } finally {
       setLoading(false);
     }
-  }, [session?.user.accessToken]);
+  }, [token]);
 
   useEffect(() => {
     load();
   }, [load]);
 
   const save = async (dto: AdminBanner): Promise<boolean> => {
-    if (!session?.user.accessToken) return false;
+    if (!token) return false;
     setSaving(true);
     // 서버 관리 필드 제거 (forbidNonWhitelisted 대응)
-    const {
-      updatedAt: _u,
-      createdAt: _c,
-      ...payload
-    } = dto as AdminBanner & Record<string, unknown>;
+    const { updatedAt: _u, createdAt: _c, ...payload } = dto as AdminBanner &
+      Record<string, unknown>;
     try {
-      const res = await apiFetch('/admin/banner', session.user.accessToken, {
-        method: 'PUT',
-        body: JSON.stringify(payload),
-      });
-      if (res.ok) {
-        await load();
-        return true;
-      }
-      return false;
+      await apiJson('/admin/banner', token, { method: 'PUT', body: JSON.stringify(payload) });
+      await load();
+      return true;
     } catch {
       return false;
     } finally {
@@ -417,40 +314,22 @@ export function useAdminBanner() {
 // ── Invite ───────────────────────────────────────────────────────
 
 export function useAdminInvite() {
-  const { data: session } = useSession();
-  const [invites, setInvites] = useState<InviteToken[]>([]);
-  const [loading, setLoading] = useState(true);
+  const { items: invites, loading, reload, token } = useAdminList<InviteToken>(
+    () => '/admin/invite',
+    (data) => (Array.isArray(data) ? (data as InviteToken[]) : []),
+    '초대 토큰',
+  );
   const [generating, setGenerating] = useState(false);
 
-  const loadInvites = useCallback(async () => {
-    if (!session?.user.accessToken) return;
-    setLoading(true);
-    try {
-      const res = await apiFetch('/admin/invite', session.user.accessToken);
-      if (res.ok) {
-        const data = await res.json();
-        setInvites(Array.isArray(data) ? data : []);
-      }
-    } finally {
-      setLoading(false);
-    }
-  }, [session?.user.accessToken]);
-
-  useEffect(() => {
-    loadInvites();
-  }, [loadInvites]);
-
   const generate = async (): Promise<{ token: string; expiresAt: string } | null> => {
-    if (!session?.user.accessToken) return null;
+    if (!token) return null;
     setGenerating(true);
     try {
-      const res = await apiFetch('/admin/invite', session.user.accessToken, { method: 'POST' });
-      if (res.ok) {
-        const data = await res.json();
-        await loadInvites();
-        return data;
-      }
-      return null;
+      const data = await apiJson<{ token: string; expiresAt: string }>('/admin/invite', token, {
+        method: 'POST',
+      });
+      await reload();
+      return data;
     } catch {
       return null;
     } finally {
@@ -458,5 +337,5 @@ export function useAdminInvite() {
     }
   };
 
-  return { invites, loading, generating, generate, reload: loadInvites };
+  return { invites, loading, generating, generate, reload };
 }

--- a/apps/seller/src/hooks/useOrderActions.ts
+++ b/apps/seller/src/hooks/useOrderActions.ts
@@ -1,50 +1,27 @@
 'use client';
 
 import { useState } from 'react';
-import { useSession } from 'next-auth/react';
 import type { OrderStatus } from '@greenhub/shared';
+import { useOrderStatusUpdate, type OrderStatusExtra } from './useOrderStatusUpdate';
 
+/** OrderCard(목록)용 주문 액션 — 인라인 준비 폼 + prompt() 취소 사유. */
 export function useOrderActions(storeId: string | null, orderId: string) {
-  const { data: session } = useSession();
-  const [actionLoading, setActionLoading] = useState(false);
-  const [actionError, setActionError] = useState<string | null>(null);
+  const { actionLoading, actionError, setActionError, updateStatus } = useOrderStatusUpdate(
+    storeId,
+    orderId,
+  );
   const [showPrepareForm, setShowPrepareForm] = useState(false);
   const [preparedAtInput, setPreparedAtInput] = useState('');
 
-  async function handleStatusChange(
-    status: OrderStatus,
-    extra?: { reason?: string; preparedAt?: string },
-  ) {
-    setActionLoading(true);
-    setActionError(null);
-    try {
-      const res = await fetch(
-        `${process.env.NEXT_PUBLIC_API_URL}/stores/${storeId}/orders/${orderId}/status`,
-        {
-          method: 'PATCH',
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${session?.user.accessToken}`,
-          },
-          body: JSON.stringify({ status, ...extra }),
-        },
-      );
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        setActionError(`오류 ${res.status}: ${body?.message ?? '상태 변경 실패'}`);
-      }
-    } catch {
-      setActionError('네트워크 오류가 발생했습니다');
-    } finally {
-      setActionLoading(false);
-    }
+  async function handleStatusChange(status: OrderStatus, extra?: OrderStatusExtra) {
+    await updateStatus(status, extra);
   }
 
   async function handlePrepare() {
     const extra = preparedAtInput
       ? { preparedAt: new Date(preparedAtInput).toISOString() }
       : undefined;
-    await handleStatusChange('PREPARING', extra);
+    await updateStatus('PREPARING', extra);
     setShowPrepareForm(false);
     setPreparedAtInput('');
   }
@@ -55,12 +32,13 @@ export function useOrderActions(storeId: string | null, orderId: string) {
       if (reason !== null) alert('취소 사유는 최소 5자 이상 입력해주세요.');
       return;
     }
-    await handleStatusChange('CANCELLED', { reason: reason.trim() });
+    await updateStatus('CANCELLED', { reason: reason.trim() });
   }
 
   return {
     actionLoading,
     actionError,
+    setActionError,
     showPrepareForm,
     setShowPrepareForm,
     preparedAtInput,

--- a/apps/seller/src/hooks/useOrderStatusUpdate.ts
+++ b/apps/seller/src/hooks/useOrderStatusUpdate.ts
@@ -1,0 +1,46 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import { useSession } from 'next-auth/react';
+import type { OrderStatus } from '@greenhub/shared';
+import { apiJson } from '@/lib/api';
+
+export interface OrderStatusExtra {
+  reason?: string;
+  preparedAt?: string;
+}
+
+/**
+ * 주문 상태 변경 PATCH의 공통 코어.
+ * OrderCard용 `useOrderActions`·상세용 `useOrderDetailActions`가 이 훅을 공유한다 —
+ * fetch·에러 처리는 여기 한 곳, 사유 입력 UI(prompt vs 모달)만 래퍼에서 분기.
+ */
+export function useOrderStatusUpdate(storeId: string | null, orderId: string) {
+  const { data: session } = useSession();
+  const [actionLoading, setActionLoading] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  const updateStatus = useCallback(
+    async (status: OrderStatus, extra?: OrderStatusExtra): Promise<boolean> => {
+      if (!storeId) return false;
+      setActionLoading(true);
+      setActionError(null);
+      try {
+        await apiJson(
+          `/stores/${storeId}/orders/${orderId}/status`,
+          session?.user.accessToken ?? '',
+          { method: 'PATCH', body: JSON.stringify({ status, ...extra }) },
+        );
+        return true;
+      } catch (e) {
+        setActionError(e instanceof Error ? e.message : '오류가 발생했습니다');
+        return false;
+      } finally {
+        setActionLoading(false);
+      }
+    },
+    [storeId, orderId, session?.user.accessToken],
+  );
+
+  return { actionLoading, actionError, setActionError, updateStatus };
+}

--- a/apps/seller/src/lib/api.ts
+++ b/apps/seller/src/lib/api.ts
@@ -1,5 +1,17 @@
 const BASE_URL = process.env.NEXT_PUBLIC_API_URL;
 
+/** API 응답이 2xx가 아닐 때 던지는 에러. `.message`는 서버 본문 메시지 또는 상태코드 폴백. */
+export class ApiError extends Error {
+  constructor(
+    public status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'ApiError';
+  }
+}
+
+/** Railway API에 인증 헤더를 붙여 fetch. 응답 검사 없이 raw Response 반환. */
 export async function apiFetch(
   path: string,
   token: string,
@@ -13,4 +25,22 @@ export async function apiFetch(
       ...options.headers,
     },
   });
+}
+
+/**
+ * apiFetch + 응답 검사 + JSON 파싱을 묶은 헬퍼.
+ * 2xx가 아니면 서버 본문 `message`를 담아 `ApiError`를 던진다.
+ * 본문이 없으면 빈 객체를 반환(상태 변경 PATCH 등 응답 바디 없는 경우 대응).
+ */
+export async function apiJson<T = unknown>(
+  path: string,
+  token: string,
+  options: RequestInit = {},
+): Promise<T> {
+  const res = await apiFetch(path, token, options);
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as { message?: string };
+    throw new ApiError(res.status, body?.message ?? `서버 오류 (${res.status})`);
+  }
+  return (await res.json().catch(() => ({}))) as T;
 }

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -32,7 +32,7 @@
 
 ## 1. seller 앱 (`apps/seller`)
 
-> 설계 문서: `docs/판매자 설계 - 1단계 요구사항 정의.md`, `docs/판매자 설계 - 2단계 IA.md`
+> 설계 문서: `docs/design/판매자-1단계-요구사항.md`, `docs/design/판매자-2단계-IA.md`
 > 배포: Vercel (Root Directory: `apps/seller`)
 
 ### 1-1. 인프라 / 공통
@@ -424,15 +424,17 @@
 
 ## 12. 후속 인프라·보안 정비 (세션22~25 잔여)
 
-> 기준일: 2026-05-16 (세션31 — P2-A 계측 + throttler fix)
-> 진입점: 다음 세션 시작 시 [docs/archive/sessions/session35-prep.md](archive/sessions/session35-prep.md) → 본 §12 우선순위 표 순서로 확인.
+> 기준일: 2026-05-17 (세션35 — docs 정리)
+> 진입점: 다음 세션 시작 시 [docs/archive/sessions/session36-prep.md](archive/sessions/session36-prep.md) → 본 §12 우선순위 표 순서로 확인.
 > **세션29 완료**: §12-2 e2e 잔여 B·C·D 전부 해소 (run 25957177092 — 167 passed / 0 failed).
 > **세션30 완료**: P2-C `CRITICAL_LOGIC.md` 한도 정책 — 옵션 3 변형 채택·아카이브 분리(1415→229라인).
 > **세션31 완료**: P2-A Railway latency 계측(`/auth/login` p50 922ms·0% 실패) + 계측 중 발견한 throttler 전역 누수 버그 수정 (#CL-30).
 > **세션32 완료**: e2e 안정성 2건 해소 — `consumer-groupbuy:14` flake + `cleanup-spec-residue` CI 인증 실패. 풀런 167/0 유지·cleanup `users=2` 정상 동작.
 > **세션33 완료**: P3 `/admin/banner` prerender 실패 해소 — firebase `getAuth` 지연 초기화 (#CL-31). 코드로 종결, Vercel 환경변수 조치 불필요로 확정.
 > **세션34 완료**: P3 consumer@test.com 강한비번 전환 — Firestore `passwordHash` 갱신 + `apps/e2e/.env`·repo Secret `TEST_CONSUMER_PASSWORD` 교체. 풀런 167/0 유지.
-> **다음 세션 최우선**: P3 잔여 기능 항목 (`useOrderActions` 통합 / G1 거점 수정 페이지 / Driver Kakao Maps SDK).
+> **세션35 완료**: docs 정리 — `memory.md` 200라인 한도 요약·아카이브(197→50라인) + 폴더 이동으로 깨진 상호 참조 링크 14곳 수정 + 변경 이력 순서·누락 보정. 코드 변경 없음.
+> **세션36 완료**: seller 프론트엔드 리팩토링 5-Phase (#CL-32) — ProductForm 705→154라인(Fatal Constraint 해소), API 레이어 `apiJson` 통일, useAdmin 462→341 팩토리화, `useOrderActions` 통합(P3 종결), 공통 UI 컴포넌트 9개 페이지 치환. 빌드 통과.
+> **다음 세션 최우선**: P3 잔여 기능 항목 (G1 거점 수정 페이지 / Driver Kakao Maps SDK).
 
 ### 12-1. 우선순위
 
@@ -447,7 +449,7 @@
 | ✅ P2 | Railway throttler 전역 누수 수정 — `auth` throttler 제거 (#CL-30, 2026-05-16 세션31) | 인프라/버그 | — |
 | ⏹️ P2 | Vercel function cold-start mitigation 검토 — #CL-30으로 데이터상 불필요 판정 (moot) | 성능 | — |
 | ✅ P2 | `CRITICAL_LOGIC.md` 한도 정책 — 옵션 3+ 채택, 아카이브 분리 (2026-05-16 세션30 완료) | 문서 정책 | 단독 |
-| 🟢 P3 | `useOrderActions` 훅 통합 (detail/OrderCard 시그니처 통일) | DX | UI 리팩토링 사이클 |
+| ✅ P3 | seller 프론트엔드 리팩토링 5-Phase — `useOrderActions` 통합 포함 (#CL-32, 2026-05-17 세션36) | DX/구조 | — |
 | ✅ P3 | `/admin/banner` prerender 실패 — firebase getAuth 지연 초기화 (2026-05-17 세션33 완료) | 환경설정 | — |
 | 🟢 P3 | G1: `apps/seller/src/app/hubs/[id]/page.tsx` 거점 수정 페이지 | 기능 | — |
 | 🟢 P3 | Driver Kakao Maps SDK 연동 | 기능 | — |
@@ -709,11 +711,13 @@ P2-A 계측 중 `/health`가 ~10~19회 후 429 반환 발견. `ThrottlerModule`�
 | 2026-05-15 | **세션23**: 셀러 fatal constraint 해소 — `orders/[id]`·`settlements` 페이지 분할 (#CL-22) |
 | 2026-05-15 | **세션24**: e2e 회귀 검증 (회귀 0건) + 인증 헬퍼 진단 강화 (#CL-23) |
 | 2026-05-15 | **세션25**: 사전 결함 정리 — biome 파싱 에러·`.env.vercel.tmp` gitignore·driver Credentials 부재 검증 (#CL-25) / §12 후속 정비 백로그 신설 |
+| 2026-05-15 | **세션26**: #CL-21 옵션 A 보강 — `preview` 브랜치 신설(Vercel branch Preview 자동 배포)·21개 spec `BASE` 환경변수화·`.github/workflows/e2e.yml` 신설. Vercel seller·consumer Production env `E2E_TEST_SECRET` 삭제(Preview·Development 유지·#CL-21). Preview SSO 우회 — Protection Bypass 시크릿 3개 + `global-setup.ts` `_vercel_jwt` storageState 도입 |
 | 2026-05-16 | **세션27**: #CL-21 후속 — gh CLI 설치·repo Secrets 11개 등록·`sync-preview.yml` 자동 머지 워크플로 신설·e2e.yml pnpm 충돌 수정. e2e CI 가동(124 passed/37 fail). 37건은 #CL-23 인증 race로 확정 |
 | 2026-05-16 | **세션28**: #CL-23 인증 race 해소 — e2e storageState 패턴 도입(T0~T5). 실패 37건 증거 재분류(A23/B5/C2/D7), globalSetup 세션 쿠키 발급 + 11개 인증 describe 배선 + spec 로그인 제거. CI 2회 풀런 124/37→145/16·146/15, `set-cookie count=0` 0건. 잔여 B·C·D는 §12-2 분리 기록 (#CL-27) |
 | 2026-05-16 | **세션29**: e2e 잔여 B·C·D 해소. T0 run 25952638293 재확인(B5·C2·D8·flake1). C — perf-css `networkidle` 제거(vercel.live 상시 연결 원인, 로컬 15/15 통과). B·D — trace로 단일 원인 확정: Railway API가 Vercel preview origin에 CORS 미허용 → `apiFetch`·`/auth/firebase-token` 차단. `main.ts`에 팀 스코프 정규식 추가 (#CL-28). 재배포(c5ee52f push 자동 트리거) 후 풀런 run 25957177092 **167 passed / 0 failed / 11 skipped** — B5·D8 + 인증 race 전부 해소 |
 | 2026-05-16 | **세션30**: P2-C `CRITICAL_LOGIC.md` 한도 정책 — 옵션 3 변형 채택(누적 결정 로그는 500라인 모듈화 예외 + 1000라인 초과 시 종결 엔트리 아카이브). `#CL-19` 경계로 분할 — 2026-03~04 종결 엔트리 1208라인을 `archive/CRITICAL_LOGIC_archive_20260516.md`로 이관, 활성 파일 1415→229라인. `CLAUDE.md` §1 예외 규칙 명시 |
 | 2026-05-16 | **세션31**: P2-A Railway latency 계측 — synthetic 측정 스크립트 `scripts/measure-api-latency.mjs` 신설(Railway CLI 접근, `/auth/login` p50 922ms·0% 실패·서버작업 ~510ms). 계측 중 throttler 전역 누수 버그 발견 — `auth`(10/분) throttler가 `/health` 등 비인증 라우트까지 적용. `app.module.ts` `auth` throttler 제거 + 인증 라우트 `@Throttle` 라우트한정 오버라이드 (#CL-30). 재배포(23e3528) 후 헤더 검증, e2e run 25962635875 167/0. P2-B는 moot 종결 |
+| 2026-05-17 | **세션32**: e2e 안정성 2건 해소. ① `consumer-groupbuy:14` flake — `list.or(empty)` 확정 렌더 대기로 오판 차단(`abd2a13`). ② `cleanup-spec-residue` CI 인증 실패 — `FIREBASE_SERVICE_ACCOUNT_JSON` env 기반 인증 전환 + `e2e.yml`·repo Secret 등록(`b095023`), Windows gh CLI 파이프 BOM 혼입 방어 + Secret no-BOM 재업로드(`4934468`). 풀런 run 25965438455 **167/0**, cleanup `users=2` 정상 삭제 |
 | 2026-05-17 | **세션33**: P3 `/admin/banner` prerender 실패 해소. 원인 — `firebase.ts`가 모듈 로드 시 `getAuth(app)` 평가 → apiKey 부재 시 동기 throw → 빌드 prerender 첫 firebase-import 페이지 크래시. `getAuth`/`getStorage` 지연 초기화 함수로 전환(사용처 전부 클라이언트 런타임). env 미주입 로컬 빌드 — 수정 전 크래시 재현, 수정 후 빌드 성공. Vercel은 env 존재로 무영향(환경변수 조치 불필요 확정). 커밋 `32738fb` (#CL-31) |
 | 2026-05-17 | **세션34**: P3 consumer@test.com 강한비번 전환. `reset-user-password.mjs`로 Firestore `passwordHash`를 30자 랜덤 비번(bcrypt-12)으로 갱신, `apps/e2e/.env`·repo Secret `TEST_CONSUMER_PASSWORD` 동기 교체. `/auth/login` curl로 새 비번 200·기존 401 확인, e2e 풀런 run 25966655016 **167/0**. 세션22 편의 결정(`feedback_security_convenience`)을 보안 우선으로 재확인·전환 |
-| 2026-05-17 | **세션32**: e2e 안정성 2건 해소. ① `consumer-groupbuy:14` flake — `list.or(empty)` 확정 렌더 대기로 오판 차단(`abd2a13`). ② `cleanup-spec-residue` CI 인증 실패 — `FIREBASE_SERVICE_ACCOUNT_JSON` env 기반 인증 전환 + `e2e.yml`·repo Secret 등록(`b095023`), Windows gh CLI 파이프 BOM 혼입 방어 + Secret no-BOM 재업로드(`4934468`). 풀런 run 25965438455 **167/0**, cleanup `users=2` 정상 삭제 |
+| 2026-05-17 | **세션35**: docs 정리 세션 — P3 잔여 3건은 사용자 결정으로 별도 세션 이관. `memory.md` 200라인 한도 임박(197) → 50라인 이내 요약(50라인)·세션22~34 상세를 `archive/memory_archive_20260517.md`로 아카이브. 폴더 이동(`docs/design/`·`docs/specs/api/`)으로 깨진 design↔api spec 상호 참조 링크 14곳 수정. 본 변경 이력 — 세션32 행 순서 보정·누락된 세션26 행 추가. 코드 변경 없음 |

--- a/docs/CRITICAL_LOGIC.md
+++ b/docs/CRITICAL_LOGIC.md
@@ -287,3 +287,25 @@ P2-A(Railway `/auth/login` latency 계측)는 세션28·29·30에 3회 이월된
 
 **검증**: env 미주입 로컬 빌드 — 수정 전 `/admin/banner` prerender 크래시 재현, 수정 후 빌드 성공(전 라우트 정상 출력). 커밋 `32738fb`.
 
+
+---
+
+## [결정 #CL-32] seller 프론트엔드 리팩토링 — SDD 레이어 분리 (2026-05-17, 세션36)
+
+### 결정: 셀러앱 프론트엔드를 5개 Phase로 구조 정비
+
+**배경**: 사용자 요청으로 셀러앱 프론트엔드 전수 진단 후 리팩토링. `ProductForm.tsx` 705라인 = Fatal Constraint(500라인) 위반. API 호출 방식 3종 파편화, `useAdmin.ts` 462라인(거의 동일한 훅 7개 복붙), `useOrderActions`↔`useOrderDetailActions` 시그니처 불일치(BACKLOG P3), 페이지 셸/상태 UI 중복.
+
+**Phase 1 — ProductForm 분리**: `ProductForm.tsx` 705→154라인. `useProductForm`(상태·draft·AI·검증·제출 240줄) 훅 + `productForm.types.ts`(타입·상수·defaultForm) + `Step1Basic`/`Step5Pricing` 스텝 본문 + `StepIndicator` + `FormPrimitives`(FieldCard·ChoiceRow 공유) 추출.
+
+**Phase 2 — API 레이어 통일**: `lib/api.ts`에 `apiJson<T>()` + `ApiError` 추가. `res.ok` 검사·JSON 언래핑·서버 `message` 추출을 한 곳에 묶음. 기존 `apiFetch`(raw Response)는 유지. ProductForm·useOrderActions의 raw `fetch` 마이그레이션.
+
+**Phase 3 — useAdmin 팩토리화**: 462→341라인. 제네릭 `useAdminList<T>`(data/loading/error + 토큰 가드 + 자동 로드) 코어 + `runAction`/`withQuery`/`pick` 헬퍼. 7훅이 코어 위 얇은 래퍼로 재작성. 부수 효과 — !res.ok·네트워크 오류 메시지가 `apiJson` 경유로 단일화("…조회 중 오류 발생").
+
+**Phase 4 — 주문 액션 훅 통합 (BACKLOG P3 종결)**: 공통 코어 `useOrderStatusUpdate`(PATCH·loading·error) 신설. `useOrderActions`(OrderCard·prompt 취소)와 `useOrderDetailActions`(상세·모달 취소)가 코어를 공유 — fetch·에러 처리는 한 곳, 사유 입력 UI만 래퍼에서 분기. 시그니처는 `updateStatus(status, extra)`로 통일. 두 훅의 외부 반환 형태는 보존(소비처 무수정).
+
+**Phase 5 — 공통 UI 컴포넌트**: `components/`에 `PageShell`·`PageHeader`(sticky prop)·`EmptyState`·`LoadingState` 신설. 표준 헤더·로딩·빈 상태를 쓰던 9개 페이지 치환(products·orders·order detail·product edit·settings·settlements·hubs×3 + ProductForm). 로딩 표시를 `LoadingState`(스피너)로 통일 — 일부 페이지의 "불러오는 중…" 텍스트 변형 제거.
+
+**제외**: `app/page.tsx`(홈)는 `100dvh` 사용 — PageShell `100vh` 치환 시 모바일 뷰포트 회귀 우려로 미변환. admin `page.tsx`+`_client.tsx` 분리(#CL-31 패턴)는 의도된 설계라 유지.
+
+**검증**: `pnpm --filter seller build` 성공 — TypeScript 통과, 22개 라우트 전부 생성. biome lint 신규 에러 0건(잔존 2건은 `VarietySelector`·`app/page.tsx` 사전 결함). e2e는 push 시 CI에서 검증(베이스라인 167 passed).

--- a/docs/archive/memory_archive_20260517.md
+++ b/docs/archive/memory_archive_20260517.md
@@ -1,0 +1,135 @@
+# Green Love — 프로젝트 메모리 아카이브 (세션22~34)
+
+> 아카이브 생성: 2026-05-17 (세션35 진입 시 `docs/memory.md` 200라인 한도 요약).
+> 활성 SSOT: `docs/memory.md` · 이전 아카이브: `memory_archive_20260425.md`
+> 본 파일은 세션22~34의 세션별 상세 narrative를 보존한다. 설계 결정 정본은
+> `docs/CRITICAL_LOGIC.md` #CL-19~#CL-31.
+
+---
+
+## ✅ 완료된 작업 (세션22까지)
+
+| 항목 | 완료일 |
+|------|--------|
+| Consumer/Seller/Driver DS + 성능(53→99) + PWA/CORS + 상품등록 버그 | 2026-04-25~05-01 |
+| DS 리팩토링·툴체인·a11y·e2e 전체 구축·OrderGroup 리팩토링 | 2026-05-02~06 |
+| BUG-SEC 초대토큰·next-auth beta.31·G4 셀러 대시보드 | 2026-05-08 |
+| **세션18**: G2 상품명·preparedAt UI·B1 pre-fill·B2 에러피드백·G3 날짜선택기 | 2026-05-08 |
+| **세션19**: 보안 패치 — Next.js 16.2.5 + React 19.2.6 CVE, HTTP 보안헤더, auth.ts 강화 | 2026-05-09 |
+| **세션20**: 루트 vercel.json 삭제·Railway CORS fix·login force-dynamic·E2E_TEST 값 수정 | 2026-05-10 |
+| **세션21**: 세션20이 남긴 허위 BLOCKER 검증·정정 | 2026-05-10 |
+| **세션22**: E2E 보안 결함 정리 — Vercel `E2E_TEST` Production 제거·약한비번 54건 일소·**옵션 B 헤더 게이팅 도입** | 2026-05-10 |
+| **세션23**: 셀러 fatal constraint 해소 — `orders/[id]` 629→217·`settlements` 531→116 분할 (#CL-22) | 2026-05-15 |
+| **세션24**: 세션23 e2e 회귀 검증 (회귀 0건) + 인증 헬퍼 진단 강화 (#CL-23) | 2026-05-15 |
+| **세션25**: 사전 결함 정리 — biome.json 파싱 에러·`.env.vercel.tmp` gitignore·driver Credentials 부재 확인 (#CL-25) | 2026-05-15 |
+| **세션26**: #CL-21 옵션 A 보강 — Production env `E2E_TEST_SECRET` 제거 + Preview SSO bypass 도입 | 2026-05-15 |
+| **세션27**: #CL-21 후속 — repo Secrets 11개 등록 + `sync-preview.yml` 자동 머지 워크플로 + e2e CI 가동 | 2026-05-16 |
+| **세션28**: #CL-23 인증 race 해소 — e2e storageState 패턴(T0~T5). CI 풀런 124/37→145/16·146/15, race 0건 | 2026-05-16 |
+| **세션29**: e2e 잔여 B·C·D 전부 해소 — C(perf-css networkidle 제거)·B·D 단일 원인 CORS fix(#CL-28). 재배포 후 풀런 167/0 | 2026-05-16 |
+| **세션30**: P2-C #CL-29 — 누적 결정 로그 한도 정책(500라인 예외+1000라인 트리거). CRITICAL_LOGIC.md 1415→229라인 아카이브 분리 | 2026-05-16 |
+| **세션31**: P2-A Railway latency 계측(synthetic) + 계측 중 발견한 throttler 전역 누수 버그 수정 (#CL-30) | 2026-05-16 |
+| **세션32**: e2e 안정성 2건 — consumer-groupbuy flake + cleanup-spec-residue CI 인증(env 전환·BOM 방어). 풀런 167/0 | 2026-05-17 |
+| **세션33**: P3 `/admin/banner` prerender 실패 해소 — seller firebase `getAuth` 지연 초기화 (#CL-31) | 2026-05-17 |
+| **세션34**: P3 consumer@test.com 강한비번 전환 — Firestore `passwordHash` + `.env`·repo Secret 동기 교체, 풀런 167/0 | 2026-05-17 |
+
+---
+
+## ✅ 세션22 — 보안 결함 정리 (BLOCKER 해소)
+
+**트랙별 결과**:
+- **트랙 1**: seller·consumer Vercel `E2E_TEST` Production env 삭제 + 재배포 → `/login` HTML에서 `type="email"`·`type="password"` 0건 확인
+- **트랙 2**: `scripts/delete-test-accounts.mjs --apply`로 54건 user + 2건 refreshToken 삭제. seller@test.com만 보존 결정. 새 e2e consumer로 `consumer@test.com` 생성(test1234 — 사용자 결정, 강한비번 권장은 follow-up). `seller-auth-invite.spec.ts`에 `afterAll` cleanup + `scripts/cleanup-spec-residue.mjs` 헬퍼 추가
+- **트랙 3 옵션 B**: `E2E_TEST_SECRET` 32자 6환경 적용. `auth.ts`(seller·consumer) Credentials Provider 상시 등록 + `request.headers.get('x-e2e-test-token')` 검증. `apps/e2e/tests/_helpers/auth.ts` + `playwright.config.ts extraHTTPHeaders` 도입. 12개 spec helper migration 완료
+- **트랙 4 통합 검증 5종**: 폼 노출 0, 약한비번 401, 보존 200, Firestore email-provider 2건(seller·consumer), 헤더 없는 credentials 호출 → `error=CredentialsSignin` ✓
+
+**상세 설계**: `docs/CRITICAL_LOGIC.md` #CL-20 (옵션 B), #CL-21 (옵션 A 향후 과제)
+**원본 가이드**: `docs/archive/sessions/session22-prep.md`
+
+---
+
+## 세션26 — #CL-21 옵션 A 보강 완료
+
+- `preview` 브랜치 신설 → Vercel branch Preview 배포(`{project}-git-preview-…vercel.app`) 자동화. 21개 spec `BASE` 환경변수화. `.github/workflows/e2e.yml` 신설.
+- Vercel seller·consumer **Production** env `E2E_TEST_SECRET` 삭제 (Preview·Development 유지) + 빈 커밋 재배포.
+- **Preview SSO 우회**: Preview는 Vercel Authentication(SSO) 기본 보호 → Protection Bypass for Automation 시크릿 3개 발급. `global-setup.ts`가 bypass 쿼리로 `_vercel_jwt` 쿠키 발급 → `storageState`(`apps/e2e/.bypass-state.json`) 재사용. bypass 헤더도 전역 주입 금지(Firebase CORS).
+- 검증: Production 유효 헤더로도 거부 / Preview 정상. smoke seller-orders 11/12·consumer-mypage 9/10.
+- **주의**: PowerShell `Get-Content -Raw`가 UTF-8을 CP949로 오독 → 한글 mojibake 손상. spec 일괄 편집 시 Python(명시적 utf-8) 또는 Edit 도구 사용.
+- **잔여**: GitHub repo Secrets 등록 전 CI 미동작. `preview` ↔ `main` 주기 동기화 필요.
+
+상세: `docs/CRITICAL_LOGIC.md` #CL-21
+
+---
+
+## 세션27 — #CL-21 후속: e2e CI 활성화
+
+- gh CLI 2.92.0 winget 설치(`C:\Program Files\GitHub CLI`) → `booker-lab` 인증(ADMIN).
+- `gh secret set`으로 repo Secrets 11개 등록 (`apps/e2e/.env` 값 그대로).
+- `.github/workflows/sync-preview.yml` 신설 — `main` push → `preview` 자동 merge·push → `gh workflow run e2e.yml` 디스패치. (GITHUB_TOKEN push는 재귀방지로 e2e push트리거 미발화 → workflow_dispatch로 우회.)
+- `e2e.yml` `pnpm/action-setup version:9` 고정 제거 (packageManager pnpm@10.32.1 충돌).
+- **e2e CI 가동 확인**: 124 passed / 37 failed. 37건 전부 셀러 인증 spec — `set-cookie count=0` = **#CL-23 인증 race** (CI는 spec별 독립 인증으로 race 증폭). 셀러앱 코드 무변경이므로 회귀 아님.
+
+---
+
+## 세션28 — #CL-23 인증 race 해소: storageState 패턴 (#CL-27)
+
+- **T0 재분류**: s27 실패 37건을 run 로그 + error-context 37개 증거로 재분류 — A 인증 race 23 / B Railway `Failed to fetch` 5 / C waitForLoadState 2 / D realtime 미정착 7. 「셀러 33건 전부 A」 가설 반증.
+- **T1~T3**: `global-setup.ts`가 seller·consumer 1회 로그인 → `.auth-state.json` 발급. 11개 인증 describe에 `test.use({ storageState })` 배선, spec 개별 `loginViaCredentials` 제거. globalSetup 로그인은 race 흡수용 재시도 3회 — #CL-23의 helper-retry 기각과 구분(globalSetup 단일 지점이라 N 미증폭).
+- **T4 검증**: e2e CI 2회 연속 풀런 124/37 → **145/16 · 146/15**. `set-cookie count=0` 두 번 모두 0건 → 인증 race 23→0 확정.
+- **잔여 14~15건**: B·C·D + flake, 전부 storageState 무관 → `BACKLOG.md §12-2` 분리 기록.
+- 인증 호출 풀런당 67회+retry → 2회.
+
+상세: `docs/CRITICAL_LOGIC.md` #CL-27
+
+---
+
+## 세션29 — e2e 잔여 B·C·D 해소 (#CL-28)
+
+- **T0 재확인**: 최신 풀런 run 25952638293 — B 5·C 2·D 8·flake 1 (세션28과 동일, 인증 race 0건 유지).
+- **C 완료**: `perf-css-regression:87·:103` Seller 로그인 — `waitForLoadState('networkidle')`가 Vercel preview의 `vercel.live` 피드백 위젯 상시 연결로 30s 타임아웃. trace로 확정(리소스 ~2.7s 완료, Firebase 호출 0). `networkidle` 제거 → 폼 렌더 + 1.5s 정착. 로컬 perf-css 15/15 통과.
+- **B·D 단일 원인**: trace 콘솔에서 CORS 에러 확정 — Railway API가 Vercel preview origin에 `Access-Control-Allow-Origin` 미발급. B = `apiFetch` 차단, D = `/auth/firebase-token` fetch 차단 → `firebaseReady=false` → 대시보드 `연결 중` 고착. **D는 B의 하위 증상.** cold-start 가설 반증(전구간 분포·firestore는 정상).
+- **수정**: `apps/api/src/main.ts` origin 콜백에 팀 스코프(`jos-projects-d1cecc0c`) 한정 정규식 추가. D spec 무변경.
+- **검증 완료**: `c5ee52f` push가 Railway 자동 재배포 트리거 → preview origin CORS 발급·비매칭 차단 curl 확인 → e2e 풀런 run 25957177092 **167 passed / 0 failed / 11 skipped**. B 5·D 8 + 인증 race 전부 해소(178→0 fail).
+
+상세: `docs/CRITICAL_LOGIC.md` #CL-28
+
+---
+
+## 세션30 — CRITICAL_LOGIC.md 한도 정책 (#CL-29)
+
+- **P2-C 완료**: 누적 결정 로그(`CRITICAL_LOGIC.md`·`BACKLOG.md`·memory 아카이브)는 시계열 append-only — 분리 시 이력 파편화·#CL 연속성/앵커 손상. **500라인 모듈화 한도 예외**로 CLAUDE.md §1 명시. 단 무한 증가 방어로 **1000라인 초과 시 종결 엔트리 아카이브**(크기 기준, 죽은 엔트리만).
+- **적용**: `#CL-19` 경계 분할 — 2026-03~04 종결 엔트리 1208라인을 `archive/CRITICAL_LOGIC_archive_20260516.md`로 이관. 활성 파일 1415→**229라인**. 참조 링크 정합성 검토 완료.
+- 상세: `docs/CRITICAL_LOGIC.md` #CL-29.
+
+---
+
+## 세션31 — P2-A Railway latency 계측 + throttler fix (#CL-30)
+
+- **P2-A 완료**: Railway 배포 로그에 요청 단위 로그가 전무 → synthetic 측정 스크립트 `scripts/measure-api-latency.mjs` 신설(Railway CLI로 대시보드 없이 접근, 60초 윈도우당 8회 페이싱). `/auth/login` p50 922ms·p95 1551ms·p99 1687ms·**0% 실패**, `/health` p50 409ms. 서버 작업 ≈ ~510ms(Firestore 조회+bcrypt factor-12+토큰 발급, bcrypt 지배적). ~0.9s steady는 e2e 차단 요인 아님 → P2-B(cold-start) 데이터상 불필요 종결(moot).
+- **throttler 버그 발견·수정 (#CL-30)**: 측정 중 `/health`가 ~10~19회 후 429. `ThrottlerModule`의 named throttler는 전 라우트 전역 적용 → `auth`(10/분) 등록만으로 `/health` 등 비인증 라우트까지 10/분에 묶여 `default`(100/분) 무효화. 수정: `auth` throttler 제거 + 인증 라우트(register·login·kakao-login·refresh)에 `@Throttle({default:{limit:10}})` 라우트 한정 오버라이드. 커밋 `23e3528` 재배포 후 헤더 검증 — `/health` `x-ratelimit-limit:100`·`/auth/login` `:10`.
+
+상세: `docs/CRITICAL_LOGIC.md` #CL-30
+
+---
+
+## 세션32 — e2e 안정성 2건 해소
+
+- **consumer-groupbuy:14 flake**: `waitForSelector('모집 중').catch()` 후 `empty.isVisible()`가 false면 "모집 중"을 강제 단언 — 페이지 로딩 중이면 리스트도 empty-state도 미렌더라 오판. `list.or(empty)` 확정 렌더 대기 후 분기로 수정 (커밋 `abd2a13`).
+- **cleanup-spec-residue CI 인증 실패**: 스크립트가 gitignore된 로컬 키 `apps/api/firebase-adminsdk.json`을 `require` → CI 러너 부재로 `exit=1`, seller-auth-invite `afterAll` 정리 무력화(세션22 이후 상존). `FIREBASE_SERVICE_ACCOUNT_JSON` env 우선·로컬 키 fallback(`firestore.module.ts`와 동일 규약) 전환 + `e2e.yml` env 주입 + repo Secret 등록 (커밋 `b095023`). 후속: Windows gh CLI 파이프 업로드 시 선두 BOM(U+FEFF) 혼입 → `JSON.parse` 실패 → BOM 제거 방어 + Secret no-BOM 재업로드 (커밋 `4934468`).
+- **검증**: e2e 풀런 run 25965438455 **167 passed / 0 failed**, cleanup 로그 `users=2 tokens=0 skipped=0` (세션22 이후 처음으로 CI에서 잔여 계정 정리 동작).
+
+---
+
+## 세션33 — `/admin/banner` prerender 실패 해소 (#CL-31)
+
+- **원인**: `apps/seller/src/lib/firebase.ts`가 모듈 최상위에서 `getAuth(app)` 평가 → `apiKey` 부재 시 `getAuth`가 동기 throw(`auth/invalid-api-key`). 빌드 prerender가 firebase를 import하는 첫 페이지(`/admin/banner`, 알파벳 우선)를 평가하다 크래시 → 빌드 abort. 페이지 자체 버그 아님.
+- **Vercel 무영향**: 셀러 앱 정상 배포·e2e 167/0 → Vercel 빌드 env엔 firebase 변수 존재. 실패는 변수가 비표준 `.env.vercel.local`에만 있고 `.env.local`엔 없는 로컬·env 미주입 빌드 한정. BACKLOG의 "Vercel 환경변수 점검"은 불필요로 확정.
+- **수정**: `getAuth`/`getStorage`를 지연 초기화 함수 `getFirebaseAuth()`/`getFirebaseStorage()`로 전환(메모이즈). 사용처(`useFirebaseAuth`·`useOrders`·`onboarding`·`ImageUpload`·`admin/banner`) 전부 클라이언트 런타임이라 모듈 로드 평가 불필요. `db`는 미throw로 즉시 초기화 유지.
+- **검증**: env 미주입 로컬 빌드 — 수정 전 크래시 재현, 수정 후 빌드 성공(전 라우트). 커밋 `32738fb`.
+
+---
+
+## 세션34 — consumer 강한비번 전환
+
+- **배경**: 세션22에 편의 우선으로 채택한 `consumer@test.com` 약한비번(`test1234!`)을 보안 follow-up으로 전환. 사용자가 보안 우선으로 정책 재확인.
+- **처리**: `scripts/reset-user-password.mjs`로 Firestore `users` 문서 `passwordHash`를 30자 랜덤 비번(bcrypt-12)으로 갱신. `apps/e2e/.env`(gitignored)·repo Secret `TEST_CONSUMER_PASSWORD` 동기 교체(`gh secret set --body`로 BOM 회피). `/auth/login` 직접 curl — 새 비번 200·기존 401 확인.
+- **검증**: e2e 풀런 run 25966655016 **167 passed / 0 failed / 11 skipped**. `seller@test.com`은 본 항목 범위 밖 — 약한비번 유지.

--- a/docs/archive/sessions/session36-prep.md
+++ b/docs/archive/sessions/session36-prep.md
@@ -1,0 +1,57 @@
+# 세션36 진입 가이드 — P3 잔여 기능 항목
+
+> 작성: 2026-05-17 (세션35 종료 시) · SSOT: `docs/BACKLOG.md` §12
+> 선행: 세션35 — docs 정리(코드 변경 없음). e2e 베이스라인 167/0 유지.
+> 진행 원칙: **아토믹 태스크 단위** — 한 태스크 = 한 커밋. 각 태스크 끝에 **정합성 검토** 후 통과해야 다음 진행.
+
+---
+
+## 배경
+
+세션35는 docs 정리 세션이었다. 사용자가 P3 잔여 3건을 별도 세션 작업으로 두기로 결정해
+세션35는 문서 정비에 집중했다:
+
+- `docs/memory.md` 200라인 한도 임박(197라인) → 50라인 이내 요약(50라인).
+  세션22~34 상세 narrative는 `docs/archive/memory_archive_20260517.md`로 아카이브.
+- 폴더 이동(`docs/design/`·`docs/specs/api/`)으로 깨진 design↔api spec 상호 참조 링크 14곳 수정.
+- `docs/BACKLOG.md` 변경 이력 — 세션32 행 순서 보정 + 누락된 세션26 행 추가.
+
+`docs/BACKLOG.md` §12-1 우선순위 표에서 **P0·P1·P2 + e2e 안정성 + `/admin/banner` +
+consumer 강한비번 전부 종결**. 남은 것은 **P3 기능 항목 3건**이다.
+
+---
+
+## 핸드오프 — P3 잔여 (모두 신규 기능, 별도 기능 세션 권장)
+
+| 항목 | 범위 | 비고 |
+|------|------|------|
+| **`useOrderActions` 훅 통합** | detail용 `useOrderDetailActions`(모달 reason+apiFetch)와 OrderCard용 `useOrderActions`(prompt() reason+raw fetch) 시그니처 통일 | #CL-22 분리 항목. 단순 통합 시 동작 변경 위험 — UI 리팩토링 사이클에서 일괄 |
+| **G1 거점 수정 페이지** | `apps/seller/src/app/hubs/[id]/page.tsx` 신규 구현 | Phase B 잔여. 규모 중~대. `/hubs/[id]` 거점 상세·`/hubs/[id]/pickup`은 이미 존재 — edit 화면만 누락 |
+| **Driver Kakao Maps SDK** | 드라이버 앱 Kakao Maps SDK 연동 | 신규 SDK 연동. 밀크런 경로 프리뷰(§7 Should Have)와 연계 가능 |
+
+---
+
+## T0. 진입 — 현황 재확인 (먼저 수행)
+
+- [ ] 최신 `e2e.yml` run 확인 — `gh run list --workflow=e2e.yml`. 167/0 유지 여부.
+  - gh CLI 경로: `C:\Program Files\GitHub CLI\gh.exe` (PATH 미등록 — `&` 호출 연산자)
+  - 세션35는 코드 변경 없음(docs만) → 베이스라인 run 25966655016 (167/0).
+- [ ] `docs/memory.md` 라인 수 확인 — 50라인. 200라인 한도 여유 있음.
+- [ ] `docs/BACKLOG.md` §12-1 우선순위 표에서 P3 상태 확인.
+- [ ] **정합성 검토**: 167/0에서 회귀했다면 P3 착수 전 회귀 원인 우선 처리.
+
+---
+
+## 세션 종료 시
+
+- [ ] `docs/BACKLOG.md` §12 — 처리한 항목 완료 체크 + 변경 이력.
+- [ ] 설계 결정 발생 시 `docs/CRITICAL_LOGIC.md` 신규 #CL 기록 (현재 #CL-31까지).
+- [ ] `docs/memory.md` 세션36 섹션 갱신.
+- [ ] 다음 진입점(`session37-prep.md`) 갱신 + `BACKLOG.md` §12 진입점 링크 수정.
+
+## 참조
+
+- 한도 정책: `docs/CRITICAL_LOGIC.md` #CL-29 · 활성 결정 로그(#CL-19~#CL-31)
+- e2e 인증 패턴(storageState): `docs/memory.md` 「e2e 인증 패턴」 절
+- 베이스라인 풀런: run 25966655016 (167 passed / 0 failed / 11 skipped)
+- e2e 워크플로: `.github/workflows/e2e.yml` · 동기화 `sync-preview.yml`

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -1,197 +1,51 @@
 # Green Love — 프로젝트 메모리
 
 > **SSOT** — 세션 종료 시 최신화. 200라인 초과 시 50라인 이내 요약 후 아카이브.
-> 아카이브: `docs/archive/memory_archive_20260425.md`
+> 아카이브: `archive/memory_archive_20260425.md` · `archive/memory_archive_20260517.md` (세션22~34 상세)
 
-최종 수정: 2026-05-17 (세션34 — consumer 강한비번 전환)
-
----
-
-## ✅ 완료된 작업 (세션22까지)
-
-| 항목 | 완료일 |
-|------|--------|
-| Consumer/Seller/Driver DS + 성능(53→99) + PWA/CORS + 상품등록 버그 | 2026-04-25~05-01 |
-| DS 리팩토링·툴체인·a11y·e2e 전체 구축·OrderGroup 리팩토링 | 2026-05-02~06 |
-| BUG-SEC 초대토큰·next-auth beta.31·G4 셀러 대시보드 | 2026-05-08 |
-| **세션18**: G2 상품명·preparedAt UI·B1 pre-fill·B2 에러피드백·G3 날짜선택기 | 2026-05-08 |
-| **세션19**: 보안 패치 — Next.js 16.2.5 + React 19.2.6 CVE, HTTP 보안헤더, auth.ts 강화 | 2026-05-09 |
-| **세션20**: 루트 vercel.json 삭제·Railway CORS fix·login force-dynamic·E2E_TEST 값 수정 | 2026-05-10 |
-| **세션21**: 세션20이 남긴 허위 BLOCKER 검증·정정 | 2026-05-10 |
-| **세션22**: E2E 보안 결함 정리 — Vercel `E2E_TEST` Production 제거·약한비번 54건 일소·**옵션 B 헤더 게이팅 도입** | 2026-05-10 |
-| **세션23**: 셀러 fatal constraint 해소 — `orders/[id]` 629→217·`settlements` 531→116 분할 (#CL-22) | 2026-05-15 |
-| **세션24**: 세션23 e2e 회귀 검증 (회귀 0건) + 인증 헬퍼 진단 강화 (#CL-23) | 2026-05-15 |
-| **세션25**: 사전 결함 정리 — biome.json 파싱 에러·`.env.vercel.tmp` gitignore·driver Credentials 부재 확인 (#CL-25) | 2026-05-15 |
-| **세션26**: #CL-21 옵션 A 보강 — Production env `E2E_TEST_SECRET` 제거 + Preview SSO bypass 도입 | 2026-05-15 |
-| **세션27**: #CL-21 후속 — repo Secrets 11개 등록 + `sync-preview.yml` 자동 머지 워크플로 + e2e CI 가동 | 2026-05-16 |
-| **세션28**: #CL-23 인증 race 해소 — e2e storageState 패턴(T0~T5). CI 풀런 124/37→145/16·146/15, race 0건 | 2026-05-16 |
-| **세션29**: e2e 잔여 B·C·D 전부 해소 — C(perf-css networkidle 제거)·B·D 단일 원인 CORS fix(#CL-28). 재배포 후 풀런 167/0 | 2026-05-16 |
-| **세션30**: P2-C #CL-29 — 누적 결정 로그 한도 정책(500라인 예외+1000라인 트리거). CRITICAL_LOGIC.md 1415→229라인 아카이브 분리 | 2026-05-16 |
-| **세션31**: P2-A Railway latency 계측(synthetic) + 계측 중 발견한 throttler 전역 누수 버그 수정 (#CL-30) | 2026-05-16 |
-| **세션32**: e2e 안정성 2건 — consumer-groupbuy flake + cleanup-spec-residue CI 인증(env 전환·BOM 방어). 풀런 167/0 | 2026-05-17 |
-| **세션33**: P3 `/admin/banner` prerender 실패 해소 — seller firebase `getAuth` 지연 초기화 (#CL-31) | 2026-05-17 |
-| **세션34**: P3 consumer@test.com 강한비번 전환 — Firestore `passwordHash` + `.env`·repo Secret 동기 교체, 풀런 167/0 | 2026-05-17 |
+최종 수정: 2026-05-17 (세션35 — docs 정리)
 
 ---
 
-## ✅ 세션22 — 보안 결함 정리 (BLOCKER 해소)
+## 진행 현황
 
-**트랙별 결과**:
-- **트랙 1**: seller·consumer Vercel `E2E_TEST` Production env 삭제 + 재배포 → `/login` HTML에서 `type="email"`·`type="password"` 0건 확인
-- **트랙 2**: `scripts/delete-test-accounts.mjs --apply`로 54건 user + 2건 refreshToken 삭제. seller@test.com만 보존 결정. 새 e2e consumer로 `consumer@test.com` 생성(test1234 — 사용자 결정, 강한비번 권장은 follow-up). `seller-auth-invite.spec.ts`에 `afterAll` cleanup + `scripts/cleanup-spec-residue.mjs` 헬퍼 추가
-- **트랙 3 옵션 B**: `E2E_TEST_SECRET` 32자 6환경 적용. `auth.ts`(seller·consumer) Credentials Provider 상시 등록 + `request.headers.get('x-e2e-test-token')` 검증. `apps/e2e/tests/_helpers/auth.ts` + `playwright.config.ts extraHTTPHeaders` 도입. 12개 spec helper migration 완료
-- **트랙 4 통합 검증 5종**: 폼 노출 0, 약한비번 401, 보존 200, Firestore email-provider 2건(seller·consumer), 헤더 없는 credentials 호출 → `error=CredentialsSignin` ✓
+세션22까지 + 세션23~36 완료. 직전 **세션35** = docs 정리, **세션36** = seller 프론트엔드 리팩토링 5-Phase (#CL-32).
+e2e 베이스라인 **167 passed / 0 failed / 11 skipped** (run 25966655016). 설계 결정 정본은 `docs/CRITICAL_LOGIC.md` #CL-19~#CL-32, 세션별 상세는 아카이브.
 
-**상세 설계**: [docs/CRITICAL_LOGIC.md](CRITICAL_LOGIC.md) #CL-20 (옵션 B), #CL-21 (옵션 A 향후 과제)
-**원본 가이드**: [docs/archive/sessions/session22-prep.md](archive/sessions/session22-prep.md)
+**다음 세션 진입점**: SSOT `docs/BACKLOG.md` §12.
+잔여 **P3 기능 2건**: G1 거점 수정 페이지(`hubs/[id]`) · Driver Kakao Maps SDK.
+(P0·P1·P2 + e2e 안정성 + `/admin/banner` + consumer 강한비번 + seller 프론트 리팩토링 종결. P2-B는 #CL-30으로 moot.)
 
 ---
 
-## 세션26 — #CL-21 옵션 A 보강 완료
+## e2e 인증 패턴 (옵션 B / storageState · #CL-27)
 
-- `preview` 브랜치 신설 → Vercel branch Preview 배포(`{project}-git-preview-…vercel.app`) 자동화. 21개 spec `BASE` 환경변수화. `.github/workflows/e2e.yml` 신설.
-- Vercel seller·consumer **Production** env `E2E_TEST_SECRET` 삭제 (Preview·Development 유지) + 빈 커밋 재배포.
-- **Preview SSO 우회**: Preview는 Vercel Authentication(SSO) 기본 보호 → Protection Bypass for Automation 시크릿 3개 발급. `global-setup.ts`가 bypass 쿼리로 `_vercel_jwt` 쿠키 발급 → `storageState`(`apps/e2e/.bypass-state.json`) 재사용. bypass 헤더도 전역 주입 금지(Firebase CORS).
-- 검증: Production 유효 헤더로도 거부 / Preview 정상. smoke seller-orders 11/12·consumer-mypage 9/10.
-- **주의**: PowerShell `Get-Content -Raw`가 UTF-8을 CP949로 오독 → 한글 mojibake 손상. spec 일괄 편집 시 Python(명시적 utf-8) 또는 Edit 도구 사용.
-- **잔여**: GitHub repo Secrets 등록 전 CI 미동작. `preview` ↔ `main` 주기 동기화 필요.
-
-상세: [docs/CRITICAL_LOGIC.md](CRITICAL_LOGIC.md) #CL-21
-
----
-
-## 세션27 — #CL-21 후속: e2e CI 활성화
-
-- gh CLI 2.92.0 winget 설치(`C:\Program Files\GitHub CLI`) → `booker-lab` 인증(ADMIN).
-- `gh secret set`으로 repo Secrets 11개 등록 (`apps/e2e/.env` 값 그대로).
-- `.github/workflows/sync-preview.yml` 신설 — `main` push → `preview` 자동 merge·push → `gh workflow run e2e.yml` 디스패치. (GITHUB_TOKEN push는 재귀방지로 e2e push트리거 미발화 → workflow_dispatch로 우회.)
-- `e2e.yml` `pnpm/action-setup version:9` 고정 제거 (packageManager pnpm@10.32.1 충돌).
-- **e2e CI 가동 확인**: 124 passed / 37 failed. 37건 전부 셀러 인증 spec — `set-cookie count=0` = **#CL-23 인증 race** (CI는 spec별 독립 인증으로 race 증폭). 셀러앱 코드 무변경이므로 회귀 아님.
-
----
-
-## 세션28 — #CL-23 인증 race 해소: storageState 패턴 (#CL-27)
-
-- **T0 재분류**: s27 실패 37건을 run 로그 + error-context 37개 증거로 재분류 — A 인증 race 23 / B Railway `Failed to fetch` 5 / C waitForLoadState 2 / D realtime 미정착 7. 「셀러 33건 전부 A」 가설 반증.
-- **T1~T3**: `global-setup.ts`가 seller·consumer 1회 로그인 → `.auth-state.json` 발급. 11개 인증 describe에 `test.use({ storageState })` 배선, spec 개별 `loginViaCredentials` 제거. globalSetup 로그인은 race 흡수용 재시도 3회 — #CL-23의 helper-retry 기각과 구분(globalSetup 단일 지점이라 N 미증폭).
-- **T4 검증**: e2e CI 2회 연속 풀런 124/37 → **145/16 · 146/15**. `set-cookie count=0` 두 번 모두 0건 → 인증 race 23→0 확정.
-- **잔여 14~15건**: B·C·D + flake, 전부 storageState 무관 → `BACKLOG.md §12-2` 분리 기록.
-- 인증 호출 풀런당 67회+retry → 2회.
-
-상세: [docs/CRITICAL_LOGIC.md](CRITICAL_LOGIC.md) #CL-27
-
----
-
-## 세션34 — consumer 강한비번 전환
-
-- **배경**: 세션22에 편의 우선으로 채택한 `consumer@test.com` 약한비번(`test1234!`)을 보안 follow-up으로 전환. 사용자가 보안 우선으로 정책 재확인.
-- **처리**: `scripts/reset-user-password.mjs`로 Firestore `users` 문서 `passwordHash`를 30자 랜덤 비번(bcrypt-12)으로 갱신. `apps/e2e/.env`(gitignored)·repo Secret `TEST_CONSUMER_PASSWORD` 동기 교체(`gh secret set --body`로 BOM 회피). `/auth/login` 직접 curl — 새 비번 200·기존 401 확인.
-- **검증**: e2e 풀런 run 25966655016 **167 passed / 0 failed / 11 skipped**. `seller@test.com`은 본 항목 범위 밖 — 약한비번 유지.
-
----
-
-## 세션33 — `/admin/banner` prerender 실패 해소 (#CL-31)
-
-- **원인**: `apps/seller/src/lib/firebase.ts`가 모듈 최상위에서 `getAuth(app)` 평가 → `apiKey` 부재 시 `getAuth`가 동기 throw(`auth/invalid-api-key`). 빌드 prerender가 firebase를 import하는 첫 페이지(`/admin/banner`, 알파벳 우선)를 평가하다 크래시 → 빌드 abort. 페이지 자체 버그 아님.
-- **Vercel 무영향**: 셀러 앱 정상 배포·e2e 167/0 → Vercel 빌드 env엔 firebase 변수 존재. 실패는 변수가 비표준 `.env.vercel.local`에만 있고 `.env.local`엔 없는 로컬·env 미주입 빌드 한정. BACKLOG의 "Vercel 환경변수 점검"은 불필요로 확정.
-- **수정**: `getAuth`/`getStorage`를 지연 초기화 함수 `getFirebaseAuth()`/`getFirebaseStorage()`로 전환(메모이즈). 사용처(`useFirebaseAuth`·`useOrders`·`onboarding`·`ImageUpload`·`admin/banner`) 전부 클라이언트 런타임이라 모듈 로드 평가 불필요. `db`는 미throw로 즉시 초기화 유지.
-- **검증**: env 미주입 로컬 빌드 — 수정 전 크래시 재현, 수정 후 빌드 성공(전 라우트). 커밋 `32738fb`.
-
----
-
-## 세션32 — e2e 안정성 2건 해소
-
-- **consumer-groupbuy:14 flake**: `waitForSelector('모집 중').catch()` 후 `empty.isVisible()`가 false면 "모집 중"을 강제 단언 — 페이지 로딩 중이면 리스트도 empty-state도 미렌더라 오판. `list.or(empty)` 확정 렌더 대기 후 분기로 수정 (커밋 `abd2a13`).
-- **cleanup-spec-residue CI 인증 실패**: 스크립트가 gitignore된 로컬 키 `apps/api/firebase-adminsdk.json`을 `require` → CI 러너 부재로 `exit=1`, seller-auth-invite `afterAll` 정리 무력화(세션22 이후 상존). `FIREBASE_SERVICE_ACCOUNT_JSON` env 우선·로컬 키 fallback(`firestore.module.ts`와 동일 규약) 전환 + `e2e.yml` env 주입 + repo Secret 등록 (커밋 `b095023`). 후속: Windows gh CLI 파이프 업로드 시 선두 BOM(U+FEFF) 혼입 → `JSON.parse` 실패 → BOM 제거 방어 + Secret no-BOM 재업로드 (커밋 `4934468`).
-- **검증**: e2e 풀런 run 25965438455 **167 passed / 0 failed**, cleanup 로그 `users=2 tokens=0 skipped=0` (세션22 이후 처음으로 CI에서 잔여 계정 정리 동작).
-
----
-
-## 세션31 — P2-A Railway latency 계측 + throttler fix (#CL-30)
-
-- **P2-A 완료**: Railway 배포 로그에 요청 단위 로그가 전무 → synthetic 측정 스크립트 `scripts/measure-api-latency.mjs` 신설(Railway CLI로 대시보드 없이 접근, 60초 윈도우당 8회 페이싱). `/auth/login` p50 922ms·p95 1551ms·p99 1687ms·**0% 실패**, `/health` p50 409ms. 서버 작업 ≈ ~510ms(Firestore 조회+bcrypt factor-12+토큰 발급, bcrypt 지배적). ~0.9s steady는 e2e 차단 요인 아님 → P2-B(cold-start) 데이터상 불필요 종결(moot).
-- **throttler 버그 발견·수정 (#CL-30)**: 측정 중 `/health`가 ~10~19회 후 429. `ThrottlerModule`의 named throttler는 전 라우트 전역 적용 → `auth`(10/분) 등록만으로 `/health` 등 비인증 라우트까지 10/분에 묶여 `default`(100/분) 무효화. 수정: `auth` throttler 제거 + 인증 라우트(register·login·kakao-login·refresh)에 `@Throttle({default:{limit:10}})` 라우트 한정 오버라이드. 커밋 `23e3528` 재배포 후 헤더 검증 — `/health` `x-ratelimit-limit:100`·`/auth/login` `:10`.
-
-상세: [docs/CRITICAL_LOGIC.md](CRITICAL_LOGIC.md) #CL-30
-
----
-
-## 세션30 — CRITICAL_LOGIC.md 한도 정책 (#CL-29)
-
-- **P2-C 완료**: 누적 결정 로그(`CRITICAL_LOGIC.md`·`BACKLOG.md`·memory 아카이브)는 시계열 append-only — 분리 시 이력 파편화·#CL 연속성/앵커 손상. **500라인 모듈화 한도 예외**로 CLAUDE.md §1 명시. 단 무한 증가 방어로 **1000라인 초과 시 종결 엔트리 아카이브**(크기 기준, 죽은 엔트리만).
-- **적용**: `#CL-19` 경계 분할 — 2026-03~04 종결 엔트리 1208라인을 `archive/CRITICAL_LOGIC_archive_20260516.md`로 이관. 활성 파일 1415→**229라인**. 참조 링크 정합성 검토 완료.
-- 상세: `docs/CRITICAL_LOGIC.md` #CL-29.
-
----
-
-## 세션29 — e2e 잔여 B·C·D 해소 (#CL-28)
-
-- **T0 재확인**: 최신 풀런 run 25952638293 — B 5·C 2·D 8·flake 1 (세션28과 동일, 인증 race 0건 유지).
-- **C 완료**: `perf-css-regression:87·:103` Seller 로그인 — `waitForLoadState('networkidle')`가 Vercel preview의 `vercel.live` 피드백 위젯 상시 연결로 30s 타임아웃. trace로 확정(리소스 ~2.7s 완료, Firebase 호출 0). `networkidle` 제거 → 폼 렌더 + 1.5s 정착. 로컬 perf-css 15/15 통과.
-- **B·D 단일 원인**: trace 콘솔에서 CORS 에러 확정 — Railway API가 Vercel preview origin에 `Access-Control-Allow-Origin` 미발급. B = `apiFetch` 차단, D = `/auth/firebase-token` fetch 차단 → `firebaseReady=false` → 대시보드 `연결 중` 고착. **D는 B의 하위 증상.** cold-start 가설 반증(전구간 분포·firestore는 정상).
-- **수정**: `apps/api/src/main.ts` origin 콜백에 팀 스코프(`jos-projects-d1cecc0c`) 한정 정규식 추가. D spec 무변경.
-- **검증 완료**: `c5ee52f` push가 Railway 자동 재배포 트리거 → preview origin CORS 발급·비매칭 차단 curl 확인 → e2e 풀런 run 25957177092 **167 passed / 0 failed / 11 skipped**. B 5·D 8 + 인증 race 전부 해소(178→0 fail).
-
-상세: [docs/CRITICAL_LOGIC.md](CRITICAL_LOGIC.md) #CL-28
-
----
-
-## 후속 작업 — SSOT: `docs/BACKLOG.md` §12
-
-다음 세션 진입점은 [docs/BACKLOG.md](BACKLOG.md) **§12 후속 인프라·보안 정비**. 우선순위 표 → 항목 상세 순으로 확인.
-
-- ✅ #CL-21 옵션 A(세션26)·CI(세션27) / ✅ #CL-23 인증 race(세션28) / ✅ #CL-28 B·C·D(세션29) / ✅ #CL-29 한도 정책(세션30) / ✅ #CL-30 P2-A 계측+throttler fix(세션31)
-- ✅ 세션32 e2e 안정성 2건 — consumer-groupbuy flake · cleanup-spec-residue CI 인증
-- ✅ 세션33 P3 `/admin/banner` prerender 실패 — firebase getAuth 지연 초기화(#CL-31)
-- ✅ 세션34 P3 consumer 강한비번 전환 — 풀런 167/0
-- ⏹️ P2-B Vercel cold-start — #CL-30으로 데이터상 불필요 판정(moot)
-- 🟢 **P3 (다음 세션)**: `useOrderActions` 통합 · G1 거점 수정 · Driver Maps SDK
-
----
-
-## e2e 인증 패턴 (옵션 B 이후)
-
-| 항목 | 값 |
-|------|-----|
-| 헬퍼 | `apps/e2e/tests/_helpers/auth.ts` `loginViaCredentials(page, base, email, password)` |
-| 호출 패턴 | globalSetup이 seller·consumer 1회 로그인 → `.auth-state.json` storageState 발급(#CL-27). 인증 spec은 describe 상단 `test.use({ storageState: AUTH_STATE_PATH })`만 — spec 개별 `loginViaCredentials` 호출 없음. 헬퍼는 globalSetup이 사용 |
-| 헤더 주입 | helper의 csrf GET + credentials POST 두 호출에만 명시적 (`headers: { 'x-e2e-test-token': SECRET }`) — **전역 extraHTTPHeaders 사용 금지** (Firebase Identity Toolkit 등 third-party API에 헤더가 따라가 CORS preflight 차단됨) |
-| BASE | `process.env.SELLER_BASE/CONSUMER_BASE/DRIVER_BASE` (Preview branch URL) — `apps/e2e/.env` |
-| Preview SSO 우회 | `global-setup.ts`가 `_vercel_jwt` bypass 쿠키 발급 → `storageState`(`apps/e2e/.bypass-state.json`) 재사용. bypass 시크릿은 `*_BYPASS_SECRET` env |
-| 검증 통과 | e2e CI 2회 풀런 145/16·146/15, 인증 race 0건 (#CL-27). 잔여 B·C·D는 BACKLOG §12-2 |
+- **헬퍼**: `apps/e2e/tests/_helpers/auth.ts` `loginViaCredentials(page, base, email, password)`.
+- **호출**: globalSetup이 seller·consumer 1회 로그인 → `.auth-state.json` storageState 발급. 인증 spec은 describe 상단 `test.use({ storageState })`만 — 개별 호출 없음.
+- **헤더 주입**: csrf GET + credentials POST 두 호출에만 `x-e2e-test-token` 명시. **전역 extraHTTPHeaders 금지** (Firebase 등 third-party API CORS preflight 차단).
+- **BASE**: `SELLER_BASE/CONSUMER_BASE/DRIVER_BASE` (Preview branch URL) — `apps/e2e/.env`.
+- **Preview SSO 우회**: `global-setup.ts`가 `_vercel_jwt` bypass 쿠키 발급 → `.bypass-state.json` 재사용. 시크릿 `*_BYPASS_SECRET`. bypass 헤더도 전역 주입 금지.
 
 ---
 
 ## 툴체인·배포
 
-| 항목 | 값 |
-|------|-----|
-| Railway API | `https://api-production-13e7.up.railway.app` |
-| Vercel Consumer | `https://greenlove.co.kr` |
-| Vercel Seller | `https://seller.greenlove.co.kr` |
-| next-auth | 5.0.0-beta.31 |
-| Lighthouse Perf | 99 |
+- Railway API `https://api-production-13e7.up.railway.app` · Consumer `greenlove.co.kr` · Seller `seller.greenlove.co.kr`.
+- next-auth 5.0.0-beta.31 · Lighthouse Perf 99 · pnpm@10.32.1 · gh CLI `C:\Program Files\GitHub CLI\gh.exe` (PATH 미등록).
+- e2e CI: `.github/workflows/e2e.yml` · 동기화 `sync-preview.yml` (main push → preview merge → workflow_dispatch).
 
 ---
 
 ## 핵심 기술 특이사항
 
-- **login/page.tsx (seller·consumer)**: `export const dynamic = 'force-dynamic'` — 옵션 B 도입 후 폼 노출은 항상 false지만 force-dynamic은 유지(런타임 env 평가 보장)
-- **E2E_TEST_SECRET**: 세션26부터 Vercel seller·consumer는 **Preview·Development만** (Production 제거 — #CL-21). `apps/e2e/.env`에 동일값. 32자. **MVP 출시 시 #CL-20 정리표대로 Preview도 삭제**
-- **VERCEL bypass**: Preview 배포는 SSO 보호 → 3개 프로젝트 Protection Bypass for Automation 시크릿. e2e는 `_vercel_jwt` 쿠키로 우회 (`global-setup.ts`)
-- **Railway CORS**: no-origin 요청 허용(헬스체크) — `if (!origin) return callback(null, true)` 유지 필수. Vercel preview origin은 `main.ts` 팀 스코프 정규식으로 허용(#CL-28) — `CORS_ORIGIN` env는 프로덕션 도메인만
-- **Railway throttler**: `app.module.ts`는 `default`(100/분) 단일 등록 — named throttler 추가 시 전 라우트 전역 적용되므로 금지. 인증 라우트만 `auth.controller`의 `@Throttle({default:{limit:10}})`로 오버라이드 (#CL-30)
-- **cleanup-spec-residue 인증**: `FIREBASE_SERVICE_ACCOUNT_JSON` env 우선·로컬 키 fallback. gh CLI Secret을 Windows `Get-Content \| gh secret set` 파이프로 업로드 시 선두 BOM 혼입 위험 → `[Console]::OutputEncoding`을 no-BOM UTF-8로 설정 후 업로드 (세션32)
-- **gemini-3-flash-preview**: 유효한 모델명, 변경 금지
-- **aggressiveFrontEndNavCaching: false**: 변경 금지 (RSC CORS 재발)
-- **shared 타입 변경 시**: `pnpm --filter @greenhub/shared build` 후 dist 커밋 필수
-- **useStoreProducts firebaseReady 가드 금지**: 이중 인스턴스 버그
-- **DS 폰트 예외**: BottomNav/ProductTopBar(10px), 주문상태뱃지(12px), 카운트다운(13px)
-- **공동구매 CONFIRMED**: 시스템 자동 (선착순+크론) — 셀러 수동 확정 없음
-- **preparedAt**: 빠른 선택지 UI (오늘 2시/4시/내일 오전) 확정
-- **seller register inviteToken**: seller role 가입 시 필수
-- **Portone V2**: PORTONE_V2_SECRET·PORTONE_WEBHOOK_SECRET `apps/api/.env` 반영 완료
-- **orders ?tab= 딥링크**: `window.location.search` 사용 (Suspense 빌드 에러 방지)
-- **proxy.ts**: Next.js 16 미들웨어 컨벤션 파일명, 정상 동작
-- **seller firebase.ts**: `getAuth`/`getStorage`는 지연 초기화 함수 `getFirebaseAuth()`/`getFirebaseStorage()`로만 노출 — 모듈 최상위 호출 금지(`getAuth`가 apiKey 부재 시 동기 throw → 빌드 prerender 크래시, #CL-31). `db`는 미throw로 즉시 초기화 유지
-- **AUTH_SECRET**: 3앱 Vercel 설정 완료
+- **login/page.tsx (seller·consumer)**: `export const dynamic = 'force-dynamic'` 유지 (런타임 env 평가 보장).
+- **seller firebase.ts**: `getAuth`/`getStorage`는 지연 초기화 함수 `getFirebaseAuth()`/`getFirebaseStorage()`로만 노출 — 모듈 최상위 호출 금지 (apiKey 부재 시 동기 throw → 빌드 prerender 크래시 #CL-31). `db`는 즉시 초기화 유지.
+- **E2E_TEST_SECRET**: Vercel seller·consumer는 Preview·Development만 (Production 제거 #CL-21). `apps/e2e/.env` 동일값 32자. MVP 출시 시 #CL-20 정리표대로 Preview도 삭제.
+- **Railway CORS**: no-origin 허용 유지 필수 (`if(!origin) return callback(null,true)`). Vercel preview origin은 `main.ts` 팀 스코프 정규식 허용(#CL-28). `CORS_ORIGIN` env는 프로덕션 도메인만.
+- **Railway throttler**: `app.module.ts`는 `default`(100/분) 단일 등록 — named throttler 추가 시 전 라우트 전역 적용되므로 금지. 인증 라우트만 `@Throttle({default:{limit:10}})` 오버라이드(#CL-30).
+- **cleanup-spec-residue 인증**: `FIREBASE_SERVICE_ACCOUNT_JSON` env 우선·로컬 키 fallback. gh CLI Secret 업로드 시 BOM 혼입 위험 → no-BOM UTF-8로 업로드.
+- **변경 금지**: `gemini-3-flash-preview`(유효 모델명) · `aggressiveFrontEndNavCaching:false`(RSC CORS 재발) · `useStoreProducts` firebaseReady 가드(이중 인스턴스 버그).
+- **shared 타입 변경 시**: `pnpm --filter @greenhub/shared build` 후 dist 커밋 필수. DS 폰트 예외 — BottomNav/ProductTopBar(10px)·주문상태뱃지(12px)·카운트다운(13px).
+- **도메인·기타**: 공동구매 CONFIRMED 시스템 자동(선착순+크론, 셀러 수동 확정 없음) · preparedAt 빠른 선택지 UI · seller register inviteToken 필수 · Portone V2 시크릿 `apps/api/.env` 반영 · orders `?tab=` 딥링크는 `window.location.search` · `proxy.ts` Next.js 16 미들웨어 컨벤션 · AUTH_SECRET 3앱 Vercel 완료.
+- **Windows 인코딩**: 한글 파일 일괄 편집 시 PowerShell `Get-Content`/`Set-Content` 금지(UTF-8 손상) — Python(명시적 utf-8) 또는 Edit 도구 사용.
+- **seller 프론트 구조(#CL-32)**: Railway API 호출은 `lib/api.ts`의 `apiJson<T>()`(에러 시 `ApiError` throw) 사용 — raw `fetch` 금지. 페이지 셸은 `components/`의 `PageShell`/`PageHeader`/`EmptyState`/`LoadingState` 재사용. 주문 상태 변경은 `useOrderStatusUpdate` 코어 경유. 관리자 목록 훅은 `useAdminList` 팩토리. ProductForm은 `useProductForm` 훅 + 스텝 컴포넌트로 분리.


### PR DESCRIPTION
## 개요
셀러앱 프론트엔드 전수 진단 후 5개 Phase 구조 리팩토링. 설계 결정 정본: `docs/CRITICAL_LOGIC.md` #CL-32.

## Phase별 변경
- **Phase 1 — ProductForm 분리**: `ProductForm.tsx` **705→154라인** (Fatal Constraint 500라인 위반 해소). `useProductForm` 훅 + `productForm.types` + `Step1Basic`/`Step5Pricing` + `StepIndicator` + `FormPrimitives` 추출.
- **Phase 2 — API 레이어 통일**: `lib/api.ts`에 `apiJson<T>()` + `ApiError` 추가. `res.ok` 검사·JSON 언래핑·서버 `message` 추출을 한 곳에 묶음. ProductForm·주문 훅 raw `fetch` 마이그레이션.
- **Phase 3 — useAdmin 팩토리화**: **462→341라인**. 제네릭 `useAdminList` 코어 + `runAction`/`withQuery`/`pick`. 7훅 재작성.
- **Phase 4 — 주문 액션 훅 통합**: 공통 코어 `useOrderStatusUpdate` 신설, `useOrderActions`·`useOrderDetailActions`가 공유 (BACKLOG §12 P3 종결).
- **Phase 5 — 공통 UI 컴포넌트**: `PageShell`/`PageHeader`/`EmptyState`/`LoadingState` 신설, 9개 페이지 치환.

## 검증
- `pnpm --filter seller build` 성공 — TypeScript 통과, 22개 라우트 전부 생성.
- biome lint 신규 에러 0건 (잔존 2건은 `VarietySelector`·`app/page.tsx` 사전 결함).
- e2e 베이스라인 167 passed — CI에서 검증.

## 비고
- 외부 동작 변화: useAdmin 에러 메시지가 `apiJson` 경유로 단일화 ("…조회 중 오류 발생"). 상세는 #CL-32.
- `app/page.tsx`(홈)는 `100dvh` 사용으로 PageShell 미치환 — 모바일 뷰포트 회귀 회피.
- 세션35 미커밋 docs 잔재(`memory.md`·`BACKLOG.md`·archive) 포함. `docs/design/**`·`docs/specs/api/**`의 별도 WIP은 미포함.

🤖 Generated with [Claude Code](https://claude.com/claude-code)