### PR TITLE
문서: consumer 운영 이미지 복구 결과 마감

### DIFF
--- a/docs/plans/PLAN_consumer_image_recovery.md
+++ b/docs/plans/PLAN_consumer_image_recovery.md
@@ -313,8 +313,8 @@
 - **Target**: `docs/plans/REPORT_kakao_business_channel_reapproval.md`
 - **Goal**: 검증된 변경을 main에 병합해 consumer production에 배포한다.
 - **Verify**: `git diff --check -- docs/plans/REPORT_kakao_business_channel_reapproval.md`
-- **Conclusion**: [판정 대기 — merge SHA, consumer 배포 식별자·상태, 비대상 서비스 배포 여부를 기록.]
-- **Status**: todo
+- **Conclusion**: PR #18을 merge commit `e6c2138e3c969616e19f2ba8882c1842a3cf0dfb`로 main에 병합했다. consumer production 배포 `dpl_9LQkxbkSpuHQwYnPTSYdg5L2g14g`와 GitHub deployment `5863377298`은 같은 SHA로 성공했고 운영 도메인 별칭이 연결됐다. seller production 후보 `dpl_3D2gAGP2d6Evez3fQmgsiLnN1wKE`와 driver 후보 `dpl_DSTjpvqChdJKTdrA5nNPsmVUc7td`는 Ignored Build Step으로 취소됐다. seller·driver 최신 production은 이전 SHA `098ad98c`를 유지했고 Railway API의 최신 production deployment도 같은 이전 SHA로 유지됐다.
+- **Status**: done
 
 #### Task 3.3 — 운영 이미지와 로그 재검증 [Unit: Atomic]
 
@@ -325,8 +325,8 @@
 - **Goal**: 운영 원본과 Next 이미지 프록시와 실제 브라우저에서 이미지 복구와 대체 동작을 재확인한다.
 - **Verify**: `node apps/consumer/scripts/verify-public-images.mjs`
 - **Visual Verify**: 운영 홈과 공개 상품 5개 상세를 데스크톱·375×812 모바일로 확인하고 개인정보 영역은 캡처·기록하지 않는다.
-- **Conclusion**: [판정 대기 — 원본·프록시·브라우저 상태, 콘솔과 Vercel 오류 로그 결과를 기록.]
-- **Status**: todo
+- **Conclusion**: 운영 배너와 활성 상품 5개 원본은 6/6 HTTP 200 `image/png`, 운영 Next 이미지 프록시도 HTTP 200 `image/png`이었다. 데스크톱과 375×812 모바일 홈·공개 상품 상세 5개에서 배너·대표·상세·스토어 로고 실제 크기가 모두 양수였고 깨진 이미지 0건, 가로 넘침 없음, 브라우저 애플리케이션 오류 0건이었다. consumer Vercel 최근 1시간 런타임 오류와 배포별 5xx는 모두 0건이었다.
+- **Status**: done
 
 #### Task 3.4 — 문서와 다음 인계 프롬프트 마감 [Unit: Atomic]
 
@@ -336,12 +336,13 @@
 - **Target**: `docs/plans/PROMPT_consumer_image_recovery.md`
 - **Goal**: 최종 branch·HEAD·diff·검증·PR·배포·외부 변경·남은 위험을 다음 인계 프롬프트에 기록한다.
 - **Verify**: `git diff --check -- docs/plans/PROMPT_consumer_image_recovery.md`
-- **Conclusion**: [판정 대기 — 최종 인계 정보와 미완료 게이트를 기록.]
-- **Status**: todo
+- **Conclusion**: branch·기능 HEAD·main merge SHA·diff·검증·PR·배포·Firebase 변경·운영 DB와 외부 서비스 상태·남은 위험을 `PROMPT_consumer_image_recovery.md`에 최종 인계로 갱신했다. 인계 문서 자체의 closeout commit과 main 반영 결과는 최종 응답에 별도로 기록한다.
+- **Status**: done
 
 ## Closeout
 
-- **Status**: todo
+- **Status**: done
 - **완료 조건**: 실제 운영 사진 복구, 강제 실패 대체, consumer 검증, PR·production 배포, 운영 재검증이 모두 통과해야 한다.
-- **차단 조건**: Blaze 전환이 승인되지 않고 대체 저장소도 합의되지 않으면 실제 사진 복구는 완료로 선언하지 않는다.
+- **완료 결과**: 승인된 Blaze 전환으로 기존 원본 접근을 복구했고 실패 대체 처리, 자동·화면 검증, PR·production 배포, 운영 재검증을 모두 통과했다.
+- **차단 조건**: 없음.
 - **별도 계획 조건**: 기존 객체가 유실됐거나 Blaze 전환을 선택하지 않으면 승인된 원본 자산과 저장소 제공자를 정한 새 마이그레이션 Blueprint를 만든다.

--- a/docs/plans/PROMPT_consumer_image_recovery.md
+++ b/docs/plans/PROMPT_consumer_image_recovery.md
@@ -1,85 +1,89 @@
 <!-- Language: ko -->
 
-# consumer 운영 이미지 복구 작업 프롬프트
+# consumer 운영 이미지 복구 최종 인계
 
-아래 내용을 새 작업의 첫 메시지로 그대로 사용한다.
-
----
-
-`C:\Develop\greenhub`의 카카오 심사용 consumer 홈페이지 후속 작업으로 운영 이미지 복구를 수행한다. 모든 응답·작업 설명·코드 주석·문서 내용·commit 메시지는 한국어로 작성한다.
-
-실제 작업 위치:
+## 현재 상태
 
 - worktree: `C:\Users\tazan\.codex\worktrees\7573\greenhub`
 - branch: `codex/kakao-business-channel-proof`
-- 시작 기준 HEAD: `0a02b31806812e85104a409f4284302f64e38c17`
-- 시작 기준 상태: clean
-- 로컬 branch는 원격 작업 branch보다 2개 commit 앞선 상태다.
+- 최종 기능·검증 HEAD: `9be3473e7b54f8dc6a0c71651387bfaf56dc8c50`
+- main 병합 SHA: `e6c2138e3c969616e19f2ba8882c1842a3cf0dfb`
+- PR: #18, `MERGED`
+- 기능 branch는 원격 작업 branch와 동기화됐고 기능·배포 작업 종료 시 작업 트리와 staging은 비어 있었다.
+- 이 인계와 PLAN·REPORT closeout을 담는 문서 commit은 문서 자체가 자신의 SHA를 포함할 수 없으므로 최종 응답과 `git log -1`에서 확인한다.
 
-시작 전 필수 확인:
+## 수행한 변경
 
-1. 지정 worktree에서 branch와 HEAD를 확인한다.
-2. `git status`, 작업 트리 diff, staging diff를 모두 확인한다.
-3. branch, HEAD, clean 상태가 시작 기준과 다르거나 예상하지 못한 변경이 있으면 아무것도 수정하지 말고 즉시 중단해 보고한다.
-4. `apps/consumer/AGENTS.md`, `docs/memory.md`, `docs/plans/PLAN_consumer_image_recovery.md`, `docs/plans/REPORT_kakao_business_channel_reapproval.md`를 먼저 읽는다.
-5. consumer 코드를 수정하기 전에 설치된 Next.js 16 문서에서 현재 Image와 Server·Client Component 규칙을 확인한다.
+- `apps/consumer/src/components/ResilientImage.tsx`
+  - 원본 실패를 한 번 감지해 로컬 이미지 또는 화면별 대체 UI로 전환한다.
+  - 대체 이미지도 실패하면 최종 숨김으로 종료해 무한 재시도를 막는다.
+  - 자유 비율 상세 이미지 실패 시 해당 요소만 숨기는 경계를 포함한다.
+- `HeroBanner`, `ProductCard`, `HomeProductList`, `DeadlineSection`, `ProductImages`, `ProductInfo`, `ProductActions`
+  - 배너 사진 숨김, 상품 로컬 대체 이미지, 상세 이미지 숨김, 스토어 첫 글자 아바타를 적용했다.
+- `apps/consumer/src/components/ResilientImage.test.mjs`
+  - 이미지 실패 계약 5건을 추가했다.
+- `apps/consumer/scripts/verify-public-images.mjs`
+  - 주소와 토큰 없이 구분값·호스트·HTTP 상태·콘텐츠 형식만 출력한다.
+- `docs/plans/PLAN_consumer_image_recovery.md`, `docs/plans/REPORT_kakao_business_channel_reapproval.md`
+  - 승인·구현·검증·배포·운영 결과를 기록했다.
+- `packages/shared`, API, seller, driver 코드는 변경하지 않았다.
 
-확정된 장애 증거:
+## 검증 결과
 
-- 운영 배너와 활성 상품 5개의 이미지 주소는 모두 `firebasestorage.googleapis.com`을 사용한다.
-- 배너와 상품 5개 원본은 모두 HTTP `402 Payment Required`, 콘텐츠 형식 `application/json`을 반환했다.
-- 운영 홈의 배너와 상품 이미지 5개는 로드 완료 상태지만 실제 크기가 `0×0`이었다.
-- 공개 상품 상세 5개에서 대표·상세 이미지와 공통 스토어 로고도 실제 크기가 `0×0`이었다.
-- Vercel 최근 오류 로그와 브라우저 콘솔에는 관련 서버 예외가 없었다.
-- Firebase 공식 정책상 2026년 2월 3일부터 기존 Cloud Storage 버킷 접근에도 Blaze 요금제가 필요하며 Spark 프로젝트의 요청은 `402` 또는 `403`으로 실패한다.
+- 구현 전 계약 RED: 공통 컴포넌트 부재로 종료 코드 1을 확인했다.
+- 이미지 계약 구현 후: 5/5 통과.
+- 관련 consumer 회귀 계약: 17/17 통과, 실패 0건.
+- consumer TypeScript: 종료 코드 0.
+- consumer lint: 오류 0건, 기존 경고 23건.
+- consumer production build: Next.js 16.2.5 compile·TypeScript·정적 페이지 13/13 통과.
+- `git diff --check`: 종료 코드 0.
+- 읽기 전용 원본 검증: 배너와 활성 상품 5개 6/6 HTTP 200, `image/png`.
+- 배포 후보 데스크톱·375×812:
+  - 홈 배너·상품 5개, 상세 5개의 대표·상세·스토어 로고 실제 크기 양수.
+  - 강제 실패 시 배너 사진만 숨고 문구·버튼 유지.
+  - 상품 5개는 로컬 대체 이미지, 자유 비율 상세는 숨김, 스토어 로고는 `디` 아바타로 전환.
+  - 대체 이미지 자체 실패는 최종 숨김으로 종료.
+  - 깨진 이미지 0건, 가로 넘침 없음, 애플리케이션 오류 0건.
+- 운영 재검증:
+  - 원본 6/6과 Next 이미지 프록시 HTTP 200 이미지 응답.
+  - 데스크톱·375×812 홈과 공개 상품 상세 5개 모두 실제 크기 양수.
+  - 깨진 이미지 0건, 가로 넘침 없음, 브라우저 오류 0건.
+  - consumer Vercel 최근 1시간 런타임 오류 0건, production 5xx 0건.
 
-작업 목표:
+## commit·push·PR·배포
 
-1. `docs/plans/PLAN_consumer_image_recovery.md`의 Task를 순서대로 실행한다.
-2. Firebase Storage 접근을 복구해 기존 배너·상품·상세·스토어 사진이 다시 보이게 한다.
-3. 원본 장애가 재발해도 배너는 사진 없이 유지하고 상품은 로컬 대체 이미지, 스토어 로고는 첫 글자 아바타로 표시한다.
-4. consumer 테스트, lint, production build, 데스크톱과 375×812 모바일 검증을 통과한다.
-5. 검증된 consumer 범위만 commit·push·PR·main 병합·production 배포하고 운영 화면과 로그를 재확인한다.
+- `936a5c9` — `consumer 운영 이미지 복구와 실패 대체 처리`
+- `d7afe55` — `consumer 검증기 경로를 앱 범위로 제한`
+- `9be3473` — `이미지 복구 PR 검증 결과 기록`
+- 모두 원격 작업 branch에 push했다.
+- PR #18의 검사가 모두 통과한 뒤 merge commit 방식으로 main에 병합했다.
+- consumer production:
+  - Vercel `dpl_9LQkxbkSpuHQwYnPTSYdg5L2g14g`, `READY`
+  - GitHub deployment `5863377298`, 성공
+  - merge SHA와 일치하고 `greenlove.co.kr` 별칭 연결·HTTP 200 확인
+- seller production 후보 `dpl_3D2gAGP2d6Evez3fQmgsiLnN1wKE`와 driver 후보 `dpl_DSTjpvqChdJKTdrA5nNPsmVUc7td`는 Ignored Build Step으로 취소됐다.
+- seller·driver와 Railway API 최신 production은 이전 SHA `098ad98c`를 유지했다.
+- 루트 `scripts/**`에 검증기를 처음 추가·이동한 두 commit에서는 seller·driver 미리보기가 예상 밖으로 실제 생성됐다. 상태만 확인하고 rollback하지 않았으며 최종 consumer 경로로 옮긴 뒤 seller·driver Ignore 동작을 재확인했다.
 
-승인 범위:
+## Firebase·DB·외부 서비스
 
-- consumer 코드 수정, 테스트, 검증, 한국어 checkpoint commit, push, PR, main 병합과 consumer production 배포는 승인됐다.
-- Firebase Blaze 전환, Cloud Billing 계정 연결, 카드·결제수단 선택, 비용 발생과 예산 설정은 아직 승인되지 않았다.
-- Task 0.2에서 실제 요금제와 Billing 상태를 읽기 전용으로 확인한 뒤 Blaze 전환이 필요하면 예상 영향과 예산 알림 방안을 짧게 보고하고 사용자의 명시적 승인을 요청한다.
-- 비용 변경 승인 전에는 Firebase 플랜이나 Billing 상태를 변경하지 않는다.
+- 사용자 승인 뒤 운영 프로젝트 `green-e4fe3`를 기존 활성 Cloud Billing 계정에 연결했다.
+- 현재 `billingEnabled=true`, 결제 계정 `open=true`, Firebase `Blaze / 사용한 만큼만 지불` 상태다.
+- 운영 프로젝트만 범위로 한정한 월 10,000원 예산과 실제 비용 10·50·90·100% 알림을 만들었다.
+- 다른 Firebase 프로젝트·결제 계정과 결제수단은 변경하거나 닫지 않았다.
+- 기존 상품·배너·스토어 DB 주소와 문서, Firebase Storage 객체는 변경하지 않았다.
+- 카카오 재신청과 카카오 채널·이메일·DNS·ALIGO·공개 소식은 변경하지 않았다.
 
-구현 원칙:
+## 남은 위험과 권장 작업
 
-- 기존 Firebase 이미지 주소와 객체를 보존한 상태에서 접근 복구를 우선한다.
-- Blaze 전환 뒤 기존 원본이 200으로 회복되면 상품·배너·스토어 DB 주소를 수정하지 않는다.
-- 일부 객체가 404 또는 권한 오류라면 정확한 누락 대상만 보고하고 승인된 원본 없이 임의 교체하지 않는다.
-- Blaze 전환이 승인되지 않으면 consumer 실패 대체 처리까지만 진행할 수 있지만 실제 사진 복구 완료로 선언하지 않는다. 저장소 마이그레이션은 별도 계획으로 분리한다.
-- `packages/shared`, API, seller, driver는 변경하지 않는다.
-- 배너 데이터와 문구·동작은 유지하고 이미지 실패 시 사진 구획만 숨긴다.
-- 상품 대표 사진 실패 시 기존 로컬 대체 이미지를 사용한다.
-- 상품 상세의 자유 비율 이미지 실패는 레이아웃을 깨뜨리지 않도록 해당 이미지만 숨긴다.
-- 스토어 로고 실패는 기존 미등록 분기와 같은 첫 글자 아바타로 수렴한다.
-- 대체 이미지 실패가 무한 재시도되지 않도록 실패 전환을 한 번으로 제한한다.
-- 실패 계약을 먼저 추가하고 구현 뒤 통과시킨다.
-- 여러 TSX 컴포넌트를 수정한 뒤 React 접근성·상태·성능 회귀를 점검한다.
+- 예산 알림은 비용을 자동 차단하지 않으며 알림이 지연될 수 있다.
+- Firebase 무료 사용량을 초과하면 사용량 기반 비용이 발생할 수 있으므로 첫 결제 주기 동안 비용과 Storage 사용량을 주기적으로 확인한다.
+- 월 10,000원 예산의 10% 알림이 도착하면 예상 트래픽인지 먼저 확인하고, 이상 사용이면 Storage 요청량과 다운로드량을 조사한다.
+- 카카오 재신청은 승인되지 않았으므로 별도 명시적 요청 전에는 수행하지 않는다.
 
-검증 원칙:
+## 다음 시작 시 확인
 
-- 원본 검증기는 전체 이미지 주소와 토큰을 출력하지 않고 이름, 호스트, HTTP 상태와 콘텐츠 형식만 출력한다.
-- 배너, 활성 상품 5개, 상품 상세 이미지와 스토어 로고를 확인한다.
-- 배포 후보에서 정상 원본 표시와 네트워크 실패 강제 시 대체 표시를 모두 검증한다.
-- 운영에서는 홈과 상품 상세 5개를 확인하되 주소·연락처 등 개인정보 영역의 전체 화면이나 전체 DOM을 출력하지 않는다.
-- consumer 관련 계약 테스트, `pnpm --filter consumer lint`, `pnpm --filter consumer build`, `git diff --check`를 통과한다.
-- 배포 뒤 consumer Vercel 오류 로그와 브라우저 콘솔 오류를 확인한다.
-- seller·driver·Railway API에 새 배포가 생겼는지 확인하고 예상 밖 배포가 있으면 상태만 보고하며 추가 변경하지 않는다.
-
-외부 변경 제한:
-
-- 카카오 재신청과 카카오 채널·이메일·DNS·ALIGO·공개 소식은 변경하지 않는다.
-- 상품·배너·스토어 문서를 삭제하지 않는다.
-- 주소, 비공개 Gmail, 로그인·인증 정보, 사업자등록증 이미지와 생년월일을 기록하거나 재출력하지 않는다.
-- Git 작성자·커미터는 저장소 이력의 공개 GitHub `noreply` 메타데이터를 사용한다.
-
-작업 완료 또는 중단 시 새로운 인계 프롬프트를 갱신한다. 최종 인계에는 branch·HEAD·git 상태·전체 diff·수정 파일·검증 결과·commit·push·PR·배포 식별자·Firebase 변경·운영 확인·남은 위험을 포함한다.
-
----
+1. `git status --short --branch`, `git diff`, `git diff --cached`를 확인한다.
+2. `git log -1 --oneline`과 `origin/main`을 확인해 이 closeout 문서 commit과 main 반영 상태를 확인한다.
+3. 이미지 이상 재발 시 `node apps/consumer/scripts/verify-public-images.mjs`로 원본부터 확인한다.
+4. Firebase 비용 경고가 오면 프로젝트 범위·Storage 사용량·요청량을 읽기 전용으로 먼저 점검한다.

--- a/docs/plans/REPORT_kakao_business_channel_reapproval.md
+++ b/docs/plans/REPORT_kakao_business_channel_reapproval.md
@@ -345,7 +345,33 @@
 - 최초 검증기는 루트 `scripts/**`에 있어 seller·driver Ignore 명령의 공통 영향 경로로 판정됐다. 그 결과 비대상 미리보기가 실제 생성됐으며 상태만 기록하고 rollback하지 않았다.
 - production의 비대상 배포를 막기 위해 검증기를 내용 변경 없이 `apps/consumer/scripts/verify-public-images.mjs`로 옮기고 한국어 commit `d7afe55`로 push했다.
 - 경로 이동 commit도 루트 파일 삭제 자체 때문에 비대상 미리보기가 한 번 더 생성됐지만, PR의 main 대비 최종 diff에는 루트 `scripts/**`가 없고 `apps/consumer/**`와 문서만 남았다.
-- 다음 문서 전용 commit에서 seller·driver 검사가 Ignored Build Step으로 종료되는지 확인한 뒤에만 병합한다.
+- 문서 전용 최신 commit `9be3473`에서 consumer 미리보기는 성공했고 seller·driver는 모두 `Canceled by Ignored Build Step`으로 종료됐다.
+
+### 이미지 복구 Task 3.2 — main 병합과 consumer production 배포
+
+- **Status**: done
+- PR #18의 모든 검사가 통과한 뒤 merge commit `e6c2138e3c969616e19f2ba8882c1842a3cf0dfb`로 main에 병합했다.
+- consumer production 배포 `dpl_9LQkxbkSpuHQwYnPTSYdg5L2g14g`와 GitHub deployment `5863377298`은 merge SHA와 일치하고 READY·성공 상태다. `greenlove.co.kr`을 포함한 운영 별칭이 연결되고 원시 HTTP 200을 확인했다.
+- seller production 후보 `dpl_3D2gAGP2d6Evez3fQmgsiLnN1wKE`와 driver 후보 `dpl_DSTjpvqChdJKTdrA5nNPsmVUc7td`는 Ignored Build Step으로 취소됐다.
+- seller·driver 최신 production은 이전 SHA `098ad98c`의 deployment를 유지했다. Railway API 최신 production deployment도 2026년 8월 11일의 같은 이전 SHA를 유지해 새 배포나 restart가 없었다.
+
+### 이미지 복구 Task 3.3 — 운영 이미지와 로그 재검증
+
+- **Status**: done
+- 운영 배너와 활성 상품 5개 원본은 6/6 HTTP 200, `image/png`이었다. 전체 주소와 토큰은 기록하지 않았다.
+- 운영 Next 이미지 프록시는 배너 기준 HTTP 200, `image/png`을 반환했다.
+- 데스크톱과 375×812 모바일 홈에서 배너와 상품 5개가 모두 양수 실제 크기로 표시됐고 깨진 이미지 0건, 가로 넘침 없음이었다.
+- 공개 상품 상세 5개 모두 대표·상세 이미지와 공통 스토어 로고가 양수 실제 크기로 표시됐고 깨진 이미지 0건, 가로 넘침 없음이었다.
+- 브라우저 애플리케이션 콘솔·페이지 오류는 0건이었다. consumer Vercel 최근 1시간 런타임 오류와 production 배포 5xx 집계도 0건이었다.
+- 운영 DB의 상품·배너·스토어 주소와 문서, Storage 객체는 변경하지 않았다.
+
+### 이미지 복구 Task 3.4 — closeout과 외부 상태
+
+- **Status**: done
+- Firebase 운영 프로젝트는 승인된 활성 Billing 계정에 연결된 Blaze 상태이며 프로젝트 한정 월 10,000원 예산과 실제 비용 10·50·90·100% 알림이 설정됐다.
+- 다른 Firebase 프로젝트·결제 계정과 결제수단은 변경하거나 닫지 않았다.
+- 카카오 재신청, 카카오 채널·이메일·DNS·ALIGO·공개 소식은 변경하지 않았다.
+- 기능·배포 작업은 완료됐고 남은 운영 위험은 예산 알림이 비용을 차단하지 않으며 지연될 수 있다는 점, Firebase 무료 사용량 초과 시 사용량 기반 비용이 발생할 수 있다는 점이다.
 
 - PR #13, 후속 증빙 PR #14와 화면 정돈 PR #15를 merge commit 방식으로 `main`에 병합하고 consumer production만 새 성공 배포로 전환했다.
 - PR #15 병합 SHA의 GitHub deployment는 `Production – greenhubconsumer` 1건뿐이며 seller·driver는 배포 경로 필터에 따라 기존 서비스 배포를 유지했다.


### PR DESCRIPTION
## 변경 내용
- consumer 운영 이미지 복구의 main 병합·production 배포·운영 재검증 결과를 PLAN과 REPORT에 기록합니다.
- branch, 기능 HEAD, 검증, PR, 배포, Firebase·DB·외부 서비스 상태와 남은 위험을 최종 인계 문서로 마감합니다.

## 검증
- 문서 3개 `git diff --check` 통과
- 기능 변경 없음
- seller·driver·Railway API 변경 없음