### PR TITLE
docs: current router 및 성능 문서 분류 정합화

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ workspace 범위는 `pnpm-workspace.yaml`의 `apps/*`, `packages/*`, `scripts`�
 - Firebase 권한은 `firestore.rules`, `storage.rules`, 인덱스는 `firestore.indexes.json`에서 관리합니다.
 - 다역할 사용자 흐름의 최종 회귀 검증은 `apps/e2e`가 담당합니다.
 - 신규 기능 또는 공개 계약 변경은 관련 `docs/specs/`를 확인하고 구현과 함께 정합화합니다.
+- `main` 통합은 production 배포 승인이 아닙니다. production은 활성 배포 안전 계약의 exact-SHA 검증과 별도 승인 경계를 따릅니다.
 
 ## 로컬 개발과 검증
 
@@ -87,7 +88,7 @@ pnpm --filter consumer dev --port 3001
 # 전체 production build 대상
 pnpm build
 
-# workspace typecheck
+# typecheck script가 정의된 workspace만 재귀 실행
 pnpm typecheck
 
 # Firebase Rules
@@ -100,6 +101,8 @@ pnpm test:e2e
 
 API와 consumer는 포트를 따로 지정하지 않으면 둘 다 3000을 사용할 수 있습니다. 로컬 전체 포트·`dev.bat` 동작은 `docs/URLS.md`, 안전한 통합 검증 순서는 `docs/INTEGRATION_TEST.md`를 확인합니다.
 
+`pnpm typecheck`는 root에서 `pnpm -r typecheck`를 실행하므로 **각 package에 `typecheck` script가 있는 범위만** 검사합니다. 모든 앱의 TypeScript 검증을 자동 보장한다고 가정하지 말고, 필요한 package의 실제 script를 확인합니다.
+
 `pnpm lint`는 workspace별 lint를 재귀 실행하며 API lint는 수정형(`--fix`)이므로 읽기 전용 검증 용도로 사용하기 전에 실제 스크립트를 확인해야 합니다.
 
 환경 변수는 저장소에 비밀값을 기록하지 않고 각 실행 환경에서 관리합니다.
@@ -111,10 +114,11 @@ API와 consumer는 포트를 따로 지정하지 않으면 둘 다 3000을 사�
 | 문서 | 역할 |
 |---|---|
 | `AGENTS.md` | 저장소 작업 규칙과 승인 경계 |
+| `docs/README.md` | current 계약과 역사 자료를 구분하는 전체 문서 라우터 |
 | `docs/memory.md` | 현재 브랜치, 활성 작업, 차단 요인, 다음 작업의 현재 상태 SSOT |
 | `docs/PROJECT_MAP.md` | 저장소 영역과 필요한 Context를 찾는 라우터 |
 | `docs/BACKLOG.md` | 미완료·향후 작업 목록 |
-| `docs/specs/` | API·도메인·운영 계약 |
+| `docs/specs/` | API·도메인·운영 계약과 하위 라우터 |
 | `docs/CRITICAL_LOGIC.md` | 되돌리기 어려운 설계 결정과 이유 |
 | `docs/TROUBLESHOOTING.md` | 알려진 문제와 해결 기록 |
 | `docs/URLS.md` | canonical URL, 인증 URL 정책 연결, 로컬 포트 |

--- a/docs/PROJECT_MAP.md
+++ b/docs/PROJECT_MAP.md
@@ -97,14 +97,14 @@ scripts ───> Firebase Admin·배포 서비스·운영 환경
 | shared | 대상 타입·유틸·test | 대응 domain spec | 실제 import 사용처만 검색 |
 | UI | theme/style/component | 직접 관련 frontend 문서 | 실제 소비 앱만 확인 |
 | scripts | 대상 script + 호출 workflow/package script | 직접 관련 ops/gate 문서 | 데이터면 domain/shared, 배포면 infrastructure |
-| infrastructure | `.github/workflows`, Firebase/Vercel/Railway 설정 | 직접 관련 ops/security 문서 | 증거가 있을 때만 앱 소스로 확장 |
+| infrastructure | `.github/workflows`, Firebase/Vercel/Railway 설정 | 직접 관련 ops/security 문서 + 배포 작업이면 활성 deployment safety PLAN | 증거가 있을 때만 앱 소스로 확장 |
 
 ## 6. 도메인 빠른 라우팅
 
 | 도메인 | 1차 코드 | 1차 명세 |
 |---|---|---|
 | 인증 | `apps/api/src/auth`, 각 앱 `src/auth.ts` | `docs/specs/api/auth.md` |
-| 상품 | `apps/api/src/products`, `src/varieties` | `docs/specs/api/products.md`, `docs/specs/ai_product_content.md` |
+| 상품 | `apps/api/src/products`, `apps/api/src/varieties`, AI 사용 시 `apps/api/src/ai` | `docs/specs/api/products.md`; AI 상세 생성은 실제 AI 코드 우선 + `docs/specs/ai_product_content.md`는 설계 참고 |
 | 주문 | `apps/api/src/orders` | `docs/specs/api/orders.md` |
 | 결제 | `apps/api/src/payments`, consumer payment flow | `docs/specs/api/payments.md` + 판매 공개 시 `docs/specs/legal/README.md` |
 | 알림 | `apps/api/src/notifications` | `docs/specs/api/notifications.md` + 실제 고객 발송 시 legal 검토 |

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,9 +20,10 @@
 - Frontend: `docs/specs/frontend/README.md`
 - Ops: `docs/specs/ops/README.md`
 - Legal: `docs/specs/legal/README.md`
+- Performance optimization history: `docs/specs/perf/README.md`
 - Security: `docs/security/README.md`
 - Design history: `docs/design/README.md`
-- Performance evidence: `docs/performance/README.md`
+- Performance measurement evidence: `docs/performance/README.md`
 - Plans: `docs/plans/README.md`
 
 회차 직배송의 통합 동작 계약은 `docs/specs/mvp-sales-round-direct-delivery.md`를 사용한다.
@@ -41,6 +42,7 @@
 - `docs/archive/**`
 - `docs/discussions/**`
 - 구현 전에 작성된 `*-plan.md`, `*-roadmap.md`, `*-sdd.md`
+- `docs/specs/perf/README.md`가 historical로 분류한 과거 최적화 문서
 - 특정 과거 SHA·PR·workflow run·세션 기준 체크리스트와 검증 기록
 - 과거 외부 심사·배포·장애 snapshot
 

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -6,14 +6,15 @@
 
 현재 활성 여부는 파일명이나 체크박스가 아니라 `docs/memory.md`가 결정한다.
 
-2026-08-23 기준 현재 재개·출시 계약은:
+2026-08-23 기준 현재 활성 계약은 다음 3개다.
 
-- `HANDOFF_mvp_round_direct_aligo_review_pause.md`
-- `PLAN_mvp_round_direct_launch_blockers.md`
-
-이다.
+- `HANDOFF_mvp_round_direct_aligo_review_pause.md` — ALIGO 외부 심사 대기와 재개 순서
+- `PLAN_mvp_round_direct_launch_blockers.md` — 실제 출시 dependency와 승인 게이트
+- `PLAN_deployment_safety_guards_20260823.md` — `main` 통합과 production 배포 분리, exact-SHA 배포 원칙, Issue #32 관리자 게이트
 
 현재 상태 자체는 `docs/memory.md`, 미완료 작업은 `docs/BACKLOG.md`가 정본이다.
+
+특히 `PLAN_deployment_safety_guards_20260823.md`는 파일명 패턴상 `PLAN_*`이지만 `docs/memory.md`가 명시적으로 활성화한 현재 계약이다. Issue #32가 닫히거나 `docs/memory.md`에서 비활성화되기 전까지 역사 자료로 분류하지 않는다.
 
 ## 기본적으로 역사 자료인 문서
 
@@ -40,3 +41,5 @@
 ## 승인 경계
 
 과거 PLAN·REPORT에 실행 명령이나 승인 문구가 남아 있어도 현재 승인으로 간주하지 않는다. production 배포·환경변수·실결제/환불·실제 알림 발송·운영 데이터 변경은 현재 Task의 별도 승인을 요구한다.
+
+`main` merge 자체는 production 배포 승인이 아니며, 배포 안전 계약이 요구하는 exact release SHA 검증과 별도 `Task 3.1 승인`을 거친다.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -12,6 +12,8 @@
 
 AI 상품 콘텐츠는 현재 전용 domain router가 없다. 실제 계약을 확인할 때는 `apps/api/src/ai/**`, 관련 seller/consumer 코드와 `api/products.md`를 우선하고, `ai_product_content.md`는 구현 배경·필드 설계 참고자료로 함께 본다. 문서 상단의 과거 상태 문구나 단계 체크리스트를 현재 진행 상태로 사용하지 않는다.
 
+성능 최적화 문서는 `perf/README.md`를 먼저 확인한다. `perf/*.md`의 2026-04 성능 수치와 실행 계획은 현재 baseline이 아니라 historical optimization record다.
+
 ## 역사 계획
 
 다음은 `docs/memory.md` 또는 `docs/BACKLOG.md`에서 다시 활성화하지 않는 한 기본적으로 역사 자료다.
@@ -20,6 +22,7 @@ AI 상품 콘텐츠는 현재 전용 domain router가 없다. 실제 계약을 �
 - `*-roadmap.md`
 - 구현 전 SDD/리팩터링 계획
 - 특정 과거 테스트/시각 검증 체크리스트
+- `perf/README.md`가 historical로 분류한 과거 최적화 분석
 
 예: `seller-order-group-refactor-plan.md` 같은 문서는 현재 회차 주문 계약보다 우선하지 않는다.
 

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -7,10 +7,10 @@
 - 회차 직배송: `mvp-sales-round-direct-delivery.md`
 - API: `api/README.md`에서 현행 domain spec 선택
 - 운영: `ops/README.md`
-- 법적 문서: `legal/consumer-legal-documents.md`
+- 법적 문서: `legal/README.md`를 먼저 열고, 현재 공개 문안 정본은 `legal/consumer-legal-documents.md`를 사용
 - frontend: `frontend/README.md`의 라우팅 규칙을 먼저 확인
 
-AI 상품 콘텐츠는 실제 대상 코드와 `ai_product_content.md`를 함께 확인한다.
+AI 상품 콘텐츠는 현재 전용 domain router가 없다. 실제 계약을 확인할 때는 `apps/api/src/ai/**`, 관련 seller/consumer 코드와 `api/products.md`를 우선하고, `ai_product_content.md`는 구현 배경·필드 설계 참고자료로 함께 본다. 문서 상단의 과거 상태 문구나 단계 체크리스트를 현재 진행 상태로 사용하지 않는다.
 
 ## 역사 계획
 

--- a/docs/specs/ops/README.md
+++ b/docs/specs/ops/README.md
@@ -8,6 +8,8 @@
 
 현재 외부 상태와 출시 순서는 `docs/memory.md`와 활성 HANDOFF·PLAN이 우선한다.
 
+배포 방식·`main` 통합·exact-SHA production 배포 판단은 `docs/plans/PLAN_deployment_safety_guards_20260823.md`를 함께 확인한다.
+
 ## 출시 순서 주의
 
 운영 런북은 일상 운영·장애·롤백 절차를 설명하지만 **출시 dependency의 정본은 아니다.**
@@ -15,6 +17,8 @@
 특히 현재 production `/privacy`, `/terms`는 비판매 상태를 전제로 하므로, 실제 release SHA를 확정하기 전에 `docs/specs/legal/README.md`의 판매 활성화 법적 문서 재정합화 게이트를 수행한다.
 
 런북의 판매 모드 전환 조건을 읽을 때도 활성 `PLAN_mvp_round_direct_launch_blockers.md`의 최신 dependency가 우선한다.
+
+또한 `main` merge는 production 배포 승인이 아니다. production 배포는 활성 deployment safety PLAN이 요구하는 exact release SHA 검증과 별도 승인 경계를 따른다.
 
 ## 조건부 후속 계획
 

--- a/docs/specs/perf/README.md
+++ b/docs/specs/perf/README.md
@@ -1,0 +1,32 @@
+# Performance spec 문서 라우팅
+
+> `docs/specs/perf/`의 파일들은 2026-04 성능 측정과 당시 코드 구조를 전제로 작성된 **최적화 계획/분석 기록**이다. 현재 성능 baseline이나 즉시 실행할 Task 목록으로 사용하지 않는다.
+
+## 현재 분류
+
+다음 문서는 모두 historical optimization record다.
+
+- `image-optimization.md` — 당시 `next/image` 전환 계획과 2026-04 Lighthouse baseline
+- `bundle-optimization.md` — 당시 번들 분석·HeroBanner SSR 전환 제안
+- `mantine-treeshaking.md` — 당시 Mantine tree-shaking 검토
+- `redirect-optimization.md` — 당시 redirect/렌더링 최적화 검토
+
+문서 안의 `현재`, `필수`, `진행 금지`, 성능 수치, 파일 줄번호, 실행 명령은 **작성 당시 기준**이다. `docs/memory.md` 또는 `docs/BACKLOG.md`가 명시적으로 재활성화하지 않는 한 현재 지시로 승계하지 않는다.
+
+## 현재 성능 작업을 시작할 때
+
+1. 최신 `main` SHA를 고정한다.
+2. 대상 앱의 현재 코드와 `next.config.*`, package script를 먼저 확인한다.
+3. production을 변경하는 측정 대신 가능한 한 Preview/격리 환경에서 baseline을 다시 만든다.
+4. Lighthouse, Web Vitals, bundle 분석은 측정 시각·환경·SHA를 함께 기록한다.
+5. 과거 수치와 새 수치를 직접 이어 붙이지 않는다.
+6. 실제 병목이 확인된 항목만 새 Task/Backlog로 올린다.
+
+현재 출시에서 정식 부하테스트 재개 조건은 `docs/BACKLOG.md`의 `LOAD-TEST-FORMAL`과 `docs/specs/ops/k6-load-test-plan.md`를 따른다.
+
+## 성능 증거 저장 위치와 구분
+
+- `docs/performance/README.md` — 과거 Lighthouse/load raw artifact의 보존·해석 규칙
+- `docs/specs/perf/` — 과거 최적화 아이디어와 설계 기록
+
+둘 다 현재 baseline의 자동 정본이 아니다. 최신 성능 판단은 현재 SHA에서 새로 측정한 증거를 사용한다.


### PR DESCRIPTION
## 목적

문서 감사의 낮은 우선순위 잔여 항목인 current router/참조 무결성을 정리합니다.

## 수정

- `docs/plans/README.md`: memory가 활성화한 deployment safety PLAN 누락 수정
- `docs/specs/README.md`: legal은 `legal/README.md`를 먼저 거치도록 라우팅, AI 구현계획을 current 진행 상태로 오해하지 않도록 분류
- `docs/PROJECT_MAP.md`: AI 상품 콘텐츠는 실제 코드+products current spec 우선, 과거 AI 문서는 설계 참고로 격하
- `docs/specs/ops/README.md`: production 배포 판단 시 deployment safety PLAN 연결
- `docs/specs/perf/README.md`: 2026-04 성능 최적화 4개 문서를 historical optimization record로 분류
- `docs/README.md`: performance optimization history와 measurement evidence 경로 분리
- `README.md`: root `pnpm typecheck`가 typecheck script가 정의된 workspace만 검사한다는 점 명시, 문서 전체 라우터 추가

## 확인 결과

- 현재 legal 문서는 `salesMode=legacy`/비판매 공개 상태와 모순되지 않아 문구를 선제 변경하지 않음
- `apps/consumer/src/app/legal-documents.test.mjs`도 2026-08-19 비판매 공개 계약을 고정하고 있음
- `docs/specs/perf/*`는 모두 2026-04 당시 수치·파일 구조·실행 계획을 전제로 해 current baseline으로 쓰지 않도록 라우팅함

문서-only PR이며 production/환경변수/외부 provider/운영 데이터 변경은 없습니다.