### PR TITLE
docs: 주문 mutation 권한 검증 갭 정합화

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -2,7 +2,7 @@
 
 # Greenhub Backlog
 
-> 기준일: 2026-08-23 KST
+> 기준일: 2026-08-24 KST
 >
 > 현재 미완료·향후 작업만 관리한다. 완료 상세는 Git history, `docs/CRITICAL_LOGIC.md`, `docs/archive/`, 완료 PLAN·REPORT를 사용한다.
 
@@ -41,6 +41,33 @@
 - [ ] 수정이 포함된 SHA를 `main`에 통합한 뒤 actual release SHA 후보에 포함
 
 문서만으로 이 불변식을 완료 처리하지 않는다. 정본: `docs/specs/api/payments.md`.
+
+### P0 — ORDER-MUTATION-AUTHORIZATION-COVERAGE
+
+주문 조회 authorization은 `OrdersQueryService`와 직접 테스트가 일치해 `VERIFIED`다. 반면 `OrdersLifecycleService.assertOrderActionAccess()`의 mutation authorization은 구현돼 있으나 권한 우회 방지 핵심 거부 시나리오를 직접 고정하는 회귀 테스트가 충분하지 않다.
+
+현재 구현·검증:
+
+- [x] seller mutation은 해당 store `ownerId`와 requester 일치 요구
+- [x] driver mutation은 배정된 `driverId` 일치 요구
+- [x] 미배정 `PREPARING → DELIVERING`은 최초 driver claim으로 허용하고 `driverId` 기록
+- [x] consumer는 자신의 주문만 action access 통과
+- [x] consumer가 `DELIVERY_HELD`를 위장 요청하는 직접 거부 테스트
+- [x] 정상 seller/driver 회차 E2E 흐름
+- [x] 조회 권한의 consumer/seller/driver/admin 직접 거부·허용 테스트
+
+남음:
+
+- [ ] 다른 store의 seller가 `PATCH .../status`를 시도하면 403
+- [ ] 다른 store의 seller가 `PATCH .../delivery-hold`를 시도하면 403
+- [ ] `driverId`가 다른 주문을 비담당 driver가 상태 변경하면 403
+- [ ] 미배정 주문은 `PREPARING → DELIVERING` 최초 claim 외 driver mutation 거부
+- [ ] 최초 claim 성공 시 정확한 `driverId` 기록 직접 검증
+- [ ] 거부된 mutation에서 주문 write·알림·환불·정산 side effect 0 확인
+- [ ] 필요한 경우 admin 의도된 허용 범위 직접 검증
+- [ ] 회귀가 포함된 SHA를 `main`에 통합한 뒤 actual release SHA 후보에 포함
+
+권한은 P0 계약이므로 위 핵심 거부 회귀가 추가되기 전 mutation authorization 전체를 `VERIFIED`로 처리하지 않는다. 정본: `docs/specs/api/orders.md`.
 
 ### P0 — DEPLOY-SAFETY-MAIN-PROTECTION
 
@@ -119,6 +146,7 @@ Issue #32 완료 전에도 repo-side Vercel guard는 동작하지만, direct pus
 ### P0 — 출시 후보 검증·운영 준비
 
 - [ ] PAYMENT-FINALIZATION-PAID-GUARD 완료 및 `main` 통합
+- [ ] ORDER-MUTATION-AUTHORIZATION-COVERAGE 완료 및 `main` 통합
 - [ ] Issue #32 branch protection 완료
 - [ ] 법적 페이지 포함 actual release SHA 확정
 - [ ] exact SHA 원격 회차 E2E chromium 26 + mobile 26 = 52건 통과
@@ -222,3 +250,4 @@ Issue #32 완료 전에도 repo-side Vercel guard는 동작하지만, direct pus
 4. Backlog 체크박스는 production 변경 승인으로 간주하지 않는다.
 5. 현재 출시 우선순위 충돌 시 `docs/memory.md`와 활성 HANDOFF·PLAN을 우선한다.
 6. 모든 repository 변경은 direct `main`이 아니라 branch+PR로 수행한다.
+7. 문서 정합성 판정과 `VERIFIED` 승격은 `docs/DOCUMENT_CONSISTENCY.md`를 따른다.

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -6,7 +6,8 @@
 
 ## 검증 기준
 
-- Git·GitHub·Vercel 직접 재검증: `2026-08-23 KST`
+- Git·GitHub 직접 재검증: `2026-08-24 KST`
+- Vercel 배포 안전 증거: `2026-08-23 KST`
 - ALIGO 상태: 2026-08-23 provider 등록 결과
 - 운영 상태 변경은 별도 승인 없이 수행하지 않는다.
 
@@ -41,7 +42,7 @@ Vercel Hobby build-rate-limit 때문에 docs-only PR에 Vercel check failure가 
 
 남은 관리자 P0:
 
-- GitHub `main`은 마지막 재조회에서 `protected=false`.
+- GitHub `main`은 2026-08-24 재조회에서도 `protected=false`.
 - Issue #32 `P0: main branch protection / ruleset 활성화`가 남아 있다.
 - 목표: PR required, `Deployment safety guard / verify` required check, force push·branch delete 차단.
 - 연결된 GitHub 도구와 실행 환경에는 branch protection mutation·인증된 관리자 UI·GitHub token이 없어 Issue #32 완료 전까지 정책+CI 방어 상태다.
@@ -61,7 +62,7 @@ Vercel Hobby build-rate-limit 때문에 docs-only PR에 Vercel check failure가 
 - 회차 출시 후보 production 배포, 첫 운영 회차 생성, `salesMode` 전환은 미실행.
 - 판매 모드는 최신 운영 확인 기준 `legacy`.
 
-## 현재 확인된 코드 P0
+## 현재 확인된 P0
 
 ### 결제 최종화 provider 상태 방어
 
@@ -77,6 +78,20 @@ Vercel Hobby build-rate-limit 때문에 docs-only PR에 Vercel check failure가 
 이 항목은 **actual release SHA 확정 전 해결·회귀 검증이 필요한 P0**다. 최소 회귀 범위는 `PENDING`, `FAILED`, `CANCELLED`, `PAID`, 금액 불일치, legacy/group 및 회차 경로다.
 
 정본: `docs/specs/api/payments.md`, `docs/BACKLOG.md`
+
+### 주문 mutation authorization 회귀 검증
+
+주문 조회 권한은 consumer/seller/driver/admin별 직접 테스트가 존재해 `VERIFIED`다.
+
+주문 상태 변경은 `OrdersLifecycleService.assertOrderActionAccess()`에서 seller store 소유권, driver 배정, consumer 주문 소유권을 검사하고 정상 회차 E2E도 존재한다. 그러나 2026-08-24 감사에서는 다음 직접 거부 회귀를 확인하지 못했다.
+
+- 다른 store seller의 order status/delivery-hold mutation 거부
+- 이미 다른 기사에게 배정된 주문의 비담당 driver mutation 거부
+- 미배정 주문의 최초 `PREPARING → DELIVERING` 외 driver mutation 거부와 side-effect 0 보장
+
+권한은 P0 계약이므로 이 범위는 현재 **`IMPLEMENTED / UNVERIFIED` + `COVERAGE GAP`**로 취급하고 actual release SHA 확정 전 직접 회귀를 추가한다.
+
+정본: `docs/specs/api/orders.md`, `docs/BACKLOG.md`
 
 ## ALIGO 템플릿 상태
 
@@ -116,11 +131,12 @@ Vercel Hobby build-rate-limit 때문에 docs-only PR에 Vercel check failure가 
 - 마지막 전체 원격 회차 E2E 성공 증거: SHA `6e0fc9d4cec08073ed2504208cc8bb1ea395ee7d`, run `32351887404`.
 - chromium 26 + mobile 26 = 총 52건 및 양쪽 fixture cleanup 성공.
 - 이 과거 run을 현재 release SHA 검증으로 확장하지 않는다.
-- 법적 페이지와 현재 P0 코드 보정까지 포함한 실제 출시 대상 SHA를 고정한 뒤 52건+cleanup을 다시 통과해야 한다.
+- 법적 페이지와 현재 P0 코드·검증 보정까지 포함한 실제 출시 대상 SHA를 고정한 뒤 52건+cleanup을 다시 통과해야 한다.
 
 ## 활성 문서
 
 - 전체 문서 라우팅: `docs/README.md`
+- 문서 정합성 감사 기준: `docs/DOCUMENT_CONSISTENCY.md`
 - 작업 규칙: `AGENTS.md`
 - Context 라우터: `docs/PROJECT_MAP.md`
 - 현재 상태 SSOT: 이 문서
@@ -146,12 +162,13 @@ Vercel Hobby build-rate-limit 때문에 docs-only PR에 Vercel check failure가 
 ## 다음 작업
 
 1. **P0 병렬 코드 게이트**: 결제 finalization이 비`PAID` provider 상태를 자체 차단하도록 구현·회귀 검증 후 `main` 통합.
-2. **P0 병렬 관리자 게이트**: Issue #32의 `main` branch protection/ruleset 활성화.
-3. **외부 차단**: ALIGO 8종 심사 결과 대기. 승인 전 실제 발송·운영 ALIGO 설정은 진행하지 않는다.
-4. 8종 승인 후 격리 알림톡 정상 발송 → SMS fallback 검증.
-5. 판매 활성화 법적 문서·테스트 재정합화.
-6. 법적 변경과 모든 P0 코드 보정까지 포함한 actual release SHA 확정 → 원격 회차 E2E 52건+cleanup.
-7. 운영 Firebase 재조회 → ALIGO 운영 설정 → 별도 `Task 3.1 승인` → exact-SHA production 배포.
-8. 이후 첫 회차 검수 → 최종 출시 판정 → `salesMode: round_direct` 전환.
+2. **P0 병렬 검증 게이트**: 주문 mutation authorization의 타-store seller·비담당 driver·미배정 first-claim 경계를 직접 회귀 테스트하고 `main` 통합.
+3. **P0 병렬 관리자 게이트**: Issue #32의 `main` branch protection/ruleset 활성화.
+4. **외부 차단**: ALIGO 8종 심사 결과 대기. 승인 전 실제 발송·운영 ALIGO 설정은 진행하지 않는다.
+5. 8종 승인 후 격리 알림톡 정상 발송 → SMS fallback 검증.
+6. 판매 활성화 법적 문서·테스트 재정합화.
+7. 법적 변경과 모든 P0 코드·검증 보정까지 포함한 actual release SHA 확정 → 원격 회차 E2E 52건+cleanup.
+8. 운영 Firebase 재조회 → ALIGO 운영 설정 → 별도 `Task 3.1 승인` → exact-SHA production 배포.
+9. 이후 첫 회차 검수 → 최종 출시 판정 → `salesMode: round_direct` 전환.
 
-문서 정합성 감사 자체는 앞으로도 **branch + PR**로 수행하고, current 계약과 직접 충돌하는 문서만 수정한다.
+문서 정합성 감사는 `docs/DOCUMENT_CONSISTENCY.md`를 따르고, repository 변경은 **branch + PR**로 수행한다.

--- a/docs/plans/HANDOFF_mvp_round_direct_aligo_review_pause.md
+++ b/docs/plans/HANDOFF_mvp_round_direct_aligo_review_pause.md
@@ -4,25 +4,26 @@
 
 > 현재 재개 순서만 유지한다. 상세 과거 증거는 `docs/plans/REPORT_mvp_round_direct_launch.md`와 Git 이력에서 확인한다.
 
-## 현재 상태 — 2026-08-23 KST
+## 현재 상태 — 2026-08-24 KST
 
 - 회차 직배송 MVP는 PR #11을 통해 `main` 통합 완료.
 - 기능 통합 기준 SHA: `e55f25914cc7d01576fbd4639583daaf0fe6385e`.
 - 카카오 비즈니스 채널 최종 승인 완료.
 - ALIGO 발신 프로필·`senderkey` 준비 완료.
-- 회차 알림 템플릿 8종 provider 등록·심사 요청 완료, 전부 `검수중`.
+- 회차 알림 템플릿 8종 provider 등록·심사 요청 완료, 마지막 확인 시 전부 `검수중`.
 - 실제 알림톡·SMS 발송 0건.
 - production ALIGO 자격 증명·8종 매핑 미반영.
 - 첫 운영 회차 미생성, `salesMode=legacy`.
 
-현재 외부 차단점은 **ALIGO 8종 provider 심사 완료**다.
+현재 외부 차단점은 **ALIGO 8종 provider 심사 완료**다. provider 상태는 새 작업 시작 시 다시 조회한다.
 
-동시에 해결 가능한 P0는 두 가지다.
+동시에 해결 가능한 P0는 세 가지다.
 
 1. **결제 finalization `PAID` 최종 방어** — 현재 `main`의 `finalizePaidOrder()`는 전달받은 provider status를 자체 강제하지 않음.
-2. **Issue #32 `main` branch protection/ruleset 활성화**.
+2. **주문 mutation authorization 직접 회귀** — 권한 guard는 구현돼 있으나 타-store seller·비담당 driver·미배정 first-claim 경계를 직접 고정하는 회귀가 부족함.
+3. **Issue #32 `main` branch protection/ruleset 활성화**.
 
-현재 상태 정본은 `docs/memory.md`, 미완료 목록은 `docs/BACKLOG.md`를 우선한다.
+현재 상태 정본은 `docs/memory.md`, 미완료 목록은 `docs/BACKLOG.md`를 우선한다. 문서 정합성 판정은 `docs/DOCUMENT_CONSISTENCY.md`를 따른다.
 
 ## 결제 finalization P0
 
@@ -47,6 +48,23 @@
 
 정본: `docs/specs/api/payments.md`.
 
+## 주문 mutation authorization P0
+
+주문 조회 authorization은 consumer/seller/driver/admin별 직접 테스트가 존재해 `VERIFIED`다.
+
+상태 변경은 `OrdersLifecycleService.assertOrderActionAccess()`가 다음 경계를 구현한다.
+
+- seller: 해당 store owner만 변경 가능
+- driver: 배정된 기사만 변경 가능
+- 미배정 driver: `PREPARING → DELIVERING` 최초 claim만 허용 후 `driverId` 기록
+- consumer: 자신의 주문만 action access 통과, 실제 전이는 consumer FSM이 추가 제한
+
+그러나 문서 감사에서 타-store seller mutation, 비담당 driver mutation, 미배정 first-claim 외 driver mutation과 거부 side-effect 0을 직접 고정하는 회귀 테스트는 확인되지 않았다.
+
+따라서 현재 상태는 **`IMPLEMENTED / UNVERIFIED` + `COVERAGE GAP`**이며 actual release SHA를 확정하기 전 직접 회귀를 추가하고 `main`에 통합한다.
+
+정본: `docs/specs/api/orders.md`.
+
 ## 배포 안전성 변경
 
 2026-08-23 배포 감사에서 `main` push가 문서 변경만으로 Vercel production deployment를 만들던 구조를 확인했고 repo-side remediation을 적용했다.
@@ -61,7 +79,7 @@
 
 남음:
 
-- GitHub `main`은 마지막 재조회에서 `protected=false`.
+- GitHub `main`은 2026-08-24 재조회에서도 `protected=false`.
 - Issue #32에서 PR required + safety required check + force-push/delete 차단 필요.
 
 **중요:** `main` merge는 더 이상 production 배포 경로가 아니다. production은 actual release SHA를 고정·검증한 뒤 별도 승인으로 exact-SHA deploy/promotion을 수행한다.
@@ -85,6 +103,8 @@ production `/privacy`, `/terms`는 현재 비판매 상태를 전제로 한다.
 
 ## ALIGO 템플릿 현황
 
+마지막 확인 snapshot: 2026-08-23.
+
 | 논리 템플릿 | 상태 |
 |---|---|
 | `ORDER_ACCEPTED` | 검수중 |
@@ -98,13 +118,14 @@ production `/privacy`, `/terms`는 현재 비판매 상태를 전제로 한다.
 
 - 중복·오류·반려 없음.
 - 비밀값 원문 기록 금지.
+- 현재성이 필요한 경우 provider에서 다시 조회한다.
 
 ## 검증 기준
 
 - 마지막 전체 원격 회차 E2E 역사 증거: SHA `6e0fc9d4cec08073ed2504208cc8bb1ea395ee7d`, run `32351887404`.
 - chromium 26 + mobile 26 = 52, 양쪽 cleanup 성공.
 - 현재 release SHA 증거로 확장 적용하지 않는다.
-- 결제 finalization P0와 법적 변경까지 포함한 actual release SHA에서 다시 검증한다.
+- 결제 finalization P0, 주문 authorization P0와 법적 변경까지 포함한 actual release SHA에서 다시 검증한다.
 
 ## 지금 하지 말아야 할 작업
 
@@ -115,25 +136,26 @@ production `/privacy`, `/terms`는 현재 비판매 상태를 전제로 한다.
 - `main` merge를 production 배포 승인으로 해석.
 - 별도 Task 승인 없이 production 배포·Firebase 운영 변경·운영 회차 생성·`salesMode` 변경.
 - 비판매 법적 문구를 판매 공개 전에 임의로 미리 전환.
-- 결제 finalization P0가 `main`에 반영되기 전에 release SHA를 확정.
+- 현재 P0 코드·검증 게이트가 `main`에 반영되기 전에 release SHA를 확정.
 
 ## 지금 병렬로 할 수 있는 작업
 
 1. 결제 finalization `PAID` guard 구현·회귀 검증·통합.
-2. Issue #32 `main` protection/ruleset 관리자 설정.
-3. read-only 문서/코드 정합성 감사.
-4. ALIGO provider 심사 상태 조회.
+2. 주문 mutation authorization 직접 거부 회귀 테스트·통합.
+3. Issue #32 `main` protection/ruleset 관리자 설정.
+4. read-only 문서/코드 정합성 감사.
+5. ALIGO provider 심사 상태 조회.
 
 ## ALIGO 승인 뒤 재개 순서
 
-1. 결제 finalization P0가 `main`에 통합됐는지 확인.
+1. 결제 finalization P0와 주문 mutation authorization P0가 `main`에 통합됐는지 확인.
 2. 8종 모두 승인/수정요청/반려 여부 확인.
 3. 승인 `tpl_code` 8종 ↔ 내부 논리 템플릿 1:1 매핑 검사.
 4. 별도 승인 후 격리 실제 알림톡 정상 발송.
 5. 별도 승인 후 SMS fallback 실제 검증.
 6. 판매 활성화 법적 문서·테스트 재정합화.
 7. Issue #32 완료 확인.
-8. 법적 변경과 모든 P0 코드 보정까지 포함한 actual release SHA 확정.
+8. 법적 변경과 모든 P0 코드·검증 보정까지 포함한 actual release SHA 확정.
 9. exact SHA 원격 회차 E2E 52건 + fixture cleanup.
 10. 운영 Firebase read-only 재조회.
 11. 별도 승인 후 production ALIGO 설정 반영·검증.
@@ -151,6 +173,7 @@ production `/privacy`, `/terms`는 현재 비판매 상태를 전제로 한다.
 - [x] repo-side `main` 자동 production deploy 차단
 - [x] deployment safety CI와 docs-only ignore 적용
 - [ ] 결제 finalization `PAID` guard + 회귀 검증 + `main` 통합
+- [ ] 주문 mutation authorization 직접 거부 회귀 + `main` 통합
 - [ ] Issue #32 branch protection/ruleset
 - [ ] ALIGO 템플릿 8종 최종 승인
 - [ ] 실제 알림톡 정상 발송

--- a/docs/plans/PLAN_mvp_round_direct_launch_blockers.md
+++ b/docs/plans/PLAN_mvp_round_direct_launch_blockers.md
@@ -7,15 +7,17 @@
 ## 문서 메타
 
 - 작성일: 2026-07-28
-- 최종 정합화: 2026-08-23 KST
+- 최종 정합화: 2026-08-24 KST
 - 상태: `paused_external_review`
 - Priority: P0
 - 현재 외부 차단점: ALIGO 회차 알림 템플릿 8종 provider 심사 완료
 - 병렬 코드 P0: 결제 finalization `PAID` 최종 방어
+- 병렬 검증 P0: 주문 mutation authorization 직접 거부 회귀
 - 병렬 관리자 P0: GitHub Issue #32 `main` branch protection/ruleset
 - 현재 상태 SSOT: `docs/memory.md`
 - 재개 순서: `docs/plans/HANDOFF_mvp_round_direct_aligo_review_pause.md`
 - 결제 계약: `docs/specs/api/payments.md`
+- 주문 계약: `docs/specs/api/orders.md`
 - 배포 안전 계약: `docs/plans/PLAN_deployment_safety_guards_20260823.md`
 - 판매 활성화 법적 게이트: `docs/specs/legal/README.md`
 - 운영 런북: `docs/specs/ops/mvp-sales-round-runbook.md`
@@ -32,7 +34,8 @@
 - production 회차 앱 배포·첫 회차 생성·`salesMode` 전환 미실행.
 - `salesMode=legacy` 유지.
 - 현재 `/terms`, `/privacy`는 비판매 상태를 전제로 하므로 실제 판매 활성화 전 재정합화가 필요하다.
-- 현재 `main`의 `PaymentFinalizationService.finalizePaidOrder()`는 전달받은 provider `status === 'PAID'`를 메서드 내부에서 독립적으로 강제하지 않는다. 이 항목은 actual release SHA 확정 전 해결·회귀 검증해야 한다.
+- 현재 `main`의 `PaymentFinalizationService.finalizePaidOrder()`는 전달받은 provider `status === 'PAID'`를 메서드 내부에서 독립적으로 강제하지 않는다. actual release SHA 확정 전 해결·회귀 검증해야 한다.
+- 주문 조회 authorization은 직접 테스트가 존재해 `VERIFIED`지만, order mutation authorization은 seller 타-store·비담당 driver·미배정 driver first-claim 경계의 직접 거부 회귀가 부족해 `IMPLEMENTED / UNVERIFIED` 상태다.
 
 ## 배포 안전 기준선
 
@@ -45,7 +48,7 @@
 - deployment safety CI 추가.
 - direct `main` 작업은 `AGENTS.md`에서 금지.
 
-그러나 GitHub `main` 자체는 마지막 재조회 기준 `protected=false`이므로 Issue #32 완료가 출시 전 필수다.
+그러나 GitHub `main` 자체는 2026-08-24 재조회 기준 `protected=false`이므로 Issue #32 완료가 출시 전 필수다.
 
 **이제 `main` merge는 production 배포 수단이 아니다.** 운영 배포는 아래 Task 3 단계에서 검증된 exact release SHA를 명시적으로 deploy/promote한다.
 
@@ -56,6 +59,7 @@
 | 0 | repo-side 자동배포 차단 | 완료 |
 | 0A | GitHub `main` branch protection/ruleset | **미완료 — Issue #32** |
 | 0B | 결제 finalization 비`PAID` 최종 차단 + 회귀 | **미완료 — P0** |
+| 0C | 주문 mutation authorization 직접 거부 회귀 | **미완료 — P0 COVERAGE GAP** |
 | 1 | ALIGO 8종 provider 최종 승인 | **검수중** |
 | 2 | 실제 알림톡 정상 발송 | 미실행 |
 | 3 | SMS fallback 실제 검증 | 미실행 |
@@ -73,18 +77,19 @@
 
 1. 모든 repository 변경은 최신 `main`에서 목적별 branch를 만들고 PR로 통합한다.
 2. direct `main` commit/push를 하지 않는다.
-3. dependency 순서대로 Task를 실행하되 결제 finalization P0와 Issue #32는 ALIGO 심사와 병렬로 해결할 수 있다.
+3. dependency 순서대로 Task를 실행하되 결제 finalization P0, 주문 mutation authorization P0와 Issue #32는 ALIGO 심사와 병렬로 해결할 수 있다.
 4. 외부 서비스 변경·실제 발송·운영 변수·Firebase 운영 변경·production 배포·운영 데이터·`salesMode` 변경은 해당 승인 게이트를 따른다.
 5. 한 Task의 승인을 이후 운영 변경 승인으로 확대 해석하지 않는다.
 6. 비밀값·고객 개인정보·사진 원본·서명 URL을 Git/문서/증거에 남기지 않는다.
-7. 결제 finalization P0와 법적 페이지 변경까지 포함한 actual release SHA를 확정하기 전 release 검증을 완료로 기록하지 않는다.
+7. 현재 P0 코드·검증 보정과 법적 페이지 변경까지 포함한 actual release SHA를 확정하기 전 release 검증을 완료로 기록하지 않는다.
 8. actual release SHA의 원격 회차 E2E 52건과 cleanup 통과 전 production 배포 금지.
 9. Issue #32의 `main` 보호 완료 전 production release 금지.
 10. `main` merge·빈 commit·재-push를 production 배포 트리거로 사용하지 않는다.
 11. production 배포 직전·직후 provider metadata Git SHA가 승인 release SHA와 동일한지 확인한다.
 12. ALIGO 실제 발송 검증 실패 시 알림 없는 출시를 임의 승인하지 않는다.
 13. 첫 회차가 검수된 `SCHEDULED`가 아니면 `salesMode`를 전환하지 않는다.
-14. 미검증 항목을 완료로 기록하지 않는다.
+14. `docs/DOCUMENT_CONSISTENCY.md` 기준에서 `IMPLEMENTED / UNVERIFIED`인 P0를 완료로 간주하지 않는다.
+15. 미검증 항목을 완료로 기록하지 않는다.
 
 ## Execution Plan
 
@@ -120,6 +125,20 @@
   - 회차 reservation/race 회귀 유지
 - Contract: `docs/specs/api/payments.md`
 - Status: todo_code
+
+#### Task 0.5 — 주문 mutation authorization 직접 회귀
+- Dependency: 없음. ALIGO 심사·Task 0.3·0.4와 병렬 가능.
+- Goal: 구현된 `assertOrderActionAccess()`의 권한 경계를 직접 거부 테스트로 고정한다.
+- Required:
+  - 타-store seller의 status mutation 403
+  - 타-store seller의 delivery-hold mutation 403
+  - 비담당 driver의 assigned order mutation 403
+  - 미배정 주문은 `PREPARING → DELIVERING` first-claim만 허용
+  - first-claim 성공 시 `driverId` 기록
+  - 거부된 mutation의 order write·notification·refund·settlement side effect 0
+  - 필요 시 admin 의도된 허용 범위 고정
+- Contract: `docs/specs/api/orders.md`
+- Status: todo_test
 
 ### Phase 1 — ALIGO 알림 게이트
 
@@ -158,7 +177,7 @@
 - Status: todo
 
 #### Task 2.2 — actual release SHA 확정
-- Dependency: Task 0.3, Task 0.4, Task 2.1
+- Dependency: Task 0.3, Task 0.4, Task 0.5, Task 2.1
 - Goal: 운영에 올릴 단 하나의 exact `main` SHA 고정.
 - 과거 `6e0fc9d...` run은 역사 증거일 뿐 현재 release 증거가 아니다.
 - Status: todo
@@ -239,7 +258,7 @@
 
 #### Task 5.3 — 최종 출시 판정
 - Dependency: Task 5.2
-- 대조: exact SHA, payment P0, branch protection, Firebase, ALIGO, legal, 첫 회차, 예외, 담당자, rollback.
+- 대조: exact SHA, payment P0, order authorization P0, branch protection, Firebase, ALIGO, legal, 첫 회차, 예외, 담당자, rollback.
 - Status: todo
 
 ### Phase 6 — 판매 모드 전환
@@ -269,6 +288,7 @@
 ## Completion Criteria
 
 - 결제 finalization 비`PAID` 차단과 회귀 검증이 `main`에 포함됨.
+- 주문 mutation authorization 핵심 거부 회귀가 `main`에 포함되고 P0 권한 계약이 `VERIFIED`로 승격됨.
 - Issue #32 branch protection/ruleset 완료.
 - ALIGO 8종 최종 승인.
 - 실제 알림톡·SMS fallback 검증.
@@ -285,6 +305,7 @@
 
 - 코드 통합: 완료
 - 결제 finalization `PAID` 최종 방어: **미완료 — P0**
+- 주문 mutation authorization 직접 회귀: **미완료 — P0 COVERAGE GAP**
 - repo-side production auto-deploy 분리: 완료
 - docs-only Preview/E2E 억제: 완료
 - GitHub `main` protection: **미완료 — Issue #32**

--- a/docs/specs/api/orders.md
+++ b/docs/specs/api/orders.md
@@ -2,7 +2,7 @@
 
 # Orders API / Domain Spec
 
-> **최종 정합화**: 2026-08-23
+> **최종 정합화**: 2026-08-24
 > **상태**: Current
 > **공통 타입 정본**: `packages/shared/src/order.types.ts`
 > **FSM 정본**: `apps/api/src/orders/orders.helpers.ts` 및 lifecycle service
@@ -236,6 +236,42 @@ PATCH /stores/:storeId/orders/:orderId/hub-confirm
 
 `GET /stores/:storeId/orders`의 현재 controller query는 `userId?`, `status?`, `saleType?`다. 과거 문서의 `driverId` query를 현재 공개 controller 계약으로 사용하지 않는다.
 
+## 7A. 역할·소유권 검증 상태
+
+문서 정합성 기준은 `docs/DOCUMENT_CONSISTENCY.md`를 따른다. 역할별 FSM이 존재한다는 사실과 실제 소유권·배정 권한이 회귀 테스트로 보장된다는 사실을 구분한다.
+
+### 조회 권한 — `VERIFIED`
+
+`OrdersQueryService`와 `orders-query.service.spec.ts`가 직접 대조된다.
+
+- consumer: 요청 query의 `userId`와 무관하게 자신의 주문만 목록 조회하며 타인 상세는 거부한다.
+- seller: `stores/{storeId}.ownerId === requesterId`인 스토어의 목록·상세만 허용한다.
+- driver: `order.driverId === requesterId`로 배정된 주문의 목록·상세만 허용한다.
+- admin: 스토어 주문 전체 조회를 허용한다.
+- storeId 없는 단건 조회도 seller 소유권과 driver 배정을 다시 검증한다.
+- 회차 직배송 완료 사진 URL도 주문 조회 권한을 통과한 뒤에만 생성한다.
+
+### 상태 변경 권한 — `IMPLEMENTED / UNVERIFIED`
+
+`OrdersLifecycleService.assertOrderActionAccess()`의 현재 구현은 다음과 같다.
+
+- admin: 일반 action ownership guard 통과.
+- seller: 해당 `storeId`의 실제 `ownerId`와 requester가 일치해야 변경 가능.
+- driver: 이미 `driverId`가 있으면 해당 기사만 변경 가능.
+- driver 첫 수거: `driverId`가 없고 주문이 `PREPARING`이며 요청 전이가 `DELIVERING`일 때만 최초 claim을 허용하고 이후 `driverId`를 기록한다.
+- consumer: 자신의 주문에 대해서만 action access를 통과하며 실제 허용 전이는 consumer FSM이 추가 제한한다.
+
+현재 직접 검증된 근거에는 consumer의 위장 `DELIVERY_HELD` 요청 거부, 정상 seller/driver 회차 흐름, 배송사진 타인 접근 거부가 포함된다.
+
+그러나 2026-08-24 문서 감사 기준으로 다음 mutation authorization 거부 시나리오를 직접 고정하는 회귀 테스트는 확인되지 않았다.
+
+- 다른 스토어의 seller가 `PATCH .../status` 또는 `delivery-hold`를 시도하는 경우
+- 이미 다른 기사에게 배정된 주문을 비담당 driver가 변경하는 경우
+- 미배정 주문에서 허용된 최초 `PREPARING → DELIVERING` 이외의 driver action이 거부되는 경우
+- 위 거부 요청에서 주문·알림·환불·정산 side effect가 발생하지 않는지 확인
+
+권한은 P0 계약이므로 위 직접 회귀가 추가되기 전 상태 변경 authorization 전체를 `VERIFIED`로 표현하지 않는다. 추적: `docs/BACKLOG.md`의 `ORDER-MUTATION-AUTHORIZATION-COVERAGE`.
+
 ## 8. 배송 사진
 
 회차 직배송의 현재 정본 사진 경로는 단순 `photoUrl` 첨부가 아니라 서버가 파일을 수신·보관하고 완료 처리하는 전용 API다.
@@ -304,9 +340,12 @@ legacy 공동구매에는 `RECRUITING`, `CONFIRMED`, `GROUP_*` 알림, `groupPro
 - `apps/api/src/orders/orders.controller.ts`
 - `apps/api/src/orders/orders.helpers.ts`
 - `apps/api/src/orders/*lifecycle*`
+- `apps/api/src/orders/orders-query.service.spec.ts`
 - 관련 unit/spec tests
 - `apps/e2e`의 영향 시나리오
 - 회차 변경이면 `docs/specs/mvp-sales-round-direct-delivery.md`
+
+권한 계약은 `docs/DOCUMENT_CONSISTENCY.md`에 따라 직접 거부 회귀가 없으면 구현 존재만으로 `VERIFIED` 처리하지 않는다.
 
 상태 전이·권한·결제·환불을 문서 예시만 보고 운영 데이터에 직접 적용하지 않는다.
 
@@ -314,6 +353,7 @@ legacy 공동구매에는 `RECRUITING`, `CONFIRMED`, `GROUP_*` 알림, `groupPro
 
 | 날짜 | 내용 |
 |---|---|
+| 2026-08-24 | 조회 authorization은 VERIFIED, mutation authorization은 직접 거부 회귀 부족으로 IMPLEMENTED / UNVERIFIED 분리 |
 | 2026-08-23 | `DELIVERY_HELD`, 회차 snapshot, 현재 endpoint/FSM, 재배송·배송사진·알림 계약에 맞춰 전면 정합화 |
 | 2026-04-23 | legacy 공동구매 수량 용어 반영 |
 | 2026-03-26 | 초기 orders 설계 초안 |


### PR DESCRIPTION
## 변경
- Orders current spec에서 조회 권한은 `VERIFIED`, mutation 권한은 `IMPLEMENTED / UNVERIFIED`로 분리
- 타-store seller, 비담당 driver, 미배정 driver first-claim 경계의 직접 회귀 부족을 P0 `COVERAGE GAP`으로 등록
- memory, Backlog, 활성 PLAN/HANDOFF에 영향 기반으로 최소 전파

## 근거
- `OrdersQueryService`는 consumer/seller/driver/admin 조회 권한 직접 테스트 존재
- `OrdersLifecycleService.assertOrderActionAccess()`는 mutation guard 구현 존재
- consumer 위장 hold 거부와 정상 seller/driver 흐름은 테스트되지만 핵심 mutation authorization 거부 케이스는 직접 회귀가 부족함

## 범위
- docs-only
- 코드/production/provider 변경 없음