### PR TITLE
docs(session37): 세션36 후속 백로그 등재 + 세션37 진입 가이드

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -425,7 +425,7 @@
 ## 12. 후속 인프라·보안 정비 (세션22~25 잔여)
 
 > 기준일: 2026-05-17 (세션35 — docs 정리)
-> 진입점: 다음 세션 시작 시 [docs/archive/sessions/session36-prep.md](archive/sessions/session36-prep.md) → 본 §12 우선순위 표 순서로 확인.
+> 진입점: 다음 세션 시작 시 [docs/archive/sessions/session37-prep.md](archive/sessions/session37-prep.md) → 본 §12 우선순위 표 순서로 확인.
 > **세션29 완료**: §12-2 e2e 잔여 B·C·D 전부 해소 (run 25957177092 — 167 passed / 0 failed).
 > **세션30 완료**: P2-C `CRITICAL_LOGIC.md` 한도 정책 — 옵션 3 변형 채택·아카이브 분리(1415→229라인).
 > **세션31 완료**: P2-A Railway latency 계측(`/auth/login` p50 922ms·0% 실패) + 계측 중 발견한 throttler 전역 누수 버그 수정 (#CL-30).
@@ -454,6 +454,8 @@
 | 🟢 P3 | G1: `apps/seller/src/app/hubs/[id]/page.tsx` 거점 수정 페이지 | 기능 | — |
 | 🟢 P3 | Driver Kakao Maps SDK 연동 | 기능 | — |
 | ✅ P3 | consumer@test.com 강한비번 전환 — 30자 랜덤 비번 (2026-05-17 세션34 완료) | 보안 | 단독 |
+| 🟢 P4 | global-setup flake 보강 — `storageState` 직전 navigation 안정 대기 (세션36 관찰) | e2e 안정성 | 단독 |
+| 🟢 P4 | CI 액션 Node.js 20 deprecation 대응 — 2026-06-02 강제 전환 (세션36 관찰) | CI 유지보수 | 단독 |
 | ⏳ 외부 | 네이버페이 채널키 승인 → Vercel 환경변수 설정 | 외부 연동 | 승인 메일 대기 |
 
 ### 12-2. 상세 작업
@@ -620,11 +622,11 @@ P2-A 계측 중 `/health`가 ~10~19회 후 429 반환 발견. `ThrottlerModule`�
 
 ---
 
-#### [ ] P3 — `useOrderActions` 훅 통합
+#### [x] P3 — `useOrderActions` 훅 통합 (2026-05-17 세션36 완료)
 
 **배경**: 세션23 #CL-22에서 분리됐던 항목. detail용 `useOrderDetailActions`(모달 reason + apiFetch)와 OrderCard용 `useOrderActions`(prompt() reason + raw fetch) 시그니처 불일치.
 
-**처리 방침**: UI 리팩토링 사이클에서 양쪽 일괄 정비. 단순 통합 시 동작 변경 위험.
+**처리**: seller 프론트엔드 5-Phase 리팩토링(#CL-32)의 Phase 4로 일괄 정비. 공통 코어 `useOrderStatusUpdate`(PATCH·loading·error) 신설 — 두 훅이 코어를 공유하고 사유 입력 UI(prompt vs 모달)만 래퍼에서 분기. 시그니처는 `updateStatus(status, extra)`로 통일, 외부 반환 형태는 보존(소비처 무수정). e2e 167/0 회귀 없음(run 25970814882 재실행). 상세: [docs/CRITICAL_LOGIC.md #CL-32](CRITICAL_LOGIC.md)
 
 ---
 
@@ -648,6 +650,13 @@ P2-A 계측 중 `/health`가 ~10~19회 후 429 반환 발견. `ThrottlerModule`�
 
 - [ ] G1: `apps/seller/src/app/hubs/[id]/page.tsx` — 거점 수정 페이지 (Phase B 잔여)
 - [ ] Driver Kakao Maps SDK 연동
+
+#### [ ] P4 — e2e 안정성·CI 정비 (세션36 관찰 등재)
+
+**배경**: 세션36 머지 후 e2e 1차 실행이 `global-setup.ts:133` `context.storageState()`에서 실패 — `Navigation interrupted by another navigation to /login`. 재실행은 167/0 통과 → flake 확정(코드 무관, consumer 앱 미변경).
+
+- [ ] **global-setup flake 보강**: `loginWithRetry`는 `loginViaCredentials`의 throw만 흡수하고, 로그인 성공 후 `storageState` 시점의 in-flight 네비게이션 레이스는 못 잡는다. `global-setup.ts:133` `context.storageState()` 직전에 `page.waitForLoadState('networkidle')`(또는 명시적 안정 대기)를 넣어 레이스 창을 닫는다. 규모 소(小). #CL-23/#CL-27 인증 레이스 계열의 잔여 보강.
+- [ ] **CI 액션 Node.js 20 deprecation**: `actions/checkout@v4`·`actions/setup-node@v4`·`actions/upload-artifact@v4`·`pnpm/action-setup@v4`가 Node.js 20 — 2026-06-02 강제 Node.js 24 전환. 각 액션 최신 버전으로 갱신하거나 `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` 설정. `.github/workflows/*.yml` 전반 점검.
 
 #### [⏳] 외부 대기
 

--- a/docs/archive/sessions/session37-prep.md
+++ b/docs/archive/sessions/session37-prep.md
@@ -1,0 +1,78 @@
+# 세션37 진입 가이드 — P3 잔여 기능 + P4 정비
+
+> 작성: 2026-05-17 (세션36 종료 시) · SSOT: `docs/BACKLOG.md` §12
+> 선행: 세션36 — seller 프론트엔드 5-Phase 리팩토링(#CL-32). e2e 167/0 유지(run 25970814882).
+> 진행 원칙: **아토믹 태스크 단위** — 한 태스크 = 한 커밋. 각 태스크 끝에 **정합성 검토** 후 통과해야 다음 진행.
+
+---
+
+## 배경
+
+세션36은 셀러앱 프론트엔드를 5개 Phase로 리팩토링했다(#CL-32, main `8111b3b`):
+
+- **Phase 1**: `ProductForm.tsx` 705→154라인 — Fatal Constraint(500라인) 위반 해소.
+- **Phase 2**: `lib/api.ts`에 `apiJson<T>()`+`ApiError` — raw fetch 통일.
+- **Phase 3**: `useAdmin.ts` 462→341라인 — `useAdminList` 팩토리화.
+- **Phase 4**: `useOrderStatusUpdate` 공통 코어로 주문 액션 훅 통합 (BACKLOG P3 종결).
+- **Phase 5**: `PageShell`/`PageHeader`/`EmptyState`/`LoadingState` 신설, 9개 페이지 치환.
+
+`docs/BACKLOG.md` §12-1에서 **P0·P1·P2·P3 구조 항목 + e2e 안정성 + `/admin/banner` +
+consumer 강한비번 + `useOrderActions` 통합 전부 종결**. 남은 것은 **P3 기능 2건 + P4 정비 2건**이다.
+
+---
+
+## 핸드오프 — 잔여 작업
+
+| 우선 | 항목 | 범위 | 비고 |
+|------|------|------|------|
+| 🟢 P3 | **G1 거점 수정 페이지** | `apps/seller/src/app/hubs/[id]` edit 화면 신규 구현 | Phase B 잔여. 규모 중~대. `/hubs/[id]` 상세·`/hubs/[id]/pickup`은 존재 — edit만 누락. 세션36 신설 `PageShell`/`PageHeader`/`FormPrimitives`·`apiJson` 재사용 가능 |
+| 🟢 P3 | **Driver Kakao Maps SDK** | 드라이버 앱 Kakao Maps SDK 연동 | 신규 SDK 연동. 밀크런 경로 프리뷰(§7 Should Have)와 연계 가능 |
+| 🟢 P4 | **global-setup flake 보강** | `apps/e2e/global-setup.ts:133` `context.storageState()` 직전 navigation 안정 대기 추가 | 규모 소(小). 세션36 e2e 1차 실패(재실행 통과)로 가시화된 #CL-23/#CL-27 인증 레이스 잔여. 아래 상세 참조 |
+| 🟢 P4 | **CI 액션 Node.js 20 deprecation** | `.github/workflows/*.yml` 액션 버전 갱신 | 2026-06-02 강제 Node.js 24 전환. `actions/checkout`·`setup-node`·`upload-artifact`·`pnpm/action-setup` |
+
+권장 착수 순서: **P4 global-setup 보강(소규모·빠름)** → P4 CI 액션 → P3 G1 → P3 Driver. P4 둘은 단독·저위험이라 워밍업으로 적합.
+
+---
+
+## P4 global-setup flake — 상세
+
+세션36 머지 후 e2e 1차 실행(run 25970814882)이 `global-setup.ts:133`
+`await context.storageState({ path: AUTH_STATE_PATH })`에서 실패:
+`browserContext.storageState: Navigation to *** is interrupted by another navigation to ***/login`.
+
+- **원인**: `loginWithRetry`는 `loginViaCredentials`의 **throw**만 흡수한다. 로그인이
+  성공(throw 없음)했어도 직후 클라이언트 네비게이션이 in-flight인 상태에서
+  `storageState()`가 호출되면, 세션 미확정 페이지가 `/login`으로 리다이렉트되며 레이스.
+- **재실행 결과**: 동일 코드·환경에서 167/0 통과 → flake 확정. 코드 무관(consumer 앱 미변경).
+- **처리 방향**: line 133 직전에 `await page.waitForLoadState('networkidle')`(또는
+  로그인 후 안착 페이지의 명시적 안정 대기)를 넣어 레이스 창을 닫는다. `loginViaCredentials`
+  helper(`tests/_helpers/auth.ts`) 내부에서 처리할지 global-setup에서 처리할지 검토.
+
+---
+
+## T0. 진입 — 현황 재확인 (먼저 수행)
+
+- [ ] 최신 `e2e.yml` run 확인 — `gh run list --workflow=e2e.yml`. 167/0 유지 여부.
+  - gh CLI 경로: `C:\Program Files\GitHub CLI\gh.exe` (PATH 미등록 — `&` 호출 연산자)
+  - 세션36 베이스라인: run 25970814882 (167 passed / 0 failed / 11 skipped).
+- [ ] `docs/memory.md` 라인 수 확인 — 약 52라인. 200라인 한도 여유 있음.
+- [ ] `docs/CRITICAL_LOGIC.md` 라인 수 확인 — 약 311라인. 1000라인 한도 여유 있음.
+- [ ] `docs/BACKLOG.md` §12-1 우선순위 표에서 P3·P4 상태 확인.
+- [ ] **정합성 검토**: 167/0에서 회귀했다면 잔여 착수 전 회귀 원인 우선 처리.
+
+---
+
+## 세션 종료 시
+
+- [ ] `docs/BACKLOG.md` §12 — 처리한 항목 완료 체크 + 변경 이력.
+- [ ] 설계 결정 발생 시 `docs/CRITICAL_LOGIC.md` 신규 #CL 기록 (현재 #CL-32까지).
+- [ ] `docs/memory.md` 세션37 섹션 갱신.
+- [ ] 다음 진입점(`session38-prep.md`) 갱신 + `BACKLOG.md` §12 진입점 링크 수정.
+
+## 참조
+
+- 한도 정책: `docs/CRITICAL_LOGIC.md` #CL-29 · 활성 결정 로그(#CL-19~#CL-32)
+- seller 프론트 구조(#CL-32): `apiJson` 사용·공통 UI 컴포넌트·`useAdminList`·`useOrderStatusUpdate`
+- e2e 인증 패턴(storageState): `docs/memory.md` 「e2e 인증 패턴」 절
+- 베이스라인 풀런: run 25970814882 (167 passed / 0 failed / 11 skipped)
+- e2e 워크플로: `.github/workflows/e2e.yml` · 동기화 `sync-preview.yml`

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -10,11 +10,11 @@
 ## 진행 현황
 
 세션22까지 + 세션23~36 완료. 직전 **세션35** = docs 정리, **세션36** = seller 프론트엔드 리팩토링 5-Phase (#CL-32).
-e2e 베이스라인 **167 passed / 0 failed / 11 skipped** (run 25966655016). 설계 결정 정본은 `docs/CRITICAL_LOGIC.md` #CL-19~#CL-32, 세션별 상세는 아카이브.
+e2e 베이스라인 **167 passed / 0 failed / 11 skipped** (run 25970814882, 세션36 머지 후). 설계 결정 정본은 `docs/CRITICAL_LOGIC.md` #CL-19~#CL-32, 세션별 상세는 아카이브.
 
-**다음 세션 진입점**: SSOT `docs/BACKLOG.md` §12.
-잔여 **P3 기능 2건**: G1 거점 수정 페이지(`hubs/[id]`) · Driver Kakao Maps SDK.
-(P0·P1·P2 + e2e 안정성 + `/admin/banner` + consumer 강한비번 + seller 프론트 리팩토링 종결. P2-B는 #CL-30으로 moot.)
+**다음 세션 진입점**: `docs/archive/sessions/session37-prep.md` · SSOT `docs/BACKLOG.md` §12.
+잔여: **P3 기능 2건**(G1 거점 수정 페이지 `hubs/[id]` · Driver Kakao Maps SDK) + **P4 정비 2건**(global-setup flake 보강 · CI 액션 Node.js 20 deprecation — 세션36 관찰 등재).
+(P0·P1·P2·P3 구조 + e2e 안정성 + `/admin/banner` + consumer 강한비번 + seller 프론트 리팩토링 종결. P2-B는 #CL-30으로 moot.)
 
 ---
 


### PR DESCRIPTION
## 개요
세션36(seller 프론트 리팩토링 #CL-32) 후속. 문서만 변경 — 코드·빌드 영향 없음.

## 변경
- **`BACKLOG.md` §12**: `useOrderActions` 통합 항목 완료 처리(#CL-32). P4 2건 신규 등재 — 우선순위 표 + 상세 절.
  - global-setup flake 보강 — `storageState` 직전 navigation 안정 대기
  - CI 액션 Node.js 20 deprecation 대응 (2026-06-02 강제 전환)
- **`session37-prep.md` 신설**: P3 잔여 2건 + P4 2건 핸드오프, 권장 착수 순서, global-setup flake 상세.
- **`memory.md`**: e2e 베이스라인 run 25970814882로 갱신, 진입점 링크 session37-prep로 변경.

🤖 Generated with [Claude Code](https://claude.com/claude-code)