### PR TITLE
chore: production 배포 안전장치 분리

### DIFF
--- a/.github/workflows/deployment-safety.yml
+++ b/.github/workflows/deployment-safety.yml
@@ -1,0 +1,22 @@
+name: Deployment safety guard
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+      - name: Verify deployment safety invariants
+        run: node scripts/verify-deployment-safety.mjs

--- a/.github/workflows/sync-preview.yml
+++ b/.github/workflows/sync-preview.yml
@@ -1,11 +1,14 @@
 name: Sync preview branch
 
-# main 에 푸시되면 preview 브랜치를 자동으로 최신화한다.
-# preview 는 영구 e2e 환경 브랜치이므로 항상 main 과 동기 상태여야 한다.
+# main 에 코드/구성 변경이 푸시되면 preview 브랜치를 자동으로 최신화한다.
+# docs-only 변경은 Preview 배포와 일반 E2E를 불필요하게 만들지 않도록 제외한다.
 
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
   workflow_dispatch:
 
 # 동시 실행 방지 — preview push 충돌 회피
@@ -45,7 +48,6 @@ jobs:
       # dispatch 가 stale(이전 커밋) preview 를 검사한다(세션39·60·61 race).
       # 3앱 Preview deployment 가 현재 preview HEAD 로 success 할 때까지 폴링하고,
       # timeout 시 fail-fast(exit 1)로 e2e dispatch 를 차단해 배포 지연을 노출한다.
-      # node 는 ubuntu-latest 기본 설치본(v20+) 사용 — 의존성 없음(gh CLI + 빌트인만).
       - name: Wait for preview deploy (SHA-matched deployments poll)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,14 @@
 
 기준선이 다르면 임의로 전환하거나 덮어쓰지 말고 차이를 먼저 보고한다. 사용자의 기존 dirty 변경은 보존하며, 해당 변경을 되돌리거나 덮어쓰거나 함께 커밋하지 않는다.
 
+### `main` 변경 규칙
+
+- `main`에는 문서-only 변경을 포함해 직접 commit/push하지 않는다.
+- 모든 변경은 목적별 branch에서 만들고 PR을 통해 `main`으로 통합한다.
+- `main` 통합 자체를 production 배포 승인으로 해석하지 않는다.
+- production 배포는 현재 출시 PLAN의 별도 승인 게이트와 실제 release SHA 확인 뒤에만 수행한다.
+- exact-SHA 배포 또는 promotion 절차가 불명확하면 임의 production 배포보다 중단을 우선한다.
+
 ## 3. 최소 Context 로딩
 
 다음 순서로 필요한 범위만 읽는다.

--- a/apps/consumer/vercel.json
+++ b/apps/consumer/vercel.json
@@ -1,6 +1,12 @@
 {
+  "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "nextjs",
   "buildCommand": "cd ../.. && pnpm --filter @greenhub/shared build && pnpm --filter consumer build",
   "installCommand": "cd ../.. && pnpm install --frozen-lockfile",
-  "outputDirectory": ".next"
+  "outputDirectory": ".next",
+  "git": {
+    "deploymentEnabled": {
+      "main": false
+    }
+  }
 }

--- a/apps/driver/vercel.json
+++ b/apps/driver/vercel.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "git": {
+    "deploymentEnabled": {
+      "main": false
+    }
+  }
+}

--- a/apps/seller/vercel.json
+++ b/apps/seller/vercel.json
@@ -1,6 +1,12 @@
 {
+  "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "nextjs",
   "buildCommand": "cd ../.. && pnpm --filter @greenhub/shared build && pnpm --filter seller build",
   "installCommand": "cd ../.. && pnpm install --frozen-lockfile",
-  "outputDirectory": ".next"
+  "outputDirectory": ".next",
+  "git": {
+    "deploymentEnabled": {
+      "main": false
+    }
+  }
 }

--- a/docs/plans/PLAN_deployment_safety_guards_20260823.md
+++ b/docs/plans/PLAN_deployment_safety_guards_20260823.md
@@ -1,0 +1,29 @@
+# Deployment Safety Guards — 2026-08-23
+
+> 상태: in_progress
+
+## 확인된 위험
+
+- GitHub `main`은 현재 branch protection/ruleset이 비활성 상태다.
+- Vercel consumer/seller/driver 3개 프로젝트는 GitHub `main` push에 대해 production-target deployment를 생성한다.
+- consumer는 docs-only `main` commit도 실제 production deployment `READY`까지 진행했다.
+- `.github/workflows/sync-preview.yml`은 모든 `main` push에서 `preview`를 자동 동기화한 뒤 3앱 Preview 배포 대기와 일반 E2E dispatch까지 수행한다.
+
+## 목표 상태
+
+1. `main` merge 자체가 production 배포를 의미하지 않는다.
+2. production은 승인된 release SHA를 명시적으로 배포하는 경로만 사용한다.
+3. docs-only 변경은 preview sync/E2E를 불필요하게 실행하지 않는다.
+4. `main` 직접 push를 차단하고 PR 기반 변경만 허용한다.
+
+## 적용 순서
+
+1. repository-side Vercel Git deployment guard 추가
+2. docs-only `main` push의 preview sync 제외
+3. GitHub `main` branch protection/ruleset 적용
+4. Vercel project Git integration에서 `main` auto production deploy 비활성화 확인
+5. exact-SHA production deploy 승인 경로 확정
+
+## 승인
+
+사용자 `배포 안전장치 변경 승인` 수신 후 수행한다.

--- a/scripts/verify-deployment-safety.mjs
+++ b/scripts/verify-deployment-safety.mjs
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const apps = ['consumer', 'seller', 'driver'];
+
+for (const app of apps) {
+  const path = `apps/${app}/vercel.json`;
+  const config = JSON.parse(readFileSync(path, 'utf8'));
+
+  assert.equal(
+    config.git?.deploymentEnabled?.main,
+    false,
+    `${path}: git.deploymentEnabled.main must remain false`,
+  );
+}
+
+const syncPreview = readFileSync('.github/workflows/sync-preview.yml', 'utf8');
+assert.match(syncPreview, /paths-ignore:/, 'sync-preview.yml must keep a docs-only ignore gate');
+assert.match(syncPreview, /['"]docs\/\*\*['"]/, 'sync-preview.yml must ignore docs/**');
+assert.match(syncPreview, /['"]\*\*\/\*\.md['"]/, 'sync-preview.yml must ignore **/*.md');
+
+const agents = readFileSync('AGENTS.md', 'utf8');
+assert.match(
+  agents,
+  /`main`에는 문서-only 변경을 포함해 직접 commit\/push하지 않는다\./,
+  'AGENTS.md must keep the no-direct-main rule',
+);
+
+console.log('Deployment safety guard: OK');


### PR DESCRIPTION
## 목적

`main` push가 문서 변경만으로도 Vercel production-target deployment와 preview sync/E2E를 연쇄 실행하는 현재 구조를 차단합니다.

## 변경

- consumer/seller/driver `vercel.json`에서 `git.deploymentEnabled.main=false`
- docs-only `main` push는 `sync-preview.yml`에서 제외
- `AGENTS.md`에 direct-main 금지와 production 별도 승인 규칙 추가
- `scripts/verify-deployment-safety.mjs` 추가
- `deployment-safety.yml` CI guard 추가
- 작업 계약 문서 추가

## 검증 목표

- feature branch Preview는 계속 가능
- merge 후 `main` commit으로 production auto-deploy가 생성되지 않아야 함
- docs-only `main` 변경은 preview sync/E2E를 발화시키지 않아야 함

## 남은 관리자 설정

GitHub branch protection/ruleset 자체는 repository 관리자 설정이 필요합니다. 연결된 GitHub 도구에 해당 mutation이 노출되지 않아 PR 병합 후 별도 확인 대상으로 남깁니다.
