### PR TITLE
docs: 결제 최종화 current gap 정합화

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -18,6 +18,30 @@
 
 ## ACTIVE
 
+### P0 — PAYMENT-FINALIZATION-PAID-GUARD
+
+현재 `main`의 `apps/api/src/payments/payment-finalization.service.ts`는 `finalizePaidOrder()` 내부에서 전달받은 PortOne 결제의 `status === 'PAID'`를 자체 강제하지 않는다.
+
+현재 방어:
+
+- [x] scheduler 경로는 `paymentData.status === 'PAID'`일 때만 finalization 호출
+- [x] webhook 경로는 `Transaction.Paid` 이벤트에서 PortOne 원격 결제 재조회
+- [x] 금액 불일치 환불·취소 처리 존재
+
+남음:
+
+- [ ] finalization service 자체에서 비`PAID` 입력 차단
+- [ ] `PENDING` 회귀 테스트
+- [ ] `FAILED` 회귀 테스트
+- [ ] `CANCELLED` 회귀 테스트
+- [ ] `PAID` 일반/공동구매 정상 경로 테스트
+- [ ] `PAID` 회차 주문 정상 경로 테스트
+- [ ] 금액 불일치 회귀 유지
+- [ ] 기존 회차 reservation/race 회귀 유지
+- [ ] 수정이 포함된 SHA를 `main`에 통합한 뒤 actual release SHA 후보에 포함
+
+문서만으로 이 불변식을 완료 처리하지 않는다. 정본: `docs/specs/api/payments.md`.
+
 ### P0 — DEPLOY-SAFETY-MAIN-PROTECTION
 
 repo-side 자동배포 차단은 완료됐지만 GitHub `main` 자체 보호는 아직 비활성이다.
@@ -94,6 +118,7 @@ Issue #32 완료 전에도 repo-side Vercel guard는 동작하지만, direct pus
 
 ### P0 — 출시 후보 검증·운영 준비
 
+- [ ] PAYMENT-FINALIZATION-PAID-GUARD 완료 및 `main` 통합
 - [ ] Issue #32 branch protection 완료
 - [ ] 법적 페이지 포함 actual release SHA 확정
 - [ ] exact SHA 원격 회차 E2E chromium 26 + mobile 26 = 52건 통과

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -61,6 +61,23 @@ Vercel Hobby build-rate-limit 때문에 docs-only PR에 Vercel check failure가 
 - 회차 출시 후보 production 배포, 첫 운영 회차 생성, `salesMode` 전환은 미실행.
 - 판매 모드는 최신 운영 확인 기준 `legacy`.
 
+## 현재 확인된 코드 P0
+
+### 결제 최종화 provider 상태 방어
+
+현재 `main`의 `apps/api/src/payments/payment-finalization.service.ts`는 `finalizePaidOrder()` 내부에서 전달받은 `paymentData.status === 'PAID'`를 독립적으로 강제하지 않는다.
+
+현재 일반 호출 경로는 일부 방어를 갖는다.
+
+- `cleanupPendingOrders()`는 원격 상태가 `PAID`일 때만 finalization을 호출한다.
+- webhook은 `Transaction.Paid` 이벤트에서 원격 결제를 다시 조회한다.
+
+그러나 finalization service 자체가 비`PAID` 입력을 최종 차단하는 구조는 아니다. 따라서 문서·테스트에서 “최종화 계층이 모든 비`PAID`를 차단한다”고 간주하지 않는다.
+
+이 항목은 **actual release SHA 확정 전 해결·회귀 검증이 필요한 P0**다. 최소 회귀 범위는 `PENDING`, `FAILED`, `CANCELLED`, `PAID`, 금액 불일치, legacy/group 및 회차 경로다.
+
+정본: `docs/specs/api/payments.md`, `docs/BACKLOG.md`
+
 ## ALIGO 템플릿 상태
 
 - 발신 프로필 1건 정상, `senderkey` 발급 완료.
@@ -99,7 +116,7 @@ Vercel Hobby build-rate-limit 때문에 docs-only PR에 Vercel check failure가 
 - 마지막 전체 원격 회차 E2E 성공 증거: SHA `6e0fc9d4cec08073ed2504208cc8bb1ea395ee7d`, run `32351887404`.
 - chromium 26 + mobile 26 = 총 52건 및 양쪽 fixture cleanup 성공.
 - 이 과거 run을 현재 release SHA 검증으로 확장하지 않는다.
-- 법적 페이지까지 포함한 실제 출시 대상 SHA를 고정한 뒤 52건+cleanup을 다시 통과해야 한다.
+- 법적 페이지와 현재 P0 코드 보정까지 포함한 실제 출시 대상 SHA를 고정한 뒤 52건+cleanup을 다시 통과해야 한다.
 
 ## 활성 문서
 
@@ -128,12 +145,13 @@ Vercel Hobby build-rate-limit 때문에 docs-only PR에 Vercel check failure가 
 
 ## 다음 작업
 
-1. **P0 병렬 관리자 게이트**: Issue #32의 `main` branch protection/ruleset 활성화.
-2. **외부 차단**: ALIGO 8종 심사 결과 대기. 승인 전 실제 발송·운영 ALIGO 설정은 진행하지 않는다.
-3. 8종 승인 후 격리 알림톡 정상 발송 → SMS fallback 검증.
-4. 판매 활성화 법적 문서·테스트 재정합화.
-5. 법적 변경까지 포함한 actual release SHA 확정 → 원격 회차 E2E 52건+cleanup.
-6. 운영 Firebase 재조회 → ALIGO 운영 설정 → 별도 `Task 3.1 승인` → exact-SHA production 배포.
-7. 이후 첫 회차 검수 → 최종 출시 판정 → `salesMode: round_direct` 전환.
+1. **P0 병렬 코드 게이트**: 결제 finalization이 비`PAID` provider 상태를 자체 차단하도록 구현·회귀 검증 후 `main` 통합.
+2. **P0 병렬 관리자 게이트**: Issue #32의 `main` branch protection/ruleset 활성화.
+3. **외부 차단**: ALIGO 8종 심사 결과 대기. 승인 전 실제 발송·운영 ALIGO 설정은 진행하지 않는다.
+4. 8종 승인 후 격리 알림톡 정상 발송 → SMS fallback 검증.
+5. 판매 활성화 법적 문서·테스트 재정합화.
+6. 법적 변경과 모든 P0 코드 보정까지 포함한 actual release SHA 확정 → 원격 회차 E2E 52건+cleanup.
+7. 운영 Firebase 재조회 → ALIGO 운영 설정 → 별도 `Task 3.1 승인` → exact-SHA production 배포.
+8. 이후 첫 회차 검수 → 최종 출시 판정 → `salesMode: round_direct` 전환.
 
 문서 정합성 감사 자체는 앞으로도 **branch + PR**로 수행하고, current 계약과 직접 충돌하는 문서만 수정한다.

--- a/docs/specs/api/payments.md
+++ b/docs/specs/api/payments.md
@@ -12,7 +12,8 @@
 
 - 결제 검증·최종화·환불·재배송비 결제 처리는 NestJS API가 소유한다.
 - consumer는 PortOne V2 SDK로 결제 UI를 시작하지만 결제 성공 여부를 클라이언트 반환값만으로 확정하지 않는다.
-- 서버는 PortOne V2 API를 재조회해 금액·상태를 검증한 뒤 주문/결제 상태를 확정한다.
+- 현재 일반 진입 경로는 PortOne V2 API를 재조회한 뒤 상태·금액에 따라 주문/결제를 수렴시킨다.
+- **주의:** 현재 `main`의 `PaymentFinalizationService.finalizePaidOrder()` 자체는 전달받은 `paymentData.status === 'PAID'`를 독립적으로 재검증하지 않는다. 따라서 이 메서드를 “어떤 호출 경로에서도 비`PAID`를 차단하는 최종 보안 경계”로 문서화하면 안 된다.
 - webhook은 중요한 수렴 경로지만 유일한 수렴 경로가 아니다. 15분 이상 `PENDING` 주문도 scheduler가 PortOne을 재조회해 paid/cancel/확인필요 상태로 수렴시킨다.
 - legacy 본 결제와 회차 직배송 본 결제는 같은 payment finalization 기반을 공유하지만, 회차 주문은 `checkoutReservations`와 용량 반환·재확보 규칙을 추가로 사용한다.
 - 재배송비는 본 결제와 별개의 `orderCharges` 결제로 관리한다.
@@ -102,13 +103,37 @@ webhook-signature
 3. `Transaction.Ready`는 상태 변경 없이 무시한다.
 4. `Transaction.Paid`가 아닌 이벤트는 아직 처리 가능한 `PENDING` 주문을 `payment_failed`로 취소·release하는 경로로 보낸다.
 5. `Transaction.Paid`이면 webhook body의 금액을 신뢰하지 않고 `GET /payments/{paymentId}`로 PortOne 원격 결제를 다시 조회한다.
-6. 원격 결제 정보를 `PaymentFinalizationService.finalizePaidOrder()`에 전달한다.
+6. 현재 코드에서는 취소된 주문에 대해서만 원격 `paymentData.status !== 'PAID'`를 명시적으로 차단한 뒤 `PaymentFinalizationService.finalizePaidOrder()`에 전달한다.
 
-중복 webhook은 최종화 service의 상태 검사와 transaction으로 멱등 처리한다. “PENDING 아니면 무조건 skip”보다 실제 구현의 `canFinalize()` 조건을 따른다.
+중복 webhook은 최종화 service의 주문 상태 검사와 transaction으로 멱등 처리한다. “PENDING 아니면 무조건 skip”보다 실제 구현의 `canFinalize()` 조건을 따른다.
 
 ## 6. 결제 성공 최종화
 
-`PaymentFinalizationService.finalizePaidOrder()`의 핵심 계약:
+`PaymentFinalizationService.finalizePaidOrder()`의 현재 구현을 설명한다.
+
+### 현재 구현 한계 — provider 상태 최종 방어
+
+현재 `main`에서 이 메서드는 다음을 자체 검사한다.
+
+- 주문 존재 여부
+- 주문이 `canFinalize()` 가능한 상태인지
+- PortOne 금액과 주문 금액 일치 여부
+- 회차 reservation/capacity 조건
+
+그러나 **전달된 `paymentData.status`가 실제 `PAID`인지 메서드 내부에서 직접 차단하지 않는다.**
+
+현재 일반 호출 경로의 방어는 다음과 같다.
+
+- `cleanupPendingOrders()`는 `paymentData.status === 'PAID'`일 때만 finalization을 호출한다.
+- webhook은 `Transaction.Paid` 이벤트에서 원격 결제를 재조회하지만, `PENDING` 주문에 대해 재조회 결과의 status를 finalization 직전에 다시 강제하지 않는다.
+
+따라서 원하는 불변식은 다음과 같지만, **현재 `main` 구현 완료 사실로 읽으면 안 된다.**
+
+```text
+finalizePaidOrder(paymentData) accepts only paymentData.status === 'PAID'
+```
+
+이 방어가 코드와 회귀 테스트로 통합되기 전까지는 `finalizePaidOrder()`를 독립적인 `PAID` 최종 보안 경계로 취급하지 않는다.
 
 ### 금액 검증
 
@@ -126,6 +151,8 @@ PortOne payment.amount.total === orders.totalAmount
 클라이언트가 보낸 금액을 최종 검증값으로 사용하지 않는다.
 
 ### 정상 결제
+
+호출자가 실제 `PAID` 결제만 전달했다는 전제 아래 현재 finalization은:
 
 - `saleType === 'group'` → `RECRUITING`
 - 그 외 → `ACCEPTED`
@@ -317,12 +344,15 @@ export interface Payment {
 - 회차 결제면 `docs/specs/mvp-sales-round-direct-delivery.md`
 - 운영 예외면 runbook
 
+특히 finalization 안전성 변경 시 `PENDING`, `FAILED`, `CANCELLED`, `PAID`, 금액 불일치와 회차/legacy 경로를 각각 회귀 테스트로 확인한다. 문서에 적힌 원하는 불변식을 구현 완료 증거로 대신하지 않는다.
+
 실제 결제·환불은 테스트 문서에 적힌 예시만으로 실행하지 않는다. 대상 환경과 승인 범위를 확인한다.
 
 ## 변경 이력
 
 | 날짜 | 내용 |
 |---|---|
+| 2026-08-23 | 현재 `main`의 `finalizePaidOrder()`가 provider `PAID` 상태를 자체 차단하지 않는 구현 한계를 명시하고 호출 경로 의존성을 정합화 |
 | 2026-08-23 | webhook 서명, PortOne 재조회, PENDING reconciliation, 늦은 결제 재확보/환불, refund claim, 재배송비 결제에 맞춰 전면 정합화 |
 | 2026-03-27 | PortOne V2 초기 전환 |
 | 2026-03-26 | 초기 payments 설계 초안 |


### PR DESCRIPTION
## 변경
- `PaymentFinalizationService.finalizePaidOrder()`가 현재 `main`에서 provider `PAID` 상태를 자체 강제하지 않는 점을 payments current spec에 명시
- 해당 항목을 `docs/memory.md`의 현재 코드 P0로 반영
- `docs/BACKLOG.md` ACTIVE에 `PAYMENT-FINALIZATION-PAID-GUARD` 추가

## 근거
- scheduler는 `paymentData.status === 'PAID'`일 때만 finalization 호출
- webhook은 `Transaction.Paid`에서 원격 결제를 재조회하지만 PENDING 주문에 대해 finalization 내부 PAID guard는 없음

## 범위
- docs-only
- production/provider/secret 변경 없음
- 코드 동작 변경 없음