### PR TITLE
docs: 주문 direct Firestore read P0 정합화

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -42,9 +42,44 @@
 
 문서만으로 이 불변식을 완료 처리하지 않는다. 정본: `docs/specs/api/payments.md`.
 
+### P0 — ORDER-DIRECT-READ-AUTHORIZATION-AND-MINIMIZATION
+
+2026-08-24 감사에서 API 주문 조회 authorization과 실제 seller/driver 클라이언트 read 경계가 다름을 확인했다.
+
+현재 구현·증거:
+
+- [x] `OrdersQueryService`는 driver 상세를 `order.driverId === requesterId`로 제한하고 해당 API 권한 테스트가 존재
+- [x] `firestore.rules`는 `role == 'driver'`이면 `orders/{orderId}`를 store/status/배정과 무관하게 read 허용
+- [x] driver 보드는 미배정 `PREPARING` direct/hub 주문 discovery를 위해 Firestore `orders`를 직접 query
+- [x] driver 상세는 Firestore `orders/{orderId}`를 직접 `onSnapshot()`
+- [x] seller 주문 목록도 같은-store `orders` 원문을 직접 구독
+- [x] 회차 주문 원문에는 배송 수행 필드 외에 `acquisition`, `marketingConsent`, `clientOrderPayloadHash`, reservation 관련 내부 필드가 함께 저장될 수 있음
+- [x] 현재 Firestore Rules 테스트가 driver의 다른 store 주문 직접 read를 성공 케이스로 고정
+
+판정:
+
+- API layer read authorization만 보면 배정 기사 경계가 `VERIFIED`다.
+- end-to-end 주문 read authorization은 direct Firestore 경로가 API보다 넓으므로 **`IMPLEMENTATION FINDING` P0**다.
+- seller/driver의 역할별 최소 필드 제공도 raw document read 때문에 현재 `VERIFIED`가 아니다.
+
+남음:
+
+- [ ] 미배정 `PREPARING` direct/hub 주문을 driver가 discovery해야 하는 제품 의도를 명시하고 discovery에 필요한 최소 필드 정의
+- [ ] 임의 driver가 다른 기사 배정 주문·완료 주문·일반 임의 주문 원문을 직접 read하지 못하도록 경계 축소
+- [ ] assigned driver 상세에 필요한 배송지·연락처·상품·보류 정보만 제공하는 역할별 DTO/projection 또는 동등한 데이터 분리
+- [ ] seller 주문 read도 판매 업무에 필요한 필드만 제공하고 `marketingConsent`, `acquisition` 등 불필요한 고객/행동 메타데이터 노출 제거
+- [ ] raw `orders` 직접 구독을 유지할 경우 Rules만으로 field minimization이 가능한지 검증하고, 불가능하면 API/projection 구조로 전환
+- [ ] `firestore.rules`의 broad `role == 'driver'` read 제거 또는 안전한 discovery/assigned 조건으로 대체
+- [ ] `tests/firestore/firestore-rules.test.mjs`의 broad driver 성공 기대를 제거하고 허용/거부 경계를 직접 검증
+- [ ] driver가 임의 order ID로 다른 주문 상세을 읽을 수 없는 직접 Rules/앱 회귀
+- [ ] seller 타-store read 거부와 seller/driver 정상 보드·상세 기능 회귀 유지
+- [ ] 변경이 포함된 SHA를 `main`에 통합한 뒤 actual release SHA 후보에 포함
+
+이 finding을 법적 문구를 넓혀 정당화하지 않는다. 먼저 실제 read 경계를 최소화·검증한 뒤 `docs/specs/legal/README.md`의 seller/driver 개인정보 처리 문구를 확정한다. 기술 정본: `docs/specs/api/orders.md`.
+
 ### P0 — ORDER-MUTATION-AUTHORIZATION-COVERAGE
 
-주문 조회 authorization은 `OrdersQueryService`와 직접 테스트가 일치해 `VERIFIED`다. 반면 `OrdersLifecycleService.assertOrderActionAccess()`의 mutation authorization은 구현돼 있으나 권한 우회 방지 핵심 거부 시나리오를 직접 고정하는 회귀 테스트가 충분하지 않다.
+주문 API 조회 authorization은 `OrdersQueryService`와 직접 테스트가 일치해 해당 API 계층에서는 `VERIFIED`다. 반면 `OrdersLifecycleService.assertOrderActionAccess()`의 mutation authorization은 구현돼 있으나 권한 우회 방지 핵심 거부 시나리오를 직접 고정하는 회귀 테스트가 충분하지 않다.
 
 현재 구현·검증:
 
@@ -54,7 +89,7 @@
 - [x] consumer는 자신의 주문만 action access 통과
 - [x] consumer가 `DELIVERY_HELD`를 위장 요청하는 직접 거부 테스트
 - [x] 정상 seller/driver 회차 E2E 흐름
-- [x] 조회 권한의 consumer/seller/driver/admin 직접 거부·허용 테스트
+- [x] API 조회 권한의 consumer/seller/driver/admin 직접 거부·허용 테스트
 
 남음:
 
@@ -136,7 +171,7 @@ Issue #32 완료 전에도 repo-side Vercel guard는 동작하지만, direct pus
 - [ ] 주문 성립·취소·환불·배송·재배송비·배송 보류 정책 검수
 - [ ] PortOne·실제 결제사업자 개인정보 처리 역할 검수
 - [ ] ALIGO 고객 알림 전화번호·메시지 처리 고지 검수
-- [ ] seller·driver 고객 배송정보 접근 설명 검수
+- [ ] `ORDER-DIRECT-READ-AUTHORIZATION-AND-MINIMIZATION` 해결 후 seller·driver 고객 배송정보 접근 설명 검수
 - [ ] 시행일·이전 버전 관리
 - [ ] `apps/consumer/src/app/legal-documents.test.mjs` 갱신
 - [ ] 변경된 `/privacy`, `/terms`를 release SHA에 포함
@@ -146,6 +181,7 @@ Issue #32 완료 전에도 repo-side Vercel guard는 동작하지만, direct pus
 ### P0 — 출시 후보 검증·운영 준비
 
 - [ ] PAYMENT-FINALIZATION-PAID-GUARD 완료 및 `main` 통합
+- [ ] ORDER-DIRECT-READ-AUTHORIZATION-AND-MINIMIZATION 완료 및 `main` 통합
 - [ ] ORDER-MUTATION-AUTHORIZATION-COVERAGE 완료 및 `main` 통합
 - [ ] Issue #32 branch protection 완료
 - [ ] 법적 페이지 포함 actual release SHA 확정

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -64,6 +64,22 @@ Vercel Hobby build-rate-limit 때문에 docs-only PR에 Vercel check failure가 
 
 ## 현재 확인된 P0
 
+### 주문 direct Firestore read authorization·개인정보 최소화
+
+2026-08-24 감사에서 API read guard와 실제 seller/driver client read 경계가 다름을 확인했다.
+
+- API `OrdersQueryService`는 driver 주문 조회를 배정된 `driverId`로 제한하고 직접 테스트가 존재한다.
+- 그러나 `firestore.rules`는 `role == 'driver'`이면 `orders` 문서를 store/status/배정과 무관하게 read 허용한다.
+- driver 보드·상세와 seller 주문 목록은 Firestore `orders` 원문을 직접 구독한다.
+- 회차 order 원문에는 배송 수행 정보 외에도 `acquisition`, `marketingConsent`, `clientOrderPayloadHash`, reservation 관련 내부 필드가 함께 저장될 수 있다.
+- 현재 Firestore Rules 테스트도 driver의 다른 store 주문 직접 read를 성공 케이스로 고정한다.
+
+따라서 API 조회 authorization만 `VERIFIED`이며, **시스템 전체 driver read authorization과 seller/driver 데이터 최소화는 `IMPLEMENTATION FINDING` P0**다.
+
+미배정 `PREPARING` direct/hub 주문 discovery가 현재 제품 흐름에 필요한 점은 보존하되, 임의 driver의 arbitrary order 원문 접근과 역할에 불필요한 필드 노출은 actual release SHA 확정 전에 제거·직접 검증한다.
+
+정본: `docs/specs/api/orders.md`, `docs/BACKLOG.md`, 법적 선행 게이트 `docs/specs/legal/README.md`.
+
 ### 결제 최종화 provider 상태 방어
 
 현재 `main`의 `apps/api/src/payments/payment-finalization.service.ts`는 `finalizePaidOrder()` 내부에서 전달받은 `paymentData.status === 'PAID'`를 독립적으로 강제하지 않는다.
@@ -81,7 +97,7 @@ Vercel Hobby build-rate-limit 때문에 docs-only PR에 Vercel check failure가 
 
 ### 주문 mutation authorization 회귀 검증
 
-주문 조회 권한은 consumer/seller/driver/admin별 직접 테스트가 존재해 `VERIFIED`다.
+주문 API 조회 권한은 consumer/seller/driver/admin별 직접 테스트가 존재해 **API 계층에서는** `VERIFIED`다.
 
 주문 상태 변경은 `OrdersLifecycleService.assertOrderActionAccess()`에서 seller store 소유권, driver 배정, consumer 주문 소유권을 검사하고 정상 회차 E2E도 존재한다. 그러나 2026-08-24 감사에서는 다음 직접 거부 회귀를 확인하지 못했다.
 
@@ -122,6 +138,8 @@ Vercel Hobby build-rate-limit 때문에 docs-only PR에 Vercel check failure가 
 - 현재 공개 문서는 상용 주문·결제·배송을 운영하지 않는 **비판매 상태**를 명시한다.
 - 개인정보 정본은 PortOne·결제사업자를 현재 상용 처리 수탁자로 운영하지 않는다고 적고 있다.
 - 실제 고객 ALIGO 알림 처리도 판매 활성화 기준으로 재검수해야 한다.
+- seller/driver 고객정보 접근 문구는 `ORDER-DIRECT-READ-AUTHORIZATION-AND-MINIMIZATION` P0 해결 전 최종 확정하지 않는다.
+- broad direct read를 법적 문구로 정당화하지 않고 실제 접근 경계를 먼저 최소화한다.
 - 기존 법적 고지 production 반영 완료는 **판매 활성화 법적 준비 완료를 뜻하지 않는다.**
 - ALIGO 실제 발송 검증 뒤 release SHA 고정 전에 `docs/specs/legal/README.md`의 P0 재정합화 게이트를 완료한다.
 - 판매 공개 전에는 비판매 문구를 임의로 `판매 중`으로 미리 바꾸지 않는다.
@@ -161,14 +179,15 @@ Vercel Hobby build-rate-limit 때문에 docs-only PR에 Vercel check failure가 
 
 ## 다음 작업
 
-1. **P0 병렬 코드 게이트**: 결제 finalization이 비`PAID` provider 상태를 자체 차단하도록 구현·회귀 검증 후 `main` 통합.
-2. **P0 병렬 검증 게이트**: 주문 mutation authorization의 타-store seller·비담당 driver·미배정 first-claim 경계를 직접 회귀 테스트하고 `main` 통합.
-3. **P0 병렬 관리자 게이트**: Issue #32의 `main` branch protection/ruleset 활성화.
-4. **외부 차단**: ALIGO 8종 심사 결과 대기. 승인 전 실제 발송·운영 ALIGO 설정은 진행하지 않는다.
-5. 8종 승인 후 격리 알림톡 정상 발송 → SMS fallback 검증.
-6. 판매 활성화 법적 문서·테스트 재정합화.
-7. 법적 변경과 모든 P0 코드·검증 보정까지 포함한 actual release SHA 확정 → 원격 회차 E2E 52건+cleanup.
-8. 운영 Firebase 재조회 → ALIGO 운영 설정 → 별도 `Task 3.1 승인` → exact-SHA production 배포.
-9. 이후 첫 회차 검수 → 최종 출시 판정 → `salesMode: round_direct` 전환.
+1. **P0 병렬 코드 게이트**: 주문 direct Firestore read를 안전한 discovery/assigned 경계와 역할별 최소 데이터로 축소하고 Rules·frontend 회귀를 `main`에 통합.
+2. **P0 병렬 코드 게이트**: 결제 finalization이 비`PAID` provider 상태를 자체 차단하도록 구현·회귀 검증 후 `main` 통합.
+3. **P0 병렬 검증 게이트**: 주문 mutation authorization의 타-store seller·비담당 driver·미배정 first-claim 경계를 직접 회귀 테스트하고 `main` 통합.
+4. **P0 병렬 관리자 게이트**: Issue #32의 `main` branch protection/ruleset 활성화.
+5. **외부 차단**: ALIGO 8종 심사 결과 대기. 승인 전 실제 발송·운영 ALIGO 설정은 진행하지 않는다.
+6. 8종 승인 후 격리 알림톡 정상 발송 → SMS fallback 검증.
+7. 주문 read 최소화 P0 해결을 전제로 판매 활성화 법적 문서·테스트 재정합화.
+8. 법적 변경과 모든 P0 코드·검증 보정까지 포함한 actual release SHA 확정 → 원격 회차 E2E 52건+cleanup.
+9. 운영 Firebase 재조회 → ALIGO 운영 설정 → 별도 `Task 3.1 승인` → exact-SHA production 배포.
+10. 이후 첫 회차 검수 → 최종 출시 판정 → `salesMode: round_direct` 전환.
 
 문서 정합성 감사는 `docs/DOCUMENT_CONSISTENCY.md`를 따르고, repository 변경은 **branch + PR**로 수행한다.

--- a/docs/plans/HANDOFF_mvp_round_direct_aligo_review_pause.md
+++ b/docs/plans/HANDOFF_mvp_round_direct_aligo_review_pause.md
@@ -17,13 +17,42 @@
 
 현재 외부 차단점은 **ALIGO 8종 provider 심사 완료**다. provider 상태는 새 작업 시작 시 다시 조회한다.
 
-동시에 해결 가능한 P0는 세 가지다.
+동시에 해결 가능한 P0는 네 가지다.
 
-1. **결제 finalization `PAID` 최종 방어** — 현재 `main`의 `finalizePaidOrder()`는 전달받은 provider status를 자체 강제하지 않음.
-2. **주문 mutation authorization 직접 회귀** — 권한 guard는 구현돼 있으나 타-store seller·비담당 driver·미배정 first-claim 경계를 직접 고정하는 회귀가 부족함.
-3. **Issue #32 `main` branch protection/ruleset 활성화**.
+1. **주문 direct Firestore read authorization·데이터 최소화** — API보다 넓은 driver direct read와 raw order 필드 노출을 안전한 discovery/assigned 경계로 축소해야 함.
+2. **결제 finalization `PAID` 최종 방어** — 현재 `main`의 `finalizePaidOrder()`는 전달받은 provider status를 자체 강제하지 않음.
+3. **주문 mutation authorization 직접 회귀** — 권한 guard는 구현돼 있으나 타-store seller·비담당 driver·미배정 first-claim 경계를 직접 고정하는 회귀가 부족함.
+4. **Issue #32 `main` branch protection/ruleset 활성화**.
 
 현재 상태 정본은 `docs/memory.md`, 미완료 목록은 `docs/BACKLOG.md`를 우선한다. 문서 정합성 판정은 `docs/DOCUMENT_CONSISTENCY.md`를 따른다.
+
+## 주문 direct Firestore read P0
+
+2026-08-24 감사에서 API 주문 조회 authorization과 seller/driver가 실제 사용하는 Firestore read 경계가 서로 다름을 확인했다.
+
+현재 사실:
+
+- API `OrdersQueryService`는 driver 주문 상세을 `order.driverId === requesterId`로 제한한다.
+- `firestore.rules`는 `role == 'driver'`이면 주문의 store/status/배정과 무관하게 `orders` read를 허용한다.
+- driver 보드는 미배정 `PREPARING` direct/hub 주문 discovery를 위해 raw Firestore query를 사용한다.
+- driver 상세는 arbitrary `orders/{orderId}`를 raw Firestore `onSnapshot()`으로 읽는다.
+- seller 주문 목록도 same-store raw `orders` 문서를 직접 구독한다.
+- 회차 주문 원문에는 배송 수행 외 `acquisition`, `marketingConsent`, 내부 hash/reservation 메타데이터가 함께 존재할 수 있다.
+- 현재 Firestore Rules 테스트는 driver의 다른 store 주문 direct read를 성공 케이스로 고정한다.
+
+따라서 API 계층 조회 권한만 `VERIFIED`이며 시스템 전체 driver read authorization과 seller/driver 최소 데이터 제공은 **`IMPLEMENTATION FINDING` P0**다.
+
+actual release SHA 확정 전에:
+
+- 미배정 `PREPARING` direct/hub discovery 의도와 필요한 최소 필드를 명시하고,
+- 임의 driver의 타-driver/완료/기타 arbitrary order 원문 read를 차단하고,
+- assigned driver와 seller에 필요한 역할별 최소 필드만 제공하며,
+- `firestore.rules`와 Rules 테스트를 해당 계약으로 변경하고,
+- seller/driver 보드·상세·first-claim 회귀를 확인한다.
+
+Rules만으로 field minimization이 불가능하면 API DTO, safe projection 또는 민감/내부 필드 분리 등 동등한 구조를 사용한다. broad 구현을 개인정보처리방침 문구로 정당화하지 않는다.
+
+정본: `docs/specs/api/orders.md`, `docs/specs/legal/README.md`.
 
 ## 결제 finalization P0
 
@@ -50,7 +79,7 @@
 
 ## 주문 mutation authorization P0
 
-주문 조회 authorization은 consumer/seller/driver/admin별 직접 테스트가 존재해 `VERIFIED`다.
+주문 API 조회 authorization은 consumer/seller/driver/admin별 직접 테스트가 존재해 **API 계층에서는** `VERIFIED`다.
 
 상태 변경은 `OrdersLifecycleService.assertOrderActionAccess()`가 다음 경계를 구현한다.
 
@@ -92,6 +121,7 @@ production `/privacy`, `/terms`는 현재 비판매 상태를 전제로 한다.
 
 따라서 ALIGO 실제 발송 검증 뒤 release SHA를 고정하기 전에:
 
+- 주문 direct Firestore read P0를 해결해 seller/driver 실제 접근 범위를 최소화·검증하고,
 - 실제 주문·결제·취소·환불·배송·재배송비·보류 정책,
 - PortOne/결제사업자 개인정보 처리,
 - ALIGO 고객 알림 처리,
@@ -100,6 +130,8 @@ production `/privacy`, `/terms`는 현재 비판매 상태를 전제로 한다.
 - `legal-documents.test.mjs`
 
 을 `docs/specs/legal/README.md` 계약에 맞게 갱신한다.
+
+현재 broad direct read를 설명하기 위해 공개 개인정보 문구를 넓히지 않는다. 실제 접근 경계를 먼저 수정한다.
 
 ## ALIGO 템플릿 현황
 
@@ -125,7 +157,7 @@ production `/privacy`, `/terms`는 현재 비판매 상태를 전제로 한다.
 - 마지막 전체 원격 회차 E2E 역사 증거: SHA `6e0fc9d4cec08073ed2504208cc8bb1ea395ee7d`, run `32351887404`.
 - chromium 26 + mobile 26 = 52, 양쪽 cleanup 성공.
 - 현재 release SHA 증거로 확장 적용하지 않는다.
-- 결제 finalization P0, 주문 authorization P0와 법적 변경까지 포함한 actual release SHA에서 다시 검증한다.
+- 주문 direct read P0, 결제 finalization P0, 주문 mutation authorization P0와 법적 변경까지 포함한 actual release SHA에서 다시 검증한다.
 
 ## 지금 하지 말아야 할 작업
 
@@ -136,24 +168,26 @@ production `/privacy`, `/terms`는 현재 비판매 상태를 전제로 한다.
 - `main` merge를 production 배포 승인으로 해석.
 - 별도 Task 승인 없이 production 배포·Firebase 운영 변경·운영 회차 생성·`salesMode` 변경.
 - 비판매 법적 문구를 판매 공개 전에 임의로 미리 전환.
+- broad seller/driver 주문 read를 개인정보 문구 확대만으로 정당화.
 - 현재 P0 코드·검증 게이트가 `main`에 반영되기 전에 release SHA를 확정.
 
 ## 지금 병렬로 할 수 있는 작업
 
-1. 결제 finalization `PAID` guard 구현·회귀 검증·통합.
-2. 주문 mutation authorization 직접 거부 회귀 테스트·통합.
-3. Issue #32 `main` protection/ruleset 관리자 설정.
-4. read-only 문서/코드 정합성 감사.
-5. ALIGO provider 심사 상태 조회.
+1. 주문 direct Firestore read authorization·데이터 최소화 구현·Rules/frontend 회귀·통합.
+2. 결제 finalization `PAID` guard 구현·회귀 검증·통합.
+3. 주문 mutation authorization 직접 거부 회귀 테스트·통합.
+4. Issue #32 `main` protection/ruleset 관리자 설정.
+5. read-only 문서/코드 정합성 감사.
+6. ALIGO provider 심사 상태 조회.
 
 ## ALIGO 승인 뒤 재개 순서
 
-1. 결제 finalization P0와 주문 mutation authorization P0가 `main`에 통합됐는지 확인.
+1. 주문 direct read P0, 결제 finalization P0, 주문 mutation authorization P0가 `main`에 통합됐는지 확인.
 2. 8종 모두 승인/수정요청/반려 여부 확인.
 3. 승인 `tpl_code` 8종 ↔ 내부 논리 템플릿 1:1 매핑 검사.
 4. 별도 승인 후 격리 실제 알림톡 정상 발송.
 5. 별도 승인 후 SMS fallback 실제 검증.
-6. 판매 활성화 법적 문서·테스트 재정합화.
+6. 주문 read 최소화 결과를 전제로 판매 활성화 법적 문서·테스트 재정합화.
 7. Issue #32 완료 확인.
 8. 법적 변경과 모든 P0 코드·검증 보정까지 포함한 actual release SHA 확정.
 9. exact SHA 원격 회차 E2E 52건 + fixture cleanup.
@@ -172,6 +206,7 @@ production `/privacy`, `/terms`는 현재 비판매 상태를 전제로 한다.
 - [x] ALIGO 템플릿 8종 등록·심사 요청
 - [x] repo-side `main` 자동 production deploy 차단
 - [x] deployment safety CI와 docs-only ignore 적용
+- [ ] 주문 direct Firestore read authorization·데이터 최소화 + Rules/frontend 회귀 + `main` 통합
 - [ ] 결제 finalization `PAID` guard + 회귀 검증 + `main` 통합
 - [ ] 주문 mutation authorization 직접 거부 회귀 + `main` 통합
 - [ ] Issue #32 branch protection/ruleset

--- a/docs/plans/PLAN_mvp_round_direct_launch_blockers.md
+++ b/docs/plans/PLAN_mvp_round_direct_launch_blockers.md
@@ -11,6 +11,7 @@
 - 상태: `paused_external_review`
 - Priority: P0
 - 현재 외부 차단점: ALIGO 회차 알림 템플릿 8종 provider 심사 완료
+- 병렬 보안 P0: 주문 direct Firestore read authorization·역할별 데이터 최소화
 - 병렬 코드 P0: 결제 finalization `PAID` 최종 방어
 - 병렬 검증 P0: 주문 mutation authorization 직접 거부 회귀
 - 병렬 관리자 P0: GitHub Issue #32 `main` branch protection/ruleset
@@ -35,7 +36,8 @@
 - `salesMode=legacy` 유지.
 - 현재 `/terms`, `/privacy`는 비판매 상태를 전제로 하므로 실제 판매 활성화 전 재정합화가 필요하다.
 - 현재 `main`의 `PaymentFinalizationService.finalizePaidOrder()`는 전달받은 provider `status === 'PAID'`를 메서드 내부에서 독립적으로 강제하지 않는다. actual release SHA 확정 전 해결·회귀 검증해야 한다.
-- 주문 조회 authorization은 직접 테스트가 존재해 `VERIFIED`지만, order mutation authorization은 seller 타-store·비담당 driver·미배정 driver first-claim 경계의 직접 거부 회귀가 부족해 `IMPLEMENTED / UNVERIFIED` 상태다.
+- 주문 API 조회 authorization은 직접 테스트가 존재해 API 계층에서는 `VERIFIED`다. 그러나 driver/seller 앱은 raw Firestore `orders` read를 사용하고, current Rules는 `role == 'driver'`이면 배정·store·상태와 무관하게 주문 read를 허용하므로 시스템 전체 read authorization·데이터 최소화는 P0 `IMPLEMENTATION FINDING`이다.
+- order mutation authorization은 seller 타-store·비담당 driver·미배정 driver first-claim 경계의 직접 거부 회귀가 부족해 `IMPLEMENTED / UNVERIFIED` 상태다.
 
 ## 배포 안전 기준선
 
@@ -60,6 +62,7 @@
 | 0A | GitHub `main` branch protection/ruleset | **미완료 — Issue #32** |
 | 0B | 결제 finalization 비`PAID` 최종 차단 + 회귀 | **미완료 — P0** |
 | 0C | 주문 mutation authorization 직접 거부 회귀 | **미완료 — P0 COVERAGE GAP** |
+| 0D | 주문 direct Firestore read authorization·데이터 최소화 | **미완료 — P0 IMPLEMENTATION FINDING** |
 | 1 | ALIGO 8종 provider 최종 승인 | **검수중** |
 | 2 | 실제 알림톡 정상 발송 | 미실행 |
 | 3 | SMS fallback 실제 검증 | 미실행 |
@@ -77,19 +80,20 @@
 
 1. 모든 repository 변경은 최신 `main`에서 목적별 branch를 만들고 PR로 통합한다.
 2. direct `main` commit/push를 하지 않는다.
-3. dependency 순서대로 Task를 실행하되 결제 finalization P0, 주문 mutation authorization P0와 Issue #32는 ALIGO 심사와 병렬로 해결할 수 있다.
+3. dependency 순서대로 Task를 실행하되 주문 direct read P0, 결제 finalization P0, 주문 mutation authorization P0와 Issue #32는 ALIGO 심사와 병렬로 해결할 수 있다.
 4. 외부 서비스 변경·실제 발송·운영 변수·Firebase 운영 변경·production 배포·운영 데이터·`salesMode` 변경은 해당 승인 게이트를 따른다.
 5. 한 Task의 승인을 이후 운영 변경 승인으로 확대 해석하지 않는다.
 6. 비밀값·고객 개인정보·사진 원본·서명 URL을 Git/문서/증거에 남기지 않는다.
-7. 현재 P0 코드·검증 보정과 법적 페이지 변경까지 포함한 actual release SHA를 확정하기 전 release 검증을 완료로 기록하지 않는다.
+7. 주문 direct read 최소화, 결제/권한 P0 보정과 법적 페이지 변경까지 포함한 actual release SHA를 확정하기 전 release 검증을 완료로 기록하지 않는다.
 8. actual release SHA의 원격 회차 E2E 52건과 cleanup 통과 전 production 배포 금지.
 9. Issue #32의 `main` 보호 완료 전 production release 금지.
 10. `main` merge·빈 commit·재-push를 production 배포 트리거로 사용하지 않는다.
 11. production 배포 직전·직후 provider metadata Git SHA가 승인 release SHA와 동일한지 확인한다.
 12. ALIGO 실제 발송 검증 실패 시 알림 없는 출시를 임의 승인하지 않는다.
 13. 첫 회차가 검수된 `SCHEDULED`가 아니면 `salesMode`를 전환하지 않는다.
-14. `docs/DOCUMENT_CONSISTENCY.md` 기준에서 `IMPLEMENTED / UNVERIFIED`인 P0를 완료로 간주하지 않는다.
-15. 미검증 항목을 완료로 기록하지 않는다.
+14. `docs/DOCUMENT_CONSISTENCY.md` 기준에서 `IMPLEMENTED / UNVERIFIED`, `COVERAGE GAP`, `IMPLEMENTATION FINDING`인 P0를 완료로 간주하지 않는다.
+15. broad 주문 read를 개인정보처리방침 문구를 넓혀 정당화하지 않고 실제 접근 경계를 먼저 최소화한다.
+16. 미검증 항목을 완료로 기록하지 않는다.
 
 ## Execution Plan
 
@@ -140,6 +144,23 @@
 - Contract: `docs/specs/api/orders.md`
 - Status: todo_test
 
+#### Task 0.6 — 주문 direct Firestore read authorization·데이터 최소화
+- Dependency: 없음. ALIGO 심사·Task 0.3~0.5와 병렬 가능.
+- Goal: 미배정 수거 후보 discovery는 보존하되 seller/driver가 raw `orders` 원문을 필요 이상으로 읽는 구조를 제거한다.
+- Required:
+  - driver discovery 계약: 미배정 `PREPARING` + `direct|hub` 등 실제 필요한 대상과 최소 노출 필드 확정
+  - 임의 driver의 타-driver/완료/기타 arbitrary order raw read 차단
+  - assigned driver 상세의 최소 배송 필드만 제공
+  - seller 주문 read의 업무상 불필요 `marketingConsent`, `acquisition`, 내부 hash/reservation 메타데이터 노출 제거
+  - `firestore.rules` broad `role == 'driver'` 허용 제거 또는 안전 조건으로 대체
+  - Rules만으로 필드 최소화가 불가능하면 API DTO/safe projection/민감 필드 분리 중 동등한 구조 적용
+  - `tests/firestore/firestore-rules.test.mjs`의 다른 store driver read 성공 기대 제거
+  - 허용 discovery, assigned detail, 비담당/임의 read 거부, seller cross-store 거부 직접 테스트
+  - seller/driver 정상 보드·상세·first-claim 회귀 유지
+- Contract: `docs/specs/api/orders.md`
+- Legal dependency: `docs/specs/legal/README.md`
+- Status: todo_code_security
+
 ### Phase 1 — ALIGO 알림 게이트
 
 #### Task 1.1 — 발신 프로필·코드 매핑 기반
@@ -165,19 +186,19 @@
 ### Phase 2 — 판매 공개 계약·release SHA
 
 #### Task 2.1 — 판매 활성화 법적 문서 재정합화
-- Dependency: Task 1.5
+- Dependency: Task 1.5, Task 0.6
 - Contract: `docs/specs/legal/README.md`
 - Required:
   - 주문 성립·취소·환불·배송·재배송비·배송 보류
   - PortOne/결제사업자 개인정보 처리
   - ALIGO 고객 알림 처리
-  - seller/driver 배송정보 접근
+  - seller/driver 배송정보 접근은 Task 0.6에서 검증된 최소 접근 구조를 기준으로 설명
   - 시행일·이전 버전
   - `legal-documents.test.mjs` 갱신
 - Status: todo
 
 #### Task 2.2 — actual release SHA 확정
-- Dependency: Task 0.3, Task 0.4, Task 0.5, Task 2.1
+- Dependency: Task 0.3, Task 0.4, Task 0.5, Task 0.6, Task 2.1
 - Goal: 운영에 올릴 단 하나의 exact `main` SHA 고정.
 - 과거 `6e0fc9d...` run은 역사 증거일 뿐 현재 release 증거가 아니다.
 - Status: todo
@@ -258,7 +279,7 @@
 
 #### Task 5.3 — 최종 출시 판정
 - Dependency: Task 5.2
-- 대조: exact SHA, payment P0, order authorization P0, branch protection, Firebase, ALIGO, legal, 첫 회차, 예외, 담당자, rollback.
+- 대조: exact SHA, payment P0, order direct-read P0, order mutation P0, branch protection, Firebase, ALIGO, legal, 첫 회차, 예외, 담당자, rollback.
 - Status: todo
 
 ### Phase 6 — 판매 모드 전환
@@ -287,8 +308,9 @@
 
 ## Completion Criteria
 
+- 주문 direct Firestore read가 안전한 discovery/assigned 경계와 역할별 최소 데이터 계약으로 축소되고 Rules·frontend 회귀가 `main`에 포함됨.
 - 결제 finalization 비`PAID` 차단과 회귀 검증이 `main`에 포함됨.
-- 주문 mutation authorization 핵심 거부 회귀가 `main`에 포함되고 P0 권한 계약이 `VERIFIED`로 승격됨.
+- 주문 mutation authorization 핵심 거부 회귀가 `main`에 포함되고 P0 mutation 권한 계약이 `VERIFIED`로 승격됨.
 - Issue #32 branch protection/ruleset 완료.
 - ALIGO 8종 최종 승인.
 - 실제 알림톡·SMS fallback 검증.
@@ -304,6 +326,7 @@
 ## 현재 Closeout Roll-up
 
 - 코드 통합: 완료
+- 주문 direct Firestore read authorization·데이터 최소화: **미완료 — P0 IMPLEMENTATION FINDING**
 - 결제 finalization `PAID` 최종 방어: **미완료 — P0**
 - 주문 mutation authorization 직접 회귀: **미완료 — P0 COVERAGE GAP**
 - repo-side production auto-deploy 분리: 완료

--- a/docs/specs/api/orders.md
+++ b/docs/specs/api/orders.md
@@ -156,6 +156,8 @@ FSM 표만 보고 상태를 직접 Firestore에서 수정하지 않는다.
 
 이 문서에 Firestore 내부 필드를 별도 복제하지 않는다. 새 공개 필드를 추가하면 shared 타입을 먼저 확인한다.
 
+**주의:** 실제 `orders` Firestore 문서에는 shared `Order` 공개 타입 외에 `clientOrderPayloadHash`, `reservationId`, `marketingConsent` 등 내부 처리 필드가 함께 존재할 수 있다. raw Firestore document read를 공개 DTO와 동일한 것으로 취급하지 않는다.
+
 ## 6. 주문 생성 입력
 
 현재 `CreateOrderDto`는 legacy와 회차 주문을 함께 수용한다.
@@ -238,18 +240,53 @@ PATCH /stores/:storeId/orders/:orderId/hub-confirm
 
 ## 7A. 역할·소유권 검증 상태
 
-문서 정합성 기준은 `docs/DOCUMENT_CONSISTENCY.md`를 따른다. 역할별 FSM이 존재한다는 사실과 실제 소유권·배정 권한이 회귀 테스트로 보장된다는 사실을 구분한다.
+문서 정합성 기준은 `docs/DOCUMENT_CONSISTENCY.md`를 따른다. API service의 권한과 실제 frontend가 사용하는 direct Firestore read를 별개의 신뢰 경계로 검증한다.
 
-### 조회 권한 — `VERIFIED`
+### API 조회 권한 — `VERIFIED`
 
 `OrdersQueryService`와 `orders-query.service.spec.ts`가 직접 대조된다.
 
 - consumer: 요청 query의 `userId`와 무관하게 자신의 주문만 목록 조회하며 타인 상세는 거부한다.
 - seller: `stores/{storeId}.ownerId === requesterId`인 스토어의 목록·상세만 허용한다.
-- driver: `order.driverId === requesterId`로 배정된 주문의 목록·상세만 허용한다.
+- driver: API 경로에서는 `order.driverId === requesterId`로 배정된 주문의 목록·상세만 허용한다.
 - admin: 스토어 주문 전체 조회를 허용한다.
 - storeId 없는 단건 조회도 seller 소유권과 driver 배정을 다시 검증한다.
 - 회차 직배송 완료 사진 URL도 주문 조회 권한을 통과한 뒤에만 생성한다.
+
+이 판정은 **API 계층에 한정**된다. 현재 seller/driver 앱의 실제 주문 read 전체를 `VERIFIED`라는 뜻이 아니다.
+
+### Direct Firestore 주문 read — `IMPLEMENTATION FINDING` P0
+
+2026-08-24 현재 `firestore.rules`와 seller/driver frontend를 대조한 결과 API 권한보다 넓은 client read 경로가 존재한다.
+
+현재 구현:
+
+- `firestore.rules`의 `orders/{orderId}`는 seller에게 `resource.data.storeId == request.auth.token.storeId`, admin에게 role 기반 read를 허용한다.
+- 같은 rule은 **`request.auth.token.role == 'driver'`이면 주문의 `driverId`, 상태, store와 무관하게 read를 허용**한다.
+- driver `board/_client.tsx`는 `PREPARING` + `direct|hub` 주문을 raw Firestore query로 discovery한다. 미배정 수거 후보 discovery 자체는 현재 제품 흐름에 사용된다.
+- driver 주문 상세 `board/[orderId]/page.tsx`는 `orders/{orderId}`를 raw Firestore `onSnapshot()`으로 직접 읽는다.
+- seller `useOrders.ts`도 자신의 store 주문을 raw Firestore document 형태로 직접 구독한다.
+- 회차 order 원문은 배송 수행 필드 외에 `acquisition`, `marketingConsent`, `clientOrderPayloadHash`, `reservationId` 등 역할별 업무에 반드시 필요한 것으로 입증되지 않은 필드를 포함할 수 있다.
+- `tests/firestore/firestore-rules.test.mjs`는 현재 driver가 다른 store 주문을 직접 읽는 동작을 성공 케이스로 고정하고 있다.
+
+따라서 다음 두 계약은 현재 `VERIFIED`가 아니다.
+
+1. **driver read authorization** — 임의 driver가 배정되지 않은 일반/완료/타-driver 주문 원문을 읽지 못한다는 보장.
+2. **seller/driver data minimization** — 역할 수행에 필요한 고객·배송 필드만 제공된다는 보장.
+
+미배정 `PREPARING` direct/hub 주문을 모든 driver에게 보여주는 discovery 의도와, 모든 주문 원문을 role 하나로 읽게 하는 현재 rule을 동일시하지 않는다.
+
+actual release SHA 확정 전 최소 완료 조건:
+
+- driver의 미배정 수거 후보 discovery 목적·대상 상태·deliveryMethod·허용 필드를 명시한다.
+- 임의 driver가 다른 기사 배정 주문, 완료 주문, 기타 임의 order ID 원문을 직접 읽지 못하게 한다.
+- 배정 이후 driver 상세는 배송 수행에 필요한 최소 필드만 제공한다.
+- seller도 업무에 불필요한 `marketingConsent`, `acquisition` 등 고객 행동·동의 메타데이터와 내부 처리 필드를 raw order read로 받지 않도록 한다.
+- Firestore Rules는 위 read 경계를 직접 강제한다. Rules만으로 field minimization이 불가능하면 API DTO, 별도 safe projection, 민감/내부 필드 분리 등 동등한 구조를 사용한다.
+- `tests/firestore/firestore-rules.test.mjs`의 broad driver 성공 기대를 제거하고 discovery 허용, assigned detail 허용, 비담당/임의 read 거부를 직접 테스트한다.
+- seller/driver frontend 정상 보드·상세 흐름과 회차 first-claim을 회귀 검증한다.
+
+추적: `docs/BACKLOG.md`의 `ORDER-DIRECT-READ-AUTHORIZATION-AND-MINIMIZATION`.
 
 ### 상태 변경 권한 — `IMPLEMENTED / UNVERIFIED`
 
@@ -341,11 +378,14 @@ legacy 공동구매에는 `RECRUITING`, `CONFIRMED`, `GROUP_*` 알림, `groupPro
 - `apps/api/src/orders/orders.helpers.ts`
 - `apps/api/src/orders/*lifecycle*`
 - `apps/api/src/orders/orders-query.service.spec.ts`
+- `firestore.rules`
+- `tests/firestore/firestore-rules.test.mjs`
+- seller/driver의 raw Firestore order read 사용처
 - 관련 unit/spec tests
 - `apps/e2e`의 영향 시나리오
 - 회차 변경이면 `docs/specs/mvp-sales-round-direct-delivery.md`
 
-권한 계약은 `docs/DOCUMENT_CONSISTENCY.md`에 따라 직접 거부 회귀가 없으면 구현 존재만으로 `VERIFIED` 처리하지 않는다.
+권한·개인정보 계약은 `docs/DOCUMENT_CONSISTENCY.md`에 따라 API 테스트만 통과했다고 시스템 전체를 `VERIFIED` 처리하지 않는다. client SDK + Rules 우회 경로와 역할별 필드 최소화까지 함께 확인한다.
 
 상태 전이·권한·결제·환불을 문서 예시만 보고 운영 데이터에 직접 적용하지 않는다.
 
@@ -353,7 +393,8 @@ legacy 공동구매에는 `RECRUITING`, `CONFIRMED`, `GROUP_*` 알림, `groupPro
 
 | 날짜 | 내용 |
 |---|---|
-| 2026-08-24 | 조회 authorization은 VERIFIED, mutation authorization은 직접 거부 회귀 부족으로 IMPLEMENTED / UNVERIFIED 분리 |
+| 2026-08-24 | API 조회 authorization과 direct Firestore read를 분리하고 broad driver read·raw order 최소화 부재를 P0 IMPLEMENTATION FINDING으로 명시 |
+| 2026-08-24 | API 조회 authorization은 VERIFIED, mutation authorization은 직접 거부 회귀 부족으로 IMPLEMENTED / UNVERIFIED 분리 |
 | 2026-08-23 | `DELIVERY_HELD`, 회차 snapshot, 현재 endpoint/FSM, 재배송·배송사진·알림 계약에 맞춰 전면 정합화 |
 | 2026-04-23 | legacy 공동구매 수량 용어 반영 |
 | 2026-03-26 | 초기 orders 설계 초안 |

--- a/docs/specs/legal/README.md
+++ b/docs/specs/legal/README.md
@@ -2,7 +2,7 @@
 
 # Legal 문서 라우터와 판매 활성화 게이트
 
-> 최종 정합화: 2026-08-23 KST
+> 최종 정합화: 2026-08-24 KST
 > 상태: Current
 
 ## 현재 정본
@@ -33,17 +33,42 @@
 2. 주문 성립 시점, 취소·환불, 배송, 재배송비, 배송 보류 등 실제 MVP 정책과 공개 문구가 일치하는지 확인한다.
 3. PortOne 및 실제 결제사업자의 개인정보 처리 역할·데이터 흐름을 확인해 개인정보처리방침에 필요한 내용을 반영한다.
 4. 실제 고객 알림에 ALIGO를 사용한다면 전화번호·메시지 처리 흐름과 처리위탁/외부 서비스 고지 필요 범위를 확인한다.
-5. seller·driver에게 고객 배송정보가 노출되는 실제 처리 구조와 제3자 제공/내부 업무처리 설명이 일치하는지 확인한다.
+5. seller·driver에게 고객 배송정보가 노출되는 실제 처리 구조와 제3자 제공/내부 업무처리 설명이 일치하는지 확인한다. 특히 `docs/specs/api/orders.md`의 direct Firestore read P0가 해결되어 **업무 수행에 필요한 범위로 실제 접근 경계가 먼저 축소·검증**된 뒤 공개 문구를 확정한다.
 6. 시행일을 갱신하고 필요하면 이전 버전을 보존한다.
 7. `apps/consumer/src/app/legal-documents.test.mjs`의 **비판매 상태 고정 assertion**을 새 공개 계약에 맞게 수정한다.
 8. 변경된 법적 페이지가 release SHA에 포함된 뒤 production 배포 전에 비로그인 `/privacy`, `/terms`를 재검증한다.
 
 이 게이트는 법률 자문을 대체하려는 것이 아니라, **현재 공개 문서와 실제 출시 동작이 서로 모순되는 것을 방지하기 위한 저장소 정합성 게이트**다. 법적 판단이 필요한 항목은 별도 확인을 거친다.
 
+### 현재 확인된 선행 P0 — 주문 직접 읽기와 최소 접근
+
+2026-08-24 코드·Rules 감사에서 다음을 확인했다.
+
+- API `OrdersQueryService`는 driver 상세 조회를 `order.driverId === requesterId`로 제한한다.
+- 반면 `firestore.rules`의 `orders` read는 `role == 'driver'`이면 주문의 `driverId`, 상태, store와 무관하게 허용한다.
+- driver 보드와 상세 화면은 API가 아니라 Firestore `orders` 문서를 직접 구독한다.
+- seller 주문 목록도 Firestore `orders` 원문을 직접 구독한다.
+- 회차 주문 원문에는 배송 수행 정보 외에도 `acquisition`, `marketingConsent`, `clientOrderPayloadHash`, reservation 관련 필드 등 역할별 업무에 반드시 필요한 것으로 입증되지 않은 데이터가 함께 저장될 수 있다.
+- 현재 Firestore Rules 테스트는 driver가 다른 store 주문을 직접 읽는 동작을 성공 케이스로 고정하고 있다.
+
+따라서 **API 조회 권한이 안전하다는 사실만으로 seller/driver의 실제 고객정보 접근 계약이 `VERIFIED`라고 판단하지 않는다.** 이 상태에서 법적 문구를 넓혀 현재 구현을 정당화해서는 안 된다.
+
+판매 활성화 법적 문구를 확정하기 전에 최소한 다음이 먼저 충족되어야 한다.
+
+- 미배정 `PREPARING` direct/hub 주문을 기사에게 discovery할 필요가 있다면 그 목적과 허용 필드를 별도 계약으로 명시한다.
+- 임의 driver가 배정되지 않은 일반 주문·완료 주문·다른 기사 주문 원문을 직접 읽을 수 없어야 한다.
+- seller/driver에 제공하는 주문 데이터는 역할 수행에 필요한 필드만 반환하는 DTO·projection 또는 동등한 데이터 분리를 사용한다.
+- `marketingConsent`, `acquisition` 등 배송·판매 수행에 불필요한 정보가 raw order read를 통해 전달되지 않도록 한다.
+- Firestore Rules와 직접 Rules 테스트가 위 경계를 거부/허용 케이스로 고정한다.
+- frontend가 raw `orders` 직접 읽기를 계속 사용한다면 Rules만으로 필드 최소화가 가능한지 검증하고, 불가능하면 API/projection 등 구조를 변경한다.
+
+정본과 remediation Acceptance Criteria는 `docs/specs/api/orders.md`, `docs/BACKLOG.md`를 따른다.
+
 ## 실행 순서 관계
 
 - ALIGO provider 심사 대기 중에는 현재 공개 문구를 미리 `판매 중` 상태로 바꾸지 않는다.
 - ALIGO 실제 격리 발송 검증과 같은 테스트는 별도 승인·격리 데이터로 수행할 수 있다.
+- seller/driver 주문 read authorization·데이터 최소화 P0가 해결되기 전에는 판매 활성화 개인정보 문구를 최종 확정하지 않는다.
 - 실제 출시 대상 SHA를 고정하기 **전에** 법적 문서와 공개 페이지 변경을 완료해야 한다. 법적 페이지 코드 변경도 release SHA의 일부이기 때문이다.
 - 최종 `salesMode: round_direct` 전환 전에 production에서 새 법적 문서가 노출되는지 확인한다.
 


### PR DESCRIPTION
## 변경
- 주문 API 조회 권한과 실제 direct Firestore read 경계를 분리해 문서화
- `role == driver` broad order read를 P0 `IMPLEMENTATION FINDING`으로 등록
- seller/driver raw order document의 개인정보·내부 필드 최소화 부재를 P0로 등록
- 미배정 `PREPARING` direct/hub discovery 의도는 보존하되 arbitrary order read와 불필요 필드 노출을 금지하는 Acceptance Criteria 정의
- Orders spec, memory, Backlog, 활성 launch PLAN/HANDOFF, legal gate에 영향 기반으로 전파

## 직접 근거
- `OrdersQueryService`: driver API read는 assigned `driverId`로 제한
- `firestore.rules`: role=driver이면 order read 전면 허용
- driver board/detail과 seller order list가 raw Firestore `orders`를 직접 구독
- 회차 order 원문에 acquisition/marketingConsent/internal metadata 존재 가능
- Firestore Rules test가 driver의 다른 store order read를 success로 고정

## 판정
- API 조회 authorization: VERIFIED
- 시스템 전체 driver read authorization: P0 IMPLEMENTATION FINDING
- seller/driver data minimization: P0 IMPLEMENTATION FINDING

## 범위
- docs-only
- 코드, Rules, production, provider 변경 없음