### PR TITLE
docs: 관리자 강제 환불 lifecycle P0 정합화

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -42,6 +42,42 @@
 
 문서만으로 이 불변식을 완료 처리하지 않는다. 정본: `docs/specs/api/payments.md`.
 
+### P0 — ADMIN-FORCE-REFUND-CONSISTENCY
+
+2026-08-24 감사에서 `AdminService.forceRefund()`가 정상 주문 취소 lifecycle의 금전·capacity·정산 후속효과를 우회함을 확인했다.
+
+현재 구현·증거:
+
+- [x] admin refund는 주문 존재 후 `CANCELLED`만 거부
+- [x] `PaymentsService.processRefundByOrderId()`로 본 결제만 환불 시도
+- [x] 이후 주문을 직접 `CANCELLED`로 write
+- [x] `PaymentRefundService`의 본 결제 refund claim/idempotency는 별도 검증됨
+- [x] 정상 회차 취소는 본 결제 + paid 재배송비 환불, cancellation retry state, reservation/counter 반환, held counter 감소, settlement 취소를 수행
+- [x] admin force refund는 `refundOrderChargesByOrderId`, reservation/capacity release, held counter 조정, `cancelSettlement()`을 호출하지 않음
+- [x] admin 경로는 `PENDING`, `DELIVERY_HELD`, `DELIVERED`, `PICKED_UP`, `REVIEWED` 등도 `CANCELLED` 외면 별도 상태 제한 없이 진입 가능
+- [x] payment 없음/비`PAID`가 refund service에서 no-op여도 admin 경로는 이후 주문을 `CANCELLED`로 직접 변경 가능
+
+판정:
+
+- provider 본 결제 환불 멱등성은 `VERIFIED`지만 **admin 주문 환불 전체 일관성은 `IMPLEMENTATION FINDING` P0**다.
+- 특히 회차 reservation/counters, paid redelivery charge, pending/confirmed settlement, paid settlement 회계가 admin 경로에서 정상 취소 계약과 수렴한다고 보장할 수 없다.
+
+남음:
+
+- [ ] admin 환불 허용 주문 상태를 명시적으로 정의
+- [ ] 회차 주문 admin 환불이 `RoundOrderLifecycleService` 취소 불변식을 재사용하거나 동등한 단일 orchestration으로 수렴
+- [ ] 본 결제 + 연결 paid 재배송비를 중복 없이 함께 환불
+- [ ] HELD/CONSUMED reservation 및 round/item counters 정확히 반환
+- [ ] `DELIVERY_HELD` 취소 시 `heldOrderCount` 정확히 감소
+- [ ] pending/confirmed settlement를 `cancelled`로 수렴
+- [ ] 이미 `paid` settlement가 있는 주문의 환불은 단순 status 역전이 아닌 명시적 회계 조정/operation issue/승인 정책 결정
+- [ ] provider refund 성공 후 local side-effect 실패 시 재시도 상태 보존, 외부 환불 중복 방지
+- [ ] 정상 취소와 admin 환불 동시 실행이 하나의 결과로 수렴
+- [ ] `PENDING`, `ACCEPTED`, `DELIVERY_HELD`, `DELIVERED/REVIEWED`, paid settlement, paid redelivery charge 조합 직접 회귀
+- [ ] 수정이 포함된 SHA를 `main`에 통합한 뒤 actual release SHA 후보에 포함
+
+정본: `docs/specs/api/admin.md`, 정산 영향: `docs/specs/api/settlements.md`.
+
 ### P0 — ORDER-DIRECT-READ-AUTHORIZATION-AND-MINIMIZATION
 
 2026-08-24 감사에서 API 주문 조회 authorization과 실제 seller/driver 클라이언트 read 경계가 다름을 확인했다.
@@ -219,6 +255,7 @@ Issue #32 완료 전에도 repo-side Vercel guard는 동작하지만, direct pus
 ### P0 — 출시 후보 검증·운영 준비
 
 - [ ] PAYMENT-FINALIZATION-PAID-GUARD 완료 및 `main` 통합
+- [ ] ADMIN-FORCE-REFUND-CONSISTENCY 완료 및 `main` 통합
 - [ ] ORDER-DIRECT-READ-AUTHORIZATION-AND-MINIMIZATION 완료 및 `main` 통합
 - [ ] AUTH-DRIVER-APPROVAL-AND-SESSION-REVOCATION 완료 및 `main` 통합
 - [ ] ORDER-MUTATION-AUTHORIZATION-COVERAGE 완료 및 `main` 통합

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -36,7 +36,6 @@ repo-side remediation은 완료됐다.
 - PR #31: 세 앱 순수 docs/Markdown 변경의 Vercel build skip `ignoreCommand` 추가
 - pure-docs branch commit `ebf44c104b2e8758733fd14501fd0e820d575ae4` 이후 세 Vercel 프로젝트 신규 deployment 0건 확인
 - docs-only PR #33 merge 이후에도 세 Vercel 프로젝트 신규 deployment 0건 확인
-- PR #33 생성 시각은 2026-08-23 13:57 UTC이고, 당시 최신 `preview` sync commit `b1c92cedf01f3c2ce596251bcc86066314ebc40f`의 시각은 13:55:32 UTC다. PR #33 이후 더 새로운 preview sync가 없어 docs-only main merge가 `sync-preview`를 발화하지 않았음을 확인했다.
 
 Vercel Hobby build-rate-limit 때문에 docs-only PR에 Vercel check failure가 생길 수 있지만, 실제 deployment가 0건이면 배포 회귀로 판정하지 않는다. `Deployment safety guard` 자체 성공 여부와 Vercel deployment 목록을 분리해 본다.
 
@@ -45,7 +44,6 @@ Vercel Hobby build-rate-limit 때문에 docs-only PR에 Vercel check failure가 
 - GitHub `main`은 2026-08-24 재조회에서도 `protected=false`.
 - Issue #32 `P0: main branch protection / ruleset 활성화`가 남아 있다.
 - 목표: PR required, `Deployment safety guard / verify` required check, force push·branch delete 차단.
-- 연결된 GitHub 도구와 실행 환경에는 branch protection mutation·인증된 관리자 UI·GitHub token이 없어 Issue #32 완료 전까지 정책+CI 방어 상태다.
 
 **중요:** `main` merge는 production 배포 승인이 아니다. production은 검증된 exact release SHA와 별도 `Task 3.1 승인`을 사용해야 하며, 빈 commit·재-push로 배포를 유도하지 않는다.
 
@@ -63,6 +61,19 @@ Vercel Hobby build-rate-limit 때문에 docs-only PR에 Vercel check failure가 
 - 판매 모드는 최신 운영 확인 기준 `legacy`.
 
 ## 현재 확인된 P0
+
+### 관리자 강제 환불 주문·정산·capacity 일관성
+
+2026-08-24 감사에서 `AdminService.forceRefund()`가 정상 주문 cancellation lifecycle과 다른 후속효과를 수행함을 확인했다.
+
+- admin 환불은 `CANCELLED`만 거부하고 본 결제 환불 후 주문을 직접 `CANCELLED`로 갱신한다.
+- 정상 회차 취소는 본 결제·paid 재배송비 환불, cancellation 재시도 상태, reservation/counter 반환, held count 조정, settlement 취소까지 수행한다.
+- admin 경로는 재배송비 환불·reservation/capacity 반환·held count 조정·`cancelSettlement()`을 호출하지 않는다.
+- 완료/정산 생성 주문도 `CANCELLED`가 아니면 별도 상태 제한 없이 admin 환불 경로에 진입할 수 있다.
+
+따라서 provider 본 결제 환불 멱등성은 별도로 `VERIFIED`지만 **admin 주문 환불 전체 일관성은 `IMPLEMENTATION FINDING` P0**다. paid settlement 이후 환불은 단순 settlement 역전이 아니라 별도 회계 조정 정책이 필요하다.
+
+정본: `docs/specs/api/admin.md`, `docs/specs/api/settlements.md`, `docs/BACKLOG.md`.
 
 ### Driver 승인 게이트·세션 권한 수명주기
 
@@ -99,72 +110,48 @@ Vercel Hobby build-rate-limit 때문에 docs-only PR에 Vercel check failure가 
 
 현재 `main`의 `apps/api/src/payments/payment-finalization.service.ts`는 `finalizePaidOrder()` 내부에서 전달받은 `paymentData.status === 'PAID'`를 독립적으로 강제하지 않는다.
 
-현재 일반 호출 경로는 일부 방어를 갖는다.
-
 - `cleanupPendingOrders()`는 원격 상태가 `PAID`일 때만 finalization을 호출한다.
 - webhook은 `Transaction.Paid` 이벤트에서 원격 결제를 다시 조회한다.
 
-그러나 finalization service 자체가 비`PAID` 입력을 최종 차단하는 구조는 아니다. 따라서 문서·테스트에서 “최종화 계층이 모든 비`PAID`를 차단한다”고 간주하지 않는다.
+그러나 finalization service 자체가 비`PAID` 입력을 최종 차단하는 구조는 아니다. 이 항목은 **actual release SHA 확정 전 해결·회귀 검증이 필요한 P0**다.
 
-이 항목은 **actual release SHA 확정 전 해결·회귀 검증이 필요한 P0**다. 최소 회귀 범위는 `PENDING`, `FAILED`, `CANCELLED`, `PAID`, 금액 불일치, legacy/group 및 회차 경로다.
-
-정본: `docs/specs/api/payments.md`, `docs/BACKLOG.md`
+정본: `docs/specs/api/payments.md`, `docs/BACKLOG.md`.
 
 ### 주문 mutation authorization 회귀 검증
 
 주문 API 조회 권한은 consumer/seller/driver/admin별 직접 테스트가 존재해 **API 계층에서는** `VERIFIED`다.
 
-주문 상태 변경은 `OrdersLifecycleService.assertOrderActionAccess()`에서 seller store 소유권, driver 배정, consumer 주문 소유권을 검사하고 정상 회차 E2E도 존재한다. 그러나 2026-08-24 감사에서는 다음 직접 거부 회귀를 확인하지 못했다.
-
-- 다른 store seller의 order status/delivery-hold mutation 거부
-- 이미 다른 기사에게 배정된 주문의 비담당 driver mutation 거부
-- 미배정 주문의 최초 `PREPARING → DELIVERING` 외 driver mutation 거부와 side-effect 0 보장
+상태 변경 guard는 구현돼 있으나 2026-08-24 감사에서 타-store seller, 비담당 driver, 미배정 first-claim 외 action의 직접 거부 회귀를 충분히 확인하지 못했다.
 
 권한은 P0 계약이므로 이 범위는 현재 **`IMPLEMENTED / UNVERIFIED` + `COVERAGE GAP`**로 취급하고 actual release SHA 확정 전 직접 회귀를 추가한다.
 
-정본: `docs/specs/api/orders.md`, `docs/BACKLOG.md`
+정본: `docs/specs/api/orders.md`, `docs/BACKLOG.md`.
 
 ## ALIGO 템플릿 상태
 
 - 발신 프로필 1건 정상, `senderkey` 발급 완료.
 - 내부 논리 템플릿 코드 ↔ provider `tpl_code` 분리 및 필수 변수 검증 구현 완료.
-- 아래 8종 provider 등록·심사 요청 완료, 현재 모두 `검수중`.
-
-| 논리 템플릿 | 상태 |
-|---|---|
-| `ORDER_ACCEPTED` | 검수중 |
-| `ORDER_PREPARING` | 검수중 |
-| `ORDER_DELIVERING` | 검수중 |
-| `ORDER_DELIVERY_HELD` | 검수중 |
-| `ORDER_REDELIVERY_PAYMENT_REQUESTED` | 검수중 |
-| `ORDER_REDELIVERY_SCHEDULED` | 검수중 |
-| `ORDER_DELIVERED` | 검수중 |
-| `ORDER_CANCELLED` | 검수중 |
-
+- 8종 provider 등록·심사 요청 완료. 마지막 확인 snapshot(2026-08-23)에서 모두 `검수중`.
 - 실제 알림톡·SMS 발송: 0건
 - 실제 알림톡 정상 발송·SMS fallback 검증: 미실행
 - 운영 ALIGO 자격 증명 4개·`ALIGO_TEMPLATE_CODES_JSON`: 미반영
 
-현재 출시 흐름의 외부 차단점은 ALIGO 8종 심사 완료다.
+현재성이 필요한 경우 provider에서 다시 조회한다.
 
 ## 판매 활성화 법적 문서 상태
 
-- production `/privacy`, `/terms`는 2026-08-19 시행 버전이다.
-- 현재 공개 문서는 상용 주문·결제·배송을 운영하지 않는 **비판매 상태**를 명시한다.
-- 개인정보 정본은 PortOne·결제사업자를 현재 상용 처리 수탁자로 운영하지 않는다고 적고 있다.
-- 실제 고객 ALIGO 알림 처리도 판매 활성화 기준으로 재검수해야 한다.
+- production `/privacy`, `/terms`는 2026-08-19 시행 버전이며 비판매 상태를 전제로 한다.
+- PortOne·결제사업자·ALIGO·seller/driver 고객정보 접근은 실제 판매 활성화 전에 재정합화해야 한다.
 - seller/driver 고객정보 접근 문구는 `ORDER-DIRECT-READ-AUTHORIZATION-AND-MINIMIZATION` P0 해결 전 최종 확정하지 않는다.
 - broad direct read를 법적 문구로 정당화하지 않고 실제 접근 경계를 먼저 최소화한다.
 - 기존 법적 고지 production 반영 완료는 **판매 활성화 법적 준비 완료를 뜻하지 않는다.**
-- ALIGO 실제 발송 검증 뒤 release SHA 고정 전에 `docs/specs/legal/README.md`의 P0 재정합화 게이트를 완료한다.
-- 판매 공개 전에는 비판매 문구를 임의로 `판매 중`으로 미리 바꾸지 않는다.
 
 ## 검증 상태
 
-- 마지막 전체 원격 회차 E2E 성공 증거: SHA `6e0fc9d4cec08073ed2504208cc8bb1ea395ee7d`, run `32351887404`.
+- 마지막 전체 원격 회차 E2E 성공 역사 증거: SHA `6e0fc9d4cec08073ed2504208cc8bb1ea395ee7d`, run `32351887404`.
 - chromium 26 + mobile 26 = 총 52건 및 양쪽 fixture cleanup 성공.
 - 이 과거 run을 현재 release SHA 검증으로 확장하지 않는다.
-- 법적 페이지와 현재 P0 코드·검증 보정까지 포함한 실제 출시 대상 SHA를 고정한 뒤 52건+cleanup을 다시 통과해야 한다.
+- 법적 페이지와 현재 모든 P0 코드·검증 보정까지 포함한 실제 출시 대상 SHA를 고정한 뒤 52건+cleanup을 다시 통과해야 한다.
 
 ## 활성 문서
 
@@ -194,15 +181,15 @@ Vercel Hobby build-rate-limit 때문에 docs-only PR에 Vercel check failure가 
 
 ## 다음 작업
 
-1. **P0 병렬 인증 게이트**: driver 관리자 승인 우회 제거 + 정지/role/store 변경의 refresh/Firebase claims 수렴 정책 확정·구현·직접 회귀 후 `main` 통합.
-2. **P0 병렬 코드 게이트**: 주문 direct Firestore read를 안전한 discovery/assigned 경계와 역할별 최소 데이터로 축소하고 Rules·frontend 회귀를 `main`에 통합.
-3. **P0 병렬 코드 게이트**: 결제 finalization이 비`PAID` provider 상태를 자체 차단하도록 구현·회귀 검증 후 `main` 통합.
-4. **P0 병렬 검증 게이트**: 주문 mutation authorization의 타-store seller·비담당 driver·미배정 first-claim 경계를 직접 회귀 테스트하고 `main` 통합.
-5. **P0 병렬 관리자 게이트**: Issue #32의 `main` branch protection/ruleset 활성화.
-6. **외부 차단**: ALIGO 8종 심사 결과 대기. 승인 전 실제 발송·운영 ALIGO 설정은 진행하지 않는다.
-7. 8종 승인 후 격리 알림톡 정상 발송 → SMS fallback 검증.
-8. 주문 read 최소화 P0 해결을 전제로 판매 활성화 법적 문서·테스트 재정합화.
-9. 법적 변경과 모든 P0 코드·검증 보정까지 포함한 actual release SHA 확정 → 원격 회차 E2E 52건+cleanup.
+1. **P0 병렬 금융 게이트**: admin force refund를 정상 cancellation/정산/capacity 불변식으로 수렴시키고 paid settlement 환불 정책을 확정·직접 회귀 후 `main` 통합.
+2. **P0 병렬 인증 게이트**: driver 관리자 승인 우회 제거 + 정지/role/store 변경의 refresh/Firebase claims 수렴 정책 확정·구현·직접 회귀 후 `main` 통합.
+3. **P0 병렬 코드 게이트**: 주문 direct Firestore read를 안전한 discovery/assigned 경계와 역할별 최소 데이터로 축소하고 Rules·frontend 회귀를 `main`에 통합.
+4. **P0 병렬 코드 게이트**: 결제 finalization이 비`PAID` provider 상태를 자체 차단하도록 구현·회귀 검증 후 `main` 통합.
+5. **P0 병렬 검증 게이트**: 주문 mutation authorization 직접 회귀 후 `main` 통합.
+6. **P0 병렬 관리자 게이트**: Issue #32의 `main` branch protection/ruleset 활성화.
+7. **외부 차단**: ALIGO 8종 심사 결과 대기.
+8. 승인 후 실제 알림톡/SMS fallback → 판매 활성화 legal 재정합화.
+9. 모든 P0 및 법적 변경을 포함한 actual release SHA 확정 → 원격 회차 E2E 52건+cleanup.
 10. 운영 Firebase 재조회 → ALIGO 운영 설정 → 별도 `Task 3.1 승인` → exact-SHA production 배포.
 11. 이후 첫 회차 검수 → 최종 출시 판정 → `salesMode: round_direct` 전환.
 

--- a/docs/plans/HANDOFF_mvp_round_direct_aligo_review_pause.md
+++ b/docs/plans/HANDOFF_mvp_round_direct_aligo_review_pause.md
@@ -2,236 +2,131 @@
 
 # 회차 직배송 MVP — ALIGO 심사 대기 인계
 
-> 현재 재개 순서만 유지한다. 상세 과거 증거는 `docs/plans/REPORT_mvp_round_direct_launch.md`와 Git 이력에서 확인한다.
+> 이 문서는 현재 재개 지점만 관리한다. 상세 상태는 `docs/memory.md`, 미완료 Acceptance Criteria는 `docs/BACKLOG.md`, 실행 의존성은 `docs/plans/PLAN_mvp_round_direct_launch_blockers.md`를 따른다.
 
 ## 현재 상태 — 2026-08-24 KST
 
-- 회차 직배송 MVP는 PR #11을 통해 `main` 통합 완료.
-- 기능 통합 기준 SHA: `e55f25914cc7d01576fbd4639583daaf0fe6385e`.
-- 카카오 비즈니스 채널 최종 승인 완료.
-- ALIGO 발신 프로필·`senderkey` 준비 완료.
-- 회차 알림 템플릿 8종 provider 등록·심사 요청 완료, 마지막 확인 시 전부 `검수중`.
+- 회차 직배송 MVP는 `main` 통합 완료.
+- 카카오 비즈니스 채널, ALIGO 발신 프로필·`senderkey`, 회차 알림 템플릿 8종 등록·심사 요청 완료.
+- 마지막 provider 확인 기준 8종 모두 `검수중`.
 - 실제 알림톡·SMS 발송 0건.
 - production ALIGO 자격 증명·8종 매핑 미반영.
 - 첫 운영 회차 미생성, `salesMode=legacy`.
+- `main` merge는 production 배포 승인이 아니며 exact release SHA + 별도 승인 절차를 사용한다.
 
-현재 외부 차단점은 **ALIGO 8종 provider 심사 완료**다. provider 상태는 새 작업 시작 시 다시 조회한다.
+현재 외부 차단점은 **ALIGO 8종 provider 심사 완료**다. provider 상태는 재개 시 직접 다시 확인한다.
 
-동시에 해결 가능한 P0는 다섯 가지다.
+ALIGO 심사와 병렬로 해결해야 할 P0는 여섯 가지다.
 
-1. **Driver 승인 게이트·세션/claims revocation** — 신규/legacy driver 자동 승인 경로 제거와 정지·role/store 변경 권한 수렴 정책 필요.
-2. **주문 direct Firestore read authorization·데이터 최소화** — API보다 넓은 driver direct read와 raw order 필드 노출을 안전한 discovery/assigned 경계로 축소해야 함.
-3. **결제 finalization `PAID` 최종 방어** — 현재 `main`의 `finalizePaidOrder()`는 전달받은 provider status를 자체 강제하지 않음.
-4. **주문 mutation authorization 직접 회귀** — 권한 guard는 구현돼 있으나 타-store seller·비담당 driver·미배정 first-claim 경계를 직접 고정하는 회귀가 부족함.
-5. **Issue #32 `main` branch protection/ruleset 활성화**.
+1. `AUTH-DRIVER-APPROVAL-AND-SESSION-REVOCATION`
+2. `ORDER-DIRECT-READ-AUTHORIZATION-AND-MINIMIZATION`
+3. `PAYMENT-FINALIZATION-PAID-GUARD`
+4. `ORDER-MUTATION-AUTHORIZATION-COVERAGE`
+5. `ADMIN-FORCE-REFUND-CONSISTENCY`
+6. Issue #32 `main` branch protection/ruleset
 
-현재 상태 정본은 `docs/memory.md`, 미완료 목록은 `docs/BACKLOG.md`를 우선한다. 문서 정합성 판정은 `docs/DOCUMENT_CONSISTENCY.md`를 따른다.
+## P0 재개 포인터
 
-## Driver 승인 게이트·세션 revocation P0
+### 1. Driver 승인·세션 권한
 
-2026-08-24 인증 감사에서 admin driver 승인 계약과 실제 Kakao 가입·refresh 경로가 충돌함을 확인했다.
+- 신규 Kakao `targetRole: driver`와 승인 필드 누락 기존 driver의 자동 승인 경로가 현재 존재한다.
+- refresh는 authoritative user 상태를 재조회하지 않고 stale `role/storeId` claims를 재사용한다.
+- 관리자 승인 전 driver 권한 차단과 suspension/role/store/approval 변경의 revocation window를 구현·직접 검증해야 한다.
+- broad driver Firestore read P0와 결합 검증한다.
 
-현재 사실:
+정본: `docs/specs/api/auth.md`, `docs/specs/api/admin.md`, `docs/BACKLOG.md`.
 
-- admin에는 `driverApproved` 승인 API가 있고 driver 앱 callback도 승인 flag를 요구한다.
-- `AuthService.kakaoLogin()`은 신규 Kakao identity가 `targetRole: driver`를 요청하면 `role: driver`, `driverApproved: true`로 즉시 생성한다.
-- 기존 driver에서 `driverApproved`가 누락된 경우도 로그인 중 자동 `true`로 보정한다.
-- 신규 로그인은 `suspended` 사용자를 차단한다.
-- 그러나 `AuthService.refresh()`는 사용자 문서를 재조회하지 않고 refresh JWT의 기존 `role/storeId`를 새 token에 재사용한다.
-- `GET /auth/firebase-token`도 현재 JWT claims로 Firebase custom claims를 발급한다.
+### 2. 주문 direct read·데이터 최소화
 
-판정:
+- API driver read는 배정 경계가 있으나 실제 driver 앱은 raw Firestore 주문을 직접 읽는다.
+- current Rules의 broad driver read와 raw order 문서의 불필요 필드 노출을 안전한 discovery/assigned 계약으로 축소해야 한다.
+- 미배정 `PREPARING` direct/hub discovery 의도는 보존한다.
 
-- 관리자 승인 전 driver 권한 획득 차단: **`IMPLEMENTATION FINDING` P0**.
-- 정지·role/store/승인 변경 후 기존 세션의 revocation window와 refresh/Firebase claim 수렴: **`DECISION REQUIRED` + P0 remediation**.
+정본: `docs/specs/api/orders.md`, `docs/specs/legal/README.md`, `docs/BACKLOG.md`.
 
-이 finding은 broad driver Firestore read P0와 결합될 수 있으므로 한쪽만 해결해 driver authorization 전체를 완료 처리하지 않는다.
+### 3. 결제 finalization `PAID` guard
 
-actual release SHA 확정 전에:
+- `PaymentFinalizationService.finalizePaidOrder()`가 비`PAID` provider 상태를 메서드 자체에서 차단하지 않는다.
+- `PENDING/FAILED/CANCELLED` 거부와 `PAID` 정상·금액 불일치·legacy/group/round 회귀를 직접 고정한다.
 
-- 신규 `targetRole: driver` 자동 승인과 승인 필드 누락 계정 로그인 자동 승인을 제거하고,
-- 필요한 legacy migration을 로그인 side effect가 아닌 명시적 절차로 분리하고,
-- 승인 전 driver 앱/API/Firebase 접근을 직접 거부 테스트로 고정하고,
-- 계정 정지 시 refresh가 새 권한 token을 발급하지 않도록 하며,
-- role/storeId/driverApproved 변경 시 authoritative user 상태로 claims를 수렴시키고,
-- 이미 발급된 access token의 revocation SLA를 명시적으로 결정·검증한다.
+정본: `docs/specs/api/payments.md`, `docs/BACKLOG.md`.
 
-정본: `docs/specs/api/auth.md`, `docs/specs/api/admin.md`.
+### 4. 주문 mutation authorization 회귀
 
-## 주문 direct Firestore read P0
+- seller store ownership, driver assignment, consumer ownership guard는 구현돼 있다.
+- 타-store seller, 비담당 driver, 미배정 first-claim 외 mutation, 거부 side-effect 0의 직접 회귀가 부족하다.
 
-2026-08-24 감사에서 API 주문 조회 authorization과 seller/driver가 실제 사용하는 Firestore read 경계가 서로 다름을 확인했다.
+정본: `docs/specs/api/orders.md`, `docs/BACKLOG.md`.
 
-현재 사실:
+### 5. Admin 강제 환불 lifecycle 정합성
 
-- API `OrdersQueryService`는 driver 주문 상세을 `order.driverId === requesterId`로 제한한다.
-- `firestore.rules`는 `role == 'driver'`이면 주문의 store/status/배정과 무관하게 `orders` read를 허용한다.
-- driver 보드는 미배정 `PREPARING` direct/hub 주문 discovery를 위해 raw Firestore query를 사용한다.
-- driver 상세는 arbitrary `orders/{orderId}`를 raw Firestore `onSnapshot()`으로 읽는다.
-- seller 주문 목록도 same-store raw `orders` 문서를 직접 구독한다.
-- 회차 주문 원문에는 배송 수행 외 `acquisition`, `marketingConsent`, 내부 hash/reservation 메타데이터가 함께 존재할 수 있다.
-- 현재 Firestore Rules 테스트는 driver의 다른 store 주문 direct read를 성공 케이스로 고정한다.
+현재 `AdminService.forceRefund()`는 정상 회차 cancellation orchestration과 수렴하지 않는다.
 
-따라서 API 계층 조회 권한만 `VERIFIED`이며 시스템 전체 driver read authorization과 seller/driver 최소 데이터 제공은 **`IMPLEMENTATION FINDING` P0**다.
+현재 차이:
 
-actual release SHA 확정 전에:
+- admin 경로: 본 결제 환불 → 주문 `CANCELLED` 직접 write
+- 정상 회차 취소: cancellation claim/state → 본 결제·추가 charge 환불 → reservation/capacity 반환 → hold counter 정합화 → 주문 취소 → settlement 취소
 
-- 미배정 `PREPARING` direct/hub discovery 의도와 필요한 최소 필드를 명시하고,
-- 임의 driver의 타-driver/완료/기타 arbitrary order 원문 read를 차단하고,
-- assigned driver와 seller에 필요한 역할별 최소 필드만 제공하며,
-- `firestore.rules`와 Rules 테스트를 해당 계약으로 변경하고,
-- seller/driver 보드·상세·first-claim 회귀를 확인한다.
+따라서 actual release SHA 확정 전 다음을 해결한다.
 
-Rules만으로 field minimization이 불가능하면 API DTO, safe projection 또는 민감/내부 필드 분리 등 동등한 구조를 사용한다. broad 구현을 개인정보처리방침 문구로 정당화하지 않는다.
+- admin 환불 허용 상태 fail-closed
+- 이미 결제된 재배송비/추가 charge 처리
+- 회차 reservation 및 sale-round/item counter 반환
+- `DELIVERY_HELD`의 `heldOrderCount` 수렴
+- `pending|confirmed` settlement 취소
+- `paid` settlement 환불의 별도 회계 조정 정책
+- provider 성공/local 실패 재시도 계약
+- seller/consumer/round cancellation과 admin refund 동시 실행의 이중환불·이중 release 방지
+- 직접 회귀 테스트
 
-정본: `docs/specs/api/orders.md`, `docs/specs/legal/README.md`.
+정본: `docs/specs/api/admin.md`, `docs/specs/api/payments.md`, `docs/specs/api/settlements.md`, `docs/specs/api/orders.md`, `docs/BACKLOG.md`.
 
-## 결제 finalization P0
+### 6. GitHub `main` protection
 
-현재 `apps/api/src/payments/payment-finalization.service.ts`의 `finalizePaidOrder()`는 주문 상태·금액·reservation을 검사하지만 전달받은 `paymentData.status === 'PAID'`를 메서드 내부에서 직접 강제하지 않는다.
+- repo-side production auto-deploy 차단은 완료.
+- GitHub `main` 자체 보호는 Issue #32에서 완료해야 한다.
+- 목표: PR required, `Deployment safety guard / verify`, force-push/delete 차단.
 
-현재 일반 호출 경로는 일부 방어한다.
-
-- scheduler는 원격 상태가 `PAID`일 때만 finalization 호출.
-- webhook은 `Transaction.Paid` 이벤트에서 원격 결제를 재조회.
-
-하지만 finalization service 자체가 비`PAID` 입력을 최종 차단하는 구조는 아니다.
-
-따라서 actual release SHA를 확정하기 전에:
-
-- 비`PAID` 차단 구현,
-- `PENDING`/`FAILED`/`CANCELLED` 회귀,
-- `PAID` 일반·공동구매·회차 정상 경로,
-- 금액 불일치,
-- 기존 reservation/race 회귀
-
-를 통과하고 수정이 `main`에 포함됐음을 확인한다.
-
-정본: `docs/specs/api/payments.md`.
-
-## 주문 mutation authorization P0
-
-주문 API 조회 authorization은 consumer/seller/driver/admin별 직접 테스트가 존재해 **API 계층에서는** `VERIFIED`다.
-
-상태 변경은 `OrdersLifecycleService.assertOrderActionAccess()`가 다음 경계를 구현한다.
-
-- seller: 해당 store owner만 변경 가능
-- driver: 배정된 기사만 변경 가능
-- 미배정 driver: `PREPARING → DELIVERING` 최초 claim만 허용 후 `driverId` 기록
-- consumer: 자신의 주문만 action access 통과, 실제 전이는 consumer FSM이 추가 제한
-
-그러나 문서 감사에서 타-store seller mutation, 비담당 driver mutation, 미배정 first-claim 외 driver mutation과 거부 side-effect 0을 직접 고정하는 회귀 테스트는 확인되지 않았다.
-
-따라서 현재 상태는 **`IMPLEMENTED / UNVERIFIED` + `COVERAGE GAP`**이며 actual release SHA를 확정하기 전 직접 회귀를 추가하고 `main`에 통합한다.
-
-정본: `docs/specs/api/orders.md`.
-
-## 배포 안전성 변경
-
-2026-08-23 배포 감사에서 `main` push가 문서 변경만으로 Vercel production deployment를 만들던 구조를 확인했고 repo-side remediation을 적용했다.
-
-- PR #30: consumer·seller·driver `main` Vercel Git auto-deploy 차단.
-- PR #30 merge 후 세 프로젝트 신규 deployment 0건 확인.
-- docs-only `main` push는 Preview sync/E2E 제외.
-- deployment safety CI 추가.
-- `AGENTS.md`: direct `main` commit/push 금지.
-- PR #31: 순수 docs/Markdown Vercel build skip.
-- pure-docs branch 검증에서도 세 프로젝트 신규 deployment 0건 확인.
-
-남음:
-
-- GitHub `main`은 2026-08-24 재조회에서도 `protected=false`.
-- Issue #32에서 PR required + safety required check + force-push/delete 차단 필요.
-
-**중요:** `main` merge는 더 이상 production 배포 경로가 아니다. production은 actual release SHA를 고정·검증한 뒤 별도 승인으로 exact-SHA deploy/promotion을 수행한다.
-
-상세: `docs/plans/PLAN_deployment_safety_guards_20260823.md`.
-
-## 판매 활성화 법적 상태
-
-production `/privacy`, `/terms`는 현재 비판매 상태를 전제로 한다.
-
-따라서 ALIGO 실제 발송 검증 뒤 release SHA를 고정하기 전에:
-
-- 주문 direct Firestore read P0를 해결해 seller/driver 실제 접근 범위를 최소화·검증하고,
-- 실제 주문·결제·취소·환불·배송·재배송비·보류 정책,
-- PortOne/결제사업자 개인정보 처리,
-- ALIGO 고객 알림 처리,
-- seller/driver 배송정보 접근,
-- 시행일·이전 버전,
-- `legal-documents.test.mjs`
-
-을 `docs/specs/legal/README.md` 계약에 맞게 갱신한다.
-
-현재 broad direct read를 설명하기 위해 공개 개인정보 문구를 넓히지 않는다. 실제 접근 경계를 먼저 수정한다.
-
-## ALIGO 템플릿 현황
-
-마지막 확인 snapshot: 2026-08-23.
-
-| 논리 템플릿 | 상태 |
-|---|---|
-| `ORDER_ACCEPTED` | 검수중 |
-| `ORDER_PREPARING` | 검수중 |
-| `ORDER_DELIVERING` | 검수중 |
-| `ORDER_DELIVERY_HELD` | 검수중 |
-| `ORDER_REDELIVERY_PAYMENT_REQUESTED` | 검수중 |
-| `ORDER_REDELIVERY_SCHEDULED` | 검수중 |
-| `ORDER_DELIVERED` | 검수중 |
-| `ORDER_CANCELLED` | 검수중 |
-
-- 중복·오류·반려 없음.
-- 비밀값 원문 기록 금지.
-- 현재성이 필요한 경우 provider에서 다시 조회한다.
-
-## 검증 기준
-
-- 마지막 전체 원격 회차 E2E 역사 증거: SHA `6e0fc9d4cec08073ed2504208cc8bb1ea395ee7d`, run `32351887404`.
-- chromium 26 + mobile 26 = 52, 양쪽 cleanup 성공.
-- 현재 release SHA 증거로 확장 적용하지 않는다.
-- auth approval/revocation P0, 주문 direct read P0, 결제 finalization P0, 주문 mutation authorization P0와 법적 변경까지 포함한 actual release SHA에서 다시 검증한다.
+정본: `docs/plans/PLAN_deployment_safety_guards_20260823.md`.
 
 ## 지금 하지 말아야 할 작업
 
-- 심사 중 템플릿 중복 등록·임의 수정.
+- 심사 중 ALIGO 템플릿 중복 등록·임의 수정.
 - 승인 전 실제 알림톡·SMS 발송.
-- ALIGO secret/`tpl_code` 원문 Git 기록.
+- secret, 실제 `tpl_code`, 고객 개인정보 원문을 Git/문서에 기록.
 - direct `main` commit/push.
 - `main` merge를 production 배포 승인으로 해석.
-- 별도 Task 승인 없이 production 배포·Firebase 운영 변경·운영 회차 생성·`salesMode` 변경.
-- 비판매 법적 문구를 판매 공개 전에 임의로 미리 전환.
-- broad seller/driver 주문 read를 개인정보 문구 확대만으로 정당화.
-- driver 자동 승인 경로를 현재 운영 승인 정책으로 정당화.
-- suspended/권한 변경 계정의 stale refresh/Firebase claims를 검증 없이 정상 동작으로 간주.
-- 현재 P0 코드·검증 게이트가 `main`에 반영되기 전에 release SHA를 확정.
+- 별도 승인 없이 production 배포·Firebase 운영 변경·운영 회차 생성·`salesMode` 변경.
+- P0 구현 결함을 법적/운영 문구 확대로 정당화.
+- 현재 P0가 `main`에 포함되기 전에 actual release SHA 확정.
 
 ## 지금 병렬로 할 수 있는 작업
 
-1. driver 승인 게이트·세션/claims revocation 구현·직접 회귀·통합.
-2. 주문 direct Firestore read authorization·데이터 최소화 구현·Rules/frontend 회귀·통합.
-3. 결제 finalization `PAID` guard 구현·회귀 검증·통합.
-4. 주문 mutation authorization 직접 거부 회귀 테스트·통합.
-5. Issue #32 `main` protection/ruleset 관리자 설정.
-6. read-only 문서/코드 정합성 감사.
-7. ALIGO provider 심사 상태 조회.
+1. driver 승인·세션 revocation 구현·회귀·통합.
+2. 주문 direct read 최소화 구현·Rules/frontend 회귀·통합.
+3. 결제 finalization `PAID` guard 구현·회귀·통합.
+4. 주문 mutation authorization 직접 거부 회귀·통합.
+5. admin 강제 환불 lifecycle 정합화 구현·회귀·통합.
+6. Issue #32 관리자 설정.
+7. read-only 문서/코드 정합성 감사.
+8. ALIGO provider 심사 상태 조회.
 
 ## ALIGO 승인 뒤 재개 순서
 
-1. auth approval/revocation P0, 주문 direct read P0, 결제 finalization P0, 주문 mutation authorization P0가 `main`에 통합됐는지 확인.
-2. 8종 모두 승인/수정요청/반려 여부 확인.
+1. 위 P0 다섯 코드/검증 게이트와 Issue #32가 완료됐는지 확인.
+2. ALIGO 8종 승인/수정요청/반려 상태 재확인.
 3. 승인 `tpl_code` 8종 ↔ 내부 논리 템플릿 1:1 매핑 검사.
 4. 별도 승인 후 격리 실제 알림톡 정상 발송.
 5. 별도 승인 후 SMS fallback 실제 검증.
-6. 주문 read 최소화 결과를 전제로 판매 활성화 법적 문서·테스트 재정합화.
-7. Issue #32 완료 확인.
-8. 법적 변경과 모든 P0 코드·검증 보정까지 포함한 actual release SHA 확정.
-9. exact SHA 원격 회차 E2E 52건 + fixture cleanup.
-10. 운영 Firebase read-only 재조회.
-11. 별도 승인 후 production ALIGO 설정 반영·검증.
-12. exact-SHA production deploy/promotion 절차 확정.
-13. 사용자의 별도 `Task 3.1 승인` 뒤에만 production 배포.
-14. deployment metadata SHA 대조 → 운영 smoke.
-15. 첫 회차 검수 → 최종 출시 판정 → `salesMode: round_direct` 전환.
+6. 주문 read 최소화와 admin 환불 실제 정책을 기준으로 판매 활성화 법적 문서·테스트 재정합화.
+7. 모든 P0 및 법적 변경을 포함한 actual release SHA 확정.
+8. exact SHA 원격 회차 E2E 52건 + fixture cleanup.
+9. 운영 Firebase read-only 재조회.
+10. 별도 승인 후 production ALIGO 설정 반영·검증.
+11. exact-SHA production deploy/promotion 절차 확정.
+12. 사용자의 별도 `Task 3.1 승인` 뒤에만 production 배포.
+13. provider deployment metadata SHA 대조 → 운영 smoke.
+14. 첫 회차 검수 → 최종 출시 판정 → `salesMode: round_direct` 전환.
 
 ## 재개 완료 조건
 
@@ -240,15 +135,15 @@ production `/privacy`, `/terms`는 현재 비판매 상태를 전제로 한다.
 - [x] ALIGO 발신 프로필·senderkey 준비
 - [x] ALIGO 템플릿 8종 등록·심사 요청
 - [x] repo-side `main` 자동 production deploy 차단
-- [x] deployment safety CI와 docs-only ignore 적용
-- [ ] driver 승인 게이트·세션/claims revocation + 직접 회귀 + `main` 통합
-- [ ] 주문 direct Firestore read authorization·데이터 최소화 + Rules/frontend 회귀 + `main` 통합
-- [ ] 결제 finalization `PAID` guard + 회귀 검증 + `main` 통합
+- [ ] driver 승인·세션/claims revocation + 직접 회귀 + `main` 통합
+- [ ] 주문 direct read authorization·데이터 최소화 + Rules/frontend 회귀 + `main` 통합
+- [ ] 결제 finalization `PAID` guard + 회귀 + `main` 통합
 - [ ] 주문 mutation authorization 직접 거부 회귀 + `main` 통합
+- [ ] admin 강제 환불 lifecycle 정합성 + 회귀 + `main` 통합
 - [ ] Issue #32 branch protection/ruleset
 - [ ] ALIGO 템플릿 8종 최종 승인
 - [ ] 실제 알림톡 정상 발송
-- [ ] SMS fallback
+- [ ] SMS fallback 실제 검증
 - [ ] 판매 활성화 법적 문서 정합화
 - [ ] actual release SHA 원격 E2E 52건+cleanup
 - [ ] production ALIGO 설정

--- a/docs/plans/PLAN_mvp_round_direct_launch_blockers.md
+++ b/docs/plans/PLAN_mvp_round_direct_launch_blockers.md
@@ -2,7 +2,7 @@
 
 # Project Blueprint: 회차 직배송 MVP 출시 차단 요소 해소
 
-> 현재 실행 계약만 유지한다. 과거 상세 증거는 `docs/plans/REPORT_mvp_round_direct_launch.md`와 Git 이력에서 확인한다.
+> 현재 실행 순서·의존성·승인 게이트만 관리한다. 현재 상태는 `docs/memory.md`, 세부 미완료·Acceptance Criteria는 `docs/BACKLOG.md`, 도메인 계약은 각 current spec을 따른다.
 
 ## 문서 메타
 
@@ -11,64 +11,28 @@
 - 상태: `paused_external_review`
 - Priority: P0
 - 현재 외부 차단점: ALIGO 회차 알림 템플릿 8종 provider 심사 완료
-- 병렬 인증 P0: driver 관리자 승인 게이트 + 세션/claims revocation
-- 병렬 보안 P0: 주문 direct Firestore read authorization·역할별 데이터 최소화
-- 병렬 코드 P0: 결제 finalization `PAID` 최종 방어
-- 병렬 검증 P0: 주문 mutation authorization 직접 거부 회귀
-- 병렬 관리자 P0: GitHub Issue #32 `main` branch protection/ruleset
 - 현재 상태 SSOT: `docs/memory.md`
-- 재개 순서: `docs/plans/HANDOFF_mvp_round_direct_aligo_review_pause.md`
+- 현재 재개 지점: `docs/plans/HANDOFF_mvp_round_direct_aligo_review_pause.md`
+- 미완료 상세: `docs/BACKLOG.md`
 - 인증 계약: `docs/specs/api/auth.md`
-- 결제 계약: `docs/specs/api/payments.md`
 - 주문 계약: `docs/specs/api/orders.md`
-- 배포 안전 계약: `docs/plans/PLAN_deployment_safety_guards_20260823.md`
+- 결제 계약: `docs/specs/api/payments.md`
+- 정산 계약: `docs/specs/api/settlements.md`
+- 관리자 계약: `docs/specs/api/admin.md`
 - 판매 활성화 법적 게이트: `docs/specs/legal/README.md`
-- 운영 런북: `docs/specs/ops/mvp-sales-round-runbook.md`
+- 배포 안전 계약: `docs/plans/PLAN_deployment_safety_guards_20260823.md`
 
-## 현재 기준선
+## 현재 출시 게이트
 
-- 회차 직배송 MVP는 PR #11을 통해 `main`에 통합됐다.
-- 기능 통합 기준 SHA: `e55f25914cc7d01576fbd4639583daaf0fe6385e`.
-- 카카오 비즈니스 채널 승인, ALIGO 발신 프로필·`senderkey`, 내부↔외부 템플릿 코드 분리 구현 완료.
-- 회차 알림 템플릿 8종 provider 등록·심사 요청 완료, 모두 `검수중`.
-- 실제 알림톡 정상 발송·SMS fallback 검증 미실행.
-- production ALIGO 자격 증명 4개와 `ALIGO_TEMPLATE_CODES_JSON` 미반영.
-- 운영 Firebase rules/indexes는 기존 준비에서 반영 완료 상태이며 출시 전 재조회 필요.
-- production 회차 앱 배포·첫 회차 생성·`salesMode` 전환 미실행.
-- `salesMode=legacy` 유지.
-- 현재 `/terms`, `/privacy`는 비판매 상태를 전제로 하므로 실제 판매 활성화 전 재정합화가 필요하다.
-- 현재 `main`의 `PaymentFinalizationService.finalizePaidOrder()`는 전달받은 provider `status === 'PAID'`를 메서드 내부에서 독립적으로 강제하지 않는다. actual release SHA 확정 전 해결·회귀 검증해야 한다.
-- 주문 API 조회 authorization은 직접 테스트가 존재해 API 계층에서는 `VERIFIED`다. 그러나 driver/seller 앱은 raw Firestore `orders` read를 사용하고, current Rules는 `role == 'driver'`이면 배정·store·상태와 무관하게 주문 read를 허용하므로 시스템 전체 read authorization·데이터 최소화는 P0 `IMPLEMENTATION FINDING`이다.
-- order mutation authorization은 seller 타-store·비담당 driver·미배정 driver first-claim 경계의 직접 거부 회귀가 부족해 `IMPLEMENTED / UNVERIFIED` 상태다.
-- driver admin 승인 계약과 달리 신규 Kakao `targetRole: driver` 및 승인 필드 누락 기존 driver가 `driverApproved: true`로 자동 수렴하는 경로가 있어 P0 `IMPLEMENTATION FINDING`이다.
-- 정지·role/store/driverApproved 변경 뒤 refresh/custom-token 권한 수렴은 stale JWT payload를 재사용하므로 revocation SLA 결정과 구현 보정이 필요하다.
-
-## 배포 안전 기준선
-
-2026-08-23 발견된 `main push → Vercel production` 자동 연결은 repo-side에서 차단했다.
-
-- PR #30: 세 프런트 `git.deploymentEnabled.main=false`.
-- PR #30 merge 뒤 3앱 신규 Vercel deployment 0건 확인.
-- docs-only `main` push는 Preview sync/E2E 제외.
-- PR #31: 순수 docs/Markdown의 Vercel build skip.
-- deployment safety CI 추가.
-- direct `main` 작업은 `AGENTS.md`에서 금지.
-
-그러나 GitHub `main` 자체는 2026-08-24 재조회 기준 `protected=false`이므로 Issue #32 완료가 출시 전 필수다.
-
-**이제 `main` merge는 production 배포 수단이 아니다.** 운영 배포는 아래 Task 3 단계에서 검증된 exact release SHA를 명시적으로 deploy/promote한다.
-
-## 출시 게이트 요약
-
-| 순서 | 게이트 | 상태 |
+| ID | 게이트 | 상태 |
 |---|---|---|
-| 0 | repo-side 자동배포 차단 | 완료 |
-| 0A | GitHub `main` branch protection/ruleset | **미완료 — Issue #32** |
-| 0B | 결제 finalization 비`PAID` 최종 차단 + 회귀 | **미완료 — P0** |
-| 0C | 주문 mutation authorization 직접 거부 회귀 | **미완료 — P0 COVERAGE GAP** |
-| 0D | 주문 direct Firestore read authorization·데이터 최소화 | **미완료 — P0 IMPLEMENTATION FINDING** |
-| 0E | driver 승인 게이트 + 세션/claims revocation | **미완료 — P0 IMPLEMENTATION FINDING / DECISION REQUIRED** |
-| 1 | ALIGO 8종 provider 최종 승인 | **검수중** |
+| 0A | GitHub `main` branch protection/ruleset | 미완료 — Issue #32 |
+| 0B | 결제 finalization 비`PAID` 최종 차단 | 미완료 — P0 |
+| 0C | 주문 mutation authorization 직접 거부 회귀 | 미완료 — P0 COVERAGE GAP |
+| 0D | 주문 direct Firestore read authorization·데이터 최소화 | 미완료 — P0 IMPLEMENTATION FINDING |
+| 0E | driver 승인 게이트 + 세션/claims revocation | 미완료 — P0 IMPLEMENTATION FINDING / DECISION REQUIRED |
+| 0F | admin 강제 환불 lifecycle 정합성 | 미완료 — P0 IMPLEMENTATION FINDING |
+| 1 | ALIGO 8종 provider 최종 승인 | 검수중 |
 | 2 | 실제 알림톡 정상 발송 | 미실행 |
 | 3 | SMS fallback 실제 검증 | 미실행 |
 | 4 | 판매 활성화 법적 문서 재정합화 | 미실행 |
@@ -79,288 +43,240 @@
 | 9 | exact-SHA production 배포 | 미실행 — 별도 Task 3.1 승인 |
 | 10 | 첫 회차 검수 | 미실행 |
 | 11 | 최종 출시 판정 | 미실행 |
-| 12 | `round_direct` 전환 | 미실행 |
+| 12 | `salesMode: round_direct` 전환 | 미실행 |
 
 ## Agent Completion Contract
 
 1. 모든 repository 변경은 최신 `main`에서 목적별 branch를 만들고 PR로 통합한다.
 2. direct `main` commit/push를 하지 않는다.
-3. dependency 순서대로 Task를 실행하되 auth P0, 주문 direct read P0, 결제 finalization P0, 주문 mutation authorization P0와 Issue #32는 ALIGO 심사와 병렬로 해결할 수 있다.
-4. 외부 서비스 변경·실제 발송·운영 변수·Firebase 운영 변경·production 배포·운영 데이터·`salesMode` 변경은 해당 승인 게이트를 따른다.
-5. 한 Task의 승인을 이후 운영 변경 승인으로 확대 해석하지 않는다.
+3. Task 0A~0F는 ALIGO 심사와 병렬 수행할 수 있다.
+4. 문서 정합성 감사에서 발견한 P0 구현 결함을 문구 변경만으로 정상화하지 않는다.
+5. `IMPLEMENTED / UNVERIFIED`, `COVERAGE GAP`, `IMPLEMENTATION FINDING`, P0 `DECISION REQUIRED`는 완료가 아니다.
 6. 비밀값·고객 개인정보·사진 원본·서명 URL을 Git/문서/증거에 남기지 않는다.
-7. auth 승인/revocation, 주문 direct read 최소화, 결제/권한 P0 보정과 법적 페이지 변경까지 포함한 actual release SHA를 확정하기 전 release 검증을 완료로 기록하지 않는다.
-8. actual release SHA의 원격 회차 E2E 52건과 cleanup 통과 전 production 배포 금지.
-9. Issue #32의 `main` 보호 완료 전 production release 금지.
-10. `main` merge·빈 commit·재-push를 production 배포 트리거로 사용하지 않는다.
-11. production 배포 직전·직후 provider metadata Git SHA가 승인 release SHA와 동일한지 확인한다.
+7. actual release SHA는 Task 0A~0F와 법적 게이트가 모두 해결된 뒤에만 확정한다.
+8. exact release SHA의 원격 회차 E2E 52건과 cleanup 통과 전 production 배포 금지.
+9. `main` merge·빈 commit·재-push를 production 배포 트리거로 사용하지 않는다.
+10. production 배포는 검증된 exact SHA/artifact와 별도 승인 게이트를 사용한다.
+11. provider metadata Git SHA가 승인 release SHA와 다르면 traffic/domain 전환을 진행하지 않는다.
 12. ALIGO 실제 발송 검증 실패 시 알림 없는 출시를 임의 승인하지 않는다.
 13. 첫 회차가 검수된 `SCHEDULED`가 아니면 `salesMode`를 전환하지 않는다.
-14. `docs/DOCUMENT_CONSISTENCY.md` 기준에서 `IMPLEMENTED / UNVERIFIED`, `COVERAGE GAP`, `IMPLEMENTATION FINDING`, P0 `DECISION REQUIRED`인 항목을 완료로 간주하지 않는다.
-15. broad 주문 read를 개인정보처리방침 문구를 넓혀 정당화하지 않고 실제 접근 경계를 먼저 최소화한다.
-16. driver role/approval은 client `targetRole` 또는 로그인 side effect만으로 부여하지 않는다.
-17. suspended 또는 권한 변경 계정이 refresh/Firebase custom token을 통해 stale 권한을 무기한 연장하지 않도록 revocation 계약을 확정한다.
-18. 미검증 항목을 완료로 기록하지 않는다.
 
-## Execution Plan
+## Phase 0 — 출시 전 코드·권한·금전 안전성
 
-### Phase 0 — 통합·배포·코드 안전성
-
-#### Task 0.1 — 회차 직배송 코드 `main` 통합
+### Task 0.1 — 회차 직배송 코드 `main` 통합
 - Status: done
-- Evidence: PR #11, 기능 통합 SHA `e55f259...`.
+- Evidence: PR #11, 기능 통합 기준 SHA `e55f25914cc7d01576fbd4639583daaf0fe6385e`.
 
-#### Task 0.2 — `main` 자동 production deploy 분리
+### Task 0.2 — `main` 자동 production deploy 분리
 - Status: done
 - Evidence: PR #30, PR #31.
-- Verify: 세 Vercel 프로젝트에서 PR #30 merge 이후 `main` deployment 0건.
 
-#### Task 0.3 — GitHub `main` protection/ruleset
-- Dependency: 없음. ALIGO 심사와 병렬 가능.
-- Goal: direct push/force push/delete를 GitHub 관리자 레벨에서 차단한다.
-- Required:
-  - PR required
-  - `Deployment safety guard / verify` required status check
-  - force push 차단
-  - branch deletion 차단
-- Tracking: Issue #32
+### Task 0.3 — GitHub `main` protection/ruleset
+- Dependency: 없음.
+- Required: PR required, `Deployment safety guard / verify`, force-push/delete 차단.
+- Tracking: Issue #32.
 - Status: todo_admin
 
-#### Task 0.4 — 결제 finalization `PAID` 최종 방어
-- Dependency: 없음. ALIGO 심사·Task 0.3과 병렬 가능.
-- Goal: `finalizePaidOrder()`가 호출 경로에 의존하지 않고 비`PAID` provider 상태를 자체 차단한다.
-- Required:
-  - `PENDING`, `FAILED`, `CANCELLED` 차단
-  - `PAID` 일반·공동구매·회차 정상 경로 유지
-  - 금액 불일치 처리 유지
-  - 회차 reservation/race 회귀 유지
+### Task 0.4 — 결제 finalization `PAID` 최종 방어
+- Dependency: 없음.
+- Goal: `finalizePaidOrder()`가 호출자에 의존하지 않고 비`PAID` provider 상태를 차단한다.
+- Verify: `PENDING`, `FAILED`, `CANCELLED`, `PAID`, 금액 불일치, legacy/group/round 경로.
 - Contract: `docs/specs/api/payments.md`
+- Backlog: `PAYMENT-FINALIZATION-PAID-GUARD`
 - Status: todo_code
 
-#### Task 0.5 — 주문 mutation authorization 직접 회귀
-- Dependency: 없음. ALIGO 심사·Task 0.3·0.4와 병렬 가능.
-- Goal: 구현된 `assertOrderActionAccess()`의 권한 경계를 직접 거부 테스트로 고정한다.
-- Required:
-  - 타-store seller의 status mutation 403
-  - 타-store seller의 delivery-hold mutation 403
-  - 비담당 driver의 assigned order mutation 403
-  - 미배정 주문은 `PREPARING → DELIVERING` first-claim만 허용
-  - first-claim 성공 시 `driverId` 기록
-  - 거부된 mutation의 order write·notification·refund·settlement side effect 0
-  - 필요 시 admin 의도된 허용 범위 고정
+### Task 0.5 — 주문 mutation authorization 직접 회귀
+- Dependency: 없음.
+- Goal: seller 타-store, 비담당 driver, 미배정 first-claim 경계와 거부 side-effect 0을 직접 고정한다.
 - Contract: `docs/specs/api/orders.md`
+- Backlog: `ORDER-MUTATION-AUTHORIZATION-COVERAGE`
 - Status: todo_test
 
-#### Task 0.6 — 주문 direct Firestore read authorization·데이터 최소화
-- Dependency: 없음. ALIGO 심사·Task 0.3~0.5와 병렬 가능.
-- Goal: 미배정 수거 후보 discovery는 보존하되 seller/driver가 raw `orders` 원문을 필요 이상으로 읽는 구조를 제거한다.
-- Required:
-  - driver discovery 계약: 미배정 `PREPARING` + `direct|hub` 등 실제 필요한 대상과 최소 노출 필드 확정
-  - 임의 driver의 타-driver/완료/기타 arbitrary order raw read 차단
-  - assigned driver 상세의 최소 배송 필드만 제공
-  - seller 주문 read의 업무상 불필요 `marketingConsent`, `acquisition`, 내부 hash/reservation 메타데이터 노출 제거
-  - `firestore.rules` broad `role == 'driver'` 허용 제거 또는 안전 조건으로 대체
-  - Rules만으로 필드 최소화가 불가능하면 API DTO/safe projection/민감 필드 분리 중 동등한 구조 적용
-  - `tests/firestore/firestore-rules.test.mjs`의 다른 store driver read 성공 기대 제거
-  - 허용 discovery, assigned detail, 비담당/임의 read 거부, seller cross-store 거부 직접 테스트
-  - seller/driver 정상 보드·상세·first-claim 회귀 유지
+### Task 0.6 — 주문 direct Firestore read authorization·데이터 최소화
+- Dependency: 없음.
+- Goal: 필요한 미배정 주문 discovery는 유지하되 arbitrary raw order read와 역할에 불필요한 필드 노출을 제거한다.
+- Verify: Rules + app/API 정상 discovery/assigned detail + 타주문/타store 거부.
 - Contract: `docs/specs/api/orders.md`
 - Legal dependency: `docs/specs/legal/README.md`
+- Backlog: `ORDER-DIRECT-READ-AUTHORIZATION-AND-MINIMIZATION`
 - Status: todo_code_security
 
-#### Task 0.7 — Driver 승인 게이트·세션/claims revocation
-- Dependency: 없음. ALIGO 심사·Task 0.3~0.6과 병렬 가능.
-- Goal: 관리자 승인 전 driver 권한 획득을 차단하고 정지·role/store/승인 변경이 기존 세션과 Firebase claims에 정의된 시간 안에 수렴하도록 한다.
+### Task 0.7 — Driver 승인 게이트·세션/claims revocation
+- Dependency: 없음.
+- Goal: 관리자 승인 전 driver 권한 획득을 차단하고, suspension/role/store/approval 변경이 정의된 revocation window 안에 API·Firebase claims에 수렴하도록 한다.
+- Verify: 신규/legacy 자동 승인 제거, 승인 전후 접근, refresh/current claims, logout/rotation 회귀.
+- Contract: `docs/specs/api/auth.md`, `docs/specs/api/admin.md`
+- Backlog: `AUTH-DRIVER-APPROVAL-AND-SESSION-REVOCATION`
+- Coupling: Task 0.6 broad driver read와 결합 회귀를 확인한다.
+- Status: todo_code_security
+
+### Task 0.8 — Admin 강제 환불 lifecycle 정합화
+- Dependency: 없음.
+- Goal: `POST /admin/orders/:orderId/refund`가 provider 본 결제 환불과 주문 `CANCELLED` 직접 write만 수행해 정상 cancellation orchestration을 우회하는 구조를 제거한다.
 - Required:
-  - 신규 Kakao `targetRole: driver`가 `driverApproved: true`를 자동 획득하지 않음
-  - 기존 승인 필드 누락 driver를 로그인 side effect로 자동 승인하지 않음
-  - 필요한 legacy migration은 명시적·감사 가능한 별도 절차
-  - 승인 전 driver 앱/API/Firebase 접근 거부, 승인 후 정상 진입
-  - refresh가 authoritative user 상태를 확인하고 suspended 계정 또는 stale role/store/approval claims를 재발급하지 않음
-  - 이미 발급된 access token의 revocation window/SLA 결정·검증
-  - 필요 시 token version/session revocation 또는 동등 서버 경계
-  - Firebase custom token 발급도 현재 authoritative 권한과 일치
-  - logout/rotation 및 consumer/seller/admin 로그인 회귀 유지
-  - `ORDER-DIRECT-READ-AUTHORIZATION-AND-MINIMIZATION`과 결합 회귀: 승인되지 않은 driver identity가 order discovery/read 권한을 얻지 못함
-- Contract: `docs/specs/api/auth.md`
-- Admin impact: `docs/specs/api/admin.md`
-- Status: todo_code_security
+  - admin 환불의 허용 주문 상태를 명시하고 완료/배송 중 등 비의도 상태를 fail-closed
+  - 본 결제 환불과 이미 결제된 재배송비/추가 charge 처리 정책 일치
+  - 회차 주문 `reservationId` release와 sale-round/item ordered counter 반환
+  - `DELIVERY_HELD` 취소 시 `heldOrderCount` 정합성 유지
+  - 연결 settlement의 `pending|confirmed → cancelled` 수렴
+  - 이미 `paid` settlement인 주문 환불은 단순 `paid → cancelled` 역전이 아닌 별도 회계 조정 정책 결정
+  - provider 환불 성공 뒤 local cancellation 실패 시 재시도 가능한 cancellation state/operation issue 또는 동등 복구 계약
+  - seller/consumer/round cancellation과 admin force-refund 동시 실행이 이중환불·이중 capacity release 없이 수렴
+  - 거부/실패 경로의 부수효과를 직접 테스트
+- Contract: `docs/specs/api/admin.md`, `docs/specs/api/payments.md`, `docs/specs/api/settlements.md`, `docs/specs/api/orders.md`
+- Backlog: `ADMIN-FORCE-REFUND-CONSISTENCY`
+- Status: todo_code_financial
 
-### Phase 1 — ALIGO 알림 게이트
+## Phase 1 — ALIGO 알림 게이트
 
-#### Task 1.1 — 발신 프로필·코드 매핑 기반
+### Task 1.1 — 발신 프로필·코드 매핑 기반
 - Status: done
 
-#### Task 1.2 — 템플릿 8종 최종 승인
-- Current: 8종 전부 `검수중`.
+### Task 1.2 — 템플릿 8종 최종 승인
+- Current: 상태 상세는 `docs/memory.md`.
 - Status: blocked_external_review
 
-#### Task 1.3 — 승인 `tpl_code` 1:1 매핑 검사
+### Task 1.3 — 승인 `tpl_code` 1:1 매핑 검사
 - Dependency: Task 1.2
 - Status: todo
 
-#### Task 1.4 — 격리 실제 알림톡 정상 발송 [승인 게이트]
+### Task 1.4 — 격리 실제 알림톡 정상 발송 [승인 게이트]
 - Dependency: Task 1.3
-- 실제 고객 발송 금지.
 - Status: todo
 
-#### Task 1.5 — SMS fallback 실제 검증 [승인 게이트]
+### Task 1.5 — SMS fallback 실제 검증 [승인 게이트]
 - Dependency: Task 1.4
 - Status: todo
 
-### Phase 2 — 판매 공개 계약·release SHA
+## Phase 2 — 판매 공개 계약·release SHA
 
-#### Task 2.1 — 판매 활성화 법적 문서 재정합화
-- Dependency: Task 1.5, Task 0.6
+### Task 2.1 — 판매 활성화 법적 문서 재정합화
+- Dependency: Task 1.5, Task 0.6, Task 0.8
+- Required: 실제 주문·취소·환불·배송·재배송비·보류, PortOne/결제사업자, ALIGO, seller/driver 최소 접근, 시행일·이전 버전, legal tests.
 - Contract: `docs/specs/legal/README.md`
-- Required:
-  - 주문 성립·취소·환불·배송·재배송비·배송 보류
-  - PortOne/결제사업자 개인정보 처리
-  - ALIGO 고객 알림 처리
-  - seller/driver 배송정보 접근은 Task 0.6에서 검증된 최소 접근 구조를 기준으로 설명
-  - 시행일·이전 버전
-  - `legal-documents.test.mjs` 갱신
 - Status: todo
 
-#### Task 2.2 — actual release SHA 확정
-- Dependency: Task 0.3, Task 0.4, Task 0.5, Task 0.6, Task 0.7, Task 2.1
+### Task 2.2 — actual release SHA 확정
+- Dependency: Task 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, Task 2.1
 - Goal: 운영에 올릴 단 하나의 exact `main` SHA 고정.
-- 과거 `6e0fc9d...` run은 역사 증거일 뿐 현재 release 증거가 아니다.
 - Status: todo
 
-#### Task 2.3 — exact SHA 전체 원격 회차 E2E
+### Task 2.3 — exact SHA 전체 원격 회차 E2E
 - Dependency: Task 2.2
 - Goal: chromium 26 + mobile 26 = 52, unexpected/skipped/flaky 0, 양쪽 cleanup 성공.
 - Status: todo
 
-#### Task 2.4 — 운영 Firebase 읽기 전용 재조회
+### Task 2.4 — 운영 Firebase 읽기 전용 재조회
 - Dependency: Task 2.3
 - Status: todo
 
-#### Task 2.5 — 운영 ALIGO 변수·매핑 반영 [승인 게이트]
+### Task 2.5 — 운영 ALIGO 변수·매핑 반영 [승인 게이트]
 - Dependency: Task 1.5, Task 2.3
-- Goal: 필수 자격 증명 4개 + `ALIGO_TEMPLATE_CODES_JSON`을 비밀값 비공개 방식으로 반영·검증.
 - Status: todo
 
-### Phase 3 — exact-SHA production 배포
+## Phase 3 — exact-SHA production 배포
 
-#### Task 3.0 — production deploy/promotion 절차 확정
+### Task 3.0 — production deploy/promotion 절차 확정
 - Dependency: Task 2.3
-- Goal: 자동 Git main deploy가 아닌 exact SHA/artifact 기반 명시적 배포 절차를 확정한다.
-- Required:
-  - 입력 release SHA 고정
-  - 배포 전 SHA 출력/검사
-  - 배포 또는 이미 검증된 artifact promotion
-  - 배포 뒤 provider metadata SHA 재검사
-  - mismatch 시 domain/traffic 전환 금지
-- Note: 현재 저장소에는 production 전용 자동 workflow가 없다.
+- Goal: exact SHA/artifact 기반 명시적 배포·promotion과 사후 SHA 검증.
 - Status: todo
 
-#### Task 3.1 — API production 배포 [별도 승인 게이트]
+### Task 3.1 — API production 배포 [별도 승인 게이트]
 - Dependency: Task 0.3, Task 2.3, Task 2.4, Task 2.5, Task 3.0
 - Important: 사용자의 별도 `Task 3.1 승인` 없이는 실행하지 않는다.
-- Verify: 배포된 API release identity/SHA를 승인값과 대조.
 - Status: todo
 
-#### Task 3.2 — consumer·seller·driver production 배포 [승인 게이트]
+### Task 3.2 — consumer·seller·driver production 배포 [승인 게이트]
 - Dependency: Task 3.1
-- Goal: 세 프런트를 승인된 동일 release SHA/artifact에서 배포.
-- Verify: 각 Vercel deployment metadata의 Git SHA 일치.
 - Status: todo
 
-#### Task 3.3 — 운영 무변경 smoke
+### Task 3.3 — 운영 무변경 smoke
 - Dependency: Task 3.2
-- 확인: health, Kakao auth, legacy 경로, 회차 read, `/privacy`, `/terms`.
+- 확인: health, Kakao auth, legacy, 회차 read, `/privacy`, `/terms`.
 - Status: todo
 
-#### Task 3.4 — 배포 후 오류 관찰
+### Task 3.4 — 배포 후 오류 관찰
 - Dependency: Task 3.3
 - Status: todo
 
-### Phase 4 — 첫 회차
+## Phase 4 — 첫 회차
 
-#### Task 4.1 — 첫 회차 `DRAFT` 생성 [승인 게이트]
+### Task 4.1 — 첫 회차 `DRAFT` 생성 [승인 게이트]
 - Dependency: Task 3.4
 - Status: todo
 
-#### Task 4.2 — 일정·지역·상품·가격·한도 검수
+### Task 4.2 — 일정·지역·상품·가격·한도 검수
 - Dependency: Task 4.1
 - Status: todo
 
-#### Task 4.3 — `SCHEDULED` 전환 [승인 게이트]
+### Task 4.3 — `SCHEDULED` 전환 [승인 게이트]
 - Dependency: Task 4.2
 - Status: todo
 
-### Phase 5 — 최종 출시 판정
+## Phase 5 — 최종 출시 판정
 
-#### Task 5.1 — 운영 역할·비상 연락·승인자 확인
+### Task 5.1 — 운영 역할·비상 연락·승인자 확인
 - Dependency: Task 4.3
 - Status: todo
 
-#### Task 5.2 — 전환·롤백 dry-run
+### Task 5.2 — 전환·롤백 dry-run
 - Dependency: Task 5.1
-- 현재 `legacy`, 예정 `round_direct`, 롤백 경로 확인.
 - Status: todo
 
-#### Task 5.3 — 최종 출시 판정
+### Task 5.3 — 최종 출시 판정
 - Dependency: Task 5.2
-- 대조: exact SHA, auth approval/revocation P0, payment P0, order direct-read P0, order mutation P0, branch protection, Firebase, ALIGO, legal, 첫 회차, 예외, 담당자, rollback.
+- 대조: exact SHA, Task 0A~0F, Firebase, ALIGO, legal, 첫 회차, 운영 예외, rollback.
 - Status: todo
 
-### Phase 6 — 판매 모드 전환
+## Phase 6 — 판매 모드 전환
 
-#### Task 6.1 — `round_direct` 전환 [최종 승인 게이트]
+### Task 6.1 — `round_direct` 전환 [최종 승인 게이트]
 - Dependency: Task 5.3 승인
 - Status: todo
 
-#### Task 6.2 — 전환 직후 smoke·rollback 판정
+### Task 6.2 — 전환 직후 smoke·rollback 판정
 - Dependency: Task 6.1
 - Status: todo
 
-#### Task 6.3 — 외부 유입 링크 공개 [승인 게이트]
+### Task 6.3 — 외부 유입 링크 공개 [승인 게이트]
 - Dependency: Task 6.2 통과
 - Status: todo
 
-### Phase 7 — 초기 안정화
+## Phase 7 — 초기 안정화
 
-#### Task 7.1 — 첫 두 회차 집중 모니터링
+### Task 7.1 — 첫 두 회차 집중 모니터링
 - Dependency: Task 6.3
 - Status: todo
 
-#### Task 7.2 — 출시 Closeout
+### Task 7.2 — 출시 Closeout
 - Dependency: Task 7.1
 - Status: todo
 
 ## Completion Criteria
 
-- driver 관리자 승인 전 권한 획득이 차단되고 정지·role/store/승인 변경의 refresh/Firebase claims 수렴 계약이 구현·직접 검증돼 `main`에 포함됨.
-- 주문 direct Firestore read가 안전한 discovery/assigned 경계와 역할별 최소 데이터 계약으로 축소되고 Rules·frontend 회귀가 `main`에 포함됨.
-- 결제 finalization 비`PAID` 차단과 회귀 검증이 `main`에 포함됨.
-- 주문 mutation authorization 핵심 거부 회귀가 `main`에 포함되고 P0 mutation 권한 계약이 `VERIFIED`로 승격됨.
+- Task 0A~0F가 모두 해결되고 P0 권한·금전 계약이 필요한 직접 테스트 증거와 함께 `main`에 포함됨.
+- admin 강제 환불이 정상 주문 취소와 동일한 금전·capacity·settlement 불변식을 보존하거나, 예외 정책이 명시적·테스트된 별도 orchestration으로 구현됨.
 - Issue #32 branch protection/ruleset 완료.
-- ALIGO 8종 최종 승인.
-- 실제 알림톡·SMS fallback 검증.
+- ALIGO 8종 최종 승인 및 실제 알림톡·SMS fallback 검증.
 - 판매 활성화 legal docs/test 정합화.
 - actual release SHA 원격 E2E 52건+cleanup 성공.
-- 운영 Firebase 상태 확인.
-- production ALIGO 설정 검증.
+- 운영 Firebase 상태 확인 및 production ALIGO 설정 검증.
 - production deploy/promotion이 exact SHA를 사용하고 provider metadata가 일치.
 - 첫 회차 `SCHEDULED`.
-- 최종 출시 승인 뒤 `round_direct` 전환·smoke 또는 rollback 성공.
+- 최종 승인 뒤 `round_direct` 전환·smoke 또는 rollback 성공.
 - 비밀값·개인정보·사진·서명 URL이 증거에 포함되지 않음.
 
 ## 현재 Closeout Roll-up
 
 - 코드 통합: 완료
-- driver 승인 게이트·세션/claims revocation: **미완료 — P0 IMPLEMENTATION FINDING / DECISION REQUIRED**
-- 주문 direct Firestore read authorization·데이터 최소화: **미완료 — P0 IMPLEMENTATION FINDING**
-- 결제 finalization `PAID` 최종 방어: **미완료 — P0**
-- 주문 mutation authorization 직접 회귀: **미완료 — P0 COVERAGE GAP**
+- driver 승인 게이트·세션/claims revocation: 미완료 — P0
+- 주문 direct Firestore read authorization·데이터 최소화: 미완료 — P0
+- 결제 finalization `PAID` 최종 방어: 미완료 — P0
+- 주문 mutation authorization 직접 회귀: 미완료 — P0
+- admin 강제 환불 lifecycle 정합성: 미완료 — P0
 - repo-side production auto-deploy 분리: 완료
-- docs-only Preview/E2E 억제: 완료
-- GitHub `main` protection: **미완료 — Issue #32**
-- ALIGO 8종 등록: 완료
-- ALIGO 8종 승인: **검수중**
+- GitHub `main` protection: 미완료 — Issue #32
+- ALIGO 8종 승인: 검수중
 - 실제 알림 발송: 미실행
 - 판매 활성화 법적 문서: 미실행
 - actual release SHA/E2E: 미실행

--- a/docs/specs/api/admin.md
+++ b/docs/specs/api/admin.md
@@ -6,6 +6,8 @@
 > **상태**: Current
 > **API 정본**: `apps/api/src/admin/**`
 > **인증 계약**: `docs/specs/api/auth.md`
+> **주문 계약**: `docs/specs/api/orders.md`
+> **결제 계약**: `docs/specs/api/payments.md`
 > **정산 계약**: `docs/specs/api/settlements.md`
 > **canonical URL**: `docs/URLS.md`
 
@@ -128,14 +130,58 @@ GET /admin/orders?storeId=<storeId>&status=<OrderStatus>
 POST /admin/orders/:orderId/refund
 ```
 
-현재 흐름:
+`AdminService.forceRefund()`의 현재 실제 흐름:
 
 1. 주문 존재 확인
-2. 이미 `CANCELLED`면 거부
-3. `PaymentsService.processRefundByOrderId()` 호출
-4. 주문을 `CANCELLED`로 갱신하고 사유 기록
+2. `status === CANCELLED`만 거부
+3. `PaymentsService.processRefundByOrderId()`로 **본 결제** 환불 시도
+4. 주문 문서를 직접 `status: CANCELLED`, `cancelReason`으로 갱신
 
-환불의 provider 멱등성·claim·운영 이슈 계약은 `docs/specs/api/payments.md`를 따른다. 이 admin endpoint를 반복 호출해 provider 상태를 추측하지 않는다.
+본 결제 provider 환불 자체의 claim/idempotency는 `PaymentRefundService`가 보호한다. 그러나 이 endpoint를 **정상 주문 취소 lifecycle과 동일한 원자적 취소 계약**으로 해석하면 안 된다.
+
+### 현재 구현 불일치 — `ADMIN-FORCE-REFUND-CONSISTENCY` P0
+
+2026-08-24 정상 회차 취소 경로와 admin force refund를 대조한 결과, admin 경로는 주문·결제·정산·회차 capacity의 후속효과를 완전히 수렴시키지 않는다.
+
+정상 회차 주문 취소(`RoundOrderLifecycleService.cancel`)는 필요 시 다음을 수행한다.
+
+- 본 결제 환불
+- paid 재배송비(`orderCharges`) 환불
+- cancellation 상태로 재시도/race 제어
+- `checkoutReservation` release
+- 회차 ordered/reserved counters 및 round item 수량 반환
+- `DELIVERY_HELD`이면 `heldOrderCount` 감소
+- 주문 `CANCELLED` 확정
+- `SettlementsService.cancelSettlement()` 호출
+
+반면 현재 `AdminService.forceRefund()`는 위에서 **본 결제 환불 + 주문 직접 CANCELLED write만 수행**한다.
+
+추가로 현재 admin 경로는 `CANCELLED` 외의 상태를 별도로 제한하지 않으므로 `PENDING`, `DELIVERY_HELD`, `DELIVERED`, `PICKED_UP`, `REVIEWED` 등에서도 진입할 수 있다. `PaymentRefundService`가 payment 없음/비`PAID`를 no-op해도 주문은 이후 `CANCELLED`로 직접 변경될 수 있다.
+
+따라서 다음 불변식은 현재 `VERIFIED`가 아니다.
+
+- admin 환불 뒤 회차 reservation/capacity가 누수 없이 반환됨
+- paid 재배송비가 함께 환불됨
+- held counter가 정확히 감소함
+- 이미 생성된 pending/confirmed settlement가 취소됨
+- paid settlement 이후 환불이 별도 회계 조정/운영 이슈로 안전하게 처리됨
+- admin 환불과 정상 취소/동시 요청이 하나의 멱등 cancellation 상태로 수렴함
+
+이 항목은 금전·정산·재고/회차 capacity를 동시에 건드리므로 **P0 `IMPLEMENTATION FINDING`**이다. 현재 admin UI에서 버튼을 제한하더라도 API/service 불변식을 대신하지 않는다.
+
+actual release SHA 확정 전 최소 완료 조건:
+
+- admin 환불의 허용 주문 상태를 명시적으로 정의한다.
+- 회차 주문은 일반 주문의 `RoundOrderLifecycleService` 취소 불변식을 재사용하거나 동등한 단일 orchestration 경계로 통합한다.
+- 본 결제와 연결된 paid 재배송비를 중복 없이 함께 환불한다.
+- HELD/CONSUMED reservation, round counters, round item quantities, heldOrderCount를 주문 상태에 맞게 정확히 반환한다.
+- pending/confirmed settlement는 cancelled로 수렴시킨다.
+- 이미 `paid` settlement가 있는 주문의 환불 정책을 명시적으로 결정한다. 단순 `paid → cancelled` 역전은 금지하고, 회계 조정/operation issue/수동 승인 등 별도 안전 경계를 둔다.
+- provider 환불 성공 후 local side-effect 실패 시 재시도 상태를 보존하고 외부 환불을 반복하지 않는다.
+- 동시 admin 환불/정상 취소가 하나의 결과로 수렴한다.
+- PENDING·ACCEPTED·DELIVERY_HELD·DELIVERED/REVIEWED·paid-settlement·redelivery-charge 조합을 직접 회귀 테스트한다.
+
+추적: `docs/BACKLOG.md`의 `ADMIN-FORCE-REFUND-CONSISTENCY`.
 
 ## 6. 정산 관리
 
@@ -287,6 +333,7 @@ Storage write/read 권한은 현재 `storage.rules`를 정본으로 확인한다
 - admin 주문 목록: 최대 200건, pagination 없음
 - admin 정산 목록: 최대 500건, pagination 없음
 - driver 목록: 최대 100건 read 후 메모리 필터
+- admin 강제 환불은 `ADMIN-FORCE-REFUND-CONSISTENCY` 해결 전 주문 취소 lifecycle과 동일한 P0 안전 계약으로 사용하지 않음
 - store 수수료 설정과 settlement 생성의 `PLATFORM_FEE_RATE` 관계는 단일 정책으로 완전히 통합돼 있지 않을 수 있으므로 변경 전 코드 재검증 필요
 - driver 관리자 승인 게이트는 `DRIVER-APPROVAL-GATE-BYPASS` 해결 전 `VERIFIED`가 아님
 - 사용자/driver `suspended` flag의 기존 세션 enforcement는 `AUTH-SESSION-CLAIM-REVOCATION` 해결 전 `VERIFIED`가 아님
@@ -304,7 +351,11 @@ admin 변경 시 최소 확인:
 - `apps/seller/src/app/admin/**`
 - `apps/seller/src/hooks/useAdmin.ts`
 - auth/orders/payments/settlements 관련 spec
+- `RoundOrderLifecycleService`와 `OrderCapacityService`
+- paid redelivery charge refund path
 - 관련 unit/E2E
+
+환불처럼 금전·주문·capacity·정산을 함께 변경하는 작업은 provider 환불 성공만으로 완료 판정하지 않는다. 모든 local side effect와 실패 재시도·race를 직접 검증한다.
 
 승인·정지처럼 권한 수명주기에 영향을 주는 변경은 admin endpoint의 Firestore write 성공만 검사하지 않고 auth refresh/custom-token 및 실제 접근 차단까지 검증한다.
 
@@ -314,6 +365,7 @@ admin 변경 시 최소 확인:
 
 | 날짜 | 내용 |
 |---|---|
+| 2026-08-24 | admin force refund가 정상 회차 취소의 재배송비·reservation/counter·settlement 후속효과를 우회하는 구조를 P0 IMPLEMENTATION FINDING으로 정합화 |
 | 2026-08-24 | driver 승인 자동 우회와 suspension 기존 세션 revocation을 auth P0와 연결하고 admin write 자체를 권한 enforcement 완료로 보지 않도록 정합화 |
 | 2026-08-23 | canonical URL, archive/restore, 현재 정산·드라이버·초대 계약, 위험한 수동 권한 부여 지침을 현행화 |
 | 2026-04-23 | banner 관리 추가 |

--- a/docs/specs/api/settlements.md
+++ b/docs/specs/api/settlements.md
@@ -2,7 +2,7 @@
 
 # Settlements API / Domain Spec
 
-> **최종 정합화**: 2026-08-23
+> **최종 정합화**: 2026-08-24
 > **상태**: Current
 > **타입·라벨 SSOT**: `packages/shared/src/settlement.types.ts`
 > **Seller API 정본**: `apps/api/src/settlements/**`
@@ -131,6 +131,22 @@ SETTLEMENT_CONFIRM_DELAY_DAYS env
 
 지급 완료 후 주문 취소·환불의 회계 처리는 단순 status 역전으로 해결하지 않는다. 현재 service는 warning을 남기고 paid settlement를 보존한다. 후속 회계 조정이 필요하면 별도 설계가 필요하다.
 
+### Admin 강제 환불과의 현재 불일치 — P0
+
+`cancelSettlement()` 자체의 위 규칙과 별개로, 현재 `AdminService.forceRefund()`는 이 메서드를 호출하지 않는다.
+
+따라서 `POST /admin/orders/:orderId/refund`를 통해 주문을 `CANCELLED`로 직접 바꿔도 기존 settlement가 `pending|confirmed|paid` 상태로 그대로 남을 수 있다.
+
+특히:
+
+- `pending|confirmed` settlement는 정상 order cancellation이면 `cancelSettlement()`로 `cancelled`되어야 하지만 admin force refund 경로는 이를 우회한다.
+- `paid` settlement는 원래도 단순 상태 역전 대상이 아니므로, 환불이 필요하다면 별도 회계 조정/운영 이슈/승인 흐름이 필요하다.
+- 현재 admin force refund는 `CANCELLED` 외 주문 상태를 제한하지 않으므로 완료/정산 생성 후 주문에도 진입할 수 있다.
+
+이 불일치는 `ADMIN-FORCE-REFUND-CONSISTENCY` P0로 추적한다. `cancelSettlement()`의 내부 멱등성만으로 admin 환불 전체 정산 일관성이 보장된다고 기록하지 않는다.
+
+정본: `docs/specs/api/admin.md`, `docs/BACKLOG.md`.
+
 ## 8. Seller 정산 API
 
 모든 seller settlement endpoint는 `JwtAuthGuard`가 적용된다.
@@ -234,7 +250,9 @@ seller/admin UI는 공통 `SettlementStatus`, `STATUS_LABEL`, `STATUS_COLOR`를 
 - 배송사진 완료 → `DELIVERED`
 - settlement 1건만 생성
 - 후속 `REVIEWED`가 동일 settlement를 중복 생성하지 않음
-- 취소/환불 경합에서 `paid` 역전 방지
+- 정상 취소/환불 경합에서 pending/confirmed settlement가 `cancelled`로 수렴
+- `paid` settlement 이후 환불은 별도 회계 정책을 따름
+- admin 강제 환불도 `ADMIN-FORCE-REFUND-CONSISTENCY` 해결 후 같은 회계 불변식에 수렴
 
 출시 상태 자체는 `docs/memory.md`와 활성 출시 PLAN을 따른다.
 
@@ -248,14 +266,19 @@ seller/admin UI는 공통 `SettlementStatus`, `STATUS_LABEL`, `STATUS_COLOR`를 
 - `apps/api/src/settlements/dto/query-settlements.dto.ts`
 - `apps/api/src/admin/admin.controller.ts`
 - `apps/api/src/admin/admin.service.ts`
+- `apps/api/src/orders/round-order-lifecycle.service.ts`
+- payment/redelivery refund paths
 - fee calculator / aggregator tests
 - seller/admin settlement UI
 - 관련 E2E
 - `firestore.indexes.json`
 
+금전 환불과 정산이 연결되는 변경은 payment provider 성공뿐 아니라 주문 상태, reservation/capacity, 재배송비, settlement 상태, 실패 재시도와 race를 함께 검증한다.
+
 ## 변경 이력
 
 | 날짜 | 내용 |
 |---|---|
+| 2026-08-24 | admin force refund가 `cancelSettlement()` 및 정상 취소 lifecycle을 우회하는 P0 정산 불일치를 명시 |
 | 2026-08-23 | 자동 confirm, transaction 멱등성, paid 역전 방지, admin 지급 API, 현재 조회/권한 계약으로 정합화 |
 | 2026-03-28 | 초기 settlements 설계 초안 |


### PR DESCRIPTION
## 변경
- `AdminService.forceRefund()`와 정상 회차 cancellation lifecycle의 차이를 P0 `ADMIN-FORCE-REFUND-CONSISTENCY`로 정합화
- 본 결제 외 paid 재배송비, reservation/capacity, held counter, settlement, paid-settlement 회계 정책 공백을 release blocker로 등록
- admin/settlements current spec → Backlog → memory → 활성 PLAN/HANDOFF로 영향 기반 전파
- 활성 PLAN/HANDOFF는 역할에 맞게 중복 세부 설명을 줄이고 실행 순서·재개 지점 중심으로 압축

## 직접 근거
- admin force refund는 `CANCELLED`만 거부하고 본 결제 환불 뒤 주문을 직접 `CANCELLED` write
- 정상 `RoundOrderLifecycleService.cancel()`은 cancellation claim/state, 본 결제+order charge 환불, reservation/counter 반환, held count 정합화, settlement 취소를 수행
- `SettlementsService.cancelSettlement()`은 `pending|confirmed → cancelled`, `paid` 역전 금지 계약을 가짐
- admin force refund는 위 lifecycle 후속효과를 호출하지 않고 완료/정산 생성 주문에도 별도 상태 제한 없이 진입 가능

## 판정
- provider 본 결제 refund idempotency: 별도 VERIFIED
- admin 주문 환불 전체 lifecycle 일관성: P0 IMPLEMENTATION FINDING

## 범위
- docs-only
- 코드/운영 데이터/provider/production 변경 없음