### PR TITLE
consumer 상품 판매자 보조 문구 제거

### DIFF
--- a/apps/consumer/src/app/products/[id]/_components/ProductActions.test.mjs
+++ b/apps/consumer/src/app/products/[id]/_components/ProductActions.test.mjs
@@ -18,4 +18,5 @@ test('판매자 연락처는 공개 사업자 정보의 주소와 전화번호�
   assert.match(source, /PUBLIC_BUSINESS_INFO\.phone/);
   assert.doesNotMatch(source, /store\.address/);
   assert.doesNotMatch(source, /store\.phone/);
+  assert.doesNotMatch(source, /store\.ceoName/);
 });

--- a/apps/consumer/src/app/products/[id]/_components/ProductActions.tsx
+++ b/apps/consumer/src/app/products/[id]/_components/ProductActions.tsx
@@ -426,11 +426,6 @@ export default function ProductActions({ product }: Props) {
               >
                 {store.name}
               </Text>
-              <Text
-                style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-text-secondary)' }}
-              >
-                {store.ceoName}
-              </Text>
             </Box>
           </Group>
           <Stack gap={4}>


### PR DESCRIPTION
## 변경 내용
- 상품 상세 판매자 정보에서 판매점 대표자 보조 줄을 제거했습니다.
- 상호, 로고, 공개 사업자 주소와 고객센터 전화번호는 유지했습니다.
- 해당 필드가 다시 렌더링되지 않도록 계약 테스트를 보강했습니다.

## 검증
- consumer 계약 테스트 25개 통과
- consumer lint 오류 없음(기존 경고 23개)
- consumer production build 통과
- git diff --check 통과