### PR TITLE
docs: driver 승인·세션 권한 P0 정합화

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -77,6 +77,44 @@
 
 이 finding을 법적 문구를 넓혀 정당화하지 않는다. 먼저 실제 read 경계를 최소화·검증한 뒤 `docs/specs/legal/README.md`의 seller/driver 개인정보 처리 문구를 확정한다. 기술 정본: `docs/specs/api/orders.md`.
 
+### P0 — AUTH-DRIVER-APPROVAL-AND-SESSION-REVOCATION
+
+2026-08-24 인증 감사에서 driver 관리자 승인 계약과 실제 Kakao 가입 경로가 충돌하고, 정지·role/store 변경 뒤 기존 세션 권한 수렴도 불완전함을 확인했다.
+
+현재 구현·증거:
+
+- [x] admin에는 `PATCH /admin/drivers/:userId/approve`와 `driverApproved` 상태가 존재
+- [x] driver NextAuth callback은 driver role에 `driverApproved === true`를 요구
+- [x] 신규 로그인은 `suspended === true` 사용자를 거부하고 해당 unit test 존재
+- [x] `AuthService.kakaoLogin()`은 기존 driver의 `driverApproved === undefined`를 로그인 중 `true`로 자동 갱신
+- [x] 신규 Kakao identity가 `targetRole: driver`를 요청하면 `role: driver`, `driverApproved: true`로 즉시 생성
+- [x] `AuthService.refresh()`는 user 문서를 재조회하지 않고 refresh JWT의 기존 `role/storeId`를 새 토큰에 재사용
+- [x] `GET /auth/firebase-token`은 현재 API JWT의 `role/storeId`로 Firebase custom claims를 생성
+- [x] `JwtStrategy`/`RolesGuard`는 token claims를 사용하며 매 요청마다 `suspended`·승인 상태를 재조회하지 않음
+
+판정:
+
+- 관리자 승인 전 driver 권한 획득 차단 계약과 신규/legacy 자동 승인 경로는 **`IMPLEMENTATION FINDING` P0**다.
+- 정지·role/store/승인 변경 이후 기존 access/refresh/Firebase claims의 허용 수명은 **`DECISION REQUIRED` + P0 authorization remediation**다.
+- 특히 suspended 계정이 refresh를 통해 stale 권한 token을 계속 재발급받는 상태를 정상 계약으로 간주하지 않는다.
+- `ORDER-DIRECT-READ-AUTHORIZATION-AND-MINIMIZATION`의 broad driver Firestore read와 결합될 수 있으므로 두 P0를 독립적으로 닫지 않는다.
+
+남음:
+
+- [ ] 신규 Kakao `targetRole: driver`가 관리자 승인 없이 `driverApproved: true` 권한을 만들지 못하도록 수정
+- [ ] 기존 `driverApproved` 누락 계정을 로그인 side effect로 자동 승인하지 않음
+- [ ] 과거 계정 migration이 필요하면 명시적·감사 가능한 별도 migration/관리 절차로 분리
+- [ ] 승인 전 driver 앱/API/Firebase 권한 거부, 승인 후 정상 진입 직접 회귀
+- [ ] 계정 정지 시 refresh token의 후속 갱신 거부 정책 확정·구현
+- [ ] refresh가 authoritative user 문서의 현재 `suspended/role/storeId/driverApproved`를 검증하고 stale claims를 재발급하지 않음
+- [ ] 이미 발급된 access token의 허용 revocation window/SLA 결정
+- [ ] 즉시 revocation이 필요하면 token version/session revocation 또는 동등 서버 경계 적용
+- [ ] Firebase custom token이 stale API claims만으로 과거 role/store 권한을 재발급하지 않도록 현재 상태 검증
+- [ ] suspended/role-changed/store-changed/driver-approval-changed/logout/rotation 회귀
+- [ ] 수정이 포함된 SHA를 `main`에 통합한 뒤 actual release SHA 후보에 포함
+
+정본: `docs/specs/api/auth.md`, admin 영향: `docs/specs/api/admin.md`.
+
 ### P0 — ORDER-MUTATION-AUTHORIZATION-COVERAGE
 
 주문 API 조회 authorization은 `OrdersQueryService`와 직접 테스트가 일치해 해당 API 계층에서는 `VERIFIED`다. 반면 `OrdersLifecycleService.assertOrderActionAccess()`의 mutation authorization은 구현돼 있으나 권한 우회 방지 핵심 거부 시나리오를 직접 고정하는 회귀 테스트가 충분하지 않다.
@@ -182,6 +220,7 @@ Issue #32 완료 전에도 repo-side Vercel guard는 동작하지만, direct pus
 
 - [ ] PAYMENT-FINALIZATION-PAID-GUARD 완료 및 `main` 통합
 - [ ] ORDER-DIRECT-READ-AUTHORIZATION-AND-MINIMIZATION 완료 및 `main` 통합
+- [ ] AUTH-DRIVER-APPROVAL-AND-SESSION-REVOCATION 완료 및 `main` 통합
 - [ ] ORDER-MUTATION-AUTHORIZATION-COVERAGE 완료 및 `main` 통합
 - [ ] Issue #32 branch protection 완료
 - [ ] 법적 페이지 포함 actual release SHA 확정

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -64,6 +64,21 @@ Vercel Hobby build-rate-limit 때문에 docs-only PR에 Vercel check failure가 
 
 ## 현재 확인된 P0
 
+### Driver 승인 게이트·세션 권한 수명주기
+
+2026-08-24 인증 감사에서 관리자 driver 승인 계약과 실제 Kakao 가입 경로가 충돌함을 확인했다.
+
+- admin에는 `driverApproved` 승인 API가 있고 driver 앱 callback도 승인 flag를 요구한다.
+- 그러나 `AuthService.kakaoLogin()`은 신규 Kakao identity가 `targetRole: driver`를 요청하면 `role: driver`, `driverApproved: true`로 즉시 생성한다.
+- 기존 driver에서 `driverApproved`가 누락된 경우도 로그인 중 `true`로 자동 보정한다.
+- 따라서 **관리자 승인 전 driver 권한 획득 차단은 현재 `IMPLEMENTATION FINDING` P0**다.
+- `AuthService.refresh()`는 user 문서를 재조회하지 않고 기존 refresh JWT의 `role/storeId`를 새 token에 재사용한다.
+- 신규 로그인은 suspended 사용자를 거부하지만 정지·role/store/승인 변경 후 기존 세션의 revocation SLA와 refresh/Firebase claim 수렴은 현재 `DECISION REQUIRED` + P0 remediation 상태다.
+
+특히 이 finding은 `ORDER-DIRECT-READ-AUTHORIZATION-AND-MINIMIZATION`의 broad driver Firestore read와 결합될 수 있으므로 두 P0를 모두 해결·직접 검증하기 전 driver 권한 경계를 `VERIFIED`로 처리하지 않는다.
+
+정본: `docs/specs/api/auth.md`, `docs/specs/api/admin.md`, `docs/BACKLOG.md`.
+
 ### 주문 direct Firestore read authorization·개인정보 최소화
 
 2026-08-24 감사에서 API read guard와 실제 seller/driver client read 경계가 다름을 확인했다.
@@ -179,15 +194,16 @@ Vercel Hobby build-rate-limit 때문에 docs-only PR에 Vercel check failure가 
 
 ## 다음 작업
 
-1. **P0 병렬 코드 게이트**: 주문 direct Firestore read를 안전한 discovery/assigned 경계와 역할별 최소 데이터로 축소하고 Rules·frontend 회귀를 `main`에 통합.
-2. **P0 병렬 코드 게이트**: 결제 finalization이 비`PAID` provider 상태를 자체 차단하도록 구현·회귀 검증 후 `main` 통합.
-3. **P0 병렬 검증 게이트**: 주문 mutation authorization의 타-store seller·비담당 driver·미배정 first-claim 경계를 직접 회귀 테스트하고 `main` 통합.
-4. **P0 병렬 관리자 게이트**: Issue #32의 `main` branch protection/ruleset 활성화.
-5. **외부 차단**: ALIGO 8종 심사 결과 대기. 승인 전 실제 발송·운영 ALIGO 설정은 진행하지 않는다.
-6. 8종 승인 후 격리 알림톡 정상 발송 → SMS fallback 검증.
-7. 주문 read 최소화 P0 해결을 전제로 판매 활성화 법적 문서·테스트 재정합화.
-8. 법적 변경과 모든 P0 코드·검증 보정까지 포함한 actual release SHA 확정 → 원격 회차 E2E 52건+cleanup.
-9. 운영 Firebase 재조회 → ALIGO 운영 설정 → 별도 `Task 3.1 승인` → exact-SHA production 배포.
-10. 이후 첫 회차 검수 → 최종 출시 판정 → `salesMode: round_direct` 전환.
+1. **P0 병렬 인증 게이트**: driver 관리자 승인 우회 제거 + 정지/role/store 변경의 refresh/Firebase claims 수렴 정책 확정·구현·직접 회귀 후 `main` 통합.
+2. **P0 병렬 코드 게이트**: 주문 direct Firestore read를 안전한 discovery/assigned 경계와 역할별 최소 데이터로 축소하고 Rules·frontend 회귀를 `main`에 통합.
+3. **P0 병렬 코드 게이트**: 결제 finalization이 비`PAID` provider 상태를 자체 차단하도록 구현·회귀 검증 후 `main` 통합.
+4. **P0 병렬 검증 게이트**: 주문 mutation authorization의 타-store seller·비담당 driver·미배정 first-claim 경계를 직접 회귀 테스트하고 `main` 통합.
+5. **P0 병렬 관리자 게이트**: Issue #32의 `main` branch protection/ruleset 활성화.
+6. **외부 차단**: ALIGO 8종 심사 결과 대기. 승인 전 실제 발송·운영 ALIGO 설정은 진행하지 않는다.
+7. 8종 승인 후 격리 알림톡 정상 발송 → SMS fallback 검증.
+8. 주문 read 최소화 P0 해결을 전제로 판매 활성화 법적 문서·테스트 재정합화.
+9. 법적 변경과 모든 P0 코드·검증 보정까지 포함한 actual release SHA 확정 → 원격 회차 E2E 52건+cleanup.
+10. 운영 Firebase 재조회 → ALIGO 운영 설정 → 별도 `Task 3.1 승인` → exact-SHA production 배포.
+11. 이후 첫 회차 검수 → 최종 출시 판정 → `salesMode: round_direct` 전환.
 
 문서 정합성 감사는 `docs/DOCUMENT_CONSISTENCY.md`를 따르고, repository 변경은 **branch + PR**로 수행한다.

--- a/docs/plans/HANDOFF_mvp_round_direct_aligo_review_pause.md
+++ b/docs/plans/HANDOFF_mvp_round_direct_aligo_review_pause.md
@@ -17,14 +17,46 @@
 
 현재 외부 차단점은 **ALIGO 8종 provider 심사 완료**다. provider 상태는 새 작업 시작 시 다시 조회한다.
 
-동시에 해결 가능한 P0는 네 가지다.
+동시에 해결 가능한 P0는 다섯 가지다.
 
-1. **주문 direct Firestore read authorization·데이터 최소화** — API보다 넓은 driver direct read와 raw order 필드 노출을 안전한 discovery/assigned 경계로 축소해야 함.
-2. **결제 finalization `PAID` 최종 방어** — 현재 `main`의 `finalizePaidOrder()`는 전달받은 provider status를 자체 강제하지 않음.
-3. **주문 mutation authorization 직접 회귀** — 권한 guard는 구현돼 있으나 타-store seller·비담당 driver·미배정 first-claim 경계를 직접 고정하는 회귀가 부족함.
-4. **Issue #32 `main` branch protection/ruleset 활성화**.
+1. **Driver 승인 게이트·세션/claims revocation** — 신규/legacy driver 자동 승인 경로 제거와 정지·role/store 변경 권한 수렴 정책 필요.
+2. **주문 direct Firestore read authorization·데이터 최소화** — API보다 넓은 driver direct read와 raw order 필드 노출을 안전한 discovery/assigned 경계로 축소해야 함.
+3. **결제 finalization `PAID` 최종 방어** — 현재 `main`의 `finalizePaidOrder()`는 전달받은 provider status를 자체 강제하지 않음.
+4. **주문 mutation authorization 직접 회귀** — 권한 guard는 구현돼 있으나 타-store seller·비담당 driver·미배정 first-claim 경계를 직접 고정하는 회귀가 부족함.
+5. **Issue #32 `main` branch protection/ruleset 활성화**.
 
 현재 상태 정본은 `docs/memory.md`, 미완료 목록은 `docs/BACKLOG.md`를 우선한다. 문서 정합성 판정은 `docs/DOCUMENT_CONSISTENCY.md`를 따른다.
+
+## Driver 승인 게이트·세션 revocation P0
+
+2026-08-24 인증 감사에서 admin driver 승인 계약과 실제 Kakao 가입·refresh 경로가 충돌함을 확인했다.
+
+현재 사실:
+
+- admin에는 `driverApproved` 승인 API가 있고 driver 앱 callback도 승인 flag를 요구한다.
+- `AuthService.kakaoLogin()`은 신규 Kakao identity가 `targetRole: driver`를 요청하면 `role: driver`, `driverApproved: true`로 즉시 생성한다.
+- 기존 driver에서 `driverApproved`가 누락된 경우도 로그인 중 자동 `true`로 보정한다.
+- 신규 로그인은 `suspended` 사용자를 차단한다.
+- 그러나 `AuthService.refresh()`는 사용자 문서를 재조회하지 않고 refresh JWT의 기존 `role/storeId`를 새 token에 재사용한다.
+- `GET /auth/firebase-token`도 현재 JWT claims로 Firebase custom claims를 발급한다.
+
+판정:
+
+- 관리자 승인 전 driver 권한 획득 차단: **`IMPLEMENTATION FINDING` P0**.
+- 정지·role/store/승인 변경 후 기존 세션의 revocation window와 refresh/Firebase claim 수렴: **`DECISION REQUIRED` + P0 remediation**.
+
+이 finding은 broad driver Firestore read P0와 결합될 수 있으므로 한쪽만 해결해 driver authorization 전체를 완료 처리하지 않는다.
+
+actual release SHA 확정 전에:
+
+- 신규 `targetRole: driver` 자동 승인과 승인 필드 누락 계정 로그인 자동 승인을 제거하고,
+- 필요한 legacy migration을 로그인 side effect가 아닌 명시적 절차로 분리하고,
+- 승인 전 driver 앱/API/Firebase 접근을 직접 거부 테스트로 고정하고,
+- 계정 정지 시 refresh가 새 권한 token을 발급하지 않도록 하며,
+- role/storeId/driverApproved 변경 시 authoritative user 상태로 claims를 수렴시키고,
+- 이미 발급된 access token의 revocation SLA를 명시적으로 결정·검증한다.
+
+정본: `docs/specs/api/auth.md`, `docs/specs/api/admin.md`.
 
 ## 주문 direct Firestore read P0
 
@@ -157,7 +189,7 @@ production `/privacy`, `/terms`는 현재 비판매 상태를 전제로 한다.
 - 마지막 전체 원격 회차 E2E 역사 증거: SHA `6e0fc9d4cec08073ed2504208cc8bb1ea395ee7d`, run `32351887404`.
 - chromium 26 + mobile 26 = 52, 양쪽 cleanup 성공.
 - 현재 release SHA 증거로 확장 적용하지 않는다.
-- 주문 direct read P0, 결제 finalization P0, 주문 mutation authorization P0와 법적 변경까지 포함한 actual release SHA에서 다시 검증한다.
+- auth approval/revocation P0, 주문 direct read P0, 결제 finalization P0, 주문 mutation authorization P0와 법적 변경까지 포함한 actual release SHA에서 다시 검증한다.
 
 ## 지금 하지 말아야 할 작업
 
@@ -169,20 +201,23 @@ production `/privacy`, `/terms`는 현재 비판매 상태를 전제로 한다.
 - 별도 Task 승인 없이 production 배포·Firebase 운영 변경·운영 회차 생성·`salesMode` 변경.
 - 비판매 법적 문구를 판매 공개 전에 임의로 미리 전환.
 - broad seller/driver 주문 read를 개인정보 문구 확대만으로 정당화.
+- driver 자동 승인 경로를 현재 운영 승인 정책으로 정당화.
+- suspended/권한 변경 계정의 stale refresh/Firebase claims를 검증 없이 정상 동작으로 간주.
 - 현재 P0 코드·검증 게이트가 `main`에 반영되기 전에 release SHA를 확정.
 
 ## 지금 병렬로 할 수 있는 작업
 
-1. 주문 direct Firestore read authorization·데이터 최소화 구현·Rules/frontend 회귀·통합.
-2. 결제 finalization `PAID` guard 구현·회귀 검증·통합.
-3. 주문 mutation authorization 직접 거부 회귀 테스트·통합.
-4. Issue #32 `main` protection/ruleset 관리자 설정.
-5. read-only 문서/코드 정합성 감사.
-6. ALIGO provider 심사 상태 조회.
+1. driver 승인 게이트·세션/claims revocation 구현·직접 회귀·통합.
+2. 주문 direct Firestore read authorization·데이터 최소화 구현·Rules/frontend 회귀·통합.
+3. 결제 finalization `PAID` guard 구현·회귀 검증·통합.
+4. 주문 mutation authorization 직접 거부 회귀 테스트·통합.
+5. Issue #32 `main` protection/ruleset 관리자 설정.
+6. read-only 문서/코드 정합성 감사.
+7. ALIGO provider 심사 상태 조회.
 
 ## ALIGO 승인 뒤 재개 순서
 
-1. 주문 direct read P0, 결제 finalization P0, 주문 mutation authorization P0가 `main`에 통합됐는지 확인.
+1. auth approval/revocation P0, 주문 direct read P0, 결제 finalization P0, 주문 mutation authorization P0가 `main`에 통합됐는지 확인.
 2. 8종 모두 승인/수정요청/반려 여부 확인.
 3. 승인 `tpl_code` 8종 ↔ 내부 논리 템플릿 1:1 매핑 검사.
 4. 별도 승인 후 격리 실제 알림톡 정상 발송.
@@ -206,6 +241,7 @@ production `/privacy`, `/terms`는 현재 비판매 상태를 전제로 한다.
 - [x] ALIGO 템플릿 8종 등록·심사 요청
 - [x] repo-side `main` 자동 production deploy 차단
 - [x] deployment safety CI와 docs-only ignore 적용
+- [ ] driver 승인 게이트·세션/claims revocation + 직접 회귀 + `main` 통합
 - [ ] 주문 direct Firestore read authorization·데이터 최소화 + Rules/frontend 회귀 + `main` 통합
 - [ ] 결제 finalization `PAID` guard + 회귀 검증 + `main` 통합
 - [ ] 주문 mutation authorization 직접 거부 회귀 + `main` 통합

--- a/docs/plans/PLAN_mvp_round_direct_launch_blockers.md
+++ b/docs/plans/PLAN_mvp_round_direct_launch_blockers.md
@@ -11,12 +11,14 @@
 - 상태: `paused_external_review`
 - Priority: P0
 - 현재 외부 차단점: ALIGO 회차 알림 템플릿 8종 provider 심사 완료
+- 병렬 인증 P0: driver 관리자 승인 게이트 + 세션/claims revocation
 - 병렬 보안 P0: 주문 direct Firestore read authorization·역할별 데이터 최소화
 - 병렬 코드 P0: 결제 finalization `PAID` 최종 방어
 - 병렬 검증 P0: 주문 mutation authorization 직접 거부 회귀
 - 병렬 관리자 P0: GitHub Issue #32 `main` branch protection/ruleset
 - 현재 상태 SSOT: `docs/memory.md`
 - 재개 순서: `docs/plans/HANDOFF_mvp_round_direct_aligo_review_pause.md`
+- 인증 계약: `docs/specs/api/auth.md`
 - 결제 계약: `docs/specs/api/payments.md`
 - 주문 계약: `docs/specs/api/orders.md`
 - 배포 안전 계약: `docs/plans/PLAN_deployment_safety_guards_20260823.md`
@@ -38,6 +40,8 @@
 - 현재 `main`의 `PaymentFinalizationService.finalizePaidOrder()`는 전달받은 provider `status === 'PAID'`를 메서드 내부에서 독립적으로 강제하지 않는다. actual release SHA 확정 전 해결·회귀 검증해야 한다.
 - 주문 API 조회 authorization은 직접 테스트가 존재해 API 계층에서는 `VERIFIED`다. 그러나 driver/seller 앱은 raw Firestore `orders` read를 사용하고, current Rules는 `role == 'driver'`이면 배정·store·상태와 무관하게 주문 read를 허용하므로 시스템 전체 read authorization·데이터 최소화는 P0 `IMPLEMENTATION FINDING`이다.
 - order mutation authorization은 seller 타-store·비담당 driver·미배정 driver first-claim 경계의 직접 거부 회귀가 부족해 `IMPLEMENTED / UNVERIFIED` 상태다.
+- driver admin 승인 계약과 달리 신규 Kakao `targetRole: driver` 및 승인 필드 누락 기존 driver가 `driverApproved: true`로 자동 수렴하는 경로가 있어 P0 `IMPLEMENTATION FINDING`이다.
+- 정지·role/store/driverApproved 변경 뒤 refresh/custom-token 권한 수렴은 stale JWT payload를 재사용하므로 revocation SLA 결정과 구현 보정이 필요하다.
 
 ## 배포 안전 기준선
 
@@ -63,6 +67,7 @@
 | 0B | 결제 finalization 비`PAID` 최종 차단 + 회귀 | **미완료 — P0** |
 | 0C | 주문 mutation authorization 직접 거부 회귀 | **미완료 — P0 COVERAGE GAP** |
 | 0D | 주문 direct Firestore read authorization·데이터 최소화 | **미완료 — P0 IMPLEMENTATION FINDING** |
+| 0E | driver 승인 게이트 + 세션/claims revocation | **미완료 — P0 IMPLEMENTATION FINDING / DECISION REQUIRED** |
 | 1 | ALIGO 8종 provider 최종 승인 | **검수중** |
 | 2 | 실제 알림톡 정상 발송 | 미실행 |
 | 3 | SMS fallback 실제 검증 | 미실행 |
@@ -80,20 +85,22 @@
 
 1. 모든 repository 변경은 최신 `main`에서 목적별 branch를 만들고 PR로 통합한다.
 2. direct `main` commit/push를 하지 않는다.
-3. dependency 순서대로 Task를 실행하되 주문 direct read P0, 결제 finalization P0, 주문 mutation authorization P0와 Issue #32는 ALIGO 심사와 병렬로 해결할 수 있다.
+3. dependency 순서대로 Task를 실행하되 auth P0, 주문 direct read P0, 결제 finalization P0, 주문 mutation authorization P0와 Issue #32는 ALIGO 심사와 병렬로 해결할 수 있다.
 4. 외부 서비스 변경·실제 발송·운영 변수·Firebase 운영 변경·production 배포·운영 데이터·`salesMode` 변경은 해당 승인 게이트를 따른다.
 5. 한 Task의 승인을 이후 운영 변경 승인으로 확대 해석하지 않는다.
 6. 비밀값·고객 개인정보·사진 원본·서명 URL을 Git/문서/증거에 남기지 않는다.
-7. 주문 direct read 최소화, 결제/권한 P0 보정과 법적 페이지 변경까지 포함한 actual release SHA를 확정하기 전 release 검증을 완료로 기록하지 않는다.
+7. auth 승인/revocation, 주문 direct read 최소화, 결제/권한 P0 보정과 법적 페이지 변경까지 포함한 actual release SHA를 확정하기 전 release 검증을 완료로 기록하지 않는다.
 8. actual release SHA의 원격 회차 E2E 52건과 cleanup 통과 전 production 배포 금지.
 9. Issue #32의 `main` 보호 완료 전 production release 금지.
 10. `main` merge·빈 commit·재-push를 production 배포 트리거로 사용하지 않는다.
 11. production 배포 직전·직후 provider metadata Git SHA가 승인 release SHA와 동일한지 확인한다.
 12. ALIGO 실제 발송 검증 실패 시 알림 없는 출시를 임의 승인하지 않는다.
 13. 첫 회차가 검수된 `SCHEDULED`가 아니면 `salesMode`를 전환하지 않는다.
-14. `docs/DOCUMENT_CONSISTENCY.md` 기준에서 `IMPLEMENTED / UNVERIFIED`, `COVERAGE GAP`, `IMPLEMENTATION FINDING`인 P0를 완료로 간주하지 않는다.
+14. `docs/DOCUMENT_CONSISTENCY.md` 기준에서 `IMPLEMENTED / UNVERIFIED`, `COVERAGE GAP`, `IMPLEMENTATION FINDING`, P0 `DECISION REQUIRED`인 항목을 완료로 간주하지 않는다.
 15. broad 주문 read를 개인정보처리방침 문구를 넓혀 정당화하지 않고 실제 접근 경계를 먼저 최소화한다.
-16. 미검증 항목을 완료로 기록하지 않는다.
+16. driver role/approval은 client `targetRole` 또는 로그인 side effect만으로 부여하지 않는다.
+17. suspended 또는 권한 변경 계정이 refresh/Firebase custom token을 통해 stale 권한을 무기한 연장하지 않도록 revocation 계약을 확정한다.
+18. 미검증 항목을 완료로 기록하지 않는다.
 
 ## Execution Plan
 
@@ -161,6 +168,24 @@
 - Legal dependency: `docs/specs/legal/README.md`
 - Status: todo_code_security
 
+#### Task 0.7 — Driver 승인 게이트·세션/claims revocation
+- Dependency: 없음. ALIGO 심사·Task 0.3~0.6과 병렬 가능.
+- Goal: 관리자 승인 전 driver 권한 획득을 차단하고 정지·role/store/승인 변경이 기존 세션과 Firebase claims에 정의된 시간 안에 수렴하도록 한다.
+- Required:
+  - 신규 Kakao `targetRole: driver`가 `driverApproved: true`를 자동 획득하지 않음
+  - 기존 승인 필드 누락 driver를 로그인 side effect로 자동 승인하지 않음
+  - 필요한 legacy migration은 명시적·감사 가능한 별도 절차
+  - 승인 전 driver 앱/API/Firebase 접근 거부, 승인 후 정상 진입
+  - refresh가 authoritative user 상태를 확인하고 suspended 계정 또는 stale role/store/approval claims를 재발급하지 않음
+  - 이미 발급된 access token의 revocation window/SLA 결정·검증
+  - 필요 시 token version/session revocation 또는 동등 서버 경계
+  - Firebase custom token 발급도 현재 authoritative 권한과 일치
+  - logout/rotation 및 consumer/seller/admin 로그인 회귀 유지
+  - `ORDER-DIRECT-READ-AUTHORIZATION-AND-MINIMIZATION`과 결합 회귀: 승인되지 않은 driver identity가 order discovery/read 권한을 얻지 못함
+- Contract: `docs/specs/api/auth.md`
+- Admin impact: `docs/specs/api/admin.md`
+- Status: todo_code_security
+
 ### Phase 1 — ALIGO 알림 게이트
 
 #### Task 1.1 — 발신 프로필·코드 매핑 기반
@@ -198,7 +223,7 @@
 - Status: todo
 
 #### Task 2.2 — actual release SHA 확정
-- Dependency: Task 0.3, Task 0.4, Task 0.5, Task 0.6, Task 2.1
+- Dependency: Task 0.3, Task 0.4, Task 0.5, Task 0.6, Task 0.7, Task 2.1
 - Goal: 운영에 올릴 단 하나의 exact `main` SHA 고정.
 - 과거 `6e0fc9d...` run은 역사 증거일 뿐 현재 release 증거가 아니다.
 - Status: todo
@@ -279,7 +304,7 @@
 
 #### Task 5.3 — 최종 출시 판정
 - Dependency: Task 5.2
-- 대조: exact SHA, payment P0, order direct-read P0, order mutation P0, branch protection, Firebase, ALIGO, legal, 첫 회차, 예외, 담당자, rollback.
+- 대조: exact SHA, auth approval/revocation P0, payment P0, order direct-read P0, order mutation P0, branch protection, Firebase, ALIGO, legal, 첫 회차, 예외, 담당자, rollback.
 - Status: todo
 
 ### Phase 6 — 판매 모드 전환
@@ -308,6 +333,7 @@
 
 ## Completion Criteria
 
+- driver 관리자 승인 전 권한 획득이 차단되고 정지·role/store/승인 변경의 refresh/Firebase claims 수렴 계약이 구현·직접 검증돼 `main`에 포함됨.
 - 주문 direct Firestore read가 안전한 discovery/assigned 경계와 역할별 최소 데이터 계약으로 축소되고 Rules·frontend 회귀가 `main`에 포함됨.
 - 결제 finalization 비`PAID` 차단과 회귀 검증이 `main`에 포함됨.
 - 주문 mutation authorization 핵심 거부 회귀가 `main`에 포함되고 P0 mutation 권한 계약이 `VERIFIED`로 승격됨.
@@ -326,6 +352,7 @@
 ## 현재 Closeout Roll-up
 
 - 코드 통합: 완료
+- driver 승인 게이트·세션/claims revocation: **미완료 — P0 IMPLEMENTATION FINDING / DECISION REQUIRED**
 - 주문 direct Firestore read authorization·데이터 최소화: **미완료 — P0 IMPLEMENTATION FINDING**
 - 결제 finalization `PAID` 최종 방어: **미완료 — P0**
 - 주문 mutation authorization 직접 회귀: **미완료 — P0 COVERAGE GAP**

--- a/docs/specs/api/admin.md
+++ b/docs/specs/api/admin.md
@@ -2,7 +2,7 @@
 
 # Admin API / Domain Spec
 
-> **최종 정합화**: 2026-08-23
+> **최종 정합화**: 2026-08-24
 > **상태**: Current
 > **API 정본**: `apps/api/src/admin/**`
 > **인증 계약**: `docs/specs/api/auth.md`
@@ -105,7 +105,9 @@ PATCH /admin/users/:userId/status
 
 이 endpoint는 Firestore `suspended` 값을 갱신한다.
 
-중요: `suspended` flag가 존재한다는 것과 모든 인증/refresh/API 경로가 정지 사용자를 동일하게 차단한다는 것은 별개다. 계정 정지 정책 변경 시 `AuthService`, JWT refresh, 각 guard의 실제 enforcement를 함께 검증한다.
+현재 신규 로그인은 suspended 사용자를 거부하지만, **기존 세션의 refresh·JWT·Firebase custom claims가 언제 무효화되는지는 별도 auth P0**다. `suspended: true` write 성공만으로 기존 세션이 즉시 차단됐다고 기록하지 않는다.
+
+정본: `docs/specs/api/auth.md`의 `AUTH-SESSION-CLAIM-REVOCATION`.
 
 ## 5. 주문 관리
 
@@ -186,6 +188,10 @@ PATCH /admin/drivers/:userId/approve
 - `role === driver` 확인
 - `driverApproved: true`
 
+이 endpoint가 존재한다는 사실과 **관리자 승인만이 driver 권한을 부여하는 유일한 경로라는 보장**은 현재 동일하지 않다. 2026-08-24 감사에서 `AuthService.kakaoLogin()`이 신규 `targetRole: driver` 사용자를 `driverApproved: true`로 생성하고, 기존 승인 필드 누락 driver도 로그인 시 자동 승인하는 경로를 확인했다.
+
+따라서 현재 driver 승인 게이트는 P0 `IMPLEMENTATION FINDING`이며, admin 승인 UI/API만 보고 `VERIFIED`로 판단하지 않는다. 정본과 완료 조건: `docs/specs/api/auth.md`의 `DRIVER-APPROVAL-GATE-BYPASS`.
+
 ### 정지/복구
 
 ```text
@@ -196,7 +202,9 @@ PATCH /admin/drivers/:userId/suspend
 { suspended: boolean }
 ```
 
-Driver Kakao 로그인은 `driverApproved`를 별도 확인한다. Preview E2E credentials는 더 좁은 allowlist/secret gate를 사용하므로 admin 승인과 E2E gate를 혼동하지 않는다.
+Driver 신규 로그인은 `suspended`를 확인하지만 기존 access/refresh/Firebase claims의 revocation 시점은 현재 명확한 계약으로 고정돼 있지 않다. 정지 write만으로 기존 driver의 주문/API/Firestore 접근이 즉시 종료됐다고 가정하지 않는다.
+
+Preview E2E credentials는 별도 allowlist/secret gate를 사용하므로 admin 승인·정지와 E2E gate를 혼동하지 않는다.
 
 ## 8. Seller 초대
 
@@ -280,7 +288,8 @@ Storage write/read 권한은 현재 `storage.rules`를 정본으로 확인한다
 - admin 정산 목록: 최대 500건, pagination 없음
 - driver 목록: 최대 100건 read 후 메모리 필터
 - store 수수료 설정과 settlement 생성의 `PLATFORM_FEE_RATE` 관계는 단일 정책으로 완전히 통합돼 있지 않을 수 있으므로 변경 전 코드 재검증 필요
-- 사용자 `suspended` flag의 enforcement는 endpoint별 인증 경로를 실제 검증해야 함
+- driver 관리자 승인 게이트는 `DRIVER-APPROVAL-GATE-BYPASS` 해결 전 `VERIFIED`가 아님
+- 사용자/driver `suspended` flag의 기존 세션 enforcement는 `AUTH-SESSION-CLAIM-REVOCATION` 해결 전 `VERIFIED`가 아님
 - admin actions의 통합 감사 로그 범위는 operation/audit 구현을 확인해야 하며 단순 endpoint 존재만으로 완전한 감사 추적을 보장하지 않는다.
 
 이 제한을 해소할 필요가 생기면 `docs/BACKLOG.md`에 현재 작업으로 승격한 뒤 별도 설계를 수행한다.
@@ -297,12 +306,15 @@ admin 변경 시 최소 확인:
 - auth/orders/payments/settlements 관련 spec
 - 관련 unit/E2E
 
+승인·정지처럼 권한 수명주기에 영향을 주는 변경은 admin endpoint의 Firestore write 성공만 검사하지 않고 auth refresh/custom-token 및 실제 접근 차단까지 검증한다.
+
 실제 환불·계정 권한 변경·운영 데이터 변경은 문서 정합성 검토 범위에서 실행하지 않는다.
 
 ## 변경 이력
 
 | 날짜 | 내용 |
 |---|---|
+| 2026-08-24 | driver 승인 자동 우회와 suspension 기존 세션 revocation을 auth P0와 연결하고 admin write 자체를 권한 enforcement 완료로 보지 않도록 정합화 |
 | 2026-08-23 | canonical URL, archive/restore, 현재 정산·드라이버·초대 계약, 위험한 수동 권한 부여 지침을 현행화 |
 | 2026-04-23 | banner 관리 추가 |
 | 2026-04-03 | driver 관리 추가 |

--- a/docs/specs/api/auth.md
+++ b/docs/specs/api/auth.md
@@ -2,7 +2,7 @@
 
 # Auth API / Domain Spec
 
-> **최종 정합화**: 2026-08-23
+> **최종 정합화**: 2026-08-24
 > **상태**: Current
 > **공통 타입 정본**: `packages/shared/src/auth.types.ts`
 > **API 정본**: `apps/api/src/auth/**`
@@ -76,9 +76,9 @@ NestJS JWT payload의 현재 계약:
 }
 ```
 
-`storeId`는 seller/admin에서 존재할 수 있고 consumer/driver는 일반적으로 `null` 또는 미설정이다. 단순 역할만으로 모든 store 데이터 접근을 허용하지 않으며 endpoint/service의 소유권 검사를 추가로 적용한다.
+`storeId`는 seller/admin에서 존재할 수 있고 consumer/driver는 일반적으로 `null` 또는 미설정이다. 단순 역할만으로 모든 store 데이터 접근을 허용하지 않으며 endpoint/service와 Firebase Rules의 소유권·배정 검사를 추가로 적용해야 한다.
 
-## 5. Kakao 역할 진입
+## 5. Kakao 역할 진입과 Driver 승인
 
 `KakaoLoginDto.targetRole` 허용값:
 
@@ -92,11 +92,38 @@ consumer | seller | driver
 - seller: `seller|admin`
 - driver: `driver|admin`
 
-Driver는 실제 role이 `driver`이면 `driverApproved`가 필요하며, 승인 전에는 정상 driver 앱 진입을 허용하지 않는다.
+### 의도된 Driver 계약
 
-역할 승격·스토어 소유권을 단순 OAuth 로그인만으로 자동 부여한다고 가정하지 않는다.
+현재 admin/API/UI 구조에는 별도의 driver 승인 상태가 존재한다.
 
-## 6. Access / Refresh token
+- `users/{userId}.driverApproved`
+- `PATCH /admin/drivers/:userId/approve`
+- driver 앱 callback은 실제 role이 `driver`일 때 `driverApproved === true`를 요구한다.
+
+따라서 **관리자 승인 전 driver 권한을 획득할 수 없다는 계약**을 current 안전 계약으로 사용한다. role 승격·driver 승인·스토어 소유권을 단순 OAuth targetRole 요청만으로 자동 부여하지 않는다.
+
+### 현재 구현 불일치 — `IMPLEMENTATION FINDING` P0
+
+2026-08-24 `AuthService.kakaoLogin()`을 직접 대조한 결과 위 계약과 충돌하는 두 경로가 존재한다.
+
+1. 기존 사용자 role이 `driver`이고 `driverApproved` 필드가 `undefined`이면 로그인 중 `driverApproved: true`를 자동 기록한다.
+2. Kakao 사용자 매핑이 없는 신규 사용자가 `targetRole: driver`를 요청하면 신규 user를 `role: driver`, `driverApproved: true`로 즉시 생성한다.
+
+즉 driver 앱 callback이 승인 flag를 확인하더라도 **API가 그 flag를 로그인 과정에서 스스로 true로 만들 수 있어 관리자 승인 게이트의 독립성이 보장되지 않는다.** `auth.service.spec.ts`는 Kakao identity·role mismatch·suspended login은 검증하지만 신규 driver가 승인 없이 생성되지 않는다는 회귀를 현재 직접 고정하지 않는다.
+
+이 항목은 `DRIVER-APPROVAL-GATE-BYPASS` P0로 추적한다. 실제 구현을 정당화하기 위해 “driver는 Kakao 가입 즉시 승인”으로 문서를 바꾸지 않는다.
+
+최소 완료 조건:
+
+- 신규 Kakao identity의 `targetRole: driver`가 관리자 승인 없이 `driverApproved: true` 권한을 만들지 못함
+- 기존 `driverApproved` 누락 계정을 로그인 시 자동 승인하지 않음
+- 과거 계정 migration이 필요하면 로그인 side effect가 아닌 명시적·감사 가능한 migration/관리 절차로 분리
+- admin 승인 전 driver 앱 정상 진입·driver API/Firestore 권한 획득 거부
+- admin 승인 후 정상 driver 로그인 유지
+- consumer/seller/admin role 진입 회귀 없음
+- 직접 unit/API/E2E 회귀로 승인 전/후 경계를 고정
+
+## 6. Access / Refresh token과 권한 변경 수렴
 
 현재 NextAuth 앱은 API가 발급한 `accessToken`과 `refreshToken`을 NextAuth JWT/session에 저장한다.
 
@@ -106,6 +133,30 @@ Driver는 실제 role이 `driver`이면 `driverApproved`가 필요하며, 승인
 - driver E2E credentials session은 앱 레이어에서 더 짧은 access-token refresh 기준을 사용한다.
 
 실제 서버 JWT 만료값은 환경 설정에 의해 달라질 수 있으므로 오래된 문서의 “항상 1시간/30일”을 외부 환경 현재값으로 단정하지 않는다.
+
+### 현재 구현 한계 — stale authorization claims
+
+현재 `AuthService.refresh()`는 refresh token 자체와 rotation record를 검증한 뒤 **기존 refresh JWT payload의 `sub/role/storeId`를 그대로 새 access/refresh token에 재사용**한다. 사용자 문서의 현재 `suspended`, `role`, `storeId`, driver 승인 상태를 refresh 시 다시 조회하지 않는다.
+
+또한 `JwtStrategy.validate()`와 `RolesGuard`는 현재 JWT payload의 role/storeId를 사용하며 매 요청마다 user 문서의 suspension/권한 변경을 재검증하지 않는다.
+
+따라서 관리자가 계정을 정지하거나 role/store 연결을 바꾼 뒤 기존 세션이 언제 차단되어야 하는지에 대한 **revocation SLA가 current spec에 명확히 정의돼 있지 않고**, 현재 refresh 경로는 stale claims를 계속 재발급할 수 있다.
+
+판정:
+
+- 신규 로그인에서 `suspended === true`를 거부하는 동작은 구현·테스트됨.
+- **이미 발급된 세션의 정지/권한 변경 수렴은 `DECISION REQUIRED` + P0 authorization remediation 대상**이다.
+- 특히 “정지된 계정이 refresh를 통해 계속 새 권한 토큰을 얻을 수 있음”을 정상 계약으로 간주하지 않는다.
+
+`AUTH-SESSION-CLAIM-REVOCATION` 최소 완료 조건:
+
+- 계정 정지 시 기존 refresh token의 후속 갱신을 거부하는 정책을 정의·구현
+- refresh 시 authoritative user 상태를 확인하고 현재 role/storeId/승인 상태와 충돌하는 stale claims를 재발급하지 않음
+- role/storeId 변경 시 다음 refresh에서 이전 권한이 유지되지 않음
+- access token 이미 발급분의 허용 revocation window를 명시적으로 결정하고 테스트함
+- 즉시 차단이 요구되면 token version/session revocation 또는 동등한 서버 검증 경계를 사용
+- logout/refresh-token rotation 동작 유지
+- suspended/role-changed/store-changed/driver-approval-changed 시나리오 직접 회귀
 
 ## 7. 현재 Auth API
 
@@ -182,7 +233,11 @@ interface SavedAddress {
 
 ## 10. Firebase Custom Token
 
-`GET /auth/firebase-token`은 현재 API JWT 사용자에게 Firebase client용 custom token을 발급하는 경로다. 이 token은 Firestore/Storage Rules에서 서버가 부여한 identity/claims와 함께 사용될 수 있다.
+`GET /auth/firebase-token`은 현재 API JWT 사용자에게 Firebase client용 custom token을 발급하는 경로다. 현재 controller는 `CurrentUser()`의 `sub/role/storeId`를 그대로 `AuthService.getFirebaseToken()`에 전달하고, service는 그 값으로 Firebase custom claims를 만든다.
+
+따라서 이 경로의 안전성은 API JWT claims의 현재성에 의존한다. `AUTH-SESSION-CLAIM-REVOCATION`이 해결되기 전에는 **정지·role/store 변경 이후 Firebase claims가 즉시 현재 상태와 일치한다고 가정하지 않는다.**
+
+특히 Firestore Rules가 `role`/`storeId` claims를 데이터 접근의 근거로 사용하므로 auth claim lifecycle과 Rules authorization을 별개의 문제로 분리하지 않는다.
 
 이 endpoint의 존재 때문에 Firebase Rules를 공개 read/write로 완화하지 않는다. Firebase 접근 계약은 현재 Rules와 해당 frontend 사용처를 함께 확인한다.
 
@@ -206,8 +261,10 @@ interface SavedAddress {
 - Kakao identity는 서버에서 access token으로 재검증한다.
 - password hash, refresh token, JWT, OAuth token, E2E shared secret을 문서·로그에 기록하지 않는다.
 - Credentials provider는 E2E gate를 제거한 채 production 로그인으로 열지 않는다.
-- role/storeId는 client 입력만으로 신뢰하지 않는다.
-- 타인 주문·스토어 접근은 endpoint별 service ownership 검사를 통과해야 한다.
+- role/storeId/driver approval은 client targetRole 또는 stale token payload만으로 최종 결정하지 않는다.
+- driver 관리자 승인 게이트를 로그인 side effect로 자동 충족시키지 않는다.
+- 계정 정지·role/store 변경이 refresh/custom-token 경로에서 무기한 과거 권한으로 유지되지 않도록 한다.
+- 타인 주문·스토어 접근은 endpoint/service와 Firebase Rules의 소유권 검사를 통과해야 한다.
 - driver E2E allowlist와 secret을 실제 운영 driver 인증 모델로 사용하지 않는다.
 - 실계정 email, 사용자 UUID, 테스트 비밀번호를 troubleshooting 문서에 정본으로 저장하지 않는다.
 
@@ -217,17 +274,23 @@ interface SavedAddress {
 
 - `apps/api/src/auth/auth.controller.ts`
 - `apps/api/src/auth/auth.service.ts`
+- `apps/api/src/auth/strategies/jwt.strategy.ts`
 - `apps/api/src/auth/types/jwt-payload.type.ts`
 - `apps/api/src/common/guards/*`
+- `apps/api/src/admin/admin.service.ts`의 approve/suspend 경로
 - 세 앱 `src/auth.ts`
+- `firestore.rules`, `storage.rules`
 - `packages/shared/src/auth.types.ts`
 - 관련 auth unit/E2E tests
 - OAuth URL 변경이면 `docs/URLS.md`, `docs/specs/ops/preview-auth-url-policy.md`
+
+권한·정지·승인 계약은 `docs/DOCUMENT_CONSISTENCY.md`에 따라 로그인 성공 테스트만으로 `VERIFIED` 처리하지 않는다. 신규 가입, 승인 전/후, suspension, refresh, Firebase custom claims까지 수명주기를 직접 검증한다.
 
 ## 변경 이력
 
 | 날짜 | 내용 |
 |---|---|
+| 2026-08-24 | 신규/legacy driver 자동 승인 경로를 P0 IMPLEMENTATION FINDING으로 분리하고, 정지·role/store 변경의 refresh/custom-token stale claims를 P0 revocation 결정·remediation으로 명시 |
 | 2026-08-23 | Kakao 운영 OAuth, E2E 전용 Credentials, driver approval, refresh/custom-token 현행 계약에 맞춰 전면 정합화 |
 | 2026-07-01 | Kakao access token 서버 검증 계약 보강 |
 | 2026-03-26 | 초기 auth 설계 초안 |


### PR DESCRIPTION
## 변경
- 신규/legacy driver의 Kakao 로그인 중 자동 승인 경로를 P0 `IMPLEMENTATION FINDING`으로 정합화
- 계정 정지·role/store/driverApproved 변경 후 refresh/Firebase custom claims의 stale authorization을 `DECISION REQUIRED` + P0 remediation으로 등록
- auth/admin current spec, memory, Backlog, 활성 launch PLAN/HANDOFF에 영향 기반으로 최소 전파
- 기존 ORDER-DIRECT-READ P0와 결합 위험을 명시하고 두 항목을 독립적으로 완료 처리하지 않도록 release dependency 연결

## 직접 근거
- `AuthService.kakaoLogin()`은 신규 `targetRole: driver` 사용자를 `driverApproved: true`로 생성
- 기존 driver의 `driverApproved === undefined`도 로그인 중 `true`로 보정
- `AuthService.refresh()`는 user 문서를 재조회하지 않고 기존 refresh JWT의 `role/storeId`를 재사용
- `GET /auth/firebase-token`은 현재 JWT의 role/storeId로 Firebase custom claims 생성
- `JwtStrategy`/`RolesGuard`는 token claims를 사용하며 suspension/approval을 매 요청 재조회하지 않음
- 현재 auth unit test는 fresh suspended login은 검증하지만 승인 전 driver 생성·refresh revocation은 직접 고정하지 않음

## 판정
- Driver 관리자 승인 게이트: P0 `IMPLEMENTATION FINDING`
- 정지·권한 변경 세션 수렴: P0 `DECISION REQUIRED` + remediation

## 범위
- docs-only
- 코드/Firebase Rules/production/provider 변경 없음