### PR TITLE
문서: Preview auth URL 정책 분리

### DIFF
--- a/docs/CRITICAL_LOGIC.md
+++ b/docs/CRITICAL_LOGIC.md
@@ -933,3 +933,20 @@ P2-A(Railway `/auth/login` latency 계측)는 세션28·29·30에 3회 이월된
 
 **병합 후 종결**: 보정 커밋 `1a924a7`을 PR #4로 merge(`8827b87`)한 뒤 `Sync preview branch` 실행 `26527167757`이 SHA 일치 고정 preview 배포를 통과했고, 이어진 `E2E Tests` 실행 `26527463226`도 성공했다. `pending-visual-verify.md`의 육안 잔여는 본 자동 종결과 분리해 미완료로 유지한다.
 
+---
+
+## [결정 #CL-56] 카카오 Preview callback은 stable branch Preview alias 기준으로만 허용한다 (2026-07-01)
+
+**배경**: PR #7 수동 smoke에서 consumer와 driver Preview는 production callback으로, seller Preview는 커밋별 Vercel URL callback으로 잡혔다. 세 앱의 `auth.ts`는 모두 `trustHost: true`와 Kakao provider를 사용하므로 코드 분기가 원인이 아니었다. `vercel env ls` 확인 결과 consumer와 driver는 Preview에도 `NEXTAUTH_URL`이 있고, seller는 Preview `NEXTAUTH_URL`이 없어 Auth.js가 현재 요청 Host를 기준으로 callback을 만든 것으로 판단했다.
+
+**결정**:
+1. 카카오 Redirect URI에는 production 도메인, local 개발 URL, 기존 project alias, 승인된 stable branch Preview alias만 등록한다.
+2. 커밋별 Preview URL은 매 배포마다 바뀌므로 등록 금지한다.
+3. Preview 로그인 완료 smoke가 필요하면 stable branch Preview alias 또는 Auth.js redirect proxy 정책을 별도 승인 후 사용한다.
+4. `VERCEL_URL`은 커밋별 deployment URL이므로 OAuth callback 기준으로 사용하지 않는다.
+5. `AUTH_URL`과 `NEXTAUTH_URL`은 같은 의미로 취급하며 서로 다른 값을 동시에 두지 않는다.
+
+**범위 분리**: 이 결정은 PR #7의 카카오 서버 검증 보강과 k6 부하테스트 범위에 섞지 않는다. 별도 브랜치 `codex/preview-auth-url-policy`에서 문서 정책 PR로 다룬다.
+
+**연관 문서**: [Preview Auth URL 정책](specs/ops/preview-auth-url-policy.md), [URLS.md](URLS.md).
+

--- a/docs/URLS.md
+++ b/docs/URLS.md
@@ -45,12 +45,24 @@
 
 ### Vercel 환경변수
 
-| 앱 | 변수명 | 값 |
-|----|--------|-----|
-| consumer | `NEXTAUTH_URL` | `https://greenlove.co.kr` |
-| seller | `NEXTAUTH_URL` | `https://seller.greenlove.co.kr` |
-| driver | `NEXTAUTH_URL` | `https://driver.greenlove.co.kr` |
-| 전체 | `NEXT_PUBLIC_API_URL` | `https://api-production-13e7.up.railway.app` |
+> 적용 환경은 2026-07-01 `vercel env ls` 기준이다. 값 자체는 내려받지 않았다.
+
+| 앱 | 변수명 | 문서 기준값 | 적용 환경 |
+|----|--------|-------------|-----------|
+| consumer | `NEXTAUTH_URL` | `https://greenlove.co.kr` | Production, Preview, Development |
+| seller | `NEXTAUTH_URL` | `https://seller.greenlove.co.kr` | Production, Development |
+| driver | `NEXTAUTH_URL` | `https://driver.greenlove.co.kr` | Production, Preview, Development |
+| 전체 | `NEXT_PUBLIC_API_URL` | `https://api-production-13e7.up.railway.app` | Production, Preview, Development |
+
+### Preview Auth URL 정책
+
+상세 정책은 `docs/specs/ops/preview-auth-url-policy.md`를 따른다.
+
+- Production 로그인은 앱별 production 도메인을 callback 기준으로 유지한다.
+- Preview에서 카카오 로그인 완료 smoke가 필요하면 stable branch Preview alias만 승인 대상으로 삼는다.
+- 커밋별 Preview URL은 카카오 Redirect URI에 등록하지 않는다.
+- `VERCEL_URL`은 커밋별 deployment URL이므로 OAuth callback 기준으로 사용하지 않는다.
+- `AUTH_URL`과 `NEXTAUTH_URL`은 같은 의미로 취급하며, 둘을 서로 다른 값으로 두지 않는다.
 
 ### Railway 환경변수
 
@@ -59,6 +71,9 @@
 | `CORS_ORIGIN` | `https://greenlove.co.kr,https://seller.greenlove.co.kr,https://driver.greenlove.co.kr` |
 
 ### 카카오 Redirect URI 전체 목록
+
+아래 목록은 production, 기존 Vercel project alias, local 개발 URL만 관리한다. 커밋별 Preview URL은 등록 금지다.
+stable branch Preview alias(`*-git-preview-*`)는 Preview 로그인 완료 smoke를 승인할 때만 별도로 추가한다.
 
 - `https://greenlove.co.kr/api/auth/callback/kakao`
 - `https://seller.greenlove.co.kr/api/auth/callback/kakao`

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -9,6 +9,9 @@
 
 ## 진행 현황
 
+**2026-07-01 후속 작업 (카카오 Preview auth URL 정책 분리 #CL-56)**:
+- PR #7 Draft 범위와 섞지 않기 위해 `origin/main`에서 `codex/preview-auth-url-policy` 브랜치를 별도로 생성했다. consumer/driver는 Preview에도 `NEXTAUTH_URL`이 있어 production callback으로, seller는 Preview `NEXTAUTH_URL` 부재로 커밋별 Preview callback으로 잡히는 차이를 확인했다. 정책은 커밋별 Preview URL의 카카오 Redirect URI 등록 금지, Preview 완료 smoke는 stable branch Preview alias 또는 Auth.js redirect proxy 승인 후 진행으로 정리했다. 문서: `docs/specs/ops/preview-auth-url-policy.md`, 결정 로그 #CL-56, `docs/URLS.md` Preview Auth URL 정책.
+
 **2026-05-28 후속 작업 (어드민 stores PR #3 병합 후 고정 preview CI 교정 #CL-55)**:
 - PR #3은 `main`에 merge commit `c982ad5`로 반영됐고, 고정 preview CI에서 드러난 기존 정산 날짜 UTC/KST 결함은 PR #4(`1a924a7`, merge `8827b87`)로 교정했다. 변경 스펙 biome 및 인증 프리뷰 대상 정산+stores `chromium` **16/16 통과**, `Sync preview branch` `26527167757`과 후속 `E2E Tests` `26527463226`도 **성공**했다. Actions에 admin 인증 시크릿은 없어 CI admin 사례는 기존대로 skip되며, PR-E 인증 프리뷰 실행 근거와 육안 잔여 위임은 유지한다.
 
@@ -71,7 +74,7 @@
 
 **세션68~69 (UX-11 orderNumber 통합 종결, `cf79560`+`a3ea5ba`, #CL-41)**:
 - **세션68(T7~T11, `cf79560`)**: shared `Order.orderNumber?:string`(T7)·`orders-create.service` 트랜잭션 내 `orderCounters/YYYYMMDD` 카운터로 `YYYYMMDD-NNNNNN` 발급(카운터 read를 첫 read로 배치=write 전 read 규칙)+응답 본문 포함(T8/T9)·프론트 표시 5곳 폴백 `orderNumber ?? <ID>`(셀러 OrderCard·OrderInfoSection·admin+AdminOrder타입, 소비자 mypage상세·결제성공)(T10)·드라이버 OrderCard는 buyerName 표시라 변경 불필요(T11). 빌드 부산물 동반 커밋(shared dist `.d.ts/.map` Railway 빌드용·seller sw.js) — 직전 BUG-16 커밋·`426e87e` 선례 따라 1커밋 포함.
-- **세션69(T12~T14, `a3ea5ba`)**: T12 `seed-e2e-orders.mjs` 3주문에 `orderNumber` 주입(`20260101-00000{1,2,3}` 고정 과거일자 prefix로 실데이터 카운터 충돌 회피·멱등 set)+`seller-parcel-ship.spec.ts`에 `주문 20260101-000003` 노출 회귀 가드 1건. T13 #CL-41 등재(CRITICAL_LOGIC 557행). 
+- **세션69(T12~T14, `a3ea5ba`)**: T12 `seed-e2e-orders.mjs` 3주문에 `orderNumber` 주입(`20260101-00000{1,2,3}` 고정 과거일자 prefix로 실데이터 카운터 충돌 회피·멱등 set)+`seller-parcel-ship.spec.ts`에 `주문 20260101-000003` 노출 회귀 가드 1건. T13 #CL-41 등재(CRITICAL_LOGIC 557행).
 - **검증**: 세션68 정적검증 전건 통과(shared 빌드 clean·API tsc/build exit 0·API테스트 2/2·셀러23·소비자13·드라이버7 라우트·셀러 biome 0e/2w). **e2e 풀런 — 자동 dispatch(26270139186) parcel spec 1건 실패 = stale preview**(sync-preview 완료 직후 시작, 세션60·61 패턴 재현), **수동 dispatch(26270156134) 30초 후 시작 → 176 passed/0 failed, parcel-ship:22 회귀가드 ✓**. 로컬 멱등 시드 재실행으로 Firestore에 orderNumber 주입 후 통과(e2e.yml seed 단계 부재 갭 여전).
 - **T14 사용자 수동 잔여 2건(자동화 불가)**: ① 운영 기존 주문(orderNumber 없음) 셀러·소비자 ID 폴백 정상 표시 스크린샷 ② 신규 주문 1건 발생 시 `orderCounters/YYYYMMDD` seq 생성·증가 Console 확인(첫 쓰기 Firestore 권한 전제).
 - **범위 외(#CL-41)**: 카운터 TTL/정리·백필 스크립트(결정③ ID폴백)·결제수단별 prefix·취소 시 번호 보존.

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -3,7 +3,7 @@
 > **SSOT** — 세션 종료 시 최신화. 200라인 초과 시 50라인 이내 요약 후 아카이브.
 > 아카이브: `archive/memory_archive_20260425.md` · `archive/memory_archive_20260517.md` (세션22~34 상세)
 
-최종 수정: 2026-05-28 (어드민 stores PR-E 머지·고정 preview CI 종결 #CL-55)
+최종 수정: 2026-07-01 (카카오 Preview auth URL 정책 분리 #CL-56)
 
 ---
 

--- a/docs/specs/ops/preview-auth-url-policy.md
+++ b/docs/specs/ops/preview-auth-url-policy.md
@@ -1,0 +1,185 @@
+# Preview Auth URL 정책
+
+> 작성일: 2026-07-01
+> 상태: Draft
+> 범위: consumer, seller, driver Preview 카카오 로그인 callback URL 정책
+
+---
+
+## 1. 배경
+
+PR #7 수동 smoke에서 세 앱 모두 `/login` 로드와 카카오 authorize 진입은 확인됐지만, Preview 안에서 로그인 완료까지 검증할 수 없었다.
+
+- consumer Preview: `redirect_uri`가 `https://greenlove.co.kr/api/auth/callback/kakao`로 잡힘
+- seller Preview: `redirect_uri`가 커밋별 Preview URL로 잡혀 카카오 `KOE006` 차단
+- driver Preview: `redirect_uri`가 `https://driver.greenlove.co.kr/api/auth/callback/kakao`로 잡힘
+
+세 앱의 `auth.ts`는 모두 `trustHost: true`와 Kakao provider를 사용하며, 로그인 버튼은 상대 경로만 넘긴다. 따라서 차이는 앱 코드 분기가 아니라 Vercel 환경변수와 Auth.js host 판단 정책에서 발생한다.
+
+## 2. 조사 결과
+
+### 2-1. 코드 기준
+
+세 앱은 모두 `NEXTAUTH_URL`, `AUTH_URL`, `VERCEL_URL`을 코드에서 직접 읽지 않는다.
+
+- `apps/consumer/src/auth.ts`: `trustHost: true`, Kakao provider, `targetRole: 'consumer'`
+- `apps/seller/src/auth.ts`: `trustHost: true`, Kakao provider, `targetRole: 'seller'`
+- `apps/driver/src/auth.ts`: `trustHost: true`, Kakao provider, `targetRole: 'driver'`
+
+Auth.js v5는 `AUTH_URL`을 `NEXTAUTH_URL` alias로 취급한다. `trustHost: true`는 요청 Host를 신뢰하도록 하며, stable URL이 없으면 현재 요청 Host 기반 callback이 만들어질 수 있다.
+
+### 2-2. Vercel 환경변수 기준
+
+`vercel env ls`로 변수명과 적용 환경만 확인했다. 값 자체는 내려받지 않았다.
+
+| 앱 | `NEXTAUTH_URL` 적용 환경 | Preview smoke 결과와의 관계 |
+| --- | --- | --- |
+| consumer | Production, Preview, Development | Preview에서도 production consumer callback 사용 |
+| seller | Production, Development | Preview에서 현재 요청 Host, 즉 커밋별 Preview callback 사용 |
+| driver | Production, Preview, Development | Preview에서도 production driver callback 사용 |
+
+### 2-3. 기존 운영 문서 기준
+
+`docs/URLS.md`에는 production 도메인과 기존 Vercel project alias가 카카오 Redirect URI 목록에 함께 기록돼 있다. 반면 커밋별 Preview URL은 매 배포마다 바뀌므로 목록 관리 대상이 될 수 없다. branch Preview alias(`*-git-preview-*`)는 Preview 로그인 완료 smoke를 승인할 때만 별도로 추가한다.
+
+기존 e2e 문서와 결정 로그에는 고정 branch Preview alias(`*-git-preview-*`)와 커밋별 deployment URL이 별개이며, Vercel이 성공한 커밋으로 branch alias를 재포인팅한다는 결정이 있다. 따라서 Preview 완료 smoke를 하려면 커밋별 URL이 아니라 stable branch Preview alias나 Auth.js redirect proxy를 기준으로 해야 한다.
+
+## 3. 운영 정책 제안
+
+### 3-1. 권장 결론
+
+**기본 정책은 production callback만 안정적으로 유지하고, Preview 카카오 완료 smoke는 별도 승인된 stable branch Preview alias에서만 허용한다.**
+
+그 이유는 카카오 Redirect URI가 정확 일치 기반이고, 커밋별 Preview URL은 무한히 늘어나며 운영 콘솔을 오염시키기 때문이다.
+
+### 3-2. 카카오 Redirect URI 등록 정책
+
+| 유형 | 정책 | 이유 |
+| --- | --- | --- |
+| Production 도메인 | 유지 | 실제 사용자 로그인 기준 |
+| 로컬 개발 URL | 유지 | 수동 개발 smoke 기준 |
+| Vercel project alias | 유지 또는 재검토 | 현재 문서에 등록돼 있으나 Preview 완료 smoke 기준과는 별개 |
+| Vercel branch Preview alias | 승인 후 등록 | Preview 완료 smoke가 필요할 때만 사용 |
+| 커밋별 Preview URL | 등록 금지 | 매 배포마다 변경되어 운영 불가 |
+
+### 3-3. `NEXTAUTH_URL`/`AUTH_URL`/`VERCEL_URL` 정책
+
+| 환경 | 정책 |
+| --- | --- |
+| Production | 앱별 production 도메인을 `NEXTAUTH_URL` 또는 `AUTH_URL`로 설정 |
+| Preview 완료 smoke 비대상 | Preview `NEXTAUTH_URL`/`AUTH_URL`을 제거하거나 production callback 사용을 명시 |
+| Preview 완료 smoke 대상 | Preview `NEXTAUTH_URL` 또는 `AUTH_URL`을 stable branch Preview alias로 설정 |
+| 모든 환경 | `VERCEL_URL`을 OAuth callback 기준으로 사용하지 않음 |
+
+`AUTH_URL`과 `NEXTAUTH_URL`은 같은 의미로 취급하므로 둘을 동시에 다른 값으로 두지 않는다. 신규 설정은 `AUTH_URL`로 통일하는 방안을 검토하되, 기존 프로젝트가 `NEXTAUTH_URL`을 쓰고 있으므로 전환은 별도 PR로 둔다.
+
+### 3-4. Preview smoke 단계 정의
+
+| 단계 | 허용 범위 | 조건 |
+| --- | --- | --- |
+| authorize 진입 smoke | 모든 Preview | 카카오 authorize URL 진입과 `redirect_uri` 관찰까지만 |
+| 완료 smoke | stable branch Preview alias 또는 production | 카카오 Redirect URI 등록과 환경변수 정책이 일치할 때만 |
+| k6 부하테스트 | 카카오 OAuth 제외 | seed email/password 또는 사전 발급 JWT만 사용 |
+
+## 4. 아토믹 태스크
+
+### T0. 현재 상태 고정
+
+- 상태: 완료
+- 목표: 앱별 Preview callback 차이 원인을 코드와 Vercel env 기준으로 분리한다.
+- 결과: consumer/driver는 Preview `NEXTAUTH_URL` 존재, seller는 Preview `NEXTAUTH_URL` 부재라는 차이를 확인했다.
+- 검증: `rg`로 앱 코드의 URL 직접 참조 부재 확인, `vercel env ls`로 변수 적용 환경 확인. 2026-07-01 재조회에서도 consumer/driver는 Preview `NEXTAUTH_URL` 존재, seller는 Preview `NEXTAUTH_URL` 부재 상태가 유지됐다.
+
+### T1. 문서 정책 고정
+
+- 상태: 완료
+- 목표: `docs/URLS.md`와 본 문서에 production, stable branch Preview, commit Preview 정책을 분리한다.
+- 결과: 커밋별 Preview URL 등록 금지와 stable branch Preview alias 승인 절차를 명시한다.
+- 검증: 문서에서 `commit Preview`와 `stable branch Preview`가 같은 정책으로 섞이지 않는다.
+
+### T2. Vercel 환경변수 정리안 확정
+
+- 상태: 대기(현황 재확인 완료)
+- 목표: consumer/seller/driver Preview의 `NEXTAUTH_URL` 또는 `AUTH_URL` 운영 방식을 하나로 맞춘다.
+- 선택지:
+  - A. Preview 완료 smoke 비대상: Preview `NEXTAUTH_URL` 제거 또는 production callback 사용 문서화
+  - B. Preview 완료 smoke 대상: 세 앱 모두 stable branch Preview alias로 통일
+- 검증: 변경 승인 후 `vercel env ls`에서 세 앱 Preview 적용 환경이 선택한 정책과 일치해야 한다.
+
+### T3. 카카오 콘솔 Redirect URI 정리
+
+- 상태: 대기
+- 목표: 카카오 Redirect URI 목록을 운영 정책과 일치시킨다.
+- 작업: production, local, 기존 project alias, 승인된 stable branch Preview alias만 남기고 커밋별 URL은 등록하지 않는다.
+- 검증: 카카오 콘솔 목록에 `-<commit-hash>-jos-projects` 형태 URL이 없다.
+
+### T4. Preview 완료 smoke 절차 문서화
+
+- 상태: 대기
+- 목표: Preview에서 어디까지 smoke 가능한지 체크리스트로 고정한다.
+- 작업: authorize 진입 smoke와 완료 smoke를 분리하고, 완료 smoke는 stable branch Preview alias 기준으로만 허용한다.
+- 검증: PR 본문에 "authorize 진입 확인"과 "로그인 완료 확인"이 섞이지 않는다.
+
+### T5. 별도 PR 운영
+
+- 상태: 대기
+- 목표: PR #7의 보안 보강·k6 범위와 Preview auth URL 정책 범위를 분리한다.
+- 작업: `codex/preview-auth-url-policy` 브랜치에서 문서 정책 PR을 만든다.
+- 검증: `git diff origin/main...HEAD`가 문서 정책 파일만 포함한다.
+
+## 5. 정합성 검토
+
+| 항목 | 판정 | 근거 |
+| --- | --- | --- |
+| PR #7 분리 | 통과 | `origin/main`에서 별도 브랜치를 생성해 정책 문서만 다룸 |
+| Production 쓰기 금지 | 통과 | Vercel env 목록 조회만 수행, env 값 변경 없음 |
+| k6 baseline 금지 | 통과 | 부하테스트 실행 없음 |
+| 카카오 반복 호출 금지 | 통과 | 카카오 authorize 재호출 없이 기존 smoke 결과와 설정만 분석 |
+| 앱 역할 범위 | 통과 | consumer/seller/driver만 포함 |
+| hub_staff 제외 | 통과 | main 기준 선행 기능이 아니므로 정책 대상에서 제외 |
+| 커밋별 Preview URL 금지 | 통과 | 등록 금지 정책으로 명시 |
+| Auth.js 기준 | 통과 | `AUTH_URL` alias와 `trustHost` 동작을 문서 기준으로 반영 |
+| Vercel 기준 | 통과 | `VERCEL_URL`은 커밋별 deployment URL이므로 OAuth callback 기준에서 제외 |
+
+## 6. 다음 대화 핸드오프 프롬프트
+
+```text
+C:\Develop\greenhub 작업을 이어서 해줘.
+
+반드시 먼저 읽을 문서:
+- docs/specs/ops/preview-auth-url-policy.md
+- docs/URLS.md
+- docs/CRITICAL_LOGIC.md
+- docs/memory.md
+
+현재 상태:
+- PR #7(`codex/kakao-auth-k6-hardening`)은 Draft 상태로 유지한다.
+- Preview auth URL 정책은 별도 브랜치 `codex/preview-auth-url-policy`에서 문서 PR로 분리한다.
+- `.codex/` 비추적 파일은 로컬 산출물이므로 stage하지 말 것.
+
+조사 결론:
+- consumer와 driver는 Preview에도 `NEXTAUTH_URL`이 있어 Preview에서 production callback으로 잡힌다.
+- seller는 Preview `NEXTAUTH_URL`이 없어 현재 요청 Host, 즉 커밋별 Preview callback으로 잡힌다.
+- 세 앱의 `auth.ts` 구조는 본질적으로 동일하며, 차이는 코드 분기가 아니라 Vercel env 적용 환경이다.
+- 커밋별 Preview URL은 카카오 Redirect URI에 등록하지 않는다.
+- Preview 로그인 완료 smoke가 필요하면 stable branch Preview alias 또는 Auth.js redirect proxy 정책으로 별도 승인 후 진행한다.
+
+이번 목표:
+1. `docs/specs/ops/preview-auth-url-policy.md`의 아토믹 태스크와 정합성 검토를 최신 상태로 확인한다.
+2. `docs/URLS.md`의 Preview auth URL 정책과 카카오 Redirect URI 목록이 충돌하지 않는지 검토한다.
+3. 필요하면 Vercel env 변경안만 제안하고, 실제 env 변경은 사용자 승인 전 실행하지 않는다.
+4. 카카오 콘솔 Redirect URI 변경도 사용자 승인 전 실행하지 않는다.
+5. 문서 PR을 열 준비가 되면 검증 결과와 남은 승인 항목을 PR 본문에 정리한다.
+
+금지:
+- production 쓰기 요청
+- production baseline 부하
+- staging/preview k6 baseline 무승인 실행
+- 카카오 OAuth 반복 호출
+- 커밋별 Preview URL의 카카오 Redirect URI 등록
+- PR #7 범위에 정책 문서를 섞는 것
+
+최소 검증:
+- git diff --check
+- git diff --name-only origin/main...HEAD
+```

--- a/docs/specs/ops/preview-auth-url-policy.md
+++ b/docs/specs/ops/preview-auth-url-policy.md
@@ -169,7 +169,8 @@ C:\Develop\greenhub 작업을 이어서 해줘.
 2. `docs/URLS.md`의 Preview auth URL 정책과 카카오 Redirect URI 목록이 충돌하지 않는지 검토한다.
 3. 필요하면 Vercel env 변경안만 제안하고, 실제 env 변경은 사용자 승인 전 실행하지 않는다.
 4. 카카오 콘솔 Redirect URI 변경도 사용자 승인 전 실행하지 않는다.
-5. 문서 PR을 열 준비가 되면 검증 결과와 남은 승인 항목을 PR 본문에 정리한다.
+5. PR #8 본문에 최신 검증 결과와 남은 승인 항목이 충분히 담겼는지 확인한다.
+6. PR #8을 Ready로 바꿀지는 사용자 승인 후 결정한다.
 
 금지:
 - production 쓰기 요청


### PR DESCRIPTION
﻿## 변경 내용

- Preview 카카오 callback URL 정책 문서를 새로 추가했습니다.
- `docs/URLS.md`에 2026-07-01 `vercel env ls` 기준 `NEXTAUTH_URL` 적용 환경을 명시했습니다.
- 카카오 Redirect URI 목록에서 production, 기존 Vercel project alias, local URL과 승인 대상 stable branch Preview alias를 분리했습니다.
- #CL-56 결정 로그와 `docs/memory.md` 후속 작업 기록을 추가했습니다.

## 검증 결과

- consumer와 driver는 Preview에도 `NEXTAUTH_URL`이 있어 Preview에서 production callback을 사용합니다.
- seller는 Preview `NEXTAUTH_URL`이 없어 현재 요청 Host, 즉 커밋별 Preview callback을 사용합니다.
- 세 앱의 `auth.ts`는 `trustHost: true`와 Kakao provider 구조가 동일하며, `NEXTAUTH_URL`/`AUTH_URL`/`VERCEL_URL`을 직접 읽지 않습니다.
- `docs/URLS.md`의 Redirect URI 목록에는 커밋별 Preview URL이 없습니다.
- 실제 Vercel env 변경, 카카오 콘솔 변경, 카카오 OAuth 반복 호출, k6 baseline 실행은 하지 않았습니다.
- `.codex/` 비추적 로컬 산출물은 stage하지 않았습니다.

## 실행한 검증

- `git diff --check`
- `git diff --name-only origin/main...HEAD`
- `vercel env ls` 목록 조회만 수행: consumer, seller, driver
- `rg "NEXTAUTH_URL|AUTH_URL|VERCEL_URL" apps/consumer/src apps/seller/src apps/driver/src`

## 남은 승인 항목

- Preview 로그인 완료 smoke를 하지 않을 경우: consumer/driver Preview `NEXTAUTH_URL` 유지 또는 제거 중 하나를 운영 정책으로 승인해야 합니다.
- Preview 로그인 완료 smoke를 할 경우: 세 앱의 stable branch Preview alias 기준 `NEXTAUTH_URL` 또는 `AUTH_URL` 설정을 별도 승인해야 합니다.
- stable branch Preview alias를 카카오 Redirect URI에 추가할지 별도 승인해야 합니다.
- Auth.js redirect proxy 정책을 채택할지는 별도 설계와 승인 후 진행해야 합니다.

## 범위 분리

- PR #7(`codex/kakao-auth-k6-hardening`)의 보안 보강 및 k6 범위와 섞지 않는 문서 PR입니다.
