### PR TITLE
docs: 출시 인계에 결제 finalization P0 반영

### DIFF
--- a/docs/plans/HANDOFF_mvp_round_direct_aligo_review_pause.md
+++ b/docs/plans/HANDOFF_mvp_round_direct_aligo_review_pause.md
@@ -17,7 +17,35 @@
 
 현재 외부 차단점은 **ALIGO 8종 provider 심사 완료**다.
 
-동시에 해결 가능한 관리자 P0는 **Issue #32 `main` branch protection/ruleset 활성화**다.
+동시에 해결 가능한 P0는 두 가지다.
+
+1. **결제 finalization `PAID` 최종 방어** — 현재 `main`의 `finalizePaidOrder()`는 전달받은 provider status를 자체 강제하지 않음.
+2. **Issue #32 `main` branch protection/ruleset 활성화**.
+
+현재 상태 정본은 `docs/memory.md`, 미완료 목록은 `docs/BACKLOG.md`를 우선한다.
+
+## 결제 finalization P0
+
+현재 `apps/api/src/payments/payment-finalization.service.ts`의 `finalizePaidOrder()`는 주문 상태·금액·reservation을 검사하지만 전달받은 `paymentData.status === 'PAID'`를 메서드 내부에서 직접 강제하지 않는다.
+
+현재 일반 호출 경로는 일부 방어한다.
+
+- scheduler는 원격 상태가 `PAID`일 때만 finalization 호출.
+- webhook은 `Transaction.Paid` 이벤트에서 원격 결제를 재조회.
+
+하지만 finalization service 자체가 비`PAID` 입력을 최종 차단하는 구조는 아니다.
+
+따라서 actual release SHA를 확정하기 전에:
+
+- 비`PAID` 차단 구현,
+- `PENDING`/`FAILED`/`CANCELLED` 회귀,
+- `PAID` 일반·공동구매·회차 정상 경로,
+- 금액 불일치,
+- 기존 reservation/race 회귀
+
+를 통과하고 수정이 `main`에 포함됐음을 확인한다.
+
+정본: `docs/specs/api/payments.md`.
 
 ## 배포 안전성 변경
 
@@ -76,6 +104,7 @@ production `/privacy`, `/terms`는 현재 비판매 상태를 전제로 한다.
 - 마지막 전체 원격 회차 E2E 역사 증거: SHA `6e0fc9d4cec08073ed2504208cc8bb1ea395ee7d`, run `32351887404`.
 - chromium 26 + mobile 26 = 52, 양쪽 cleanup 성공.
 - 현재 release SHA 증거로 확장 적용하지 않는다.
+- 결제 finalization P0와 법적 변경까지 포함한 actual release SHA에서 다시 검증한다.
 
 ## 지금 하지 말아야 할 작업
 
@@ -86,29 +115,32 @@ production `/privacy`, `/terms`는 현재 비판매 상태를 전제로 한다.
 - `main` merge를 production 배포 승인으로 해석.
 - 별도 Task 승인 없이 production 배포·Firebase 운영 변경·운영 회차 생성·`salesMode` 변경.
 - 비판매 법적 문구를 판매 공개 전에 임의로 미리 전환.
+- 결제 finalization P0가 `main`에 반영되기 전에 release SHA를 확정.
 
 ## 지금 병렬로 할 수 있는 작업
 
-1. Issue #32 `main` protection/ruleset 관리자 설정.
-2. read-only 문서/코드 정합성 감사.
-3. ALIGO provider 심사 상태 조회.
+1. 결제 finalization `PAID` guard 구현·회귀 검증·통합.
+2. Issue #32 `main` protection/ruleset 관리자 설정.
+3. read-only 문서/코드 정합성 감사.
+4. ALIGO provider 심사 상태 조회.
 
 ## ALIGO 승인 뒤 재개 순서
 
-1. 8종 모두 승인/수정요청/반려 여부 확인.
-2. 승인 `tpl_code` 8종 ↔ 내부 논리 템플릿 1:1 매핑 검사.
-3. 별도 승인 후 격리 실제 알림톡 정상 발송.
-4. 별도 승인 후 SMS fallback 실제 검증.
-5. 판매 활성화 법적 문서·테스트 재정합화.
-6. Issue #32 완료 확인.
-7. 법적 변경까지 포함한 actual release SHA 확정.
-8. exact SHA 원격 회차 E2E 52건 + fixture cleanup.
-9. 운영 Firebase read-only 재조회.
-10. 별도 승인 후 production ALIGO 설정 반영·검증.
-11. exact-SHA production deploy/promotion 절차 확정.
-12. 사용자의 별도 `Task 3.1 승인` 뒤에만 production 배포.
-13. deployment metadata SHA 대조 → 운영 smoke.
-14. 첫 회차 검수 → 최종 출시 판정 → `salesMode: round_direct` 전환.
+1. 결제 finalization P0가 `main`에 통합됐는지 확인.
+2. 8종 모두 승인/수정요청/반려 여부 확인.
+3. 승인 `tpl_code` 8종 ↔ 내부 논리 템플릿 1:1 매핑 검사.
+4. 별도 승인 후 격리 실제 알림톡 정상 발송.
+5. 별도 승인 후 SMS fallback 실제 검증.
+6. 판매 활성화 법적 문서·테스트 재정합화.
+7. Issue #32 완료 확인.
+8. 법적 변경과 모든 P0 코드 보정까지 포함한 actual release SHA 확정.
+9. exact SHA 원격 회차 E2E 52건 + fixture cleanup.
+10. 운영 Firebase read-only 재조회.
+11. 별도 승인 후 production ALIGO 설정 반영·검증.
+12. exact-SHA production deploy/promotion 절차 확정.
+13. 사용자의 별도 `Task 3.1 승인` 뒤에만 production 배포.
+14. deployment metadata SHA 대조 → 운영 smoke.
+15. 첫 회차 검수 → 최종 출시 판정 → `salesMode: round_direct` 전환.
 
 ## 재개 완료 조건
 
@@ -118,6 +150,7 @@ production `/privacy`, `/terms`는 현재 비판매 상태를 전제로 한다.
 - [x] ALIGO 템플릿 8종 등록·심사 요청
 - [x] repo-side `main` 자동 production deploy 차단
 - [x] deployment safety CI와 docs-only ignore 적용
+- [ ] 결제 finalization `PAID` guard + 회귀 검증 + `main` 통합
 - [ ] Issue #32 branch protection/ruleset
 - [ ] ALIGO 템플릿 8종 최종 승인
 - [ ] 실제 알림톡 정상 발송

--- a/docs/plans/PLAN_mvp_round_direct_launch_blockers.md
+++ b/docs/plans/PLAN_mvp_round_direct_launch_blockers.md
@@ -11,9 +11,11 @@
 - 상태: `paused_external_review`
 - Priority: P0
 - 현재 외부 차단점: ALIGO 회차 알림 템플릿 8종 provider 심사 완료
+- 병렬 코드 P0: 결제 finalization `PAID` 최종 방어
 - 병렬 관리자 P0: GitHub Issue #32 `main` branch protection/ruleset
 - 현재 상태 SSOT: `docs/memory.md`
 - 재개 순서: `docs/plans/HANDOFF_mvp_round_direct_aligo_review_pause.md`
+- 결제 계약: `docs/specs/api/payments.md`
 - 배포 안전 계약: `docs/plans/PLAN_deployment_safety_guards_20260823.md`
 - 판매 활성화 법적 게이트: `docs/specs/legal/README.md`
 - 운영 런북: `docs/specs/ops/mvp-sales-round-runbook.md`
@@ -30,6 +32,7 @@
 - production 회차 앱 배포·첫 회차 생성·`salesMode` 전환 미실행.
 - `salesMode=legacy` 유지.
 - 현재 `/terms`, `/privacy`는 비판매 상태를 전제로 하므로 실제 판매 활성화 전 재정합화가 필요하다.
+- 현재 `main`의 `PaymentFinalizationService.finalizePaidOrder()`는 전달받은 provider `status === 'PAID'`를 메서드 내부에서 독립적으로 강제하지 않는다. 이 항목은 actual release SHA 확정 전 해결·회귀 검증해야 한다.
 
 ## 배포 안전 기준선
 
@@ -52,6 +55,7 @@
 |---|---|---|
 | 0 | repo-side 자동배포 차단 | 완료 |
 | 0A | GitHub `main` branch protection/ruleset | **미완료 — Issue #32** |
+| 0B | 결제 finalization 비`PAID` 최종 차단 + 회귀 | **미완료 — P0** |
 | 1 | ALIGO 8종 provider 최종 승인 | **검수중** |
 | 2 | 실제 알림톡 정상 발송 | 미실행 |
 | 3 | SMS fallback 실제 검증 | 미실행 |
@@ -69,11 +73,11 @@
 
 1. 모든 repository 변경은 최신 `main`에서 목적별 branch를 만들고 PR로 통합한다.
 2. direct `main` commit/push를 하지 않는다.
-3. dependency 순서대로 Task를 실행하되 Issue #32는 ALIGO 심사와 병렬로 해결할 수 있다.
+3. dependency 순서대로 Task를 실행하되 결제 finalization P0와 Issue #32는 ALIGO 심사와 병렬로 해결할 수 있다.
 4. 외부 서비스 변경·실제 발송·운영 변수·Firebase 운영 변경·production 배포·운영 데이터·`salesMode` 변경은 해당 승인 게이트를 따른다.
 5. 한 Task의 승인을 이후 운영 변경 승인으로 확대 해석하지 않는다.
 6. 비밀값·고객 개인정보·사진 원본·서명 URL을 Git/문서/증거에 남기지 않는다.
-7. 법적 페이지 변경까지 포함한 actual release SHA를 확정하기 전 release 검증을 완료로 기록하지 않는다.
+7. 결제 finalization P0와 법적 페이지 변경까지 포함한 actual release SHA를 확정하기 전 release 검증을 완료로 기록하지 않는다.
 8. actual release SHA의 원격 회차 E2E 52건과 cleanup 통과 전 production 배포 금지.
 9. Issue #32의 `main` 보호 완료 전 production release 금지.
 10. `main` merge·빈 commit·재-push를 production 배포 트리거로 사용하지 않는다.
@@ -84,7 +88,7 @@
 
 ## Execution Plan
 
-### Phase 0 — 통합·배포 안전성
+### Phase 0 — 통합·배포·코드 안전성
 
 #### Task 0.1 — 회차 직배송 코드 `main` 통합
 - Status: done
@@ -105,6 +109,17 @@
   - branch deletion 차단
 - Tracking: Issue #32
 - Status: todo_admin
+
+#### Task 0.4 — 결제 finalization `PAID` 최종 방어
+- Dependency: 없음. ALIGO 심사·Task 0.3과 병렬 가능.
+- Goal: `finalizePaidOrder()`가 호출 경로에 의존하지 않고 비`PAID` provider 상태를 자체 차단한다.
+- Required:
+  - `PENDING`, `FAILED`, `CANCELLED` 차단
+  - `PAID` 일반·공동구매·회차 정상 경로 유지
+  - 금액 불일치 처리 유지
+  - 회차 reservation/race 회귀 유지
+- Contract: `docs/specs/api/payments.md`
+- Status: todo_code
 
 ### Phase 1 — ALIGO 알림 게이트
 
@@ -143,7 +158,7 @@
 - Status: todo
 
 #### Task 2.2 — actual release SHA 확정
-- Dependency: Task 0.3, Task 2.1
+- Dependency: Task 0.3, Task 0.4, Task 2.1
 - Goal: 운영에 올릴 단 하나의 exact `main` SHA 고정.
 - 과거 `6e0fc9d...` run은 역사 증거일 뿐 현재 release 증거가 아니다.
 - Status: todo
@@ -224,7 +239,7 @@
 
 #### Task 5.3 — 최종 출시 판정
 - Dependency: Task 5.2
-- 대조: exact SHA, branch protection, Firebase, ALIGO, legal, 첫 회차, 예외, 담당자, rollback.
+- 대조: exact SHA, payment P0, branch protection, Firebase, ALIGO, legal, 첫 회차, 예외, 담당자, rollback.
 - Status: todo
 
 ### Phase 6 — 판매 모드 전환
@@ -253,6 +268,7 @@
 
 ## Completion Criteria
 
+- 결제 finalization 비`PAID` 차단과 회귀 검증이 `main`에 포함됨.
 - Issue #32 branch protection/ruleset 완료.
 - ALIGO 8종 최종 승인.
 - 실제 알림톡·SMS fallback 검증.
@@ -268,6 +284,7 @@
 ## 현재 Closeout Roll-up
 
 - 코드 통합: 완료
+- 결제 finalization `PAID` 최종 방어: **미완료 — P0**
 - repo-side production auto-deploy 분리: 완료
 - docs-only Preview/E2E 억제: 완료
 - GitHub `main` protection: **미완료 — Issue #32**


### PR DESCRIPTION
## 변경
- ALIGO 심사 대기 HANDOFF에 결제 finalization `PAID` guard P0 추가
- 출시 blocker PLAN의 gate/dependency/completion criteria에 동일 P0 반영

## 목적
현재 `docs/memory.md`/`BACKLOG.md`와 활성 실행 문서의 출시 순서를 다시 일치시킨다.

## 범위
- docs-only
- 코드/외부 provider/production 변경 없음