### PR TITLE
consumer 상품 상세 판매자 연락처를 사업자 정보로 통일

### DIFF
--- a/apps/consumer/src/app/products/[id]/_components/ProductActions.test.mjs
+++ b/apps/consumer/src/app/products/[id]/_components/ProductActions.test.mjs
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const testDirectory = dirname(fileURLToPath(import.meta.url));
+const componentPath = join(testDirectory, 'ProductActions.tsx');
+
+function loadComponentSource() {
+  return readFileSync(componentPath, 'utf8');
+}
+
+test('판매자 연락처는 공개 사업자 정보의 주소와 전화번호를 사용한다', () => {
+  const source = loadComponentSource();
+
+  assert.match(source, /PUBLIC_BUSINESS_INFO\.address/);
+  assert.match(source, /PUBLIC_BUSINESS_INFO\.phone/);
+  assert.doesNotMatch(source, /store\.address/);
+  assert.doesNotMatch(source, /store\.phone/);
+});

--- a/apps/consumer/src/app/products/[id]/_components/ProductActions.tsx
+++ b/apps/consumer/src/app/products/[id]/_components/ProductActions.tsx
@@ -19,6 +19,7 @@ import {
 import { useGroupProduct } from '@/hooks/useGroupProduct';
 import { useStore } from '@/hooks/useProducts';
 import { useCart } from '@/hooks/useCart';
+import { PUBLIC_BUSINESS_INFO } from '@/lib/publicBusinessInfo';
 import GreenLoveBrandSection from '@/components/GreenLoveBrandSection';
 import ProductCTABar from '@/components/ProductCTABar';
 import ResilientImage from '@/components/ResilientImage';
@@ -434,10 +435,10 @@ export default function ProductActions({ product }: Props) {
           </Group>
           <Stack gap={4}>
             <Text style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-text-secondary)' }}>
-              📍 {store.address}
+              📍 {PUBLIC_BUSINESS_INFO.address}
             </Text>
             <Text style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-text-secondary)' }}>
-              📞 {store.phone}
+              📞 {PUBLIC_BUSINESS_INFO.phone}
             </Text>
           </Stack>
         </Box>

--- a/apps/consumer/src/components/BusinessInfoFooter.test.mjs
+++ b/apps/consumer/src/components/BusinessInfoFooter.test.mjs
@@ -24,6 +24,7 @@ test('공개 사업자 정본을 빠짐없이 렌더링한다', () => {
     '조정연',
     '505-28-01702',
     '010-4452-2104',
+    '경기도 이천시 백사면 도지리 543-2',
     'support@greenlove.co.kr',
   ];
 
@@ -56,8 +57,6 @@ test('접근 가능한 footer와 고객센터 링크를 제공한다', () => {
 test('확정되지 않은 외부 증거는 노출하지 않는다', () => {
   const source = `${loadComponentSource()}\n${loadBusinessInfoSource()}`;
 
-  assert.doesNotMatch(source, /사업장 주소/);
-  assert.doesNotMatch(source, /address:/);
   assert.doesNotMatch(source, /naver\.(?:me|com)/i);
   assert.doesNotMatch(source, /통신판매업 신고번호/);
 });

--- a/apps/consumer/src/components/BusinessRelationshipNotice.test.mjs
+++ b/apps/consumer/src/components/BusinessRelationshipNotice.test.mjs
@@ -58,14 +58,19 @@ test('상단에서는 상세 사업자정보를 반복하지 않고 footer 역�
   assert.doesNotMatch(componentSource, /PUBLIC_BUSINESS_INFO\.registrationNumber/);
 });
 
-test('공개 승인된 최소 사업자 정본만 제공한다', () => {
-  const requiredValues = ['그린러브', '디어 오키드', '조정연', '505-28-01702'];
+test('공개 승인된 사업자 정본만 제공한다', () => {
+  const requiredValues = [
+    '그린러브',
+    '디어 오키드',
+    '조정연',
+    '505-28-01702',
+    '경기도 이천시 백사면 도지리 543-2',
+  ];
 
   for (const value of requiredValues) {
     assert.match(businessInfoSource, new RegExp(value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
   }
 
-  assert.doesNotMatch(businessInfoSource, /address:/);
   assert.doesNotMatch(businessInfoSource, /gmail\.com/i);
 });
 

--- a/apps/consumer/src/lib/publicBusinessInfo.ts
+++ b/apps/consumer/src/lib/publicBusinessInfo.ts
@@ -3,6 +3,7 @@ export const PUBLIC_BUSINESS_INFO = {
   businessName: '디어 오키드',
   representative: '조정연',
   registrationNumber: '505-28-01702',
+  address: '경기도 이천시 백사면 도지리 543-2',
   phone: '010-4452-2104',
   phoneHref: 'tel:01044522104',
   email: 'support@greenlove.co.kr',


### PR DESCRIPTION
## 변경 내용
- 상품 상세 판매자 주소와 전화번호를 공개 사업자 정보 정본에서 표시합니다.
- 스토어명, 대표자명, 로고는 기존 판매자 데이터를 유지합니다.
- 판매자 연락처 회귀 계약을 추가하고 기존 공개 정보 계약을 갱신합니다.

## 검증
- consumer 계약 테스트 24개 통과
- consumer lint 오류 없음(기존 경고 23개)
- consumer production build 통과
- git diff --check 통과