### PR TITLE
[#CL-55] 고정 프리뷰 e2e 날짜 검증 KST 보정

### DIFF
--- a/apps/e2e/tests/seller-settlements.spec.ts
+++ b/apps/e2e/tests/seller-settlements.spec.ts
@@ -1,112 +1,116 @@
-import { test, expect } from '@playwright/test'
-import { AUTH_STATE_PATH } from './_helpers/auth'
+import { expect, test } from '@playwright/test';
+import { AUTH_STATE_PATH } from './_helpers/auth';
 
-const BASE = process.env['SELLER_BASE'] ?? 'https://seller.greenlove.co.kr'
+const BASE = process.env.SELLER_BASE ?? 'https://seller.greenlove.co.kr';
+const KST_OFFSET_MS = 9 * 60 * 60 * 1000;
+
+function toDateStrKST(date: Date): string {
+  return new Date(date.getTime() + KST_OFFSET_MS).toISOString().slice(0, 10);
+}
 
 // ── 비인증 ────────────────────────────────────────────────────────────────────
 
 test.describe('셀러 정산 관리 — 공개', () => {
   test('미인증 접근 시 login 리디렉션', async ({ page }) => {
-    await page.goto(`${BASE}/settlements`)
-    await expect(page).toHaveURL(/login|signin|auth/, { timeout: 10_000 })
-  })
-})
+    await page.goto(`${BASE}/settlements`);
+    await expect(page).toHaveURL(/login|signin|auth/, { timeout: 10_000 });
+  });
+});
 
 // ── 인증 후 ───────────────────────────────────────────────────────────────────
 
-const sellerEmail = process.env['TEST_SELLER_EMAIL']
-const sellerPassword = process.env['TEST_SELLER_PASSWORD']
-const skipAuth = !sellerEmail || !sellerPassword
+const sellerEmail = process.env.TEST_SELLER_EMAIL;
+const sellerPassword = process.env.TEST_SELLER_PASSWORD;
+const skipAuth = !sellerEmail || !sellerPassword;
 
 test.describe('셀러 정산 관리 — 인증', () => {
   // #CL-23: globalSetup이 발급한 세션 쿠키 재사용 — spec별 로그인 호출 제거
-  test.use({ storageState: AUTH_STATE_PATH })
+  test.use({ storageState: AUTH_STATE_PATH });
 
-  test.skip(skipAuth, '환경변수 TEST_SELLER_EMAIL / TEST_SELLER_PASSWORD 필요')
+  test.skip(skipAuth, '환경변수 TEST_SELLER_EMAIL / TEST_SELLER_PASSWORD 필요');
 
   // ── 페이지 구조 ───────────────────────────────────────────────────────────
 
   test('정산 관리 헤더 렌더링', async ({ page }) => {
-    await page.goto(`${BASE}/settlements`)
-    await expect(page.locator('text=정산 관리')).toBeVisible({ timeout: 10_000 })
-  })
+    await page.goto(`${BASE}/settlements`);
+    await expect(page.locator('text=정산 관리')).toBeVisible({ timeout: 10_000 });
+  });
 
   test('탭 3개 렌더링 (일별 요약·기간별 조회·주문별 상세)', async ({ page }) => {
-    await page.goto(`${BASE}/settlements`)
-    await expect(page.locator('text=정산 관리')).toBeVisible({ timeout: 10_000 })
+    await page.goto(`${BASE}/settlements`);
+    await expect(page.locator('text=정산 관리')).toBeVisible({ timeout: 10_000 });
     for (const label of ['일별 요약', '기간별 조회', '주문별 상세']) {
-      await expect(page.locator(`text=${label}`)).toBeVisible()
+      await expect(page.locator(`text=${label}`)).toBeVisible();
     }
-  })
+  });
 
   // ── G3: 일별 날짜 선택기 ──────────────────────────────────────────────────
 
   test('G3 — 일별 요약 탭에 날짜 선택기(date input) 렌더링', async ({ page }) => {
-    await page.goto(`${BASE}/settlements`)
-    await expect(page.locator('text=정산 관리')).toBeVisible({ timeout: 10_000 })
-    await page.locator('text=일별 요약').click()
+    await page.goto(`${BASE}/settlements`);
+    await expect(page.locator('text=정산 관리')).toBeVisible({ timeout: 10_000 });
+    await page.locator('text=일별 요약').click();
 
     // date input 존재 확인
-    await expect(page.locator('input[type="date"]').first()).toBeVisible({ timeout: 5_000 })
-  })
+    await expect(page.locator('input[type="date"]').first()).toBeVisible({ timeout: 5_000 });
+  });
 
   test('G3 — 날짜 선택기 max 값이 오늘 이하', async ({ page }) => {
-    await page.goto(`${BASE}/settlements`)
-    await expect(page.locator('text=정산 관리')).toBeVisible({ timeout: 10_000 })
-    await page.locator('text=일별 요약').click()
+    await page.goto(`${BASE}/settlements`);
+    await expect(page.locator('text=정산 관리')).toBeVisible({ timeout: 10_000 });
+    await page.locator('text=일별 요약').click();
 
-    const today = new Date().toISOString().split('T')[0]
-    const maxAttr = await page.locator('input[type="date"]').first().getAttribute('max')
-    expect(maxAttr).toBe(today)
-  })
+    const today = toDateStrKST(new Date());
+    const maxAttr = await page.locator('input[type="date"]').first().getAttribute('max');
+    expect(maxAttr).toBe(today);
+  });
 
   test('G3 — 날짜 변경 시 JS 에러 없음', async ({ page }) => {
-    const errors: string[] = []
-    page.on('pageerror', (e) => errors.push(e.message))
+    const errors: string[] = [];
+    page.on('pageerror', (e) => errors.push(e.message));
 
-    await page.goto(`${BASE}/settlements`)
-    await expect(page.locator('text=정산 관리')).toBeVisible({ timeout: 10_000 })
-    await page.locator('text=일별 요약').click()
+    await page.goto(`${BASE}/settlements`);
+    await expect(page.locator('text=정산 관리')).toBeVisible({ timeout: 10_000 });
+    await page.locator('text=일별 요약').click();
 
-    const yesterday = new Date(Date.now() - 86400000).toISOString().split('T')[0]
-    await page.locator('input[type="date"]').first().fill(yesterday)
-    await page.waitForTimeout(1_000)
+    const yesterday = toDateStrKST(new Date(Date.now() - 86400000));
+    await page.locator('input[type="date"]').first().fill(yesterday);
+    await page.waitForTimeout(1_000);
 
-    expect(errors).toHaveLength(0)
-  })
+    expect(errors).toHaveLength(0);
+  });
 
   test('G3 — 날짜 변경 후 날짜 레이블 갱신', async ({ page }) => {
-    await page.goto(`${BASE}/settlements`)
-    await expect(page.locator('text=정산 관리')).toBeVisible({ timeout: 10_000 })
-    await page.locator('text=일별 요약').click()
+    await page.goto(`${BASE}/settlements`);
+    await expect(page.locator('text=정산 관리')).toBeVisible({ timeout: 10_000 });
+    await page.locator('text=일별 요약').click();
 
     // 어제 날짜로 변경
-    const yesterday = new Date(Date.now() - 86400000)
-    const yesterdayStr = yesterday.toISOString().split('T')[0]
-    const yesterdayDay = yesterday.getDate().toString()
+    const yesterdayStr = toDateStrKST(new Date(Date.now() - 86400000));
+    const yesterdayDay = String(Number(yesterdayStr.slice(8, 10)));
 
-    await page.locator('input[type="date"]').first().fill(yesterdayStr)
-    await page.waitForTimeout(300)
+    await page.locator('input[type="date"]').first().fill(yesterdayStr);
+    await page.waitForTimeout(300);
 
     // 날짜 레이블에 어제 일(day) 숫자가 포함되어야 함
-    const labelLocator = page.locator(`text=${yesterdayDay}일`)
-    await expect(labelLocator.first()).toBeVisible({ timeout: 3_000 })
-  })
+    const labelLocator = page.locator(`text=${yesterdayDay}일`);
+    await expect(labelLocator.first()).toBeVisible({ timeout: 3_000 });
+  });
 
   // ── 탭 전환 ──────────────────────────────────────────────────────────────
 
   test('탭 전환 시 JS 에러 없음', async ({ page }) => {
-    const errors: string[] = []
-    page.on('pageerror', (e) => errors.push(e.message))
+    const errors: string[] = [];
+    page.on('pageerror', (e) => errors.push(e.message));
 
-    await page.goto(`${BASE}/settlements`)
-    await expect(page.locator('text=정산 관리')).toBeVisible({ timeout: 10_000 })
+    await page.goto(`${BASE}/settlements`);
+    await expect(page.locator('text=정산 관리')).toBeVisible({ timeout: 10_000 });
 
     for (const label of ['기간별 조회', '주문별 상세', '일별 요약']) {
-      await page.locator(`text=${label}`).click()
-      await page.waitForTimeout(500)
+      await page.locator(`text=${label}`).click();
+      await page.waitForTimeout(500);
     }
 
-    expect(errors).toHaveLength(0)
-  })
-})
+    expect(errors).toHaveLength(0);
+  });
+});

--- a/docs/CRITICAL_LOGIC.md
+++ b/docs/CRITICAL_LOGIC.md
@@ -921,3 +921,13 @@ P2-A(Railway `/auth/login` latency 계측)는 세션28·29·30에 3회 이월된
 
 **후속 범위 승격 결정 (2026-05-28)**: 사용자가 본 PR 범위에서 제외됐던 T7(판매자 상세 드릴다운)과 T8(플랫폼 기본 수수료율 설정)을 향후 구현 작업으로 등록하도록 확정했다. 두 작업은 PR-A~E의 종결 상태를 변경하지 않으며, 각각 집계 API·라우트 및 전역 config·적용 정책이라는 새 계약을 포함하므로 `docs/BACKLOG.md` 미완료 항목으로 승격하고 구현 전 별도 SDD 작성을 게이트로 둔다.
 
+---
+
+## [#CL-55 / 머지 후 CI] 고정 preview 정산 날짜 검증의 KST 계약 교정 (2026-05-28)
+
+**관찰**: PR #3 병합 뒤 `Sync preview branch`는 SHA 일치 배포까지 성공했지만, 후속 `E2E Tests` 실행 `26526534062`는 기존 `seller-settlements.spec.ts` 한 건에서만 실패했다. CI 실행 시각은 UTC `2026-05-27`이지만 앱의 날짜 선택기는 `todayKST()` 계약에 따라 `2026-05-28`을 노출해, 테스트의 UTC 기대값이 실제 제품 계약보다 하루 뒤처졌다.
+
+**결정**: 정산 e2e 날짜 입력 기대값을 앱과 같은 UTC+9 날짜 문자열 계산으로 통일한다. `max` 단언뿐 아니라 어제 날짜 입력·레이블 단언도 같은 보조 함수로 계산해 KST 자정 경계에서 재발하지 않게 한다. admin stores 신규 스펙의 CI 건너뜀은 Actions에 `TEST_ADMIN_EMAIL/PASSWORD` 시크릿이 없는 기존 구성 때문이며, PR-E의 인증 가능한 임시 프리뷰 16/16 검증 근거는 유지한다.
+
+**사전 검증**: 변경 스펙 `biome check` 통과 · 인증 가능한 프리뷰 대상으로 `seller-settlements.spec.ts`와 `admin-stores-filter-sort.spec.ts`를 함께 실행해 `chromium` **16/16 통과**.
+

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -9,6 +9,9 @@
 
 ## 진행 현황
 
+**2026-05-28 후속 작업 (어드민 stores PR #3 병합 후 고정 preview CI 교정 #CL-55)**:
+- PR #3은 `main`에 merge commit `c982ad5`로 반영됐고 `preview` SHA `d6aaf60` 배포 동기화도 통과했다. 후속 e2e `26526534062`는 신규 stores가 아닌 기존 정산 날짜 단언 한 건에서 UTC `2026-05-27` 대 KST `2026-05-28` 불일치로 실패해, `seller-settlements.spec.ts` 기대값을 앱의 KST 계약과 맞췄다. 변경 스펙 biome 및 인증 프리뷰 대상 정산+stores `chromium` **16/16 통과**. Actions에 admin 인증 시크릿은 없어 CI admin 사례는 기존대로 skip되며, PR-E 임시 프리뷰 16/16 실행 근거와 육안 잔여 위임은 유지한다.
+
 **2026-05-28 후속 작업 (어드민 stores 탭 PR-E E1 프리뷰 실행 검증 종결 #CL-55)**:
 - PR-D 육안 위임 상태에서 진행한 `admin-stores-filter-sort.spec.ts`는 인증 컨텍스트를 재사용하되 `GET /admin/stores` fixture와 `PATCH /commission` 가로채기로 운영 쓰기를 차단한다. 작업 트리를 seller 임시 프리뷰 `greenhub-seller-blkcqzhnf-jos-projects-d1cecc0c.vercel.app`에 배포해 `READY`를 확인하고 실행했으며, 실행 중 Mantine `Select`에 대한 모호한 label 선택자와 내부 키 단언 결함을 `combobox` 정확 역할·표시값 단언으로 교정했다. **정합성**: 관련 biome 통과, seller vitest 9/9, 4앱 tsc 0, seller build 통과, Playwright 수집 16건, 프리뷰 런타임 **16/16 통과**(27.3초). **잔여**: `pending-visual-verify.md`의 운영 상태변경·NumberInput 시각/실저장 육안 항목만 유지.
 - 사용자 확정 후속 구현: 본 범위에서 제외됐던 **T7 판매자 상세 드릴다운**과 **T8 플랫폼 기본 수수료율 설정**을 `BACKLOG.md` §1-8·§12-1 미완료 작업으로 등록했다. PR-A~E 종결은 유지하며, 두 작업 모두 새 API/데이터 정책을 포함하므로 착수 전 별도 SDD가 필수다.


### PR DESCRIPTION
## 원인
PR #3 병합 후 고정 `preview` 동기화와 SHA 일치 배포는 성공했으나, e2e 실행 `26526534062`가 기존 정산 날짜 단언 한 건에서 실패했습니다. 앱은 KST 오늘(`2026-05-28`)을 노출하는데 테스트가 UTC 오늘(`2026-05-27`)을 기대한 경계 시간대 결함입니다.

## 변경 사항
- `seller-settlements.spec.ts`의 날짜 계산을 앱의 KST 계약과 동일한 UTC+9 문자열 계산으로 통일했습니다.
- `max` 단언, 어제 날짜 입력, 날짜 레이블 단언이 동일 기준을 사용하도록 맞췄습니다.
- CI 발견 경위와 인증 시크릿 부재로 admin CI 스펙이 건너뛰어지는 현재 구성 상태를 결정 로그와 메모리에 기록했습니다.

## 검증
- `pnpm exec biome check apps/e2e/tests/seller-settlements.spec.ts`: 통과
- 인증 가능한 프리뷰 대상 `pnpm --filter e2e exec playwright test seller-settlements admin-stores-filter-sort --project=chromium`: 16/16 통과
- 제약 확인: 수정 테스트 116라인, `docs/CRITICAL_LOGIC.md` 933라인, `docs/memory.md` 184라인

## 제외 범위
- `pending-visual-verify.md`의 육안 검증은 미완료 상태로 유지합니다.
- CI Actions에는 `TEST_ADMIN_EMAIL/PASSWORD` 시크릿이 없어 admin 사례는 기존 구성상 건너뜁니다. PR-E stores 스펙의 인증 실행 근거는 앞선 프리뷰 16/16과 본 브랜치 대상 실행으로 보존됩니다.