### PR TITLE
chore: docs-only Vercel Preview build 제외

### DIFF
--- a/apps/consumer/vercel.json
+++ b/apps/consumer/vercel.json
@@ -4,6 +4,7 @@
   "buildCommand": "cd ../.. && pnpm --filter @greenhub/shared build && pnpm --filter consumer build",
   "installCommand": "cd ../.. && pnpm install --frozen-lockfile",
   "outputDirectory": ".next",
+  "ignoreCommand": "git diff --name-only HEAD^ HEAD | grep -qvE '(^docs/|[.]md$)' && exit 1 || exit 0",
   "git": {
     "deploymentEnabled": {
       "main": false

--- a/apps/driver/vercel.json
+++ b/apps/driver/vercel.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "git diff --name-only HEAD^ HEAD | grep -qvE '(^docs/|[.]md$)' && exit 1 || exit 0",
   "git": {
     "deploymentEnabled": {
       "main": false

--- a/apps/seller/vercel.json
+++ b/apps/seller/vercel.json
@@ -4,6 +4,7 @@
   "buildCommand": "cd ../.. && pnpm --filter @greenhub/shared build && pnpm --filter seller build",
   "installCommand": "cd ../.. && pnpm install --frozen-lockfile",
   "outputDirectory": ".next",
+  "ignoreCommand": "git diff --name-only HEAD^ HEAD | grep -qvE '(^docs/|[.]md$)' && exit 1 || exit 0",
   "git": {
     "deploymentEnabled": {
       "main": false

--- a/scripts/verify-deployment-safety.mjs
+++ b/scripts/verify-deployment-safety.mjs
@@ -2,6 +2,8 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 
 const apps = ['consumer', 'seller', 'driver'];
+const docsOnlyIgnoreCommand =
+  "git diff --name-only HEAD^ HEAD | grep -qvE '(^docs/|[.]md$)' && exit 1 || exit 0";
 
 for (const app of apps) {
   const path = `apps/${app}/vercel.json`;
@@ -11,6 +13,11 @@ for (const app of apps) {
     config.git?.deploymentEnabled?.main,
     false,
     `${path}: git.deploymentEnabled.main must remain false`,
+  );
+  assert.equal(
+    config.ignoreCommand,
+    docsOnlyIgnoreCommand,
+    `${path}: docs-only Vercel ignoreCommand must remain enabled`,
   );
 }
 


### PR DESCRIPTION
## 변경
- consumer/seller/driver `vercel.json`에 공통 `ignoreCommand` 추가
- 변경 파일이 전부 `docs/**` 또는 `*.md`이면 Vercel build를 skip
- 코드/설정 파일이 하나라도 포함되면 기존처럼 build 계속
- deployment safety 검증 스크립트가 이 규칙도 강제

## 안전성
- `main` auto production deploy 차단은 PR #30에서 이미 활성화됨
- 이 PR은 docs-only Preview build 낭비와 Hobby build-rate-limit 압박을 줄이기 위한 보강
