### PR TITLE
docs: deployment safety closeout 정합화

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -4,23 +4,44 @@
 
 > 기준일: 2026-08-23 KST
 >
-> 이 문서는 **현재 미완료·향후 작업만** 관리한다. 완료된 상세 이력은 Git history, `docs/CRITICAL_LOGIC.md`, `docs/archive/`, 완료 PLAN·REPORT에서 확인한다. 현재 출시 상태는 `docs/memory.md`, 실행 순서는 활성 HANDOFF·PLAN을 우선한다.
+> 현재 미완료·향후 작업만 관리한다. 완료 상세는 Git history, `docs/CRITICAL_LOGIC.md`, `docs/archive/`, 완료 PLAN·REPORT를 사용한다.
 
 ## 우선순위 규칙
 
 - **ACTIVE**: 지금 진행 가능한 최우선 작업
-- **BLOCKED_EXTERNAL**: 외부 심사·승인·계약 때문에 기다리는 작업
-- **NEXT**: 현재 게이트가 풀리면 바로 이어서 할 작업
+- **BLOCKED_EXTERNAL**: 외부 심사·승인 때문에 기다리는 작업
+- **NEXT**: 현재 게이트가 풀리면 바로 진행할 작업
 - **LATER**: MVP 출시를 막지 않는 후속 개선
-- **STALE_OR_SUPERSEDED**: 과거에는 미완료였지만 현재 상태를 다시 확인하기 전 실행하면 안 되는 항목
+- **STALE_OR_SUPERSEDED**: 현재 상태 재검증 전 실행 금지
 
 ---
 
 ## ACTIVE
 
-현재 즉시 실행할 P0 개발 작업은 없다. 회차 직배송 MVP 코드는 `main`에 통합됐고, 출시 흐름은 외부 ALIGO 심사 결과를 기다리는 상태다.
+### P0 — DEPLOY-SAFETY-MAIN-PROTECTION
 
-문서·코드 정합성 점검처럼 비파괴 작업은 별도 Task로 계속 수행할 수 있지만, 외부 게이트를 우회해 운영 변경을 진행하지 않는다.
+repo-side 자동배포 차단은 완료됐지만 GitHub `main` 자체 보호는 아직 비활성이다.
+
+완료:
+
+- [x] PR #30 — consumer/seller/driver `main` Vercel Git auto-deploy 차단
+- [x] PR #30 merge 뒤 3앱 Vercel 신규 deployment 0건 확인
+- [x] docs-only `main` push의 `sync-preview`/일반 E2E 제외
+- [x] `AGENTS.md` direct-main 금지 규칙
+- [x] deployment safety CI
+- [x] PR #31 — 순수 docs/Markdown Vercel build skip
+- [x] pure-docs branch commit 뒤 3앱 신규 deployment 0건 확인
+
+남음:
+
+- [ ] Issue #32 — `main` branch protection/ruleset 활성화
+- [ ] PR required
+- [ ] `Deployment safety guard / verify` required check
+- [ ] force push 차단
+- [ ] branch deletion 차단
+- [ ] 재조회에서 `protected=true` 또는 동등 enforcement 확인
+
+Issue #32 완료 전에도 repo-side Vercel guard는 동작하지만, direct push 자체를 GitHub가 강제 차단하지는 못한다. 따라서 모든 작업은 `AGENTS.md`에 따라 branch+PR로 수행한다.
 
 ---
 
@@ -37,14 +58,14 @@
 - [ ] `ORDER_DELIVERED`
 - [ ] `ORDER_CANCELLED`
 
-현재 상태:
+현재:
 
 - 8종 provider 등록·심사 요청 완료
 - 8종 모두 `검수중`
 - 중복·오류·반려 없음
 - 실제 알림톡·SMS 발송 0건
 
-재개 기준: `docs/plans/HANDOFF_mvp_round_direct_aligo_review_pause.md`
+재개 순서: `docs/plans/HANDOFF_mvp_round_direct_aligo_review_pause.md`
 
 ---
 
@@ -52,221 +73,127 @@
 
 ### P0 — 실제 알림 검증
 
-- [ ] 승인된 실제 `tpl_code` 8종과 내부 논리 템플릿의 1:1 매핑 준비상태 검사
-- [ ] 사용자 승인 후 격리 수신자 실제 알림톡 정상 발송 검증
+- [ ] 승인된 실제 `tpl_code` 8종 ↔ 내부 논리 템플릿 1:1 매핑 검사
+- [ ] 사용자 승인 후 격리 수신자 실제 알림톡 정상 발송
 - [ ] 사용자 승인 후 SMS fallback 실제 검증
 
 ### P0 — 판매 활성화 법적 문서 재정합화
 
-현재 production의 `/terms`, `/privacy`는 2026-08-19의 **비판매 상태**를 전제로 한다. 실제 release SHA를 고정하기 전에 다음을 완료한다.
+현재 production `/terms`, `/privacy`는 2026-08-19 **비판매 상태**를 전제로 한다.
 
-- [ ] 이용약관의 `현재 상용 주문·결제·배송을 운영하지 않음` 문구를 실제 판매 상태와 일치시키기
-- [ ] 주문 성립·취소·환불·배송·재배송비·배송 보류 공개 정책 검수
-- [ ] PortOne·실제 결제사업자의 개인정보 처리 역할·데이터 흐름 검수
-- [ ] ALIGO 실제 고객 알림의 전화번호·메시지 처리 흐름과 공개 고지 검수
-- [ ] seller·driver의 고객 배송정보 접근 설명 검수
-- [ ] 시행일 갱신과 필요한 이전 버전 보존
-- [ ] `apps/consumer/src/app/legal-documents.test.mjs`의 비판매 assertion을 새 계약에 맞게 갱신
-- [ ] 변경된 `/privacy`, `/terms`를 release SHA에 포함하고 production smoke 항목에 추가
+- [ ] 상용 주문·결제·배송 상태와 약관 문구 일치
+- [ ] 주문 성립·취소·환불·배송·재배송비·배송 보류 정책 검수
+- [ ] PortOne·실제 결제사업자 개인정보 처리 역할 검수
+- [ ] ALIGO 고객 알림 전화번호·메시지 처리 고지 검수
+- [ ] seller·driver 고객 배송정보 접근 설명 검수
+- [ ] 시행일·이전 버전 관리
+- [ ] `apps/consumer/src/app/legal-documents.test.mjs` 갱신
+- [ ] 변경된 `/privacy`, `/terms`를 release SHA에 포함
 
-정본: `docs/specs/legal/README.md`, `docs/specs/legal/consumer-legal-documents.md`
+정본: `docs/specs/legal/README.md`
 
 ### P0 — 출시 후보 검증·운영 준비
 
-- [ ] 법적 페이지 변경까지 포함한 실제 출시 대상 `main` SHA 확정
-- [ ] 해당 SHA에서 원격 회차 E2E chromium 26 + mobile 26 = 52건 통과
-- [ ] 동일 run에서 chromium·mobile fixture cleanup 성공
+- [ ] Issue #32 branch protection 완료
+- [ ] 법적 페이지 포함 actual release SHA 확정
+- [ ] exact SHA 원격 회차 E2E chromium 26 + mobile 26 = 52건 통과
+- [ ] 양쪽 fixture cleanup 성공
 - [ ] 운영 Firebase indexes·Firestore Rules·Storage Rules 읽기 전용 재조회
-- [ ] 사용자 승인 후 운영 ALIGO 자격 증명 4개 반영
-- [ ] 사용자 승인 후 `ALIGO_TEMPLATE_CODES_JSON` 반영 및 8종 매핑 검사
-- [ ] 별도 `Task 3.1 승인` 후 Railway production API 배포
-- [ ] consumer·seller·driver production을 동일 출시 SHA로 배포
-- [ ] 운영 무변경 smoke에서 `/privacy`, `/terms` 새 버전 포함 확인
-- [ ] 배포 후 오류 확인
+- [ ] 사용자 승인 후 운영 ALIGO 자격 증명 4개·`ALIGO_TEMPLATE_CODES_JSON` 반영
+- [ ] 8종 매핑 검사
+- [ ] production exact-SHA deploy/promotion 절차 확정
+- [ ] 별도 `Task 3.1 승인`
+- [ ] 승인된 exact release SHA로 Railway API production 배포
+- [ ] consumer·seller·driver를 동일 release SHA로 production 배포
+- [ ] deployment metadata SHA 일치 확인
+- [ ] 운영 무변경 smoke: health·인증·legacy·회차 read·`/privacy`·`/terms`
 - [ ] 첫 운영 회차 `DRAFT` 생성·검수
 - [ ] 첫 회차 `SCHEDULED` 전환
 - [ ] 최종 출시 판정·롤백 dry-run
-- [ ] 최종 승인 후 `salesMode: round_direct` 전환
-- [ ] 전환 직후 smoke 통과 뒤 외부 유입 링크 공개
+- [ ] 최종 승인 후 `salesMode: round_direct`
+- [ ] 전환 직후 smoke 뒤 외부 유입 링크 공개
 - [ ] 첫 두 회차 집중 모니터링 및 Closeout
 
-상세 dependency와 승인 게이트는 `docs/plans/PLAN_mvp_round_direct_launch_blockers.md`를 따른다.
+상세 dependency: `docs/plans/PLAN_mvp_round_direct_launch_blockers.md`
 
 ---
 
 ## LATER — 출시 후 품질·운영 개선
 
-### NOTIFICATION-RETRY-POLICY — 알림 재시도 정책 고도화
+### NOTIFICATION-RETRY-POLICY
 
-- [ ] 재시도 간격과 backoff 정책 정의
-- [ ] 일시 오류/영구 오류 분류 기준 정의
-- [ ] timeout·네트워크 예외·응답 파싱·rate limit 처리 기준 정의
-- [ ] 시도 횟수·최종 채널·실패 분류 구조화 관측 지표 정의
-- [ ] SMS 중복 발송 방지와 재시작 이후 멱등성 범위 결정
-- [ ] mock 기반 단위 테스트와 격리 staging 검증 절차 마련
+- [ ] backoff·일시/영구 오류 분류
+- [ ] timeout·rate limit 처리 기준
+- [ ] 중복 SMS 방지·재시작 이후 멱등성
+- [ ] 구조화 관측 지표와 격리 테스트
 
-### API-LINT-BASELINE — API lint 부채 분리 정리
+### API-LINT-BASELINE
 
-- [ ] `apps/api/src/auth/auth.service.ts` Firestore `data()` 반환과 주소 흐름의 `any` 제거
-- [ ] `apps/api/src/auth/auth.service.spec.ts` mock의 `any`를 타입 있는 테스트 더블로 전환
-- [ ] 수정형 lint와 읽기 전용 lint를 `lint:fix` / `lint:check`로 분리할지 결정
+- [ ] auth 흐름의 `any` 제거
+- [ ] spec mock 타입 정리
+- [ ] `lint:check` / `lint:fix` 분리 검토
 
-### LOCAL-DEV-FULLSTACK — 로컬 포트·CORS 진입점 정리
+### LOCAL-DEV-FULLSTACK
 
-현재 root `dev.bat`는 consumer 3000, seller 3001, driver 3003을 실행하고 API를 시작하지 않는다. API 기본 포트 3000과 동시에 쓰면 consumer와 충돌할 수 있다.
+- [ ] API 3000 / consumer 3001 / seller 3002 / driver 3003 launcher 설계
+- [ ] seller·driver local CORS origin 계약 확인
+- [ ] 기존 `dev.bat` frontend-only 유지 여부 결정
 
-- [ ] API 3000 / consumer 3001 / seller 3002 / driver 3003 같은 명시적 full-stack launcher 설계
-- [ ] 로컬 seller·driver API 호출에 필요한 CORS origin 계약 확인
-- [ ] 기존 `dev.bat`의 용도를 frontend-only로 유지할지 full-stack으로 교체할지 결정
+### LOAD-TEST-FORMAL
 
-### LOAD-TEST-FORMAL — 정식 부하테스트 재개 조건
+- [ ] production과 분리된 staging/equivalent 환경 확보
+- [ ] 재개 트리거 정의
+- [ ] `baseline → launch → growth → spike → soak`
+- [ ] `docs/specs/ops/k6-load-test-plan.md` 재검증
 
-- [ ] 실제 유입 증가·광고 확대·429/5xx·응답 지연 등 재개 트리거 정의 유지
-- [ ] production과 분리된 staging DB 또는 동등 격리 환경 확보
-- [ ] 환경별 k6 seed 대상과 테스트 계정 확정
-- [ ] `baseline → launch → growth → spike → soak` 단계별 실행
-- [ ] `docs/specs/ops/k6-load-test-plan.md` 재검증 후 실행
+### Seller/Admin
 
-### Seller/Admin 후속
+- [ ] ADMIN-STORES-T7 판매자 상세 드릴다운
+- [ ] ADMIN-STORES-T8 플랫폼 기본 수수료율 설정
+- [ ] 준비 물량 공동구매 주문 포함 여부 재설계
+- [ ] 필요 시 정산 UX 육안 검증 재개
 
-- [ ] **ADMIN-STORES-T7** — 판매자 상세 드릴다운
-  - store별 주문·정산 집계
-  - 상세 라우트
-  - 관리자 권한 경계
-  - 목록 URL 복원
-  - 별도 SDD 선행
-- [ ] **ADMIN-STORES-T8** — 플랫폼 기본 수수료율 설정
-  - 전역 config 모델
-  - store override 우선순위
-  - 소급 적용 여부
-  - 검증 범위 확장
-  - 별도 SDD 선행
-- [ ] 준비 물량 탭에 공동구매 주문 포함 여부 재설계
-- [ ] 정산 화면 잔여 육안 검증이 필요하면 별도 UX 검증 Task로 재개
+### Driver/배송
 
-### Seller 성능/DX
-
-- [ ] **PERF-01** — seller `<img>` → `next/image` 마이그레이션 재검토
-  - onboarding 로고/이미지
-  - 상품 이미지 업로드 썸네일
-  - Firebase Storage remotePatterns·sizes·LCP 영향 확인
-
-### Driver/배송 고도화
-
-- [ ] Driver Kakao Maps SDK 연동 필요성 재평가 후 구현
-- [ ] 밀크런 경로 프리뷰가 실제 운영에 필요해질 때 지도 경로 시각화
-- [ ] 실시간 GPS 추적은 플랫폼형 드라이버 운영 전까지 보류
+- [ ] Kakao Maps SDK 필요성 재평가
+- [ ] 밀크런 경로 프리뷰 필요 시 구현
+- [ ] 플랫폼형 드라이버 전까지 실시간 GPS 추적 보류
 
 ### 인프라 복원력
 
-- [ ] Railway 단일 장애점 리스크 재평가
-- [ ] 필요 시 Fly.io/Render 등 대체 backend contingency 비교
-- [ ] 운영 규모가 커질 때 hot-standby 필요성 결정
+- [ ] Railway 단일 장애점 재평가
+- [ ] 필요 시 대체 backend contingency 비교
+
+### 확장 트리거
+
+- [ ] 다중 판매자 Phase 2
+- [ ] 실제 협력 거점 계약 시 hub 운영 오픈
+- [ ] 필요 시 `hub_staff` 역할
+- [ ] 외부 드라이버 정산
+- [ ] 플랫폼형 드라이버 모델
+- [ ] 결제수단 확장 재평가
 
 ---
 
-## LATER — 비즈니스 확장 트리거가 있을 때
+## STALE_OR_SUPERSEDED
 
-### 다중 판매자 Phase 2
+다음은 과거 상태를 그대로 전제로 실행하지 않는다.
 
-- [ ] active 상점 목록 API
-- [ ] 상점 상세 API
-- [ ] consumer 상점 목록·상세 화면
-- [ ] 단일 상점 가정 제거 및 동적 `storeId` 전환
-- [ ] 판매자 자체 가입 → 플랫폼 승인 플로우 설계
-
-### 거점 배송 오픈
-
-트리거: 실제 협력 업체 거점 계약 확정.
-
-- [ ] 운영 거점 등록
-- [ ] consumer 배송 수단에서 `hub` 노출 조건 활성화
-- [ ] 운영 권한·픽업 절차 최종 검수
-- [ ] 필요 시 QR 픽업 인증 고도화
-
-### 거점 스태프 권한
-
-트리거: 협력 업체 직원이 직접 픽업 처리해야 할 때.
-
-- [ ] `hub_staff` 역할 설계
-- [ ] hub↔staff 관계 모델
-- [ ] 초대·온보딩 UI
-- [ ] API 권한·hub 스코핑
-- [ ] 전용 접근 경로와 감사 로그
-
-### 외부 드라이버 정산
-
-트리거: 판매자 본인이 아닌 외부 드라이버를 고용할 때.
-
-- [ ] `driverSettlements` 모델 설계
-- [ ] 건당/거리 기반 배송료 정책 결정
-- [ ] 드라이버별 정산 API
-- [ ] driver 앱 수익 요약
-- [ ] admin 지급 처리
-- [ ] 판매자 정산과 driver fee 관계 확정
-
-### 플랫폼형 드라이버 모델
-
-트리거: 불특정 다수 드라이버를 모집할 때.
-
-- [ ] 신원·면허·보험 검증 체계
-- [ ] 실시간 위치 수집
-- [ ] 자동 배정 알고리즘
-- [ ] 소비자 실시간 위치 노출
-- [ ] 자동 정산·인센티브 정책
-
-### 결제 수단 확장
-
-- [ ] 카드 PG 추가 계약 필요성을 실제 사업 운영 기준으로 재평가
-- [ ] 네이버페이 신규 출시 필요성을 현재 PortOne·사업 전략과 다시 비교한 뒤 별도 Task로 결정
+- 네이버페이 “승인 메일 대기 / 채널키만 넣으면 즉시 활성화”
+- 과거 BUG-03 Firestore 공개 read/Firebase Custom Token 가정
+- 과거 운영 DB `reset-*` / `visual-settle-*` cleanup 지시
+- 2026-05 Railway outage 당시 상태
+- PR #11 OPEN/Draft·병합 금지 표현
+- 회차 ALIGO 템플릿 8종 “미등록” 표현
+- `main` merge가 자동 production 배포를 해야 한다는 과거 전제
 
 ---
 
-## STALE_OR_SUPERSEDED — 실행 전 재검증 필수
+## 관리 원칙
 
-### 네이버페이 “승인 메일 대기 / 채널키만 넣으면 즉시 활성화”
-
-2026-04 상태 문구다. 현재 파트너 승인·계약·PortOne 채널 설정·제품 전략을 다시 확인하지 않고 환경 변수부터 추가하지 않는다.
-
-### BUG-03 — Firestore 공개 read와 Firebase Custom Token
-
-과거 Rules·인증 구조를 전제로 한 항목이다. 현재 코드와 Rules를 직접 감사한 뒤 살아 있는 결함일 때만 새 보안 Task로 등재한다.
-
-### 운영 DB의 `reset-*` / `visual-settle-*` 시드 잔존
-
-이후 출시 진단에서 기존 reset·visual 검증 시드가 운영 상품·주문·정산 컬렉션에 남아 있지 않은 것으로 확인됐다. 새 증거 없이 삭제 스크립트를 실행하지 않는다.
-
-### Railway 2026-05 Major Outage 당시 상태
-
-당시 장애 원인·복구 기록은 역사 자료다. 현재 Railway 장애로 간주하지 않는다. 단일 공급자 복원력 검토는 LATER로 유지한다.
-
-### 과거 PR #11 OPEN/Draft·병합 금지
-
-PR #11은 2026-08-23 `MERGED`·`CLOSED` 됐다. 과거 문서의 해당 표현은 현재 작업 지시가 아니다.
-
-### 회차 알림 템플릿 8종 “미등록”
-
-2026-08-23 provider 등록·심사 요청이 완료됐다. 현재 상태는 8종 모두 `검수중`이다.
-
----
-
-## DONE_HISTORY — 현재 판단에 필요한 마일스톤만
-
-- 회차 직배송 MVP 구현 완료 및 PR #11을 통해 `main` 통합
-- 기능 통합 기준 SHA `e55f25914cc7d01576fbd4639583daaf0fe6385e`
-- 카카오 비즈니스 채널 최종 승인
-- **비판매 상태 기준** consumer 법적 고지 production 반영 및 운영 검증
-- ALIGO 발신 프로필·`senderkey` 준비
-- 내부 논리 템플릿↔ALIGO `tpl_code` 분리와 필수 변수 검증 구현
-- 회차 알림 템플릿 8종 provider 등록·심사 요청
-- 운영 Firebase Rules·indexes 출시 준비 반영
-- 과거 전체 원격 회차 E2E 52건 + 양쪽 cleanup 성공 증거 확보
-
-## 백로그 관리 원칙
-
-1. 완료 항목을 장문 세션 로그로 계속 누적하지 않는다.
-2. 현재 행동 가능한 미완료만 `ACTIVE/BLOCKED_EXTERNAL/NEXT/LATER`에 둔다.
-3. 오래된 외부 상태는 실제 재조회 후 상태를 바꾼다.
-4. 외부 운영 변경은 Backlog 체크박스만으로 승인된 것으로 보지 않는다.
-5. 현재 출시 우선순위와 충돌하면 `docs/memory.md`와 활성 HANDOFF·PLAN을 우선한다.
-6. 완료 이력은 Git history 또는 `docs/archive/`를 사용한다.
+1. 완료 이력을 장문으로 누적하지 않는다.
+2. 현재 행동 가능한 미완료만 ACTIVE/BLOCKED_EXTERNAL/NEXT/LATER에 둔다.
+3. 외부 상태는 실제 재조회 뒤에만 갱신한다.
+4. Backlog 체크박스는 production 변경 승인으로 간주하지 않는다.
+5. 현재 출시 우선순위 충돌 시 `docs/memory.md`와 활성 HANDOFF·PLAN을 우선한다.
+6. 모든 repository 변경은 direct `main`이 아니라 branch+PR로 수행한다.

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -6,53 +6,61 @@
 
 ## 검증 기준
 
-- Git·GitHub 직접 재검증: `2026-08-23 KST`
-- 외부 환경 상태 기준: `2026-08-23 KST`
-- GitHub PR #11 병합 상태와 `main`↔기존 회차 branch 비교를 직접 재조회했다.
-- ALIGO 템플릿 상태는 2026-08-23 provider 등록 결과를 기준으로 한다.
-- Firebase·Railway·Vercel 운영 상태와 `salesMode`는 활성 HANDOFF의 최신 확인 결과를 사용한다.
-- 별도 승인 없이 외부 운영 상태를 변경하지 않는다.
+- Git·GitHub·Vercel 직접 재검증: `2026-08-23 KST`
+- ALIGO 상태: 2026-08-23 provider 등록 결과
+- 운영 상태 변경은 별도 승인 없이 수행하지 않는다.
 
 ## Git 기준선
 
 - 저장소: `booker-lab/greenhub`
 - 기본 브랜치: `main`
-- 통합 완료 회차 branch: `codex/mvp-sales-round-direct`
-- 기능 통합 기준 SHA: `e55f25914cc7d01576fbd4639583daaf0fe6385e`
-- PR #11은 2026-08-23 KST에 `MERGED`·`CLOSED` 됐다.
-- 병합 직후 `main`과 기존 회차 branch는 기능 기준 SHA에서 `identical`이었다.
-- 이후 문서 정합화 commit이 `main`에 추가됐으므로 새 작업 시작 시 현재 `main` HEAD를 다시 확인한다.
-- 기존 회차 branch는 새 기능 작업의 장기 기준 branch로 재사용하지 않는다.
+- 현재 확인된 `main` HEAD: `01c0bb534c780c56d483030c87f058740599f88a`
+- 회차 직배송 기능 통합 기준 SHA: `e55f25914cc7d01576fbd4639583daaf0fe6385e`
+- PR #11: `MERGED`·`CLOSED`
+- 기존 `codex/mvp-sales-round-direct`는 통합 완료 branch이며 새 작업 기준 branch로 재사용하지 않는다.
+- 새 작업은 최신 `main`에서 목적별 branch를 만들고 PR로 통합한다.
+
+## 배포 안전성 상태
+
+2026-08-23 감사에서 `main` push가 문서 변경만으로도 Vercel production-target deployment와 Preview/E2E 연쇄 실행을 만들 수 있음을 확인했다.
+
+repo-side remediation은 완료됐다.
+
+- PR #30: consumer·seller·driver `git.deploymentEnabled.main=false`
+- PR #30 merge SHA `a83fa20516ed6209a4705020cc92154f39e383ca` 이후 세 Vercel 프로젝트의 신규 deployment 0건 확인
+- `sync-preview.yml`: `docs/**`, `**/*.md`만 바뀐 `main` push 제외
+- `AGENTS.md`: 문서-only 포함 direct `main` commit/push 금지, branch+PR 통합 요구
+- `deployment-safety.yml` + `verify-deployment-safety.mjs`: 안전 invariant 검증
+- PR #31: 세 앱 순수 docs/Markdown 변경의 Vercel build skip `ignoreCommand` 추가
+- pure-docs 검증 commit `ebf44c104b2e8758733fd14501fd0e820d575ae4` 이후 세 Vercel 프로젝트 신규 deployment 0건 확인
+
+남은 관리자 P0:
+
+- GitHub `main`은 마지막 재조회에서 `protected=false`.
+- Issue #32 `P0: main branch protection / ruleset 활성화`가 남아 있다.
+- 목표: PR required, Deployment safety guard required check, force push·branch delete 차단.
+- 연결된 GitHub 도구에는 해당 관리자 mutation이 없어 Issue #32 완료 전까지 정책+CI 방어 상태다.
+
+**중요:** `main` merge는 production 배포 승인이 아니다. production은 검증된 exact release SHA와 별도 `Task 3.1 승인`을 사용해야 하며, 빈 commit·재-push로 배포를 유도하지 않는다.
+
+상세: `docs/plans/PLAN_deployment_safety_guards_20260823.md`
 
 ## 제품 현재 상태
 
 - 회차 직배송 MVP 구현은 `main`에 통합됐다.
-- API에는 회차 주문·결제 최종화·환불·재배송비·운영 예외·보관·배송 사진 흐름이 포함된다.
-- consumer에는 회차 구매 흐름, seller에는 회차 관리·주문 운영 흐름, driver에는 직배송 흐름이 구현돼 있다.
+- consumer 회차 구매, seller 회차·주문 운영, driver 직배송 흐름이 구현돼 있다.
+- API에는 회차 주문·결제 최종화·환불·재배송비·배송 보류·배송 사진·운영 예외 흐름이 포함된다.
 - 공통 회차 계약은 `packages/shared/src/sale-round.types.ts`가 소유한다.
 - 카카오 비즈니스 채널 최종 승인 완료.
-- ALIGO 발신 프로필 1건 등록과 `senderkey` 발급 완료.
-- 내부 논리 템플릿 코드↔provider `tpl_code` 분리 및 필수 변수 검증 구현 완료.
-- 회차 알림 템플릿 8종 provider 등록·심사 요청 완료.
-- 현재 8종 모두 `검수중`, 중복·오류·반려 없음.
-- 실제 알림톡·SMS 발송 0건. 실제 알림톡 정상 발송과 SMS fallback 검증 미실행.
-- 운영 ALIGO 자격 증명 4개와 `ALIGO_TEMPLATE_CODES_JSON` 미반영.
-- 회차 출시 후보 production 배포, 첫 운영 회차 생성, `salesMode` 전환 미실행.
+- 운영 Firebase indexes·Firestore Rules·Storage Rules는 기존 출시 준비에서 반영 완료 상태이며 출시 전 재조회가 필요하다.
+- 회차 출시 후보 production 배포, 첫 운영 회차 생성, `salesMode` 전환은 미실행.
 - 판매 모드는 최신 운영 확인 기준 `legacy`.
-- 운영 Firebase indexes·Firestore Rules·Storage Rules는 기존 출시 준비에서 반영 완료 상태.
-- 따라서 회차 직배송 MVP 코드는 `main`에 통합됐지만 운영 기능 공개 전인 `paused_external_review` 상태다.
 
-## 판매 활성화 법적 문서 상태
+## ALIGO 템플릿 상태
 
-- 현재 production `/privacy`, `/terms`는 2026-08-19 시행 버전이다.
-- 이용약관·개인정보처리방침은 현재 상용 주문·결제·배송을 운영하지 않는 **비판매 상태**를 명시한다.
-- 개인정보 정본은 PortOne·결제사업자를 현재 상용 처리 수탁자로 운영하지 않는다고 적고 있다.
-- 실제 고객 ALIGO 알림의 공급자 처리도 현재 공개 고지에 별도 반영돼 있지 않다.
-- 그러므로 기존 법적 고지의 production 반영 완료는 **판매 활성화 법적 준비 완료를 뜻하지 않는다.**
-- ALIGO 실제 발송 검증 뒤, 실제 출시 대상 SHA를 고정하기 전에 `docs/specs/legal/README.md`의 P0 재정합화 게이트를 수행한다.
-- 판매가 아직 공개되지 않은 현재는 비판매 문구를 임의로 먼저 `판매 중` 상태로 바꾸지 않는다.
-
-## ALIGO 템플릿 심사 현황
+- 발신 프로필 1건 정상, `senderkey` 발급 완료.
+- 내부 논리 템플릿 코드 ↔ provider `tpl_code` 분리 및 필수 변수 검증 구현 완료.
+- 아래 8종 provider 등록·심사 요청 완료, 현재 모두 `검수중`.
 
 | 논리 템플릿 | 상태 |
 |---|---|
@@ -66,60 +74,61 @@
 | `ORDER_CANCELLED` | 검수중 |
 
 - 실제 알림톡·SMS 발송: 0건
-- 비밀값 원문은 기록하지 않는다.
+- 실제 알림톡 정상 발송·SMS fallback 검증: 미실행
+- 운영 ALIGO 자격 증명 4개·`ALIGO_TEMPLATE_CODES_JSON`: 미반영
+
+현재 출시 흐름의 외부 차단점은 ALIGO 8종 심사 완료다.
+
+## 판매 활성화 법적 문서 상태
+
+- production `/privacy`, `/terms`는 2026-08-19 시행 버전이다.
+- 현재 공개 문서는 상용 주문·결제·배송을 운영하지 않는 **비판매 상태**를 명시한다.
+- 개인정보 정본은 PortOne·결제사업자를 현재 상용 처리 수탁자로 운영하지 않는다고 적고 있다.
+- 실제 고객 ALIGO 알림 처리도 판매 활성화 기준으로 재검수해야 한다.
+- 기존 법적 고지 production 반영 완료는 **판매 활성화 법적 준비 완료를 뜻하지 않는다.**
+- ALIGO 실제 발송 검증 뒤 release SHA 고정 전에 `docs/specs/legal/README.md`의 P0 재정합화 게이트를 완료한다.
+- 판매 공개 전에는 비판매 문구를 임의로 `판매 중`으로 미리 바꾸지 않는다.
 
 ## 검증 상태
 
 - 마지막 전체 원격 회차 E2E 성공 증거: SHA `6e0fc9d4cec08073ed2504208cc8bb1ea395ee7d`, run `32351887404`.
 - chromium 26 + mobile 26 = 총 52건 및 양쪽 fixture cleanup 성공.
-- 이후 commit에 이 과거 run을 현재 release SHA 성공으로 확장하지 않는다.
-- production 배포 전 실제 출시 대상 SHA에서 전체 원격 회차 E2E와 cleanup을 다시 통과해야 한다.
-
-## 문서 정합성 상태
-
-2026-08-23 문서 감사에서 다음 고위험 영역을 현재 상태와 분리·정합화했다.
-
-- 현재 상태: `memory`, 활성 HANDOFF·출시 PLAN, `BACKLOG`
-- 라우팅: `docs/README.md`, `PROJECT_MAP`, plans/API/frontend/ops/security/design/performance README
-- 실행/환경: README, `INTEGRATION_TEST`, `URLS`, `TROUBLESHOOTING`, toolchain
-- API 현행 계약: auth, products, orders, payments, notifications, hubs, settlements, admin
-- ops: 회차 runbook, E2E 환경, Preview auth URL 정책, 카카오 채널 증빙, k6 계획
-- frontend/security: 과거 `*-plan`·감사 템플릿과 현재 계약 분리, 위험한 운영 DB visual seed 지시 제거
-- legal: 비판매 공개 문서와 향후 판매 활성화 사이의 P0 재정합화 게이트 추가
-
-과거 PLAN·REPORT·frontend plan·security findings template는 삭제하지 않고 역사 자료로 보존한다. 파일 내부의 과거 `TODO/대기/next`를 현재 지시로 자동 승계하지 않는다.
+- 이 과거 run을 현재 release SHA 검증으로 확장하지 않는다.
+- 법적 페이지까지 포함한 실제 출시 대상 SHA를 고정한 뒤 52건+cleanup을 다시 통과해야 한다.
 
 ## 활성 문서
 
-- 문서 전체 라우팅: `docs/README.md`
-- 저장소 작업 규칙: `AGENTS.md`
+- 전체 문서 라우팅: `docs/README.md`
+- 작업 규칙: `AGENTS.md`
 - Context 라우터: `docs/PROJECT_MAP.md`
 - 현재 상태 SSOT: 이 문서
 - 현재 재개 순서: `docs/plans/HANDOFF_mvp_round_direct_aligo_review_pause.md`
 - 출시 실행 계약: `docs/plans/PLAN_mvp_round_direct_launch_blockers.md`
+- 배포 안전 계약: `docs/plans/PLAN_deployment_safety_guards_20260823.md`
 - 판매 활성화 법적 게이트: `docs/specs/legal/README.md`
 - 현재 미완료 작업: `docs/BACKLOG.md`
-- 설계 결정: `docs/CRITICAL_LOGIC.md`
+- 설계 결정 이력: `docs/CRITICAL_LOGIC.md`
 
-동작 계약이 충돌하면 현재 `main` 코드·설정·테스트를 기준으로 현행 spec을 정합화한다. 운영·진행 상태가 충돌하면 직접 재검증 결과, 이 문서, 최신 HANDOFF·PLAN, 역사 자료 순으로 판정한다.
+## 승인 경계
 
-## 외부 승인 경계
+명시적 승인 없이 다음을 수행하지 않는다.
 
-사용자의 명시적 승인 없이 다음을 수행하지 않는다.
-
-- ALIGO 템플릿 추가 등록·변경 또는 실제 알림톡·SMS 발송
-- 운영 자격 증명·환경 변수·데이터 변경
-- Railway·Vercel·Firebase 운영 변경 또는 배포
-- 운영 회차 생성·상태 변경 또는 `salesMode` 전환
+- ALIGO 템플릿 변경·추가 등록·실제 알림톡/SMS 발송
+- 운영 자격 증명·환경 변수·Firebase/운영 데이터 변경
+- Railway·Vercel production 배포·롤백
+- 운영 회차 생성·상태 변경·`salesMode` 전환
 - 실제 결제·환불
 
-비밀값과 개인정보 원문은 문서, 명령 출력, 로그, Git에 기록하지 않는다.
+비밀값과 고객 개인정보 원문은 문서·로그·Git에 기록하지 않는다.
 
 ## 다음 작업
 
-1. ALIGO 회차 알림 템플릿 8종 심사 결과를 기다린다. 상태가 바뀌기 전에는 실제 발송·운영 변수·배포 단계로 진행하지 않는다.
-2. 8종 승인 뒤 격리 실제 알림톡 정상 발송 → SMS fallback 검증을 수행한다.
-3. 그 다음 **판매 활성화 법적 문서 재정합화**를 완료한다. 이 단계에서 consumer `/privacy`, `/terms`와 법적 테스트가 실제 결제·알림·배송 정책과 일치해야 한다.
-4. 법적 페이지 변경까지 포함한 실제 출시 대상 SHA를 확정한 뒤 전체 원격 회차 E2E 52건+cleanup을 다시 통과시킨다.
-5. 이후 운영 Firebase 재조회 → 승인된 ALIGO 운영 설정 → 별도 `Task 3.1 승인` → production 배포 → 첫 회차 → 최종 판정 → `salesMode` 전환 순으로 진행한다.
-6. 문서 감사는 링크·참조 무결성과 개별 current spec의 코드 충돌만 낮은 우선순위로 계속 점검한다.
+1. **P0 병렬 관리자 게이트**: Issue #32의 `main` branch protection/ruleset 활성화.
+2. **외부 차단**: ALIGO 8종 심사 결과 대기. 승인 전 실제 발송·운영 ALIGO 설정은 진행하지 않는다.
+3. 8종 승인 후 격리 알림톡 정상 발송 → SMS fallback 검증.
+4. 판매 활성화 법적 문서·테스트 재정합화.
+5. 법적 변경까지 포함한 actual release SHA 확정 → 원격 회차 E2E 52건+cleanup.
+6. 운영 Firebase 재조회 → ALIGO 운영 설정 → 별도 `Task 3.1 승인` → exact-SHA production 배포.
+7. 이후 첫 회차 검수 → 최종 출시 판정 → `salesMode: round_direct` 전환.
+
+문서 정합성 감사 자체는 앞으로도 **branch + PR**로 수행하고, current 계약과 직접 충돌하는 문서만 수정한다.

--- a/docs/plans/HANDOFF_mvp_round_direct_aligo_review_pause.md
+++ b/docs/plans/HANDOFF_mvp_round_direct_aligo_review_pause.md
@@ -2,45 +2,60 @@
 
 # 회차 직배송 MVP — ALIGO 심사 대기 인계
 
-> 현재 재개 순서만 유지한다. 과거 출시 준비 상세 증거는 `docs/plans/REPORT_mvp_round_direct_launch.md`와 Git 이력에서 확인한다.
+> 현재 재개 순서만 유지한다. 상세 과거 증거는 `docs/plans/REPORT_mvp_round_direct_launch.md`와 Git 이력에서 확인한다.
 
 ## 현재 상태 — 2026-08-23 KST
 
-회차 직배송 MVP 코드는 PR #11을 통해 `main`에 통합됐다. 기능 통합 기준 SHA는 `e55f25914cc7d01576fbd4639583daaf0fe6385e`다. 기존 `codex/mvp-sales-round-direct`는 통합 완료 branch로 취급한다.
+- 회차 직배송 MVP는 PR #11을 통해 `main` 통합 완료.
+- 기능 통합 기준 SHA: `e55f25914cc7d01576fbd4639583daaf0fe6385e`.
+- 카카오 비즈니스 채널 최종 승인 완료.
+- ALIGO 발신 프로필·`senderkey` 준비 완료.
+- 회차 알림 템플릿 8종 provider 등록·심사 요청 완료, 전부 `검수중`.
+- 실제 알림톡·SMS 발송 0건.
+- production ALIGO 자격 증명·8종 매핑 미반영.
+- 첫 운영 회차 미생성, `salesMode=legacy`.
 
-카카오 비즈니스 채널 승인, ALIGO 발신 프로필, `senderkey`, 내부 논리 템플릿↔provider `tpl_code` 분리와 필수 변수 검증까지 완료됐다. 회차 알림 템플릿 8종은 2026-08-23 provider에 등록·심사 요청됐고 현재 모두 `검수중`이다.
+현재 외부 차단점은 **ALIGO 8종 provider 심사 완료**다.
 
-따라서 **현재 즉시 차단점은 ALIGO 8종 provider 심사 완료**다. 다만 심사가 끝난 뒤 곧바로 release SHA를 고정하면 안 된다. 현재 공개 `/terms`, `/privacy`는 2026-08-19의 비판매 상태를 전제로 하므로 실제 판매 공개 전에 법적 문서·공개 페이지 재정합화가 필요하다.
+동시에 해결 가능한 관리자 P0는 **Issue #32 `main` branch protection/ruleset 활성화**다.
 
-## 현재 운영 상태
+## 배포 안전성 변경
 
-| 항목 | 상태 |
-|---|---|
-| 회차 직배송 코드 | `main` 통합 완료 |
-| 카카오 비즈니스 채널 | 최종 승인 완료 |
-| consumer 법적 고지 | **비판매 상태 버전 production 반영 완료; 판매 활성화 전 개정 필요** |
-| ALIGO 발신 프로필 | 정상 1건 |
-| `senderkey` | 발급 완료 |
-| 회차 알림 템플릿 8종 | 등록 완료·전부 `검수중` |
-| 실제 알림톡 정상 발송 | 미실행 |
-| SMS fallback 검증 | 미실행 |
-| 운영 ALIGO 자격 증명·매핑 | 미반영 |
-| 운영 Firebase Rules·indexes | 이전 준비에서 반영 완료 상태 |
-| 회차 출시 후보 production 배포 | 미실행 |
-| 첫 운영 회차 | 미생성 |
-| `salesMode` | `legacy` 유지 |
+2026-08-23 배포 감사에서 `main` push가 문서 변경만으로 Vercel production deployment를 만들던 구조를 확인했고 repo-side remediation을 적용했다.
 
-## 법적 공개 문서 주의
+- PR #30: consumer·seller·driver `main` Vercel Git auto-deploy 차단.
+- PR #30 merge 후 세 프로젝트 신규 deployment 0건 확인.
+- docs-only `main` push는 Preview sync/E2E 제외.
+- deployment safety CI 추가.
+- `AGENTS.md`: direct `main` commit/push 금지.
+- PR #31: 순수 docs/Markdown Vercel build skip.
+- pure-docs branch 검증에서도 세 프로젝트 신규 deployment 0건 확인.
 
-현재 이용약관과 개인정보처리방침은 다음 전제를 명시한다.
+남음:
 
-- 현재 상용 주문·결제·배송을 운영하지 않음
-- PortOne·결제사업자를 현재 상용 처리 수탁자로 운영하지 않음
-- 실제 고객 ALIGO 알림 공급자 처리는 별도 현재 공개 고지에 반영되지 않음
+- GitHub `main`은 마지막 재조회에서 `protected=false`.
+- Issue #32에서 PR required + safety required check + force-push/delete 차단 필요.
 
-따라서 판매 활성화 전 `docs/specs/legal/README.md`의 P0 게이트를 수행한다. 이 변경은 consumer 법적 페이지 코드와 테스트를 바꾸므로 **실제 출시 대상 SHA를 확정하기 전에** 끝내야 한다.
+**중요:** `main` merge는 더 이상 production 배포 경로가 아니다. production은 actual release SHA를 고정·검증한 뒤 별도 승인으로 exact-SHA deploy/promotion을 수행한다.
 
-## ALIGO 템플릿 심사 현황
+상세: `docs/plans/PLAN_deployment_safety_guards_20260823.md`.
+
+## 판매 활성화 법적 상태
+
+production `/privacy`, `/terms`는 현재 비판매 상태를 전제로 한다.
+
+따라서 ALIGO 실제 발송 검증 뒤 release SHA를 고정하기 전에:
+
+- 실제 주문·결제·취소·환불·배송·재배송비·보류 정책,
+- PortOne/결제사업자 개인정보 처리,
+- ALIGO 고객 알림 처리,
+- seller/driver 배송정보 접근,
+- 시행일·이전 버전,
+- `legal-documents.test.mjs`
+
+을 `docs/specs/legal/README.md` 계약에 맞게 갱신한다.
+
+## ALIGO 템플릿 현황
 
 | 논리 템플릿 | 상태 |
 |---|---|
@@ -53,55 +68,63 @@
 | `ORDER_DELIVERED` | 검수중 |
 | `ORDER_CANCELLED` | 검수중 |
 
-- 중복·오류·반려: 없음
-- 실제 알림톡·SMS 발송: 0건
-- 비밀값 원문은 기록하지 않는다.
+- 중복·오류·반려 없음.
+- 비밀값 원문 기록 금지.
 
 ## 검증 기준
 
-- 마지막 전체 원격 회차 E2E 성공 증거: SHA `6e0fc9d4cec08073ed2504208cc8bb1ea395ee7d`, run `32351887404`
-- chromium 26 + mobile 26 = 52건, fixture cleanup 성공
-- 과거 run은 현재 release SHA 검증을 대신하지 않는다.
+- 마지막 전체 원격 회차 E2E 역사 증거: SHA `6e0fc9d4cec08073ed2504208cc8bb1ea395ee7d`, run `32351887404`.
+- chromium 26 + mobile 26 = 52, 양쪽 cleanup 성공.
+- 현재 release SHA 증거로 확장 적용하지 않는다.
 
 ## 지금 하지 말아야 할 작업
 
-- 심사 중 템플릿을 중복 등록하거나 임의 수정하지 않는다.
-- 승인 전 실제 알림톡·SMS를 발송하지 않는다.
-- ALIGO 자격 증명·`tpl_code` 원문을 문서·Git에 기록하지 않는다.
-- 별도 승인 없이 production 배포·환경 변수·Firebase·운영 데이터를 변경하지 않는다.
-- 운영 회차를 만들거나 `salesMode`를 변경하지 않는다.
-- 현재 비판매 약관을 그대로 둔 채 판매기능을 공개하지 않는다.
-- 반대로 판매가 아직 공개되지 않았는데 약관을 임의로 `현재 판매 중` 상태로 선반영하지 않는다.
+- 심사 중 템플릿 중복 등록·임의 수정.
+- 승인 전 실제 알림톡·SMS 발송.
+- ALIGO secret/`tpl_code` 원문 Git 기록.
+- direct `main` commit/push.
+- `main` merge를 production 배포 승인으로 해석.
+- 별도 Task 승인 없이 production 배포·Firebase 운영 변경·운영 회차 생성·`salesMode` 변경.
+- 비판매 법적 문구를 판매 공개 전에 임의로 미리 전환.
 
-## 재개 순서
+## 지금 병렬로 할 수 있는 작업
 
-1. ALIGO 템플릿 8종의 심사 결과를 확인한다.
-2. 8종 모두 승인됐는지, 수정 요청·반려가 없는지 기록한다.
-3. 승인된 실제 `tpl_code`와 논리 템플릿 8종의 매핑 준비상태를 값 비공개 방식으로 검증한다.
-4. 별도 승인 후 격리 수신자 실제 알림톡 정상 발송을 검증한다.
-5. 별도 승인 후 SMS fallback을 검증한다.
-6. **판매 활성화 법적 문서 재정합화**를 수행한다: `/terms`, `/privacy`, PortOne/결제사업자, ALIGO 고객 알림, 배송정보 접근, 취소·환불·배송 정책, 시행일·이전 버전, 법적 문서 테스트를 실제 MVP와 일치시킨다.
-7. 법적 페이지 변경까지 포함된 실제 출시 대상 `main` SHA를 확정한다.
-8. 해당 SHA에서 전체 원격 회차 E2E 52건과 fixture cleanup을 통과시킨다.
-9. 운영 Firebase 상태를 읽기 전용 재확인한다.
-10. 별도 승인 후 운영 ALIGO 자격 증명·매핑을 반영한다.
-11. `docs/plans/PLAN_mvp_round_direct_launch_blockers.md`의 Task 3.1 승인 게이트를 확인한다.
-12. 사용자의 별도 `Task 3.1 승인`이 있을 때만 production 배포로 진행한다.
-13. 배포 후 새 `/privacy`, `/terms`를 포함한 무변경 smoke → 첫 회차 검수 → 최종 출시 판정 → `salesMode` 전환 순으로 진행한다.
+1. Issue #32 `main` protection/ruleset 관리자 설정.
+2. read-only 문서/코드 정합성 감사.
+3. ALIGO provider 심사 상태 조회.
+
+## ALIGO 승인 뒤 재개 순서
+
+1. 8종 모두 승인/수정요청/반려 여부 확인.
+2. 승인 `tpl_code` 8종 ↔ 내부 논리 템플릿 1:1 매핑 검사.
+3. 별도 승인 후 격리 실제 알림톡 정상 발송.
+4. 별도 승인 후 SMS fallback 실제 검증.
+5. 판매 활성화 법적 문서·테스트 재정합화.
+6. Issue #32 완료 확인.
+7. 법적 변경까지 포함한 actual release SHA 확정.
+8. exact SHA 원격 회차 E2E 52건 + fixture cleanup.
+9. 운영 Firebase read-only 재조회.
+10. 별도 승인 후 production ALIGO 설정 반영·검증.
+11. exact-SHA production deploy/promotion 절차 확정.
+12. 사용자의 별도 `Task 3.1 승인` 뒤에만 production 배포.
+13. deployment metadata SHA 대조 → 운영 smoke.
+14. 첫 회차 검수 → 최종 출시 판정 → `salesMode: round_direct` 전환.
 
 ## 재개 완료 조건
 
-- [x] 카카오 비즈니스 채널 최종 승인
 - [x] 회차 직배송 코드 `main` 통합
-- [x] ALIGO 발신 프로필·`senderkey` 준비
-- [x] 회차 알림 템플릿 8종 provider 등록·심사 요청
-- [ ] 회차 알림 템플릿 8종 최종 승인
-- [ ] 실제 알림톡 정상 발송 검증
-- [ ] SMS fallback 검증
-- [ ] **판매 활성화용 개인정보처리방침·이용약관 재정합화**
-- [ ] 법적 페이지를 포함한 실제 출시 대상 SHA 확정
-- [ ] 해당 SHA 전체 원격 회차 E2E·cleanup 통과
-- [ ] 운영 ALIGO 설정·템플릿 매핑 검사 통과
+- [x] 카카오 비즈니스 채널 승인
+- [x] ALIGO 발신 프로필·senderkey 준비
+- [x] ALIGO 템플릿 8종 등록·심사 요청
+- [x] repo-side `main` 자동 production deploy 차단
+- [x] deployment safety CI와 docs-only ignore 적용
+- [ ] Issue #32 branch protection/ruleset
+- [ ] ALIGO 템플릿 8종 최종 승인
+- [ ] 실제 알림톡 정상 발송
+- [ ] SMS fallback
+- [ ] 판매 활성화 법적 문서 정합화
+- [ ] actual release SHA 원격 E2E 52건+cleanup
+- [ ] production ALIGO 설정
 - [ ] Task 3.1 별도 승인
 
-미완료 조건을 충족하기 전에는 회차 출시 후보를 production에 공개하거나 `salesMode`를 전환하지 않는다.
+미완료 게이트를 건너뛰어 production 배포 또는 `salesMode` 전환을 진행하지 않는다.

--- a/docs/plans/PLAN_deployment_safety_guards_20260823.md
+++ b/docs/plans/PLAN_deployment_safety_guards_20260823.md
@@ -15,6 +15,7 @@
 - `.github/workflows/deployment-safety.yml`과 `scripts/verify-deployment-safety.mjs`가 배포 안전 invariant를 검증한다.
 - PR #31로 세 앱에 docs-only `ignoreCommand`를 추가해 순수 문서/Markdown 변경의 Vercel Preview build를 skip하도록 구성했다.
 - PR #30·#31의 deployment safety CI는 모두 성공했다.
+- pure-docs branch `docs/deployment-safety-closeout`의 commit `ebf44c104b2e8758733fd14501fd0e820d575ae4` 이후 consumer·seller·driver 세 Vercel 프로젝트 신규 deployment가 0건임을 확인해 feature-branch docs-only skip을 실증했다.
 
 ### 남은 P0 관리자 게이트
 
@@ -49,9 +50,10 @@ production은 다음 조건을 모두 충족한 뒤에만 실행한다.
 ## docs-only 변경 계약
 
 - feature branch의 변경 파일이 모두 `docs/**` 또는 `*.md`이면 세 Vercel 프로젝트의 `ignoreCommand`가 build를 skip한다.
+- feature-branch pure-docs 검증은 완료됐다: `ebf44c1...` 이후 세 프로젝트 신규 deployment 0건.
 - `main`에 docs-only PR이 merge돼도 Vercel production Git deploy는 `git.deploymentEnabled.main=false` 때문에 생성되면 안 된다.
 - 같은 docs-only merge는 `sync-preview.yml`의 `paths-ignore` 때문에 `preview` branch 동기화와 일반 E2E dispatch를 만들면 안 된다.
-- 이 규칙은 이 closeout 문서 PR 자체로 실증하고 결과를 Git/Vercel 상태에서 재확인한다.
+- 이 closeout PR merge 뒤 세 Vercel 프로젝트 deployment 0건과 `preview` branch SHA 불변을 다시 확인해 main-side 검증을 마무리한다.
 
 ## 회귀 방지
 
@@ -68,4 +70,5 @@ production은 다음 조건을 모두 충족한 뒤에만 실행한다.
 
 - 사용자 승인: `배포 안전장치 변경 승인`
 - repo-side guard: PR #30, PR #31
+- pure-docs branch skip 검증: `ebf44c104b2e8758733fd14501fd0e820d575ae4`
 - 관리자 잔여 작업: Issue #32

--- a/docs/plans/PLAN_deployment_safety_guards_20260823.md
+++ b/docs/plans/PLAN_deployment_safety_guards_20260823.md
@@ -1,29 +1,71 @@
 # Deployment Safety Guards — 2026-08-23
 
-> 상태: in_progress
+> 상태: `partially_resolved_admin_gate`
+>
+> 목적: `main` 통합과 production 배포를 분리하고, 문서 변경이 production/Preview/E2E를 불필요하게 움직이지 않도록 한다.
 
-## 확인된 위험
+## 현재 판정
 
-- GitHub `main`은 현재 branch protection/ruleset이 비활성 상태다.
-- Vercel consumer/seller/driver 3개 프로젝트는 GitHub `main` push에 대해 production-target deployment를 생성한다.
-- consumer는 docs-only `main` commit도 실제 production deployment `READY`까지 진행했다.
-- `.github/workflows/sync-preview.yml`은 모든 `main` push에서 `preview`를 자동 동기화한 뒤 3앱 Preview 배포 대기와 일반 E2E dispatch까지 수행한다.
+### 완료
 
-## 목표 상태
+- PR #30으로 consumer·seller·driver의 `main` Git 자동 Vercel deployment를 차단했다.
+- PR #30 merge SHA `a83fa20516ed6209a4705020cc92154f39e383ca` 이후 세 Vercel 프로젝트에서 새 deployment가 0건임을 직접 확인했다.
+- `.github/workflows/sync-preview.yml`은 `docs/**`와 `**/*.md`만 바뀐 `main` push를 제외한다.
+- `AGENTS.md`는 문서-only 변경을 포함해 `main` 직접 commit/push를 금지하고 PR 통합을 요구한다.
+- `.github/workflows/deployment-safety.yml`과 `scripts/verify-deployment-safety.mjs`가 배포 안전 invariant를 검증한다.
+- PR #31로 세 앱에 docs-only `ignoreCommand`를 추가해 순수 문서/Markdown 변경의 Vercel Preview build를 skip하도록 구성했다.
+- PR #30·#31의 deployment safety CI는 모두 성공했다.
 
-1. `main` merge 자체가 production 배포를 의미하지 않는다.
-2. production은 승인된 release SHA를 명시적으로 배포하는 경로만 사용한다.
-3. docs-only 변경은 preview sync/E2E를 불필요하게 실행하지 않는다.
-4. `main` 직접 push를 차단하고 PR 기반 변경만 허용한다.
+### 남은 P0 관리자 게이트
 
-## 적용 순서
+- GitHub `main`은 2026-08-23 재조회 기준 여전히 `protected=false`다.
+- 연결된 GitHub 도구에는 branch protection/ruleset mutation이 노출되지 않는다.
+- 관리자 설정 작업은 Issue #32 `P0: main branch protection / ruleset 활성화`로 추적한다.
 
-1. repository-side Vercel Git deployment guard 추가
-2. docs-only `main` push의 preview sync 제외
-3. GitHub `main` branch protection/ruleset 적용
-4. Vercel project Git integration에서 `main` auto production deploy 비활성화 확인
-5. exact-SHA production deploy 승인 경로 확정
+Issue #32 완료 조건:
 
-## 승인
+1. `main`에 PR required.
+2. `Deployment safety guard / verify`를 required status check로 지정.
+3. force push 차단.
+4. branch deletion 차단.
+5. 현재 1인 저장소에서는 self-deadlock을 피하도록 required approval 0으로 시작하고, 협업자가 생기면 1 이상으로 상향.
+6. 재조회에서 `protected=true` 또는 동등한 ruleset enforcement 확인.
 
-사용자 `배포 안전장치 변경 승인` 수신 후 수행한다.
+## 현재 배포 계약
+
+`main` merge 자체는 production 배포 승인이 아니다.
+
+production은 다음 조건을 모두 충족한 뒤에만 실행한다.
+
+1. 판매 활성화 법적 문서까지 포함한 release SHA 확정.
+2. 해당 exact SHA의 회차 원격 E2E 52건 + fixture cleanup 성공.
+3. 운영 Firebase·ALIGO 선행 게이트 통과.
+4. Issue #32의 `main` 보호 완료.
+5. 사용자의 별도 `Task 3.1 승인`.
+6. 배포 직전/직후 deployment metadata의 Git SHA가 승인된 release SHA와 정확히 일치함을 확인.
+
+현재 저장소에는 production 전용 자동 workflow가 없다. 따라서 향후 Task 3.1에서는 **이미 검증된 exact SHA/artifact를 명시적으로 production에 deploy 또는 promote하는 절차**를 먼저 확정하고, 단순히 `main`을 다시 push하거나 빈 commit으로 배포를 유도하지 않는다.
+
+## docs-only 변경 계약
+
+- feature branch의 변경 파일이 모두 `docs/**` 또는 `*.md`이면 세 Vercel 프로젝트의 `ignoreCommand`가 build를 skip한다.
+- `main`에 docs-only PR이 merge돼도 Vercel production Git deploy는 `git.deploymentEnabled.main=false` 때문에 생성되면 안 된다.
+- 같은 docs-only merge는 `sync-preview.yml`의 `paths-ignore` 때문에 `preview` branch 동기화와 일반 E2E dispatch를 만들면 안 된다.
+- 이 규칙은 이 closeout 문서 PR 자체로 실증하고 결과를 Git/Vercel 상태에서 재확인한다.
+
+## 회귀 방지
+
+다음 중 하나라도 깨지면 deployment safety regression으로 P0 처리한다.
+
+- 세 앱 중 하나의 `git.deploymentEnabled.main !== false`
+- docs-only `ignoreCommand` 제거/변경
+- `sync-preview.yml`의 docs ignore 제거
+- `AGENTS.md`의 no-direct-main 규칙 제거
+- safety CI 제거 또는 실패를 무시하고 merge
+- exact release SHA 검증 없이 production 배포
+
+## 승인 기록
+
+- 사용자 승인: `배포 안전장치 변경 승인`
+- repo-side guard: PR #30, PR #31
+- 관리자 잔여 작업: Issue #32

--- a/docs/plans/PLAN_mvp_round_direct_launch_blockers.md
+++ b/docs/plans/PLAN_mvp_round_direct_launch_blockers.md
@@ -2,7 +2,7 @@
 
 # Project Blueprint: 회차 직배송 MVP 출시 차단 요소 해소
 
-> 현재 실행 계약만 유지한다. 과거 상세 진단·Task 증거는 `docs/plans/REPORT_mvp_round_direct_launch.md`와 Git 이력에서 확인한다.
+> 현재 실행 계약만 유지한다. 과거 상세 증거는 `docs/plans/REPORT_mvp_round_direct_launch.md`와 Git 이력에서 확인한다.
 
 ## 문서 메타
 
@@ -11,166 +11,193 @@
 - 상태: `paused_external_review`
 - Priority: P0
 - 현재 외부 차단점: ALIGO 회차 알림 템플릿 8종 provider 심사 완료
+- 병렬 관리자 P0: GitHub Issue #32 `main` branch protection/ruleset
 - 현재 상태 SSOT: `docs/memory.md`
-- 재개 순서 SSOT: `docs/plans/HANDOFF_mvp_round_direct_aligo_review_pause.md`
+- 재개 순서: `docs/plans/HANDOFF_mvp_round_direct_aligo_review_pause.md`
+- 배포 안전 계약: `docs/plans/PLAN_deployment_safety_guards_20260823.md`
+- 판매 활성화 법적 게이트: `docs/specs/legal/README.md`
 - 운영 런북: `docs/specs/ops/mvp-sales-round-runbook.md`
-- 판매 활성화 전 법적 게이트: `docs/specs/legal/README.md`
 
 ## 현재 기준선
 
-- 회차 직배송 MVP 코드는 PR #11을 통해 `main`에 통합됐다.
-- 기능 통합 기준 SHA: `e55f25914cc7d01576fbd4639583daaf0fe6385e`
-- PR #11: `MERGED`·`CLOSED`
-- 카카오 비즈니스 채널 최종 승인 완료.
-- ALIGO 발신 프로필과 `senderkey` 준비 완료.
-- 회차 알림 템플릿 8종은 provider 등록·심사 요청 완료, 현재 전부 `검수중`.
+- 회차 직배송 MVP는 PR #11을 통해 `main`에 통합됐다.
+- 기능 통합 기준 SHA: `e55f25914cc7d01576fbd4639583daaf0fe6385e`.
+- 카카오 비즈니스 채널 승인, ALIGO 발신 프로필·`senderkey`, 내부↔외부 템플릿 코드 분리 구현 완료.
+- 회차 알림 템플릿 8종 provider 등록·심사 요청 완료, 모두 `검수중`.
 - 실제 알림톡 정상 발송·SMS fallback 검증 미실행.
-- 운영 ALIGO 자격 증명 4개와 `ALIGO_TEMPLATE_CODES_JSON` 미반영.
-- 운영 Firebase 인덱스·Firestore Rules·Storage Rules는 이전 준비에서 반영 완료 상태.
-- 회차 출시 후보 production 배포 미실행.
-- 첫 운영 회차 미생성.
-- `salesMode`는 `legacy` 유지.
-- 현재 공개 `/terms`, `/privacy`는 2026-08-19의 **비판매 상태**를 전제로 하므로 실제 판매 공개 전에 재정합화가 필요하다.
+- production ALIGO 자격 증명 4개와 `ALIGO_TEMPLATE_CODES_JSON` 미반영.
+- 운영 Firebase rules/indexes는 기존 준비에서 반영 완료 상태이며 출시 전 재조회 필요.
+- production 회차 앱 배포·첫 회차 생성·`salesMode` 전환 미실행.
+- `salesMode=legacy` 유지.
+- 현재 `/terms`, `/privacy`는 비판매 상태를 전제로 하므로 실제 판매 활성화 전 재정합화가 필요하다.
 
-## 상태 판정 원칙
+## 배포 안전 기준선
 
-1. 현재 상태는 `docs/memory.md`를 우선한다.
-2. 재개 순서는 HANDOFF를 우선한다.
-3. 이 문서는 dependency·승인 경계를 정의한다.
-4. 과거 PLAN·REPORT·PR 본문의 상태 문구는 현재 SSOT와 충돌하면 역사 기록으로만 취급한다.
-5. 코드·설정·테스트 계약이 문서와 충돌하면 현재 `main`을 확인해 spec을 정합화한다.
-6. 법적 문서의 현재 비판매 문구를 실제 판매 활성화 이후까지 그대로 두지 않는다.
+2026-08-23 발견된 `main push → Vercel production` 자동 연결은 repo-side에서 차단했다.
 
-## 현재 출시 게이트
+- PR #30: 세 프런트 `git.deploymentEnabled.main=false`.
+- PR #30 merge 뒤 3앱 신규 Vercel deployment 0건 확인.
+- docs-only `main` push는 Preview sync/E2E 제외.
+- PR #31: 순수 docs/Markdown의 Vercel build skip.
+- deployment safety CI 추가.
+- direct `main` 작업은 `AGENTS.md`에서 금지.
 
-| 순서 | 게이트 | 상태 | 다음 조건 |
-|---|---|---|---|
-| 1 | ALIGO 8종 provider 등록 | 완료 | — |
-| 2 | ALIGO 8종 최종 승인 | **대기** | 8종 모두 승인 |
-| 3 | 실제 알림톡 정상 발송 | 미실행 | 사용자 승인 + 승인 템플릿 |
-| 4 | SMS fallback 실제 검증 | 미실행 | 사용자 승인 + 격리 수신자 |
-| 5 | 판매 활성화 법적 문서 재정합화 | **미실행** | 실제 결제·알림·배송 정책 확정 |
-| 6 | 실제 출시 대상 SHA 확정 | 미실행 | 법적 페이지 변경 포함 |
-| 7 | 동일 SHA 전체 원격 회차 E2E | 미실행 | 출시 SHA 확정 |
-| 8 | 운영 Firebase 재조회 | 미실행 | E2E 통과 |
-| 9 | 운영 ALIGO 변수·매핑 반영 | 미실행 | 사용자 승인 + 발송 검증 통과 |
-| 10 | 운영 애플리케이션 배포 | 미실행 | **Task 3.1 별도 승인** |
-| 11 | 첫 회차 검수 | 미실행 | 운영 배포·smoke 통과 |
-| 12 | 최종 출시 판정 | 미실행 | 운영 역할·롤백·예외 확인 |
-| 13 | `round_direct` 전환 | 미실행 | 최종 승인 |
+그러나 GitHub `main` 자체는 마지막 재조회 기준 `protected=false`이므로 Issue #32 완료가 출시 전 필수다.
+
+**이제 `main` merge는 production 배포 수단이 아니다.** 운영 배포는 아래 Task 3 단계에서 검증된 exact release SHA를 명시적으로 deploy/promote한다.
+
+## 출시 게이트 요약
+
+| 순서 | 게이트 | 상태 |
+|---|---|---|
+| 0 | repo-side 자동배포 차단 | 완료 |
+| 0A | GitHub `main` branch protection/ruleset | **미완료 — Issue #32** |
+| 1 | ALIGO 8종 provider 최종 승인 | **검수중** |
+| 2 | 실제 알림톡 정상 발송 | 미실행 |
+| 3 | SMS fallback 실제 검증 | 미실행 |
+| 4 | 판매 활성화 법적 문서 재정합화 | 미실행 |
+| 5 | actual release SHA 확정 | 미실행 |
+| 6 | exact SHA 원격 회차 E2E 52건+cleanup | 미실행 |
+| 7 | 운영 Firebase 재조회 | 미실행 |
+| 8 | 운영 ALIGO 설정 | 미실행 |
+| 9 | exact-SHA production 배포 | 미실행 — 별도 Task 3.1 승인 |
+| 10 | 첫 회차 검수 | 미실행 |
+| 11 | 최종 출시 판정 | 미실행 |
+| 12 | `round_direct` 전환 | 미실행 |
 
 ## Agent Completion Contract
 
-1. dependency 순서대로 한 번에 하나씩 실행한다.
-2. 각 Task 시작 전 현재 Git·배포·운영 상태를 다시 읽는다.
-3. 외부 서비스 변경, 실제 발송, 운영 환경 변수, Firebase 운영 변경, 운영 배포, 운영 데이터 변경, `salesMode` 전환은 해당 Task의 사용자 승인을 받은 뒤 실행한다.
-4. 한 승인으로 이후 다른 운영 변경까지 포괄하지 않는다.
-5. 비밀값·고객 개인정보·사진 원본·서명 URL은 문서나 증거에 기록하지 않는다.
-6. 실제 출시 대상 SHA의 전체 원격 회차 E2E가 통과하기 전 운영 배포를 진행하지 않는다.
-7. ALIGO 실제 발송 검증 실패 시 알림 없는 출시를 임의 승인하지 않는다.
-8. 판매 활성화 전에 공개 약관·개인정보처리방침의 비판매 문구와 실제 결제·알림·배송 흐름을 일치시킨다.
-9. 법적 페이지 변경은 출시 SHA 고정 전에 포함한다.
-10. 첫 회차가 검수된 `SCHEDULED` 상태가 아니면 `salesMode`를 전환하지 않는다.
-11. 결제·환불·고객 안내·배송·보관 예외가 열려 있으면 영향과 담당자 승인 없이 출시하지 않는다.
-12. 전환 직후 smoke 실패 시 신규 유입 공개를 중단하고 `legacy` 롤백을 우선한다.
-13. 이미 결제된 회차 주문은 롤백 시 삭제하거나 legacy 주문으로 변환하지 않는다.
-14. 실행하지 못한 검증을 완료로 기록하지 않는다.
+1. 모든 repository 변경은 최신 `main`에서 목적별 branch를 만들고 PR로 통합한다.
+2. direct `main` commit/push를 하지 않는다.
+3. dependency 순서대로 Task를 실행하되 Issue #32는 ALIGO 심사와 병렬로 해결할 수 있다.
+4. 외부 서비스 변경·실제 발송·운영 변수·Firebase 운영 변경·production 배포·운영 데이터·`salesMode` 변경은 해당 승인 게이트를 따른다.
+5. 한 Task의 승인을 이후 운영 변경 승인으로 확대 해석하지 않는다.
+6. 비밀값·고객 개인정보·사진 원본·서명 URL을 Git/문서/증거에 남기지 않는다.
+7. 법적 페이지 변경까지 포함한 actual release SHA를 확정하기 전 release 검증을 완료로 기록하지 않는다.
+8. actual release SHA의 원격 회차 E2E 52건과 cleanup 통과 전 production 배포 금지.
+9. Issue #32의 `main` 보호 완료 전 production release 금지.
+10. `main` merge·빈 commit·재-push를 production 배포 트리거로 사용하지 않는다.
+11. production 배포 직전·직후 provider metadata Git SHA가 승인 release SHA와 동일한지 확인한다.
+12. ALIGO 실제 발송 검증 실패 시 알림 없는 출시를 임의 승인하지 않는다.
+13. 첫 회차가 검수된 `SCHEDULED`가 아니면 `salesMode`를 전환하지 않는다.
+14. 미검증 항목을 완료로 기록하지 않는다.
 
 ## Execution Plan
 
-### Phase 0 — 코드 통합 기준선
+### Phase 0 — 통합·배포 안전성
 
 #### Task 0.1 — 회차 직배송 코드 `main` 통합
 - Status: done
-- Conclusion: PR #11 병합, 기능 통합 기준 SHA `e55f25914cc7d01576fbd4639583daaf0fe6385e`.
+- Evidence: PR #11, 기능 통합 SHA `e55f259...`.
 
-#### Task 0.2 — 병합 후 branch 상태 확인
+#### Task 0.2 — `main` 자동 production deploy 분리
 - Status: done
-- Conclusion: 병합 직후 `main`과 기존 회차 branch는 identical. 기존 branch는 통합 완료 branch로 취급한다.
+- Evidence: PR #30, PR #31.
+- Verify: 세 Vercel 프로젝트에서 PR #30 merge 이후 `main` deployment 0건.
+
+#### Task 0.3 — GitHub `main` protection/ruleset
+- Dependency: 없음. ALIGO 심사와 병렬 가능.
+- Goal: direct push/force push/delete를 GitHub 관리자 레벨에서 차단한다.
+- Required:
+  - PR required
+  - `Deployment safety guard / verify` required status check
+  - force push 차단
+  - branch deletion 차단
+- Tracking: Issue #32
+- Status: todo_admin
 
 ### Phase 1 — ALIGO 알림 게이트
 
-#### Task 1.1 — 발신 프로필·코드 매핑 구현 준비
+#### Task 1.1 — 발신 프로필·코드 매핑 기반
 - Status: done
 
-#### Task 1.2 — 회차 알림 템플릿 8종 provider 등록·심사
-- Dependency: Task 1.1
-- Current: 8종 등록·심사 요청 완료, 전부 `검수중`.
-- Status: `blocked_external_review`
+#### Task 1.2 — 템플릿 8종 최종 승인
+- Current: 8종 전부 `검수중`.
+- Status: blocked_external_review
 
-#### Task 1.3 — 승인 템플릿 매핑 준비상태 검사
-- Dependency: Task 1.2의 8종 승인
-- Goal: 승인된 `tpl_code`와 내부 논리 템플릿 8종의 1:1 매핑을 값 비공개 방식으로 검증.
+#### Task 1.3 — 승인 `tpl_code` 1:1 매핑 검사
+- Dependency: Task 1.2
 - Status: todo
 
 #### Task 1.4 — 격리 실제 알림톡 정상 발송 [승인 게이트]
 - Dependency: Task 1.3
-- Safety: 실제 고객에게 발송하지 않는다.
+- 실제 고객 발송 금지.
 - Status: todo
 
 #### Task 1.5 — SMS fallback 실제 검증 [승인 게이트]
 - Dependency: Task 1.4
 - Status: todo
 
-### Phase 2 — 판매 공개 계약과 출시 SHA
+### Phase 2 — 판매 공개 계약·release SHA
 
 #### Task 2.1 — 판매 활성화 법적 문서 재정합화
 - Dependency: Task 1.5
-- Goal: 현재 비판매 상태의 `/privacy`, `/terms`를 실제 회차 판매·결제·알림·배송 정책과 일치시킨다.
 - Contract: `docs/specs/legal/README.md`
-- Required review:
-  - 주문 성립·취소·환불·배송·재배송비·배송 보류 공개 문구
-  - PortOne/실제 결제사업자 개인정보 처리 역할
-  - ALIGO 실제 고객 알림의 전화번호·메시지 처리 흐름
-  - seller/driver의 배송정보 접근 설명
-  - 시행일·이전 버전 관리
-  - `apps/consumer/src/app/legal-documents.test.mjs`의 비판매 assertion 갱신
-- Important: **이 Task를 완료하기 전 출시 SHA를 고정하지 않는다.**
+- Required:
+  - 주문 성립·취소·환불·배송·재배송비·배송 보류
+  - PortOne/결제사업자 개인정보 처리
+  - ALIGO 고객 알림 처리
+  - seller/driver 배송정보 접근
+  - 시행일·이전 버전
+  - `legal-documents.test.mjs` 갱신
 - Status: todo
 
-#### Task 2.2 — 실제 출시 대상 SHA 확정
-- Dependency: Task 2.1
-- Goal: 운영 배포할 정확한 `main` SHA를 고정한다.
-- Note: 과거 성공 SHA `6e0fc9d...`, run `32351887404`는 역사 증거다.
+#### Task 2.2 — actual release SHA 확정
+- Dependency: Task 0.3, Task 2.1
+- Goal: 운영에 올릴 단 하나의 exact `main` SHA 고정.
+- 과거 `6e0fc9d...` run은 역사 증거일 뿐 현재 release 증거가 아니다.
 - Status: todo
 
-#### Task 2.3 — 동일 SHA 전체 원격 회차 E2E
+#### Task 2.3 — exact SHA 전체 원격 회차 E2E
 - Dependency: Task 2.2
-- Goal: chromium 26 + mobile 26 = 52건과 fixture cleanup 통과.
+- Goal: chromium 26 + mobile 26 = 52, unexpected/skipped/flaky 0, 양쪽 cleanup 성공.
 - Status: todo
 
-#### Task 2.4 — 운영 Firebase 재조회
+#### Task 2.4 — 운영 Firebase 읽기 전용 재조회
 - Dependency: Task 2.3
-- Goal: 인덱스·Firestore Rules·Storage Rules를 읽기 전용으로 재확인.
 - Status: todo
 
-#### Task 2.5 — 운영 ALIGO 변수와 템플릿 매핑 반영 [승인 게이트]
+#### Task 2.5 — 운영 ALIGO 변수·매핑 반영 [승인 게이트]
 - Dependency: Task 1.5, Task 2.3
-- Goal: 운영 API에 ALIGO 필수 설정과 8종 매핑을 값 비공개 방식으로 반영·검증.
+- Goal: 필수 자격 증명 4개 + `ALIGO_TEMPLATE_CODES_JSON`을 비밀값 비공개 방식으로 반영·검증.
 - Status: todo
 
-### Phase 3 — 동일 SHA 운영 배포
+### Phase 3 — exact-SHA production 배포
 
-#### Task 3.1 — API 운영 배포 [별도 승인 게이트]
-- Dependency: Task 2.3, Task 2.4, Task 2.5
+#### Task 3.0 — production deploy/promotion 절차 확정
+- Dependency: Task 2.3
+- Goal: 자동 Git main deploy가 아닌 exact SHA/artifact 기반 명시적 배포 절차를 확정한다.
+- Required:
+  - 입력 release SHA 고정
+  - 배포 전 SHA 출력/검사
+  - 배포 또는 이미 검증된 artifact promotion
+  - 배포 뒤 provider metadata SHA 재검사
+  - mismatch 시 domain/traffic 전환 금지
+- Note: 현재 저장소에는 production 전용 자동 workflow가 없다.
+- Status: todo
+
+#### Task 3.1 — API production 배포 [별도 승인 게이트]
+- Dependency: Task 0.3, Task 2.3, Task 2.4, Task 2.5, Task 3.0
 - Important: 사용자의 별도 `Task 3.1 승인` 없이는 실행하지 않는다.
+- Verify: 배포된 API release identity/SHA를 승인값과 대조.
 - Status: todo
 
-#### Task 3.2 — 세 프런트 운영 배포 [승인 게이트]
+#### Task 3.2 — consumer·seller·driver production 배포 [승인 게이트]
 - Dependency: Task 3.1
-- Goal: consumer·seller·driver를 API와 동일 출시 SHA로 production 배포.
+- Goal: 세 프런트를 승인된 동일 release SHA/artifact에서 배포.
+- Verify: 각 Vercel deployment metadata의 Git SHA 일치.
 - Status: todo
 
 #### Task 3.3 — 운영 무변경 smoke
 - Dependency: Task 3.2
-- Goal: health·카카오 로그인·legacy 화면·회차 읽기 경로와 `/privacy`, `/terms` 새 버전을 상태 변경 없이 확인.
+- 확인: health, Kakao auth, legacy 경로, 회차 read, `/privacy`, `/terms`.
 - Status: todo
 
 #### Task 3.4 — 배포 후 오류 관찰
 - Dependency: Task 3.3
 - Status: todo
 
-### Phase 4 — 첫 회차 준비
+### Phase 4 — 첫 회차
 
 #### Task 4.1 — 첫 회차 `DRAFT` 생성 [승인 게이트]
 - Dependency: Task 3.4
@@ -180,11 +207,11 @@
 - Dependency: Task 4.1
 - Status: todo
 
-#### Task 4.3 — 첫 회차 `SCHEDULED` 전환 [승인 게이트]
+#### Task 4.3 — `SCHEDULED` 전환 [승인 게이트]
 - Dependency: Task 4.2
 - Status: todo
 
-### Phase 5 — 최종 출시 게이트
+### Phase 5 — 최종 출시 판정
 
 #### Task 5.1 — 운영 역할·비상 연락·승인자 확인
 - Dependency: Task 4.3
@@ -192,34 +219,32 @@
 
 #### Task 5.2 — 전환·롤백 dry-run
 - Dependency: Task 5.1
-- Goal: 현재 `legacy`, 예정 `round_direct`, 롤백 경로를 읽기 전용으로 재확인.
+- 현재 `legacy`, 예정 `round_direct`, 롤백 경로 확인.
 - Status: todo
 
 #### Task 5.3 — 최종 출시 판정
 - Dependency: Task 5.2
-- Goal: 동일 SHA·Firebase·ALIGO·법적 페이지·첫 회차·운영 예외·담당자·롤백 증거를 대조.
+- 대조: exact SHA, branch protection, Firebase, ALIGO, legal, 첫 회차, 예외, 담당자, rollback.
 - Status: todo
 
-### Phase 6 — 판매 모드 전환과 공개
+### Phase 6 — 판매 모드 전환
 
 #### Task 6.1 — `round_direct` 전환 [최종 승인 게이트]
-- Dependency: Task 5.3의 출시 승인
+- Dependency: Task 5.3 승인
 - Status: todo
 
-#### Task 6.2 — 전환 직후 핵심 smoke와 롤백 판정
+#### Task 6.2 — 전환 직후 smoke·rollback 판정
 - Dependency: Task 6.1
-- Goal: 소비자 회차 노출·주소·결제 진입·seller 회차·driver 보드·알림·법적 페이지를 확인.
 - Status: todo
 
 #### Task 6.3 — 외부 유입 링크 공개 [승인 게이트]
 - Dependency: Task 6.2 통과
 - Status: todo
 
-### Phase 7 — 초기 안정화와 Closeout
+### Phase 7 — 초기 안정화
 
 #### Task 7.1 — 첫 두 회차 집중 모니터링
 - Dependency: Task 6.3
-- Goal: 결제·매입·배송·보류·사진·환불·알림·보관 예외를 두 회차 동안 기록.
 - Status: todo
 
 #### Task 7.2 — 출시 Closeout
@@ -228,27 +253,29 @@
 
 ## Completion Criteria
 
+- Issue #32 branch protection/ruleset 완료.
 - ALIGO 8종 최종 승인.
-- 격리 실제 알림톡과 SMS fallback 검증.
-- **판매 활성화에 맞는 개인정보처리방침·이용약관이 release SHA에 포함되고 production에서 확인됨.**
-- 실제 출시 대상 SHA 원격 회차 E2E 52건 + cleanup 통과.
-- 운영 Firebase 상태 기대 기준 일치.
-- 운영 ALIGO 설정·8종 매핑 검증.
-- API와 세 프런트 동일 출시 SHA production 배포.
-- 첫 회차 `SCHEDULED` 검수 완료.
-- 운영 역할·롤백 경로·최종 출시 승인 확인.
-- `round_direct` 전환 직후 smoke 통과 또는 실패 시 `legacy` 롤백 확인.
+- 실제 알림톡·SMS fallback 검증.
+- 판매 활성화 legal docs/test 정합화.
+- actual release SHA 원격 E2E 52건+cleanup 성공.
+- 운영 Firebase 상태 확인.
+- production ALIGO 설정 검증.
+- production deploy/promotion이 exact SHA를 사용하고 provider metadata가 일치.
+- 첫 회차 `SCHEDULED`.
+- 최종 출시 승인 뒤 `round_direct` 전환·smoke 또는 rollback 성공.
+- 비밀값·개인정보·사진·서명 URL이 증거에 포함되지 않음.
 
-## Closeout Roll-up
+## 현재 Closeout Roll-up
 
-- Status: `paused_external_review`
-- ALIGO 템플릿 8종 승인: 대기 — 전부 `검수중`
-- 실제 알림톡·SMS fallback: 미실행
-- 판매 활성화 법적 문서 재정합화: **미실행 — 현재 공개 문서는 비판매 상태**
-- 실제 출시 대상 SHA 전체 E2E: 미실행
-- 운영 ALIGO 변수·매핑: 미반영
-- 운영 Firebase: 이전 반영 완료, 출시 전 재조회 필요
-- 동일 SHA 운영 배포: 미실행
-- 첫 회차 준비: 미실행
-- 판매 모드 전환: 미실행, `legacy` 유지
-- 재개 문서: `docs/plans/HANDOFF_mvp_round_direct_aligo_review_pause.md`
+- 코드 통합: 완료
+- repo-side production auto-deploy 분리: 완료
+- docs-only Preview/E2E 억제: 완료
+- GitHub `main` protection: **미완료 — Issue #32**
+- ALIGO 8종 등록: 완료
+- ALIGO 8종 승인: **검수중**
+- 실제 알림 발송: 미실행
+- 판매 활성화 법적 문서: 미실행
+- actual release SHA/E2E: 미실행
+- production 설정/배포: 미실행
+- 첫 회차: 미생성
+- `salesMode`: `legacy`


### PR DESCRIPTION
## 목적

PR #30/#31로 적용한 배포 안전장치의 실제 검증 결과와 남은 관리자 P0(Issue #32)를 현재 문서 정본에 반영합니다.

## 변경

- `docs/memory.md`: main auto-deploy 차단, pure-docs skip, Issue #32 상태 반영
- `docs/BACKLOG.md`: Issue #32를 ACTIVE P0로 승격
- ALIGO HANDOFF: 배포 안전 관리자 게이트와 exact-SHA 배포 원칙 반영
- 출시 PLAN: `main merge != production deploy`, Issue #32, exact-SHA deploy/promotion 절차를 필수 게이트로 추가
- deployment safety PLAN: PR #30/#31와 pure-docs Vercel 0건 검증 기록

## 이미 확인한 증거

- PR #30 merge 후 consumer/seller/driver 신규 Vercel deployment 0건
- PR #31 merge 후 consumer/seller/driver 신규 Vercel deployment 0건
- pure-docs branch commit `ebf44c1...` 이후 3앱 신규 deployment 0건
- `main`은 여전히 `protected=false`; Issue #32로 추적

이 PR은 docs-only이므로 merge 후에도 Vercel production deployment 0건, preview branch SHA 불변을 확인해 main-side docs-only 차단을 실증합니다.
