### PR TITLE
docs: 재배송비 결제 전 배송 재개 P0 정합화

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -9,9 +9,9 @@
 ## 우선순위 규칙
 
 - **ACTIVE**: 지금 진행 가능한 최우선 작업
-- **BLOCKED_EXTERNAL**: 외부 심사·승인 때문에 기다리는 작업
-- **NEXT**: 현재 게이트가 풀리면 바로 진행할 작업
-- **LATER**: MVP 출시를 막지 않는 후속 개선
+- **BLOCKED_EXTERNAL**: 외부 심사·승인 대기
+- **NEXT**: 현재 게이트 해소 뒤 바로 진행
+- **LATER**: MVP 출시 비차단 후속
 - **STALE_OR_SUPERSEDED**: 현재 상태 재검증 전 실행 금지
 
 ---
@@ -20,188 +20,170 @@
 
 ### P0 — PAYMENT-FINALIZATION-PAID-GUARD
 
-현재 `main`의 `apps/api/src/payments/payment-finalization.service.ts`는 `finalizePaidOrder()` 내부에서 전달받은 PortOne 결제의 `status === 'PAID'`를 자체 강제하지 않는다.
+`PaymentFinalizationService.finalizePaidOrder()`가 전달받은 PortOne 결제의 `status === 'PAID'`를 자체 강제하지 않는다.
 
 현재 방어:
 
-- [x] scheduler 경로는 `paymentData.status === 'PAID'`일 때만 finalization 호출
-- [x] webhook 경로는 `Transaction.Paid` 이벤트에서 PortOne 원격 결제 재조회
-- [x] 금액 불일치 환불·취소 처리 존재
+- [x] scheduler는 원격 `PAID`일 때만 finalization 호출
+- [x] webhook은 `Transaction.Paid`에서 원격 결제 재조회
+- [x] 금액 불일치 처리 존재
 
 남음:
 
-- [ ] finalization service 자체에서 비`PAID` 입력 차단
-- [ ] `PENDING` 회귀 테스트
-- [ ] `FAILED` 회귀 테스트
-- [ ] `CANCELLED` 회귀 테스트
-- [ ] `PAID` 일반/공동구매 정상 경로 테스트
-- [ ] `PAID` 회차 주문 정상 경로 테스트
-- [ ] 금액 불일치 회귀 유지
-- [ ] 기존 회차 reservation/race 회귀 유지
-- [ ] 수정이 포함된 SHA를 `main`에 통합한 뒤 actual release SHA 후보에 포함
+- [ ] finalization boundary에서 비`PAID` 차단
+- [ ] `PENDING|FAILED|CANCELLED` 직접 거부 회귀
+- [ ] `PAID` legacy/group/round 정상 회귀
+- [ ] 금액 불일치·reservation/race 회귀 유지
+- [ ] 수정 SHA `main` 통합
 
-문서만으로 이 불변식을 완료 처리하지 않는다. 정본: `docs/specs/api/payments.md`.
+정본: `docs/specs/api/payments.md`.
+
+### P0 — ORDER-REDELIVERY-PAID-RESUME-GATE
+
+2026-08-24 감사에서 **유료 재배송비 결제 전 배송 재개 금지**라는 운영 계약이 서버와 driver UI에서 강제되지 않음을 확인했다.
+
+현재 구현·증거:
+
+- [x] 운영 runbook은 첫 고객 사유 실패를 `재배송비 1건 생성·결제. 결제 전 재배송 금지`로 명시
+- [x] `OrderChargePaymentService`는 charge 자체의 `PAID` 상태·금액·order 연결과 환불 멱등성을 직접 검증
+- [x] `orders.helpers.ts`는 driver `DELIVERY_HELD → DELIVERING`을 허용
+- [x] `OrdersLifecycleService`/`RoundOrderLifecycleService`는 해당 전환 직전에 현재 `redeliveryChargeId`의 charge `PAID` 여부를 확인하지 않음
+- [x] driver 주문 상세은 회차 직배송 `DELIVERY_HELD`이면 charge 상태와 무관하게 `배송 재개` CTA를 노출하고 `DELIVERING` PATCH 호출
+- [x] 현재 테스트는 charge 생성·결제·환불은 검증하지만 `미결제 재배송 재개 거부`를 직접 고정하지 않음
+
+판정:
+
+- 재배송비 **결제·환불 하위 계약 자체는 `VERIFIED`**다.
+- 하지만 **결제 완료를 배송 재개 전제조건으로 강제하는 주문 lifecycle은 P0 `IMPLEMENTATION FINDING`**이다.
+- UI 버튼 조건만 수정해서 닫지 않는다. API 직접 호출에서도 fail-closed여야 한다.
+
+남음:
+
+- [ ] 고객 책임 + `redeliveryFee > 0`인 현재 보류를 유료 재배송 대상으로 서버 판정
+- [ ] 현재 `redeliveryChargeId`가 현재 hold(`heldAt`)에 연결된 charge인지 검증
+- [ ] charge type/order/store/user 일치 + `status === 'PAID'`일 때만 `DELIVERY_HELD → DELIVERING` 허용
+- [ ] `PENDING|FAILED|REFUNDED|missing|mismatched`이면 order/counter/notification side effect 0으로 거부
+- [ ] 판매자/시스템 책임 또는 재배송비 없는 보류는 불필요한 결제 요구 없이 기존 정책대로 해소
+- [ ] driver UI에 charge 상태·대기 사유 표현
+- [ ] `미결제 재개 거부 → 결제 완료 → 재개 성공` unit/integration/E2E 직접 회귀
+- [ ] 변경 SHA `main` 통합
+
+정본: `docs/specs/api/orders.md`, 운영 증거: `docs/specs/ops/mvp-sales-round-runbook.md`.
 
 ### P0 — ADMIN-FORCE-REFUND-CONSISTENCY
 
-2026-08-24 감사에서 `AdminService.forceRefund()`가 정상 주문 취소 lifecycle의 금전·capacity·정산 후속효과를 우회함을 확인했다.
+`AdminService.forceRefund()`가 정상 cancellation orchestration의 금전·capacity·정산 후속효과를 우회한다.
 
-현재 구현·증거:
+확인됨:
 
-- [x] admin refund는 주문 존재 후 `CANCELLED`만 거부
-- [x] `PaymentsService.processRefundByOrderId()`로 본 결제만 환불 시도
-- [x] 이후 주문을 직접 `CANCELLED`로 write
-- [x] `PaymentRefundService`의 본 결제 refund claim/idempotency는 별도 검증됨
-- [x] 정상 회차 취소는 본 결제 + paid 재배송비 환불, cancellation retry state, reservation/counter 반환, held counter 감소, settlement 취소를 수행
-- [x] admin force refund는 `refundOrderChargesByOrderId`, reservation/capacity release, held counter 조정, `cancelSettlement()`을 호출하지 않음
-- [x] admin 경로는 `PENDING`, `DELIVERY_HELD`, `DELIVERED`, `PICKED_UP`, `REVIEWED` 등도 `CANCELLED` 외면 별도 상태 제한 없이 진입 가능
-- [x] payment 없음/비`PAID`가 refund service에서 no-op여도 admin 경로는 이후 주문을 `CANCELLED`로 직접 변경 가능
-
-판정:
-
-- provider 본 결제 환불 멱등성은 `VERIFIED`지만 **admin 주문 환불 전체 일관성은 `IMPLEMENTATION FINDING` P0**다.
-- 특히 회차 reservation/counters, paid redelivery charge, pending/confirmed settlement, paid settlement 회계가 admin 경로에서 정상 취소 계약과 수렴한다고 보장할 수 없다.
+- [x] admin 경로는 `CANCELLED`만 거부하고 본 결제 환불 뒤 주문을 직접 `CANCELLED` write
+- [x] 정상 회차 취소는 본 결제+paid 추가 charge 환불, retry state, reservation/counter 반환, held counter, settlement 취소 수행
+- [x] admin 경로는 추가 charge, reservation/capacity, held counter, settlement를 처리하지 않음
+- [x] 완료/리뷰/정산 생성 주문도 `CANCELLED`가 아니면 별도 상태 제한 없이 진입 가능
 
 남음:
 
-- [ ] admin 환불 허용 주문 상태를 명시적으로 정의
-- [ ] 회차 주문 admin 환불이 `RoundOrderLifecycleService` 취소 불변식을 재사용하거나 동등한 단일 orchestration으로 수렴
-- [ ] 본 결제 + 연결 paid 재배송비를 중복 없이 함께 환불
-- [ ] HELD/CONSUMED reservation 및 round/item counters 정확히 반환
-- [ ] `DELIVERY_HELD` 취소 시 `heldOrderCount` 정확히 감소
-- [ ] pending/confirmed settlement를 `cancelled`로 수렴
-- [ ] 이미 `paid` settlement가 있는 주문의 환불은 단순 status 역전이 아닌 명시적 회계 조정/operation issue/승인 정책 결정
-- [ ] provider refund 성공 후 local side-effect 실패 시 재시도 상태 보존, 외부 환불 중복 방지
-- [ ] 정상 취소와 admin 환불 동시 실행이 하나의 결과로 수렴
-- [ ] `PENDING`, `ACCEPTED`, `DELIVERY_HELD`, `DELIVERED/REVIEWED`, paid settlement, paid redelivery charge 조합 직접 회귀
-- [ ] 수정이 포함된 SHA를 `main`에 통합한 뒤 actual release SHA 후보에 포함
+- [ ] admin 환불 허용 상태 fail-closed 정의
+- [ ] 정상 회차 cancellation orchestration 재사용 또는 동등 단일 orchestration
+- [ ] 본 결제+paid 재배송비 중복 없는 환불
+- [ ] reservation/round/item counter·held counter 정확한 반환
+- [ ] pending/confirmed settlement 취소
+- [ ] paid settlement 환불의 별도 회계 조정/운영 예외 정책
+- [ ] provider 성공/local 실패 재시도와 동시 실행 수렴
+- [ ] 상태·settlement·charge 조합 직접 회귀
+- [ ] 변경 SHA `main` 통합
 
-정본: `docs/specs/api/admin.md`, 정산 영향: `docs/specs/api/settlements.md`.
+정본: `docs/specs/api/admin.md`, `docs/specs/api/settlements.md`.
 
 ### P0 — ORDER-DIRECT-READ-AUTHORIZATION-AND-MINIMIZATION
 
-2026-08-24 감사에서 API 주문 조회 authorization과 실제 seller/driver 클라이언트 read 경계가 다름을 확인했다.
+API 주문 조회 authorization보다 seller/driver 실제 raw Firestore read 경계가 넓다.
 
-현재 구현·증거:
+확인됨:
 
-- [x] `OrdersQueryService`는 driver 상세를 `order.driverId === requesterId`로 제한하고 해당 API 권한 테스트가 존재
-- [x] `firestore.rules`는 `role == 'driver'`이면 `orders/{orderId}`를 store/status/배정과 무관하게 read 허용
-- [x] driver 보드는 미배정 `PREPARING` direct/hub 주문 discovery를 위해 Firestore `orders`를 직접 query
-- [x] driver 상세는 Firestore `orders/{orderId}`를 직접 `onSnapshot()`
-- [x] seller 주문 목록도 같은-store `orders` 원문을 직접 구독
-- [x] 회차 주문 원문에는 배송 수행 필드 외에 `acquisition`, `marketingConsent`, `clientOrderPayloadHash`, reservation 관련 내부 필드가 함께 저장될 수 있음
-- [x] 현재 Firestore Rules 테스트가 driver의 다른 store 주문 직접 read를 성공 케이스로 고정
-
-판정:
-
-- API layer read authorization만 보면 배정 기사 경계가 `VERIFIED`다.
-- end-to-end 주문 read authorization은 direct Firestore 경로가 API보다 넓으므로 **`IMPLEMENTATION FINDING` P0**다.
-- seller/driver의 역할별 최소 필드 제공도 raw document read 때문에 현재 `VERIFIED`가 아니다.
+- [x] API driver 상세은 assigned `driverId` 제한과 직접 테스트 존재
+- [x] current Rules는 `role == driver`이면 주문을 배정/store/status와 무관하게 read 허용
+- [x] driver 보드·상세, seller 목록이 raw `orders`를 직접 사용
+- [x] raw order에 역할에 불필요한 내부/유입/동의 metadata가 존재할 수 있음
 
 남음:
 
-- [ ] 미배정 `PREPARING` direct/hub 주문을 driver가 discovery해야 하는 제품 의도를 명시하고 discovery에 필요한 최소 필드 정의
-- [ ] 임의 driver가 다른 기사 배정 주문·완료 주문·일반 임의 주문 원문을 직접 read하지 못하도록 경계 축소
-- [ ] assigned driver 상세에 필요한 배송지·연락처·상품·보류 정보만 제공하는 역할별 DTO/projection 또는 동등한 데이터 분리
-- [ ] seller 주문 read도 판매 업무에 필요한 필드만 제공하고 `marketingConsent`, `acquisition` 등 불필요한 고객/행동 메타데이터 노출 제거
-- [ ] raw `orders` 직접 구독을 유지할 경우 Rules만으로 field minimization이 가능한지 검증하고, 불가능하면 API/projection 구조로 전환
-- [ ] `firestore.rules`의 broad `role == 'driver'` read 제거 또는 안전한 discovery/assigned 조건으로 대체
-- [ ] `tests/firestore/firestore-rules.test.mjs`의 broad driver 성공 기대를 제거하고 허용/거부 경계를 직접 검증
-- [ ] driver가 임의 order ID로 다른 주문 상세을 읽을 수 없는 직접 Rules/앱 회귀
-- [ ] seller 타-store read 거부와 seller/driver 정상 보드·상세 기능 회귀 유지
-- [ ] 변경이 포함된 SHA를 `main`에 통합한 뒤 actual release SHA 후보에 포함
+- [ ] 미배정 `PREPARING` direct/hub discovery의 최소 대상·필드 정의
+- [ ] arbitrary/타-driver/완료 주문 raw read 차단
+- [ ] assigned driver·seller 최소 필드 projection/DTO 또는 동등 분리
+- [ ] broad driver rule 제거
+- [ ] Rules 및 앱 정상/거부 회귀
+- [ ] 변경 SHA `main` 통합
 
-이 finding을 법적 문구를 넓혀 정당화하지 않는다. 먼저 실제 read 경계를 최소화·검증한 뒤 `docs/specs/legal/README.md`의 seller/driver 개인정보 처리 문구를 확정한다. 기술 정본: `docs/specs/api/orders.md`.
+법적 문구를 넓혀 현재 broad read를 정당화하지 않는다. 정본: `docs/specs/api/orders.md`.
 
 ### P0 — AUTH-DRIVER-APPROVAL-AND-SESSION-REVOCATION
 
-2026-08-24 인증 감사에서 driver 관리자 승인 계약과 실제 Kakao 가입 경로가 충돌하고, 정지·role/store 변경 뒤 기존 세션 권한 수렴도 불완전함을 확인했다.
+driver 관리자 승인 계약과 실제 Kakao 가입 경로가 충돌하며 suspension/role/store 변경 뒤 stale session/claims 수렴도 불완전하다.
 
-현재 구현·증거:
+확인됨:
 
-- [x] admin에는 `PATCH /admin/drivers/:userId/approve`와 `driverApproved` 상태가 존재
-- [x] driver NextAuth callback은 driver role에 `driverApproved === true`를 요구
-- [x] 신규 로그인은 `suspended === true` 사용자를 거부하고 해당 unit test 존재
-- [x] `AuthService.kakaoLogin()`은 기존 driver의 `driverApproved === undefined`를 로그인 중 `true`로 자동 갱신
-- [x] 신규 Kakao identity가 `targetRole: driver`를 요청하면 `role: driver`, `driverApproved: true`로 즉시 생성
-- [x] `AuthService.refresh()`는 user 문서를 재조회하지 않고 refresh JWT의 기존 `role/storeId`를 새 토큰에 재사용
-- [x] `GET /auth/firebase-token`은 현재 API JWT의 `role/storeId`로 Firebase custom claims를 생성
-- [x] `JwtStrategy`/`RolesGuard`는 token claims를 사용하며 매 요청마다 `suspended`·승인 상태를 재조회하지 않음
-
-판정:
-
-- 관리자 승인 전 driver 권한 획득 차단 계약과 신규/legacy 자동 승인 경로는 **`IMPLEMENTATION FINDING` P0**다.
-- 정지·role/store/승인 변경 이후 기존 access/refresh/Firebase claims의 허용 수명은 **`DECISION REQUIRED` + P0 authorization remediation**다.
-- 특히 suspended 계정이 refresh를 통해 stale 권한 token을 계속 재발급받는 상태를 정상 계약으로 간주하지 않는다.
-- `ORDER-DIRECT-READ-AUTHORIZATION-AND-MINIMIZATION`의 broad driver Firestore read와 결합될 수 있으므로 두 P0를 독립적으로 닫지 않는다.
+- [x] admin approval endpoint와 driver app `driverApproved` gate 존재
+- [x] 신규 Kakao `targetRole: driver`가 `driverApproved: true`로 즉시 생성될 수 있음
+- [x] 기존 승인 필드 누락 driver도 로그인 side effect로 자동 승인
+- [x] refresh가 authoritative user 문서를 재조회하지 않고 기존 `role/storeId` claims 재사용
+- [x] Firebase custom token도 현재 API JWT claims 사용
 
 남음:
 
-- [ ] 신규 Kakao `targetRole: driver`가 관리자 승인 없이 `driverApproved: true` 권한을 만들지 못하도록 수정
-- [ ] 기존 `driverApproved` 누락 계정을 로그인 side effect로 자동 승인하지 않음
-- [ ] 과거 계정 migration이 필요하면 명시적·감사 가능한 별도 migration/관리 절차로 분리
-- [ ] 승인 전 driver 앱/API/Firebase 권한 거부, 승인 후 정상 진입 직접 회귀
-- [ ] 계정 정지 시 refresh token의 후속 갱신 거부 정책 확정·구현
-- [ ] refresh가 authoritative user 문서의 현재 `suspended/role/storeId/driverApproved`를 검증하고 stale claims를 재발급하지 않음
-- [ ] 이미 발급된 access token의 허용 revocation window/SLA 결정
-- [ ] 즉시 revocation이 필요하면 token version/session revocation 또는 동등 서버 경계 적용
-- [ ] Firebase custom token이 stale API claims만으로 과거 role/store 권한을 재발급하지 않도록 현재 상태 검증
-- [ ] suspended/role-changed/store-changed/driver-approval-changed/logout/rotation 회귀
-- [ ] 수정이 포함된 SHA를 `main`에 통합한 뒤 actual release SHA 후보에 포함
+- [ ] 신규/legacy 자동 승인 제거
+- [ ] 과거 계정 migration은 별도 감사 가능한 절차로 분리
+- [ ] 승인 전/후 앱·API·Firebase 직접 회귀
+- [ ] suspension/role/store/approval 변경의 revocation window/SLA 결정
+- [ ] refresh/current claims authoritative user 상태 검증
+- [ ] Firebase stale claims 재발급 차단
+- [ ] logout/rotation 포함 회귀
+- [ ] 변경 SHA `main` 통합
 
-정본: `docs/specs/api/auth.md`, admin 영향: `docs/specs/api/admin.md`.
+`ORDER-DIRECT-READ-AUTHORIZATION-AND-MINIMIZATION`과 결합 검증한다. 정본: `docs/specs/api/auth.md`.
 
 ### P0 — ORDER-MUTATION-AUTHORIZATION-COVERAGE
 
-주문 API 조회 authorization은 `OrdersQueryService`와 직접 테스트가 일치해 해당 API 계층에서는 `VERIFIED`다. 반면 `OrdersLifecycleService.assertOrderActionAccess()`의 mutation authorization은 구현돼 있으나 권한 우회 방지 핵심 거부 시나리오를 직접 고정하는 회귀 테스트가 충분하지 않다.
+`OrdersLifecycleService.assertOrderActionAccess()`의 권한 구현은 있으나 핵심 거부 회귀가 부족하다.
 
-현재 구현·검증:
+현재 구현:
 
-- [x] seller mutation은 해당 store `ownerId`와 requester 일치 요구
-- [x] driver mutation은 배정된 `driverId` 일치 요구
-- [x] 미배정 `PREPARING → DELIVERING`은 최초 driver claim으로 허용하고 `driverId` 기록
-- [x] consumer는 자신의 주문만 action access 통과
-- [x] consumer가 `DELIVERY_HELD`를 위장 요청하는 직접 거부 테스트
-- [x] 정상 seller/driver 회차 E2E 흐름
-- [x] API 조회 권한의 consumer/seller/driver/admin 직접 거부·허용 테스트
+- [x] seller store ownership
+- [x] assigned driver ownership
+- [x] 미배정 `PREPARING → DELIVERING` first claim
+- [x] consumer order ownership
 
 남음:
 
-- [ ] 다른 store의 seller가 `PATCH .../status`를 시도하면 403
-- [ ] 다른 store의 seller가 `PATCH .../delivery-hold`를 시도하면 403
-- [ ] `driverId`가 다른 주문을 비담당 driver가 상태 변경하면 403
-- [ ] 미배정 주문은 `PREPARING → DELIVERING` 최초 claim 외 driver mutation 거부
-- [ ] 최초 claim 성공 시 정확한 `driverId` 기록 직접 검증
-- [ ] 거부된 mutation에서 주문 write·알림·환불·정산 side effect 0 확인
-- [ ] 필요한 경우 admin 의도된 허용 범위 직접 검증
-- [ ] 회귀가 포함된 SHA를 `main`에 통합한 뒤 actual release SHA 후보에 포함
+- [ ] 타-store seller status/delivery-hold 403
+- [ ] 비담당 driver assigned-order mutation 403
+- [ ] first-claim 외 미배정 driver mutation 거부
+- [ ] first claim 정확한 `driverId` 기록
+- [ ] 거부된 mutation side effect 0
+- [ ] 필요한 admin 허용 범위 직접 고정
+- [ ] 변경 SHA `main` 통합
 
-권한은 P0 계약이므로 위 핵심 거부 회귀가 추가되기 전 mutation authorization 전체를 `VERIFIED`로 처리하지 않는다. 정본: `docs/specs/api/orders.md`.
+정본: `docs/specs/api/orders.md`.
 
 ### P0 — DEPLOY-SAFETY-MAIN-PROTECTION
 
-repo-side 자동배포 차단은 완료됐지만 GitHub `main` 자체 보호는 아직 비활성이다.
+repo-side production auto-deploy 차단은 완료됐지만 GitHub `main` 자체 보호는 아직 비활성이다.
 
 완료:
 
-- [x] PR #30 — consumer/seller/driver `main` Vercel Git auto-deploy 차단
-- [x] PR #30 merge 뒤 3앱 Vercel 신규 deployment 0건 확인
-- [x] docs-only `main` push의 `sync-preview`/일반 E2E 제외
-- [x] `AGENTS.md` direct-main 금지 규칙
+- [x] PR #30 세 프런트 `main` Vercel Git auto-deploy 차단
+- [x] docs-only Preview sync/E2E 제외
+- [x] `AGENTS.md` direct-main 금지
 - [x] deployment safety CI
-- [x] PR #31 — 순수 docs/Markdown Vercel build skip
-- [x] pure-docs branch commit 뒤 3앱 신규 deployment 0건 확인
+- [x] PR #31 pure docs/Markdown Vercel build skip
 
 남음:
 
-- [ ] Issue #32 — `main` branch protection/ruleset 활성화
+- [ ] Issue #32 ruleset/branch protection
 - [ ] PR required
 - [ ] `Deployment safety guard / verify` required check
-- [ ] force push 차단
-- [ ] branch deletion 차단
+- [ ] force push·branch deletion 차단
 - [ ] 재조회에서 `protected=true` 또는 동등 enforcement 확인
-
-Issue #32 완료 전에도 repo-side Vercel guard는 동작하지만, direct push 자체를 GitHub가 강제 차단하지는 못한다. 따라서 모든 작업은 `AGENTS.md`에 따라 branch+PR로 수행한다.
 
 ---
 
@@ -218,14 +200,13 @@ Issue #32 완료 전에도 repo-side Vercel guard는 동작하지만, direct pus
 - [ ] `ORDER_DELIVERED`
 - [ ] `ORDER_CANCELLED`
 
-현재:
+마지막 provider 확인 기준:
 
-- 8종 provider 등록·심사 요청 완료
+- 8종 등록·심사 요청 완료
 - 8종 모두 `검수중`
-- 중복·오류·반려 없음
 - 실제 알림톡·SMS 발송 0건
 
-재개 순서: `docs/plans/HANDOFF_mvp_round_direct_aligo_review_pause.md`
+상태는 재개 시 provider에서 다시 조회한다.
 
 ---
 
@@ -233,133 +214,119 @@ Issue #32 완료 전에도 repo-side Vercel guard는 동작하지만, direct pus
 
 ### P0 — 실제 알림 검증
 
-- [ ] 승인된 실제 `tpl_code` 8종 ↔ 내부 논리 템플릿 1:1 매핑 검사
-- [ ] 사용자 승인 후 격리 수신자 실제 알림톡 정상 발송
-- [ ] 사용자 승인 후 SMS fallback 실제 검증
+- [ ] 승인 실제 `tpl_code` 8종 ↔ 내부 논리 코드 1:1 검사
+- [ ] 별도 승인 후 격리 수신자 실제 알림톡 정상 발송
+- [ ] 별도 승인 후 SMS fallback 실제 검증
 
 ### P0 — 판매 활성화 법적 문서 재정합화
 
-현재 production `/terms`, `/privacy`는 2026-08-19 **비판매 상태**를 전제로 한다.
+현재 production `/terms`, `/privacy`는 2026-08-19 비판매 상태를 전제로 한다.
 
-- [ ] 상용 주문·결제·배송 상태와 약관 문구 일치
-- [ ] 주문 성립·취소·환불·배송·재배송비·배송 보류 정책 검수
-- [ ] PortOne·실제 결제사업자 개인정보 처리 역할 검수
-- [ ] ALIGO 고객 알림 전화번호·메시지 처리 고지 검수
-- [ ] `ORDER-DIRECT-READ-AUTHORIZATION-AND-MINIMIZATION` 해결 후 seller·driver 고객 배송정보 접근 설명 검수
+- [ ] 주문 성립·취소·환불·배송·재배송비·배송 보류 실제 정책 반영
+- [ ] 재배송비 결제 전 배송 재개 금지와 결제/환불 실제 구현 일치 확인
+- [ ] PortOne·결제사업자 개인정보 처리 역할 검수
+- [ ] ALIGO 고객 전화번호·메시지 처리 고지
+- [ ] order direct-read 최소화 해결 후 seller/driver 고객정보 접근 설명
 - [ ] 시행일·이전 버전 관리
-- [ ] `apps/consumer/src/app/legal-documents.test.mjs` 갱신
-- [ ] 변경된 `/privacy`, `/terms`를 release SHA에 포함
+- [ ] `legal-documents.test.mjs` 갱신
+- [ ] 법적 변경을 release SHA에 포함
 
-정본: `docs/specs/legal/README.md`
+정본: `docs/specs/legal/README.md`.
 
 ### P0 — 출시 후보 검증·운영 준비
 
-- [ ] PAYMENT-FINALIZATION-PAID-GUARD 완료 및 `main` 통합
-- [ ] ADMIN-FORCE-REFUND-CONSISTENCY 완료 및 `main` 통합
-- [ ] ORDER-DIRECT-READ-AUTHORIZATION-AND-MINIMIZATION 완료 및 `main` 통합
-- [ ] AUTH-DRIVER-APPROVAL-AND-SESSION-REVOCATION 완료 및 `main` 통합
-- [ ] ORDER-MUTATION-AUTHORIZATION-COVERAGE 완료 및 `main` 통합
-- [ ] Issue #32 branch protection 완료
+- [ ] `PAYMENT-FINALIZATION-PAID-GUARD`
+- [ ] `ORDER-REDELIVERY-PAID-RESUME-GATE`
+- [ ] `ADMIN-FORCE-REFUND-CONSISTENCY`
+- [ ] `ORDER-DIRECT-READ-AUTHORIZATION-AND-MINIMIZATION`
+- [ ] `AUTH-DRIVER-APPROVAL-AND-SESSION-REVOCATION`
+- [ ] `ORDER-MUTATION-AUTHORIZATION-COVERAGE`
+- [ ] Issue #32
 - [ ] 법적 페이지 포함 actual release SHA 확정
-- [ ] exact SHA 원격 회차 E2E chromium 26 + mobile 26 = 52건 통과
-- [ ] 양쪽 fixture cleanup 성공
-- [ ] 운영 Firebase indexes·Firestore Rules·Storage Rules 읽기 전용 재조회
-- [ ] 사용자 승인 후 운영 ALIGO 자격 증명 4개·`ALIGO_TEMPLATE_CODES_JSON` 반영
-- [ ] 8종 매핑 검사
+- [ ] exact SHA 원격 E2E chromium 26 + mobile 26 = 52 + cleanup
+- [ ] 운영 Firebase indexes/Rules read-only 재조회
+- [ ] 별도 승인 후 production ALIGO 설정
 - [ ] production exact-SHA deploy/promotion 절차 확정
 - [ ] 별도 `Task 3.1 승인`
-- [ ] 승인된 exact release SHA로 Railway API production 배포
-- [ ] consumer·seller·driver를 동일 release SHA로 production 배포
-- [ ] deployment metadata SHA 일치 확인
-- [ ] 운영 무변경 smoke: health·인증·legacy·회차 read·`/privacy`·`/terms`
-- [ ] 첫 운영 회차 `DRAFT` 생성·검수
-- [ ] 첫 회차 `SCHEDULED` 전환
-- [ ] 최종 출시 판정·롤백 dry-run
+- [ ] 동일 exact SHA로 API + consumer/seller/driver production 배포
+- [ ] deployment metadata SHA 확인
+- [ ] 운영 smoke
+- [ ] 첫 회차 DRAFT 검수 → SCHEDULED
+- [ ] 최종 출시 판정·rollback dry-run
 - [ ] 최종 승인 후 `salesMode: round_direct`
-- [ ] 전환 직후 smoke 뒤 외부 유입 링크 공개
-- [ ] 첫 두 회차 집중 모니터링 및 Closeout
+- [ ] 초기 두 회차 모니터링·Closeout
 
-상세 dependency: `docs/plans/PLAN_mvp_round_direct_launch_blockers.md`
+상세 dependency: `docs/plans/PLAN_mvp_round_direct_launch_blockers.md`.
 
 ---
 
 ## LATER — 출시 후 품질·운영 개선
 
 ### NOTIFICATION-RETRY-POLICY
-
 - [ ] backoff·일시/영구 오류 분류
-- [ ] timeout·rate limit 처리 기준
-- [ ] 중복 SMS 방지·재시작 이후 멱등성
-- [ ] 구조화 관측 지표와 격리 테스트
+- [ ] timeout·rate limit 처리
+- [ ] 중복 SMS 방지·재시작 멱등성
+- [ ] 구조화 관측 지표
 
 ### API-LINT-BASELINE
-
-- [ ] auth 흐름의 `any` 제거
+- [ ] auth `any` 제거
 - [ ] spec mock 타입 정리
-- [ ] `lint:check` / `lint:fix` 분리 검토
+- [ ] `lint:check` / `lint:fix` 분리
 
 ### LOCAL-DEV-FULLSTACK
-
-- [ ] API 3000 / consumer 3001 / seller 3002 / driver 3003 launcher 설계
-- [ ] seller·driver local CORS origin 계약 확인
-- [ ] 기존 `dev.bat` frontend-only 유지 여부 결정
+- [ ] API 3000 / consumer 3001 / seller 3002 / driver 3003 launcher
+- [ ] seller·driver local CORS 계약
+- [ ] 기존 `dev.bat` frontend-only 유지 여부
 
 ### LOAD-TEST-FORMAL
-
-- [ ] production과 분리된 staging/equivalent 환경 확보
-- [ ] 재개 트리거 정의
+- [ ] production 분리 staging/equivalent
+- [ ] 재개 트리거
 - [ ] `baseline → launch → growth → spike → soak`
-- [ ] `docs/specs/ops/k6-load-test-plan.md` 재검증
+- [ ] k6 plan 재검증
 
 ### Seller/Admin
-
-- [ ] ADMIN-STORES-T7 판매자 상세 드릴다운
-- [ ] ADMIN-STORES-T8 플랫폼 기본 수수료율 설정
-- [ ] 준비 물량 공동구매 주문 포함 여부 재설계
-- [ ] 필요 시 정산 UX 육안 검증 재개
+- [ ] ADMIN-STORES-T7 판매자 상세
+- [ ] ADMIN-STORES-T8 플랫폼 기본 수수료율
+- [ ] 준비 물량 공동구매 주문 포함 재설계
+- [ ] 필요 시 정산 UX 검증
 
 ### Driver/배송
-
-- [ ] Kakao Maps SDK 필요성 재평가
+- [ ] Kakao Maps SDK 재평가
 - [ ] 밀크런 경로 프리뷰 필요 시 구현
-- [ ] 플랫폼형 드라이버 전까지 실시간 GPS 추적 보류
+- [ ] 플랫폼형 드라이버 전 실시간 GPS 추적 보류
 
 ### 인프라 복원력
-
 - [ ] Railway 단일 장애점 재평가
-- [ ] 필요 시 대체 backend contingency 비교
+- [ ] backend contingency 비교
 
 ### 확장 트리거
-
 - [ ] 다중 판매자 Phase 2
-- [ ] 실제 협력 거점 계약 시 hub 운영 오픈
-- [ ] 필요 시 `hub_staff` 역할
+- [ ] 실제 협력 거점 계약 시 hub 운영
+- [ ] 필요 시 `hub_staff`
 - [ ] 외부 드라이버 정산
-- [ ] 플랫폼형 드라이버 모델
+- [ ] 플랫폼형 드라이버
 - [ ] 결제수단 확장 재평가
 
 ---
 
 ## STALE_OR_SUPERSEDED
 
-다음은 과거 상태를 그대로 전제로 실행하지 않는다.
+현재 상태를 재검증하기 전 다음 과거 전제를 실행하지 않는다.
 
 - 네이버페이 “승인 메일 대기 / 채널키만 넣으면 즉시 활성화”
 - 과거 BUG-03 Firestore 공개 read/Firebase Custom Token 가정
-- 과거 운영 DB `reset-*` / `visual-settle-*` cleanup 지시
-- 2026-05 Railway outage 당시 상태
+- 과거 운영 DB reset/visual cleanup 지시
+- 2026-05 Railway outage 상태
 - PR #11 OPEN/Draft·병합 금지 표현
-- 회차 ALIGO 템플릿 8종 “미등록” 표현
-- `main` merge가 자동 production 배포를 해야 한다는 과거 전제
-
----
+- ALIGO 8종 “미등록” 표현
+- `main` merge가 자동 production 배포를 해야 한다는 전제
 
 ## 관리 원칙
 
 1. 완료 이력을 장문으로 누적하지 않는다.
-2. 현재 행동 가능한 미완료만 ACTIVE/BLOCKED_EXTERNAL/NEXT/LATER에 둔다.
-3. 외부 상태는 실제 재조회 뒤에만 갱신한다.
-4. Backlog 체크박스는 production 변경 승인으로 간주하지 않는다.
-5. 현재 출시 우선순위 충돌 시 `docs/memory.md`와 활성 HANDOFF·PLAN을 우선한다.
-6. 모든 repository 변경은 direct `main`이 아니라 branch+PR로 수행한다.
-7. 문서 정합성 판정과 `VERIFIED` 승격은 `docs/DOCUMENT_CONSISTENCY.md`를 따른다.
+2. 현재 행동 가능한 미완료만 유지한다.
+3. 외부 상태는 직접 재조회 뒤 갱신한다.
+4. 체크박스는 production 변경 승인으로 간주하지 않는다.
+5. 우선순위 충돌 시 `docs/memory.md`와 활성 HANDOFF·PLAN을 우선한다.
+6. repository 변경은 branch+PR로 수행한다.
+7. `VERIFIED` 승격은 `docs/DOCUMENT_CONSISTENCY.md`를 따른다.

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -2,178 +2,145 @@
 
 # 프로젝트 현재 상태
 
-> 현재 작업 판단에 필요한 최소 상태만 유지한다. 완료 이력과 상세 증거는 기본 Context로 읽지 않는다.
+> 현재 작업 판단에 필요한 최소 상태만 유지한다. 완료 이력과 상세 Acceptance Criteria는 Git history·REPORT·`docs/BACKLOG.md`·current spec을 사용한다.
 
 ## 검증 기준
 
 - Git·GitHub 직접 재검증: `2026-08-24 KST`
 - Vercel 배포 안전 증거: `2026-08-23 KST`
-- ALIGO 상태: 2026-08-23 provider 등록 결과
+- ALIGO 상태: 마지막 provider 확인 `2026-08-23`
 - 운영 상태 변경은 별도 승인 없이 수행하지 않는다.
 
-## Git 기준선
+## Git·배포 기준선
 
 - 저장소: `booker-lab/greenhub`
 - 기본 브랜치: `main`
-- `main` HEAD는 문서 PR만으로도 이동하므로 이 문서에 “현재 HEAD”를 고정하지 않는다. 새 작업 시작 시 GitHub에서 직접 재조회한다.
+- `main` HEAD는 작업 시작 시 GitHub에서 직접 재조회한다.
 - 회차 직배송 기능 통합 기준 SHA: `e55f25914cc7d01576fbd4639583daaf0fe6385e`
-- 배포 안전 repo-side 통합 기준: PR #30, PR #31
-- PR #11: `MERGED`·`CLOSED`
-- 기존 `codex/mvp-sales-round-direct`는 통합 완료 branch이며 새 작업 기준 branch로 재사용하지 않는다.
-- 새 작업은 최신 `main`에서 목적별 branch를 만들고 PR로 통합한다.
+- PR #30/#31로 세 프런트의 `main` Vercel Git production auto-deploy와 pure-doc build를 repo-side에서 차단했다.
+- docs-only `main` 변경은 Preview sync/일반 E2E에서 제외된다.
+- `AGENTS.md`와 deployment safety CI가 branch+PR 원칙을 강제한다.
+- GitHub `main` 자체는 마지막 재조회에서 `protected=false`; Issue #32가 남아 있다.
 
-## 배포 안전성 상태
-
-2026-08-23 감사에서 `main` push가 문서 변경만으로도 Vercel production-target deployment와 Preview/E2E 연쇄 실행을 만들 수 있음을 확인했다.
-
-repo-side remediation은 완료됐다.
-
-- PR #30: consumer·seller·driver `git.deploymentEnabled.main=false`
-- PR #30 merge SHA `a83fa20516ed6209a4705020cc92154f39e383ca` 이후 세 Vercel 프로젝트 신규 deployment 0건 확인
-- `sync-preview.yml`: `docs/**`, `**/*.md`만 바뀐 `main` push 제외
-- `AGENTS.md`: 문서-only 포함 direct `main` commit/push 금지, branch+PR 통합 요구
-- `deployment-safety.yml` + `verify-deployment-safety.mjs`: 안전 invariant 검증
-- PR #31: 세 앱 순수 docs/Markdown 변경의 Vercel build skip `ignoreCommand` 추가
-- pure-docs branch commit `ebf44c104b2e8758733fd14501fd0e820d575ae4` 이후 세 Vercel 프로젝트 신규 deployment 0건 확인
-- docs-only PR #33 merge 이후에도 세 Vercel 프로젝트 신규 deployment 0건 확인
-
-Vercel Hobby build-rate-limit 때문에 docs-only PR에 Vercel check failure가 생길 수 있지만, 실제 deployment가 0건이면 배포 회귀로 판정하지 않는다. `Deployment safety guard` 자체 성공 여부와 Vercel deployment 목록을 분리해 본다.
-
-남은 관리자 P0:
-
-- GitHub `main`은 2026-08-24 재조회에서도 `protected=false`.
-- Issue #32 `P0: main branch protection / ruleset 활성화`가 남아 있다.
-- 목표: PR required, `Deployment safety guard / verify` required check, force push·branch delete 차단.
-
-**중요:** `main` merge는 production 배포 승인이 아니다. production은 검증된 exact release SHA와 별도 `Task 3.1 승인`을 사용해야 하며, 빈 commit·재-push로 배포를 유도하지 않는다.
-
-상세: `docs/plans/PLAN_deployment_safety_guards_20260823.md`
+**`main` merge는 production 배포 승인이 아니다.** production은 검증된 exact release SHA + 별도 승인 절차를 사용한다.
 
 ## 제품 현재 상태
 
 - 회차 직배송 MVP 구현은 `main`에 통합됐다.
-- consumer 회차 구매, seller 회차·주문 운영, driver 직배송 흐름이 구현돼 있다.
-- API에는 회차 주문·결제 최종화·환불·재배송비·배송 보류·배송 사진·운영 예외 흐름이 포함된다.
-- 공통 회차 계약은 `packages/shared/src/sale-round.types.ts`가 소유한다.
-- 카카오 비즈니스 채널 최종 승인 완료.
-- 운영 Firebase indexes·Firestore Rules·Storage Rules는 기존 출시 준비에서 반영 완료 상태이며 출시 전 재조회가 필요하다.
-- 회차 출시 후보 production 배포, 첫 운영 회차 생성, `salesMode` 전환은 미실행.
-- 판매 모드는 최신 운영 확인 기준 `legacy`.
+- consumer 구매, seller 회차·주문, driver 직배송, 결제·환불·재배송비·보류·사진·운영 예외 흐름이 존재한다.
+- 카카오 비즈니스 채널 승인 완료.
+- 운영 Firebase rules/indexes는 기존 준비에서 반영 완료 상태이나 출시 전 read-only 재조회가 필요하다.
+- production 회차 배포·첫 운영 회차·`salesMode` 전환은 미실행.
+- 판매 모드: `legacy`.
 
-## 현재 확인된 P0
+## 현재 확인된 출시 P0
 
-### 관리자 강제 환불 주문·정산·capacity 일관성
+### 1. 재배송비 결제 전 배송 재개 가드
 
-2026-08-24 감사에서 `AdminService.forceRefund()`가 정상 주문 cancellation lifecycle과 다른 후속효과를 수행함을 확인했다.
+운영 계약은 고객 책임 첫 배송 실패에서 유료 재배송비가 있으면 **결제 전 재배송 금지**를 요구한다.
 
-- admin 환불은 `CANCELLED`만 거부하고 본 결제 환불 후 주문을 직접 `CANCELLED`로 갱신한다.
-- 정상 회차 취소는 본 결제·paid 재배송비 환불, cancellation 재시도 상태, reservation/counter 반환, held count 조정, settlement 취소까지 수행한다.
-- admin 경로는 재배송비 환불·reservation/capacity 반환·held count 조정·`cancelSettlement()`을 호출하지 않는다.
-- 완료/정산 생성 주문도 `CANCELLED`가 아니면 별도 상태 제한 없이 admin 환불 경로에 진입할 수 있다.
+현재:
 
-따라서 provider 본 결제 환불 멱등성은 별도로 `VERIFIED`지만 **admin 주문 환불 전체 일관성은 `IMPLEMENTATION FINDING` P0**다. paid settlement 이후 환불은 단순 settlement 역전이 아니라 별도 회계 조정 정책이 필요하다.
+- `OrderChargePaymentService`의 charge 결제·환불 하위 계약은 직접 회귀로 `VERIFIED`다.
+- 하지만 driver `DELIVERY_HELD → DELIVERING` 서버 전환은 연결 charge의 `PAID` 상태를 확인하지 않는다.
+- driver 상세 UI도 회차 직배송 `DELIVERY_HELD`이면 charge 상태와 무관하게 `배송 재개` 버튼을 노출한다.
+
+따라서 **`ORDER-REDELIVERY-PAID-RESUME-GATE` = P0 `IMPLEMENTATION FINDING`**이다. API 직접 호출에서 미결제/실패/환불/불일치 charge를 fail-closed하고 `미결제 거부 → 결제 완료 → 정상 재개`를 직접 검증해야 한다.
+
+정본: `docs/specs/api/orders.md`, `docs/BACKLOG.md`, 운영 근거 `docs/specs/ops/mvp-sales-round-runbook.md`.
+
+### 2. 관리자 강제 환불 lifecycle 일관성
+
+`AdminService.forceRefund()`는 본 결제 환불 뒤 주문을 직접 `CANCELLED`로 write하며 정상 회차 cancellation의 추가 charge, reservation/capacity, held counter, settlement 후속효과를 재사용하지 않는다.
+
+따라서 **`ADMIN-FORCE-REFUND-CONSISTENCY` = P0 `IMPLEMENTATION FINDING`**이다. paid settlement 환불은 별도 회계 조정 정책도 필요하다.
 
 정본: `docs/specs/api/admin.md`, `docs/specs/api/settlements.md`, `docs/BACKLOG.md`.
 
-### Driver 승인 게이트·세션 권한 수명주기
+### 3. Driver 승인·세션 권한 수명주기
 
-2026-08-24 인증 감사에서 관리자 driver 승인 계약과 실제 Kakao 가입 경로가 충돌함을 확인했다.
+- 신규 Kakao `targetRole: driver`가 `driverApproved: true`로 생성될 수 있다.
+- 승인 필드 누락 기존 driver도 로그인 side effect로 자동 승인된다.
+- refresh는 authoritative user 상태를 재조회하지 않고 stale `role/storeId` claims를 재사용한다.
 
-- admin에는 `driverApproved` 승인 API가 있고 driver 앱 callback도 승인 flag를 요구한다.
-- 그러나 `AuthService.kakaoLogin()`은 신규 Kakao identity가 `targetRole: driver`를 요청하면 `role: driver`, `driverApproved: true`로 즉시 생성한다.
-- 기존 driver에서 `driverApproved`가 누락된 경우도 로그인 중 `true`로 자동 보정한다.
-- 따라서 **관리자 승인 전 driver 권한 획득 차단은 현재 `IMPLEMENTATION FINDING` P0**다.
-- `AuthService.refresh()`는 user 문서를 재조회하지 않고 기존 refresh JWT의 `role/storeId`를 새 token에 재사용한다.
-- 신규 로그인은 suspended 사용자를 거부하지만 정지·role/store/승인 변경 후 기존 세션의 revocation SLA와 refresh/Firebase claim 수렴은 현재 `DECISION REQUIRED` + P0 remediation 상태다.
-
-특히 이 finding은 `ORDER-DIRECT-READ-AUTHORIZATION-AND-MINIMIZATION`의 broad driver Firestore read와 결합될 수 있으므로 두 P0를 모두 해결·직접 검증하기 전 driver 권한 경계를 `VERIFIED`로 처리하지 않는다.
+따라서 **관리자 승인 게이트는 P0 `IMPLEMENTATION FINDING`**, suspension/role/store/approval 변경의 세션 수렴은 **P0 `DECISION REQUIRED` + remediation**이다.
 
 정본: `docs/specs/api/auth.md`, `docs/specs/api/admin.md`, `docs/BACKLOG.md`.
 
-### 주문 direct Firestore read authorization·개인정보 최소화
+### 4. 주문 direct Firestore read·개인정보 최소화
 
-2026-08-24 감사에서 API read guard와 실제 seller/driver client read 경계가 다름을 확인했다.
+API driver read는 배정 주문으로 제한되지만 current Firestore Rules는 `role == driver`이면 주문을 배정/store/status와 무관하게 read 허용하며 seller/driver 앱은 raw order document를 사용한다.
 
-- API `OrdersQueryService`는 driver 주문 조회를 배정된 `driverId`로 제한하고 직접 테스트가 존재한다.
-- 그러나 `firestore.rules`는 `role == 'driver'`이면 `orders` 문서를 store/status/배정과 무관하게 read 허용한다.
-- driver 보드·상세와 seller 주문 목록은 Firestore `orders` 원문을 직접 구독한다.
-- 회차 order 원문에는 배송 수행 정보 외에도 `acquisition`, `marketingConsent`, `clientOrderPayloadHash`, reservation 관련 내부 필드가 함께 저장될 수 있다.
-- 현재 Firestore Rules 테스트도 driver의 다른 store 주문 직접 read를 성공 케이스로 고정한다.
+따라서 API read만 `VERIFIED`이며 **시스템 전체 driver read authorization + seller/driver data minimization은 P0 `IMPLEMENTATION FINDING`**이다.
 
-따라서 API 조회 authorization만 `VERIFIED`이며, **시스템 전체 driver read authorization과 seller/driver 데이터 최소화는 `IMPLEMENTATION FINDING` P0**다.
+정본: `docs/specs/api/orders.md`, `docs/specs/legal/README.md`, `docs/BACKLOG.md`.
 
-미배정 `PREPARING` direct/hub 주문 discovery가 현재 제품 흐름에 필요한 점은 보존하되, 임의 driver의 arbitrary order 원문 접근과 역할에 불필요한 필드 노출은 actual release SHA 확정 전에 제거·직접 검증한다.
+### 5. 결제 finalization provider 상태 방어
 
-정본: `docs/specs/api/orders.md`, `docs/BACKLOG.md`, 법적 선행 게이트 `docs/specs/legal/README.md`.
+`PaymentFinalizationService.finalizePaidOrder()`가 비`PAID` provider 입력을 boundary 자체에서 차단하지 않는다. caller 방어는 있지만 최종화 불변식 전체는 보장되지 않는다.
 
-### 결제 최종화 provider 상태 방어
-
-현재 `main`의 `apps/api/src/payments/payment-finalization.service.ts`는 `finalizePaidOrder()` 내부에서 전달받은 `paymentData.status === 'PAID'`를 독립적으로 강제하지 않는다.
-
-- `cleanupPendingOrders()`는 원격 상태가 `PAID`일 때만 finalization을 호출한다.
-- webhook은 `Transaction.Paid` 이벤트에서 원격 결제를 다시 조회한다.
-
-그러나 finalization service 자체가 비`PAID` 입력을 최종 차단하는 구조는 아니다. 이 항목은 **actual release SHA 확정 전 해결·회귀 검증이 필요한 P0**다.
+따라서 **`PAYMENT-FINALIZATION-PAID-GUARD` = P0**다.
 
 정본: `docs/specs/api/payments.md`, `docs/BACKLOG.md`.
 
-### 주문 mutation authorization 회귀 검증
+### 6. 주문 mutation authorization 회귀
 
-주문 API 조회 권한은 consumer/seller/driver/admin별 직접 테스트가 존재해 **API 계층에서는** `VERIFIED`다.
+seller store ownership, driver assignment, consumer ownership guard는 구현돼 있으나 타-store seller·비담당 driver·first-claim 외 action과 거부 side-effect 0의 직접 테스트가 부족하다.
 
-상태 변경 guard는 구현돼 있으나 2026-08-24 감사에서 타-store seller, 비담당 driver, 미배정 first-claim 외 action의 직접 거부 회귀를 충분히 확인하지 못했다.
-
-권한은 P0 계약이므로 이 범위는 현재 **`IMPLEMENTED / UNVERIFIED` + `COVERAGE GAP`**로 취급하고 actual release SHA 확정 전 직접 회귀를 추가한다.
+따라서 **`ORDER-MUTATION-AUTHORIZATION-COVERAGE` = `IMPLEMENTED / UNVERIFIED` + P0 `COVERAGE GAP`**다.
 
 정본: `docs/specs/api/orders.md`, `docs/BACKLOG.md`.
 
-## ALIGO 템플릿 상태
+### 7. GitHub main protection
 
-- 발신 프로필 1건 정상, `senderkey` 발급 완료.
-- 내부 논리 템플릿 코드 ↔ provider `tpl_code` 분리 및 필수 변수 검증 구현 완료.
-- 8종 provider 등록·심사 요청 완료. 마지막 확인 snapshot(2026-08-23)에서 모두 `검수중`.
-- 실제 알림톡·SMS 발송: 0건
-- 실제 알림톡 정상 발송·SMS fallback 검증: 미실행
-- 운영 ALIGO 자격 증명 4개·`ALIGO_TEMPLATE_CODES_JSON`: 미반영
+repo-side 배포 방어는 완료됐지만 GitHub 관리자 레벨의 PR required / required check / force-push·delete 차단은 Issue #32가 남아 있다.
 
-현재성이 필요한 경우 provider에서 다시 조회한다.
+## ALIGO 상태
 
-## 판매 활성화 법적 문서 상태
+마지막 provider snapshot:
 
-- production `/privacy`, `/terms`는 2026-08-19 시행 버전이며 비판매 상태를 전제로 한다.
-- PortOne·결제사업자·ALIGO·seller/driver 고객정보 접근은 실제 판매 활성화 전에 재정합화해야 한다.
-- seller/driver 고객정보 접근 문구는 `ORDER-DIRECT-READ-AUTHORIZATION-AND-MINIMIZATION` P0 해결 전 최종 확정하지 않는다.
-- broad direct read를 법적 문구로 정당화하지 않고 실제 접근 경계를 먼저 최소화한다.
-- 기존 법적 고지 production 반영 완료는 **판매 활성화 법적 준비 완료를 뜻하지 않는다.**
+- 발신 프로필·senderkey 준비 완료.
+- 회차 알림 템플릿 8종 등록·심사 요청 완료.
+- 8종 모두 `검수중`.
+- 실제 알림톡·SMS 발송 0건.
+- production ALIGO 자격 증명 4개·`ALIGO_TEMPLATE_CODES_JSON` 미반영.
+
+새 작업에서 현재성이 필요하면 provider에서 다시 조회한다.
+
+## 판매 활성화 법적 상태
+
+- production `/privacy`, `/terms`는 2026-08-19 비판매 상태 기준이다.
+- 실제 판매 전 주문·취소·환불·재배송비·보류, PortOne/결제사업자, ALIGO, seller/driver 개인정보 접근을 재정합화해야 한다.
+- `ORDER-DIRECT-READ-AUTHORIZATION-AND-MINIMIZATION` 해결 전에 broad read를 법적 문구로 정당화하지 않는다.
+- `ORDER-REDELIVERY-PAID-RESUME-GATE`와 `ADMIN-FORCE-REFUND-CONSISTENCY` 해결 결과를 실제 재배송비·환불 약관에 반영한다.
 
 ## 검증 상태
 
-- 마지막 전체 원격 회차 E2E 성공 역사 증거: SHA `6e0fc9d4cec08073ed2504208cc8bb1ea395ee7d`, run `32351887404`.
-- chromium 26 + mobile 26 = 총 52건 및 양쪽 fixture cleanup 성공.
-- 이 과거 run을 현재 release SHA 검증으로 확장하지 않는다.
-- 법적 페이지와 현재 모든 P0 코드·검증 보정까지 포함한 실제 출시 대상 SHA를 고정한 뒤 52건+cleanup을 다시 통과해야 한다.
+- 마지막 전체 원격 회차 E2E 역사 증거: SHA `6e0fc9d4cec08073ed2504208cc8bb1ea395ee7d`, run `32351887404`.
+- chromium 26 + mobile 26 = 52, 양쪽 fixture cleanup 성공.
+- 과거 run을 현재 release SHA 증거로 확장하지 않는다.
+- 모든 출시 P0와 법적 변경을 포함한 actual release SHA에서 52건+cleanup을 다시 통과해야 한다.
 
 ## 활성 문서
 
-- 전체 문서 라우팅: `docs/README.md`
-- 문서 정합성 감사 기준: `docs/DOCUMENT_CONSISTENCY.md`
+- 문서 라우팅: `docs/README.md`
+- 정합성 기준: `docs/DOCUMENT_CONSISTENCY.md`
 - 작업 규칙: `AGENTS.md`
-- Context 라우터: `docs/PROJECT_MAP.md`
+- Context router: `docs/PROJECT_MAP.md`
 - 현재 상태 SSOT: 이 문서
-- 현재 재개 순서: `docs/plans/HANDOFF_mvp_round_direct_aligo_review_pause.md`
-- 출시 실행 계약: `docs/plans/PLAN_mvp_round_direct_launch_blockers.md`
-- 배포 안전 계약: `docs/plans/PLAN_deployment_safety_guards_20260823.md`
-- 판매 활성화 법적 게이트: `docs/specs/legal/README.md`
-- 현재 미완료 작업: `docs/BACKLOG.md`
-- 설계 결정 이력: `docs/CRITICAL_LOGIC.md`
+- 미완료 SSOT: `docs/BACKLOG.md`
+- 재개 순서: `docs/plans/HANDOFF_mvp_round_direct_aligo_review_pause.md`
+- 출시 의존성: `docs/plans/PLAN_mvp_round_direct_launch_blockers.md`
+- 배포 안전: `docs/plans/PLAN_deployment_safety_guards_20260823.md`
+- 판매 활성화 legal gate: `docs/specs/legal/README.md`
 
 ## 승인 경계
 
 명시적 승인 없이 다음을 수행하지 않는다.
 
-- ALIGO 템플릿 변경·추가 등록·실제 알림톡/SMS 발송
-- 운영 자격 증명·환경 변수·Firebase/운영 데이터 변경
-- Railway·Vercel production 배포·롤백
+- ALIGO 템플릿 변경·등록·실제 발송
+- production 자격 증명·환경 변수·Firebase/운영 데이터 변경
+- Railway/Vercel production 배포·rollback
 - 운영 회차 생성·상태 변경·`salesMode` 전환
 - 실제 결제·환불
 
@@ -181,16 +148,12 @@ Vercel Hobby build-rate-limit 때문에 docs-only PR에 Vercel check failure가 
 
 ## 다음 작업
 
-1. **P0 병렬 금융 게이트**: admin force refund를 정상 cancellation/정산/capacity 불변식으로 수렴시키고 paid settlement 환불 정책을 확정·직접 회귀 후 `main` 통합.
-2. **P0 병렬 인증 게이트**: driver 관리자 승인 우회 제거 + 정지/role/store 변경의 refresh/Firebase claims 수렴 정책 확정·구현·직접 회귀 후 `main` 통합.
-3. **P0 병렬 코드 게이트**: 주문 direct Firestore read를 안전한 discovery/assigned 경계와 역할별 최소 데이터로 축소하고 Rules·frontend 회귀를 `main`에 통합.
-4. **P0 병렬 코드 게이트**: 결제 finalization이 비`PAID` provider 상태를 자체 차단하도록 구현·회귀 검증 후 `main` 통합.
-5. **P0 병렬 검증 게이트**: 주문 mutation authorization 직접 회귀 후 `main` 통합.
-6. **P0 병렬 관리자 게이트**: Issue #32의 `main` branch protection/ruleset 활성화.
-7. **외부 차단**: ALIGO 8종 심사 결과 대기.
-8. 승인 후 실제 알림톡/SMS fallback → 판매 활성화 legal 재정합화.
-9. 모든 P0 및 법적 변경을 포함한 actual release SHA 확정 → 원격 회차 E2E 52건+cleanup.
-10. 운영 Firebase 재조회 → ALIGO 운영 설정 → 별도 `Task 3.1 승인` → exact-SHA production 배포.
-11. 이후 첫 회차 검수 → 최종 출시 판정 → `salesMode: round_direct` 전환.
-
-문서 정합성 감사는 `docs/DOCUMENT_CONSISTENCY.md`를 따르고, repository 변경은 **branch + PR**로 수행한다.
+1. `ORDER-REDELIVERY-PAID-RESUME-GATE` 구현·직접 회귀·`main` 통합.
+2. 나머지 P0 코드/권한/환불 게이트를 ALIGO 심사와 병렬 해결.
+3. Issue #32 관리자 설정.
+4. ALIGO 심사 결과 재조회.
+5. 승인 뒤 실제 알림톡 → SMS fallback.
+6. 모든 P0 결과 기준으로 판매 활성화 legal docs/test 재정합화.
+7. actual release SHA 고정 → 원격 E2E 52+cleanup → 운영 Firebase 재조회.
+8. 별도 승인 후 ALIGO production 설정·exact-SHA production deploy.
+9. 첫 회차 검수 → 최종 승인 → `salesMode: round_direct`.

--- a/docs/plans/HANDOFF_mvp_round_direct_aligo_review_pause.md
+++ b/docs/plans/HANDOFF_mvp_round_direct_aligo_review_pause.md
@@ -2,90 +2,93 @@
 
 # 회차 직배송 MVP — ALIGO 심사 대기 인계
 
-> 이 문서는 현재 재개 지점만 관리한다. 상세 상태는 `docs/memory.md`, 미완료 Acceptance Criteria는 `docs/BACKLOG.md`, 실행 의존성은 `docs/plans/PLAN_mvp_round_direct_launch_blockers.md`를 따른다.
+> 현재 재개 지점만 관리한다. 상세 상태는 `docs/memory.md`, 미완료 Acceptance Criteria는 `docs/BACKLOG.md`, 실행 의존성은 `docs/plans/PLAN_mvp_round_direct_launch_blockers.md`를 따른다.
 
 ## 현재 상태 — 2026-08-24 KST
 
-- 회차 직배송 MVP는 `main` 통합 완료.
+- 회차 직배송 MVP `main` 통합 완료.
 - 카카오 비즈니스 채널, ALIGO 발신 프로필·`senderkey`, 회차 알림 템플릿 8종 등록·심사 요청 완료.
 - 마지막 provider 확인 기준 8종 모두 `검수중`.
 - 실제 알림톡·SMS 발송 0건.
-- production ALIGO 자격 증명·8종 매핑 미반영.
+- production ALIGO 설정 미반영.
 - 첫 운영 회차 미생성, `salesMode=legacy`.
-- `main` merge는 production 배포 승인이 아니며 exact release SHA + 별도 승인 절차를 사용한다.
+- `main` merge는 production 승인/배포가 아니며 exact release SHA + 별도 승인 절차를 사용한다.
 
-현재 외부 차단점은 **ALIGO 8종 provider 심사 완료**다. provider 상태는 재개 시 직접 다시 확인한다.
+현재 외부 차단점은 **ALIGO 8종 provider 심사 완료**다. 재개 시 provider 상태를 직접 다시 확인한다.
 
-ALIGO 심사와 병렬로 해결해야 할 P0는 여섯 가지다.
+ALIGO 심사와 병렬로 해결할 출시 P0:
 
-1. `AUTH-DRIVER-APPROVAL-AND-SESSION-REVOCATION`
-2. `ORDER-DIRECT-READ-AUTHORIZATION-AND-MINIMIZATION`
-3. `PAYMENT-FINALIZATION-PAID-GUARD`
-4. `ORDER-MUTATION-AUTHORIZATION-COVERAGE`
-5. `ADMIN-FORCE-REFUND-CONSISTENCY`
-6. Issue #32 `main` branch protection/ruleset
+1. `ORDER-REDELIVERY-PAID-RESUME-GATE`
+2. `AUTH-DRIVER-APPROVAL-AND-SESSION-REVOCATION`
+3. `ORDER-DIRECT-READ-AUTHORIZATION-AND-MINIMIZATION`
+4. `PAYMENT-FINALIZATION-PAID-GUARD`
+5. `ORDER-MUTATION-AUTHORIZATION-COVERAGE`
+6. `ADMIN-FORCE-REFUND-CONSISTENCY`
+7. Issue #32 `main` protection/ruleset
 
 ## P0 재개 포인터
 
-### 1. Driver 승인·세션 권한
+### 1. 유료 재배송비 결제 전 배송 재개
 
-- 신규 Kakao `targetRole: driver`와 승인 필드 누락 기존 driver의 자동 승인 경로가 현재 존재한다.
-- refresh는 authoritative user 상태를 재조회하지 않고 stale `role/storeId` claims를 재사용한다.
-- 관리자 승인 전 driver 권한 차단과 suspension/role/store/approval 변경의 revocation window를 구현·직접 검증해야 한다.
-- broad driver Firestore read P0와 결합 검증한다.
+운영 runbook은 고객 책임 첫 배송 실패의 유료 재배송에 **결제 전 재배송 금지**를 요구한다.
+
+현재:
+
+- charge 생성·결제·환불 자체는 직접 회귀가 있어 `VERIFIED`.
+- 하지만 server lifecycle은 `DELIVERY_HELD → DELIVERING` 전에 연결 charge `PAID`를 확인하지 않는다.
+- driver 상세도 charge 상태와 무관하게 `배송 재개` CTA를 노출한다.
+
+완료 방향:
+
+- 현재 hold ↔ current `redeliveryChargeId` 연계 확인
+- `REDELIVERY_FEE`, order/store/user 일치, `PAID`일 때만 유료 재배송 재개
+- `PENDING|FAILED|REFUNDED|missing|mismatched` side-effect 0 거부
+- 재배송비 없는 판매자/시스템 책임 보류는 기존 정책 유지
+- UI 상태 표현 + `미결제 거부 → 결제 → 재개 성공` 직접 E2E
+
+정본: `docs/specs/api/orders.md`, `docs/BACKLOG.md`; 운영 근거: `docs/specs/ops/mvp-sales-round-runbook.md`.
+
+### 2. Driver 승인·세션 권한
+
+- 신규 Kakao `targetRole: driver`와 승인 필드 누락 기존 driver의 자동 승인 경로 제거.
+- suspension/role/store/approval 변경 뒤 refresh/Firebase claims가 정의된 revocation window 안에 authoritative state로 수렴하도록 보정.
+- broad driver Firestore read P0와 결합 회귀.
 
 정본: `docs/specs/api/auth.md`, `docs/specs/api/admin.md`, `docs/BACKLOG.md`.
 
-### 2. 주문 direct read·데이터 최소화
+### 3. 주문 direct read·데이터 최소화
 
-- API driver read는 배정 경계가 있으나 실제 driver 앱은 raw Firestore 주문을 직접 읽는다.
-- current Rules의 broad driver read와 raw order 문서의 불필요 필드 노출을 안전한 discovery/assigned 계약으로 축소해야 한다.
-- 미배정 `PREPARING` direct/hub discovery 의도는 보존한다.
+- 필요한 미배정 `PREPARING` direct/hub discovery는 유지.
+- arbitrary raw order read와 역할에 불필요한 내부/동의/유입 필드 노출 제거.
+- Rules + projection/API + seller/driver 정상 흐름을 함께 검증.
 
 정본: `docs/specs/api/orders.md`, `docs/specs/legal/README.md`, `docs/BACKLOG.md`.
 
-### 3. 결제 finalization `PAID` guard
+### 4. 결제 finalization `PAID` guard
 
-- `PaymentFinalizationService.finalizePaidOrder()`가 비`PAID` provider 상태를 메서드 자체에서 차단하지 않는다.
-- `PENDING/FAILED/CANCELLED` 거부와 `PAID` 정상·금액 불일치·legacy/group/round 회귀를 직접 고정한다.
+- `finalizePaidOrder()` boundary가 비`PAID` 입력을 자체 차단하도록 보정.
+- `PENDING|FAILED|CANCELLED` 거부와 `PAID` legacy/group/round 정상 회귀.
 
 정본: `docs/specs/api/payments.md`, `docs/BACKLOG.md`.
 
-### 4. 주문 mutation authorization 회귀
+### 5. 주문 mutation authorization 회귀
 
-- seller store ownership, driver assignment, consumer ownership guard는 구현돼 있다.
-- 타-store seller, 비담당 driver, 미배정 first-claim 외 mutation, 거부 side-effect 0의 직접 회귀가 부족하다.
+- 타-store seller, 비담당 driver, first-claim 외 미배정 driver action을 직접 거부 테스트로 고정.
+- 거부 side-effect 0 포함.
 
 정본: `docs/specs/api/orders.md`, `docs/BACKLOG.md`.
 
-### 5. Admin 강제 환불 lifecycle 정합성
+### 6. Admin 강제 환불 lifecycle
 
-현재 `AdminService.forceRefund()`는 정상 회차 cancellation orchestration과 수렴하지 않는다.
+- admin 본 결제 환불 + 주문 직접 `CANCELLED` write를 정상 cancellation 금전·capacity·settlement 불변식과 수렴시킨다.
+- paid settlement 환불은 별도 회계 조정 정책이 필요하다.
 
-현재 차이:
+정본: `docs/specs/api/admin.md`, `docs/specs/api/settlements.md`, `docs/BACKLOG.md`.
 
-- admin 경로: 본 결제 환불 → 주문 `CANCELLED` 직접 write
-- 정상 회차 취소: cancellation claim/state → 본 결제·추가 charge 환불 → reservation/capacity 반환 → hold counter 정합화 → 주문 취소 → settlement 취소
-
-따라서 actual release SHA 확정 전 다음을 해결한다.
-
-- admin 환불 허용 상태 fail-closed
-- 이미 결제된 재배송비/추가 charge 처리
-- 회차 reservation 및 sale-round/item counter 반환
-- `DELIVERY_HELD`의 `heldOrderCount` 수렴
-- `pending|confirmed` settlement 취소
-- `paid` settlement 환불의 별도 회계 조정 정책
-- provider 성공/local 실패 재시도 계약
-- seller/consumer/round cancellation과 admin refund 동시 실행의 이중환불·이중 release 방지
-- 직접 회귀 테스트
-
-정본: `docs/specs/api/admin.md`, `docs/specs/api/payments.md`, `docs/specs/api/settlements.md`, `docs/specs/api/orders.md`, `docs/BACKLOG.md`.
-
-### 6. GitHub `main` protection
+### 7. GitHub `main` protection
 
 - repo-side production auto-deploy 차단은 완료.
-- GitHub `main` 자체 보호는 Issue #32에서 완료해야 한다.
-- 목표: PR required, `Deployment safety guard / verify`, force-push/delete 차단.
+- Issue #32에서 PR required, safety required check, force-push/delete 차단 필요.
 
 정본: `docs/plans/PLAN_deployment_safety_guards_20260823.md`.
 
@@ -93,40 +96,41 @@ ALIGO 심사와 병렬로 해결해야 할 P0는 여섯 가지다.
 
 - 심사 중 ALIGO 템플릿 중복 등록·임의 수정.
 - 승인 전 실제 알림톡·SMS 발송.
-- secret, 실제 `tpl_code`, 고객 개인정보 원문을 Git/문서에 기록.
+- secret, 실제 `tpl_code`, 고객 개인정보 원문 Git/문서 기록.
 - direct `main` commit/push.
 - `main` merge를 production 배포 승인으로 해석.
-- 별도 승인 없이 production 배포·Firebase 운영 변경·운영 회차 생성·`salesMode` 변경.
-- P0 구현 결함을 법적/운영 문구 확대로 정당화.
-- 현재 P0가 `main`에 포함되기 전에 actual release SHA 확정.
+- 별도 승인 없는 production 배포·Firebase 운영 변경·운영 회차 생성·`salesMode` 변경.
+- P0 구현 결함을 UI·legal·운영 문구만으로 정당화.
+- P0가 `main`에 포함되기 전 actual release SHA 확정.
 
 ## 지금 병렬로 할 수 있는 작업
 
-1. driver 승인·세션 revocation 구현·회귀·통합.
-2. 주문 direct read 최소화 구현·Rules/frontend 회귀·통합.
-3. 결제 finalization `PAID` guard 구현·회귀·통합.
-4. 주문 mutation authorization 직접 거부 회귀·통합.
-5. admin 강제 환불 lifecycle 정합화 구현·회귀·통합.
-6. Issue #32 관리자 설정.
-7. read-only 문서/코드 정합성 감사.
-8. ALIGO provider 심사 상태 조회.
+1. 유료 재배송비 `PAID` resume guard 구현·회귀·통합.
+2. driver 승인·세션 revocation 구현·회귀·통합.
+3. 주문 direct read 최소화 구현·Rules/frontend 회귀·통합.
+4. payment finalization `PAID` guard 구현·회귀·통합.
+5. 주문 mutation authorization 거부 회귀·통합.
+6. admin force-refund lifecycle 정합화·회귀·통합.
+7. Issue #32 관리자 설정.
+8. read-only 문서/코드 정합성 감사.
+9. ALIGO provider 심사 상태 조회.
 
 ## ALIGO 승인 뒤 재개 순서
 
-1. 위 P0 다섯 코드/검증 게이트와 Issue #32가 완료됐는지 확인.
-2. ALIGO 8종 승인/수정요청/반려 상태 재확인.
-3. 승인 `tpl_code` 8종 ↔ 내부 논리 템플릿 1:1 매핑 검사.
+1. 위 P0 6개와 Issue #32 완료 확인.
+2. ALIGO 8종 승인/수정요청/반려 재확인.
+3. 승인 `tpl_code` 8종 ↔ 내부 논리 코드 1:1 검사.
 4. 별도 승인 후 격리 실제 알림톡 정상 발송.
 5. 별도 승인 후 SMS fallback 실제 검증.
-6. 주문 read 최소화와 admin 환불 실제 정책을 기준으로 판매 활성화 법적 문서·테스트 재정합화.
-7. 모든 P0 및 법적 변경을 포함한 actual release SHA 확정.
-8. exact SHA 원격 회차 E2E 52건 + fixture cleanup.
+6. 실제 재배송비/환불/read-minimization 결과를 기준으로 판매 활성화 legal docs/test 재정합화.
+7. 모든 P0·legal 변경 포함 actual release SHA 확정.
+8. exact SHA 원격 E2E 52 + cleanup.
 9. 운영 Firebase read-only 재조회.
-10. 별도 승인 후 production ALIGO 설정 반영·검증.
-11. exact-SHA production deploy/promotion 절차 확정.
-12. 사용자의 별도 `Task 3.1 승인` 뒤에만 production 배포.
-13. provider deployment metadata SHA 대조 → 운영 smoke.
-14. 첫 회차 검수 → 최종 출시 판정 → `salesMode: round_direct` 전환.
+10. 별도 승인 후 production ALIGO 설정.
+11. exact-SHA deploy/promotion 절차 확정.
+12. 사용자의 별도 `Task 3.1 승인` 뒤 production 배포.
+13. provider metadata SHA 대조 → 운영 smoke.
+14. 첫 회차 검수 → 최종 출시 판정 → `salesMode: round_direct`.
 
 ## 재개 완료 조건
 
@@ -134,18 +138,19 @@ ALIGO 심사와 병렬로 해결해야 할 P0는 여섯 가지다.
 - [x] 카카오 비즈니스 채널 승인
 - [x] ALIGO 발신 프로필·senderkey 준비
 - [x] ALIGO 템플릿 8종 등록·심사 요청
-- [x] repo-side `main` 자동 production deploy 차단
-- [ ] driver 승인·세션/claims revocation + 직접 회귀 + `main` 통합
-- [ ] 주문 direct read authorization·데이터 최소화 + Rules/frontend 회귀 + `main` 통합
-- [ ] 결제 finalization `PAID` guard + 회귀 + `main` 통합
-- [ ] 주문 mutation authorization 직접 거부 회귀 + `main` 통합
-- [ ] admin 강제 환불 lifecycle 정합성 + 회귀 + `main` 통합
-- [ ] Issue #32 branch protection/ruleset
-- [ ] ALIGO 템플릿 8종 최종 승인
+- [x] repo-side `main` auto-production 차단
+- [ ] 유료 재배송비 `PAID` resume gate + 직접 회귀 + `main`
+- [ ] driver 승인·세션/claims revocation + 직접 회귀 + `main`
+- [ ] 주문 direct read 최소화 + Rules/frontend 회귀 + `main`
+- [ ] payment finalization `PAID` guard + 회귀 + `main`
+- [ ] 주문 mutation authorization 거부 회귀 + `main`
+- [ ] admin force-refund lifecycle + 회귀 + `main`
+- [ ] Issue #32
+- [ ] ALIGO 8종 최종 승인
 - [ ] 실제 알림톡 정상 발송
-- [ ] SMS fallback 실제 검증
-- [ ] 판매 활성화 법적 문서 정합화
-- [ ] actual release SHA 원격 E2E 52건+cleanup
+- [ ] SMS fallback
+- [ ] 판매 활성화 legal
+- [ ] actual release SHA E2E 52+cleanup
 - [ ] production ALIGO 설정
 - [ ] Task 3.1 별도 승인
 

--- a/docs/plans/PLAN_mvp_round_direct_launch_blockers.md
+++ b/docs/plans/PLAN_mvp_round_direct_launch_blockers.md
@@ -2,7 +2,7 @@
 
 # Project Blueprint: 회차 직배송 MVP 출시 차단 요소 해소
 
-> 현재 실행 순서·의존성·승인 게이트만 관리한다. 현재 상태는 `docs/memory.md`, 세부 미완료·Acceptance Criteria는 `docs/BACKLOG.md`, 도메인 계약은 각 current spec을 따른다.
+> 실행 순서·의존성·승인 게이트만 관리한다. 현재 상태는 `docs/memory.md`, 세부 Acceptance Criteria는 `docs/BACKLOG.md`, 도메인 계약은 current spec을 따른다.
 
 ## 문서 메타
 
@@ -10,121 +10,122 @@
 - 최종 정합화: 2026-08-24 KST
 - 상태: `paused_external_review`
 - Priority: P0
-- 현재 외부 차단점: ALIGO 회차 알림 템플릿 8종 provider 심사 완료
-- 현재 상태 SSOT: `docs/memory.md`
-- 현재 재개 지점: `docs/plans/HANDOFF_mvp_round_direct_aligo_review_pause.md`
+- 외부 차단점: ALIGO 회차 알림 템플릿 8종 provider 심사 완료
+- 상태 SSOT: `docs/memory.md`
+- 재개 지점: `docs/plans/HANDOFF_mvp_round_direct_aligo_review_pause.md`
 - 미완료 상세: `docs/BACKLOG.md`
-- 인증 계약: `docs/specs/api/auth.md`
-- 주문 계약: `docs/specs/api/orders.md`
-- 결제 계약: `docs/specs/api/payments.md`
-- 정산 계약: `docs/specs/api/settlements.md`
-- 관리자 계약: `docs/specs/api/admin.md`
-- 판매 활성화 법적 게이트: `docs/specs/legal/README.md`
-- 배포 안전 계약: `docs/plans/PLAN_deployment_safety_guards_20260823.md`
+- 인증: `docs/specs/api/auth.md`
+- 주문: `docs/specs/api/orders.md`
+- 결제: `docs/specs/api/payments.md`
+- 정산: `docs/specs/api/settlements.md`
+- 관리자: `docs/specs/api/admin.md`
+- legal: `docs/specs/legal/README.md`
+- 배포 안전: `docs/plans/PLAN_deployment_safety_guards_20260823.md`
 
 ## 현재 출시 게이트
 
 | ID | 게이트 | 상태 |
 |---|---|---|
-| 0A | GitHub `main` branch protection/ruleset | 미완료 — Issue #32 |
+| 0A | GitHub `main` protection/ruleset | 미완료 — Issue #32 |
 | 0B | 결제 finalization 비`PAID` 최종 차단 | 미완료 — P0 |
 | 0C | 주문 mutation authorization 직접 거부 회귀 | 미완료 — P0 COVERAGE GAP |
-| 0D | 주문 direct Firestore read authorization·데이터 최소화 | 미완료 — P0 IMPLEMENTATION FINDING |
-| 0E | driver 승인 게이트 + 세션/claims revocation | 미완료 — P0 IMPLEMENTATION FINDING / DECISION REQUIRED |
+| 0D | 주문 direct Firestore read·데이터 최소화 | 미완료 — P0 IMPLEMENTATION FINDING |
+| 0E | driver 승인 + 세션/claims revocation | 미완료 — P0 IMPLEMENTATION FINDING / DECISION REQUIRED |
 | 0F | admin 강제 환불 lifecycle 정합성 | 미완료 — P0 IMPLEMENTATION FINDING |
+| 0G | 유료 재배송비 `PAID` 전 배송 재개 차단 | 미완료 — P0 IMPLEMENTATION FINDING |
 | 1 | ALIGO 8종 provider 최종 승인 | 검수중 |
 | 2 | 실제 알림톡 정상 발송 | 미실행 |
 | 3 | SMS fallback 실제 검증 | 미실행 |
-| 4 | 판매 활성화 법적 문서 재정합화 | 미실행 |
+| 4 | 판매 활성화 legal 재정합화 | 미실행 |
 | 5 | actual release SHA 확정 | 미실행 |
-| 6 | exact SHA 원격 회차 E2E 52건+cleanup | 미실행 |
+| 6 | exact SHA 원격 E2E 52건+cleanup | 미실행 |
 | 7 | 운영 Firebase 재조회 | 미실행 |
 | 8 | 운영 ALIGO 설정 | 미실행 |
 | 9 | exact-SHA production 배포 | 미실행 — 별도 Task 3.1 승인 |
 | 10 | 첫 회차 검수 | 미실행 |
 | 11 | 최종 출시 판정 | 미실행 |
-| 12 | `salesMode: round_direct` 전환 | 미실행 |
+| 12 | `salesMode: round_direct` | 미실행 |
 
 ## Agent Completion Contract
 
-1. 모든 repository 변경은 최신 `main`에서 목적별 branch를 만들고 PR로 통합한다.
-2. direct `main` commit/push를 하지 않는다.
-3. Task 0A~0F는 ALIGO 심사와 병렬 수행할 수 있다.
-4. 문서 정합성 감사에서 발견한 P0 구현 결함을 문구 변경만으로 정상화하지 않는다.
+1. repository 변경은 최신 `main` 기반 목적별 branch+PR로 통합한다.
+2. direct `main` commit/push 금지.
+3. Task 0A~0G는 ALIGO 심사와 병렬 수행 가능.
+4. P0 구현 결함을 문서 문구만 바꿔 정상화하지 않는다.
 5. `IMPLEMENTED / UNVERIFIED`, `COVERAGE GAP`, `IMPLEMENTATION FINDING`, P0 `DECISION REQUIRED`는 완료가 아니다.
-6. 비밀값·고객 개인정보·사진 원본·서명 URL을 Git/문서/증거에 남기지 않는다.
-7. actual release SHA는 Task 0A~0F와 법적 게이트가 모두 해결된 뒤에만 확정한다.
-8. exact release SHA의 원격 회차 E2E 52건과 cleanup 통과 전 production 배포 금지.
-9. `main` merge·빈 commit·재-push를 production 배포 트리거로 사용하지 않는다.
-10. production 배포는 검증된 exact SHA/artifact와 별도 승인 게이트를 사용한다.
-11. provider metadata Git SHA가 승인 release SHA와 다르면 traffic/domain 전환을 진행하지 않는다.
-12. ALIGO 실제 발송 검증 실패 시 알림 없는 출시를 임의 승인하지 않는다.
-13. 첫 회차가 검수된 `SCHEDULED`가 아니면 `salesMode`를 전환하지 않는다.
+6. 비밀값·고객 개인정보·사진 원본·서명 URL을 증거에 남기지 않는다.
+7. actual release SHA는 Task 0A~0G와 legal gate 해결 뒤에만 확정한다.
+8. exact release SHA E2E 52+cleanup 전 production 배포 금지.
+9. `main` merge·빈 commit·재-push를 production 트리거로 사용하지 않는다.
+10. production은 exact SHA/artifact + 별도 승인 게이트를 사용한다.
+11. provider metadata SHA 불일치 시 traffic/domain 전환 금지.
+12. ALIGO 실제 발송 실패 시 알림 없는 출시를 임의 승인하지 않는다.
+13. 첫 회차가 검수된 `SCHEDULED`가 아니면 `salesMode` 전환 금지.
+14. 금전 게이트는 UI 조건이 아니라 서버 boundary에서 fail-closed여야 한다.
 
 ## Phase 0 — 출시 전 코드·권한·금전 안전성
 
 ### Task 0.1 — 회차 직배송 코드 `main` 통합
 - Status: done
-- Evidence: PR #11, 기능 통합 기준 SHA `e55f25914cc7d01576fbd4639583daaf0fe6385e`.
+- Evidence: PR #11, 기능 통합 SHA `e55f25914cc7d01576fbd4639583daaf0fe6385e`.
 
 ### Task 0.2 — `main` 자동 production deploy 분리
 - Status: done
 - Evidence: PR #30, PR #31.
 
 ### Task 0.3 — GitHub `main` protection/ruleset
-- Dependency: 없음.
-- Required: PR required, `Deployment safety guard / verify`, force-push/delete 차단.
-- Tracking: Issue #32.
+- Dependency: 없음
+- Required: PR required, `Deployment safety guard / verify`, force-push/delete 차단
+- Tracking: Issue #32
 - Status: todo_admin
 
 ### Task 0.4 — 결제 finalization `PAID` 최종 방어
-- Dependency: 없음.
-- Goal: `finalizePaidOrder()`가 호출자에 의존하지 않고 비`PAID` provider 상태를 차단한다.
-- Verify: `PENDING`, `FAILED`, `CANCELLED`, `PAID`, 금액 불일치, legacy/group/round 경로.
-- Contract: `docs/specs/api/payments.md`
+- Dependency: 없음
+- Goal: finalization boundary가 비`PAID` provider 상태 자체 차단
+- Verify: `PENDING|FAILED|CANCELLED|PAID`, 금액 불일치, legacy/group/round
 - Backlog: `PAYMENT-FINALIZATION-PAID-GUARD`
 - Status: todo_code
 
 ### Task 0.5 — 주문 mutation authorization 직접 회귀
-- Dependency: 없음.
-- Goal: seller 타-store, 비담당 driver, 미배정 first-claim 경계와 거부 side-effect 0을 직접 고정한다.
-- Contract: `docs/specs/api/orders.md`
+- Dependency: 없음
+- Goal: 타-store seller, 비담당 driver, first-claim과 거부 side-effect 0 직접 고정
 - Backlog: `ORDER-MUTATION-AUTHORIZATION-COVERAGE`
 - Status: todo_test
 
-### Task 0.6 — 주문 direct Firestore read authorization·데이터 최소화
-- Dependency: 없음.
-- Goal: 필요한 미배정 주문 discovery는 유지하되 arbitrary raw order read와 역할에 불필요한 필드 노출을 제거한다.
-- Verify: Rules + app/API 정상 discovery/assigned detail + 타주문/타store 거부.
-- Contract: `docs/specs/api/orders.md`
-- Legal dependency: `docs/specs/legal/README.md`
+### Task 0.6 — 주문 direct Firestore read·데이터 최소화
+- Dependency: 없음
+- Goal: 필요한 discovery는 유지하고 arbitrary raw read와 불필요 필드 노출 제거
+- Verify: Rules + discovery/assigned detail + 타주문/타store 거부
 - Backlog: `ORDER-DIRECT-READ-AUTHORIZATION-AND-MINIMIZATION`
 - Status: todo_code_security
 
-### Task 0.7 — Driver 승인 게이트·세션/claims revocation
-- Dependency: 없음.
-- Goal: 관리자 승인 전 driver 권한 획득을 차단하고, suspension/role/store/approval 변경이 정의된 revocation window 안에 API·Firebase claims에 수렴하도록 한다.
-- Verify: 신규/legacy 자동 승인 제거, 승인 전후 접근, refresh/current claims, logout/rotation 회귀.
-- Contract: `docs/specs/api/auth.md`, `docs/specs/api/admin.md`
+### Task 0.7 — Driver 승인·세션/claims revocation
+- Dependency: 없음
+- Goal: 관리자 승인 전 driver 권한 차단 + suspension/role/store/approval의 정의된 revocation window 보장
+- Coupling: Task 0.6 broad driver read와 결합 회귀
 - Backlog: `AUTH-DRIVER-APPROVAL-AND-SESSION-REVOCATION`
-- Coupling: Task 0.6 broad driver read와 결합 회귀를 확인한다.
 - Status: todo_code_security
 
 ### Task 0.8 — Admin 강제 환불 lifecycle 정합화
-- Dependency: 없음.
-- Goal: `POST /admin/orders/:orderId/refund`가 provider 본 결제 환불과 주문 `CANCELLED` 직접 write만 수행해 정상 cancellation orchestration을 우회하는 구조를 제거한다.
-- Required:
-  - admin 환불의 허용 주문 상태를 명시하고 완료/배송 중 등 비의도 상태를 fail-closed
-  - 본 결제 환불과 이미 결제된 재배송비/추가 charge 처리 정책 일치
-  - 회차 주문 `reservationId` release와 sale-round/item ordered counter 반환
-  - `DELIVERY_HELD` 취소 시 `heldOrderCount` 정합성 유지
-  - 연결 settlement의 `pending|confirmed → cancelled` 수렴
-  - 이미 `paid` settlement인 주문 환불은 단순 `paid → cancelled` 역전이 아닌 별도 회계 조정 정책 결정
-  - provider 환불 성공 뒤 local cancellation 실패 시 재시도 가능한 cancellation state/operation issue 또는 동등 복구 계약
-  - seller/consumer/round cancellation과 admin force-refund 동시 실행이 이중환불·이중 capacity release 없이 수렴
-  - 거부/실패 경로의 부수효과를 직접 테스트
-- Contract: `docs/specs/api/admin.md`, `docs/specs/api/payments.md`, `docs/specs/api/settlements.md`, `docs/specs/api/orders.md`
+- Dependency: 없음
+- Goal: admin refund가 정상 cancellation의 본 결제/추가 charge/capacity/held counter/settlement 불변식과 수렴
+- Required: 허용 상태 fail-closed, paid settlement 별도 회계 정책, provider-success/local-failure 재시도, 동시 실행 수렴
 - Backlog: `ADMIN-FORCE-REFUND-CONSISTENCY`
+- Status: todo_code_financial
+
+### Task 0.9 — 유료 재배송비 결제 완료 전 배송 재개 차단
+- Dependency: 없음
+- Goal: 고객 책임 유료 재배송은 현재 hold에 연결된 `REDELIVERY_FEE` charge가 `PAID`일 때만 `DELIVERY_HELD → DELIVERING` 허용
+- Required:
+  - 현재 hold와 `redeliveryChargeId` 연계 검증
+  - charge type/order/store/user 일치 검증
+  - `PENDING|FAILED|REFUNDED|missing|mismatched` fail-closed + side effect 0
+  - 재배송비 없는 판매자/시스템 책임 보류는 불필요한 결제 gate 없음
+  - driver UI charge 상태 표현
+  - `미결제 거부 → 결제 완료 → 재개 성공` unit/integration/E2E
+- Contract: `docs/specs/api/orders.md`
+- Operational evidence: `docs/specs/ops/mvp-sales-round-runbook.md`
+- Backlog: `ORDER-REDELIVERY-PAID-RESUME-GATE`
 - Status: todo_code_financial
 
 ## Phase 1 — ALIGO 알림 게이트
@@ -133,7 +134,7 @@
 - Status: done
 
 ### Task 1.2 — 템플릿 8종 최종 승인
-- Current: 상태 상세는 `docs/memory.md`.
+- Current: `docs/memory.md`
 - Status: blocked_external_review
 
 ### Task 1.3 — 승인 `tpl_code` 1:1 매핑 검사
@@ -150,23 +151,22 @@
 
 ## Phase 2 — 판매 공개 계약·release SHA
 
-### Task 2.1 — 판매 활성화 법적 문서 재정합화
-- Dependency: Task 1.5, Task 0.6, Task 0.8
-- Required: 실제 주문·취소·환불·배송·재배송비·보류, PortOne/결제사업자, ALIGO, seller/driver 최소 접근, 시행일·이전 버전, legal tests.
-- Contract: `docs/specs/legal/README.md`
+### Task 2.1 — 판매 활성화 legal 재정합화
+- Dependency: Task 1.5, Task 0.6, Task 0.8, Task 0.9
+- Required: 주문·취소·환불·배송·재배송비·보류, PortOne/PG, ALIGO, seller/driver 최소 접근, 시행일·이전 버전, legal tests
 - Status: todo
 
 ### Task 2.2 — actual release SHA 확정
-- Dependency: Task 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, Task 2.1
-- Goal: 운영에 올릴 단 하나의 exact `main` SHA 고정.
+- Dependency: Task 0.3~0.9, Task 2.1
+- Goal: 운영 대상 단 하나의 exact `main` SHA 고정
 - Status: todo
 
 ### Task 2.3 — exact SHA 전체 원격 회차 E2E
 - Dependency: Task 2.2
-- Goal: chromium 26 + mobile 26 = 52, unexpected/skipped/flaky 0, 양쪽 cleanup 성공.
+- Goal: chromium 26 + mobile 26 = 52, unexpected/skipped/flaky 0, 양쪽 cleanup 성공
 - Status: todo
 
-### Task 2.4 — 운영 Firebase 읽기 전용 재조회
+### Task 2.4 — 운영 Firebase read-only 재조회
 - Dependency: Task 2.3
 - Status: todo
 
@@ -178,21 +178,21 @@
 
 ### Task 3.0 — production deploy/promotion 절차 확정
 - Dependency: Task 2.3
-- Goal: exact SHA/artifact 기반 명시적 배포·promotion과 사후 SHA 검증.
+- Goal: exact SHA/artifact 기반 명시적 배포와 사후 SHA 검증
 - Status: todo
 
 ### Task 3.1 — API production 배포 [별도 승인 게이트]
 - Dependency: Task 0.3, Task 2.3, Task 2.4, Task 2.5, Task 3.0
-- Important: 사용자의 별도 `Task 3.1 승인` 없이는 실행하지 않는다.
+- 사용자의 별도 `Task 3.1 승인` 없이는 실행하지 않는다.
 - Status: todo
 
 ### Task 3.2 — consumer·seller·driver production 배포 [승인 게이트]
 - Dependency: Task 3.1
 - Status: todo
 
-### Task 3.3 — 운영 무변경 smoke
+### Task 3.3 — 운영 smoke
 - Dependency: Task 3.2
-- 확인: health, Kakao auth, legacy, 회차 read, `/privacy`, `/terms`.
+- 확인: health, Kakao auth, legacy, 회차 read, `/privacy`, `/terms`
 - Status: todo
 
 ### Task 3.4 — 배포 후 오류 관찰
@@ -219,13 +219,13 @@
 - Dependency: Task 4.3
 - Status: todo
 
-### Task 5.2 — 전환·롤백 dry-run
+### Task 5.2 — 전환·rollback dry-run
 - Dependency: Task 5.1
 - Status: todo
 
 ### Task 5.3 — 최종 출시 판정
 - Dependency: Task 5.2
-- 대조: exact SHA, Task 0A~0F, Firebase, ALIGO, legal, 첫 회차, 운영 예외, rollback.
+- 대조: exact SHA, Task 0A~0G, Firebase, ALIGO, legal, 첫 회차, 운영 예외, rollback
 - Status: todo
 
 ## Phase 6 — 판매 모드 전환
@@ -239,7 +239,7 @@
 - Status: todo
 
 ### Task 6.3 — 외부 유입 링크 공개 [승인 게이트]
-- Dependency: Task 6.2 통과
+- Dependency: Task 6.2
 - Status: todo
 
 ## Phase 7 — 초기 안정화
@@ -254,31 +254,32 @@
 
 ## Completion Criteria
 
-- Task 0A~0F가 모두 해결되고 P0 권한·금전 계약이 필요한 직접 테스트 증거와 함께 `main`에 포함됨.
-- admin 강제 환불이 정상 주문 취소와 동일한 금전·capacity·settlement 불변식을 보존하거나, 예외 정책이 명시적·테스트된 별도 orchestration으로 구현됨.
-- Issue #32 branch protection/ruleset 완료.
-- ALIGO 8종 최종 승인 및 실제 알림톡·SMS fallback 검증.
+- Task 0A~0G가 직접 테스트 증거와 함께 `main`에 포함됨.
+- 유료 재배송비 결제 완료 전 배송 재개가 서버에서 fail-closed되고 정상 결제 뒤 재개 회귀가 포함됨.
+- admin 환불이 정상 cancellation 금전·capacity·settlement 불변식과 수렴하거나 명시적 별도 정책으로 검증됨.
+- Issue #32 완료.
+- ALIGO 8종 승인 + 실제 알림톡/SMS fallback 검증.
 - 판매 활성화 legal docs/test 정합화.
-- actual release SHA 원격 E2E 52건+cleanup 성공.
-- 운영 Firebase 상태 확인 및 production ALIGO 설정 검증.
-- production deploy/promotion이 exact SHA를 사용하고 provider metadata가 일치.
+- actual release SHA E2E 52+cleanup 성공.
+- 운영 Firebase·ALIGO 설정 확인.
+- exact SHA production metadata 일치.
 - 첫 회차 `SCHEDULED`.
 - 최종 승인 뒤 `round_direct` 전환·smoke 또는 rollback 성공.
-- 비밀값·개인정보·사진·서명 URL이 증거에 포함되지 않음.
 
 ## 현재 Closeout Roll-up
 
 - 코드 통합: 완료
-- driver 승인 게이트·세션/claims revocation: 미완료 — P0
-- 주문 direct Firestore read authorization·데이터 최소화: 미완료 — P0
-- 결제 finalization `PAID` 최종 방어: 미완료 — P0
-- 주문 mutation authorization 직접 회귀: 미완료 — P0
-- admin 강제 환불 lifecycle 정합성: 미완료 — P0
+- payment finalization P0: 미완료
+- redelivery paid-before-resume P0: 미완료
+- admin force-refund P0: 미완료
+- order direct-read P0: 미완료
+- auth approval/revocation P0: 미완료
+- order mutation coverage P0: 미완료
 - repo-side production auto-deploy 분리: 완료
 - GitHub `main` protection: 미완료 — Issue #32
 - ALIGO 8종 승인: 검수중
 - 실제 알림 발송: 미실행
-- 판매 활성화 법적 문서: 미실행
+- legal: 미실행
 - actual release SHA/E2E: 미실행
 - production 설정/배포: 미실행
 - 첫 회차: 미생성

--- a/docs/specs/api/orders.md
+++ b/docs/specs/api/orders.md
@@ -5,21 +5,20 @@
 > **최종 정합화**: 2026-08-24
 > **상태**: Current
 > **공통 타입 정본**: `packages/shared/src/order.types.ts`
-> **FSM 정본**: `apps/api/src/orders/orders.helpers.ts` 및 lifecycle service
-> **회차 직배송 추가 계약**: `docs/specs/mvp-sales-round-direct-delivery.md`
+> **FSM 구현 정본**: `apps/api/src/orders/orders.helpers.ts`, `apps/api/src/orders/*lifecycle*`
+> **회차 직배송 제품 계약**: `docs/specs/mvp-sales-round-direct-delivery.md`
+> **운영 계약**: `docs/specs/ops/mvp-sales-round-runbook.md`
 
 ## 1. 소유권
 
 `orders`는 consumer·seller·driver가 공유하는 핵심 도메인이다.
 
-- 주문 생성·검증·상태 전이·취소·재배송비·배송 보류·배송 사진 완료 같은 쓰기는 NestJS API가 소유한다.
-- frontend는 현재 API와 허용된 Firebase read 경로를 사용한다.
-- 공개 상태·주문 DTO의 공통 정본은 `packages/shared/src/order.types.ts`다.
-- legacy 일반 판매·공동구매와 `schemaVersion: 2` 회차 주문이 같은 도메인에 공존하므로 한 흐름의 규칙을 다른 흐름에 임의 적용하지 않는다.
+- 주문 생성·검증·상태 전이·취소·재배송비·배송 보류·배송 사진 완료 같은 write는 NestJS API가 소유한다.
+- 공개 주문 타입은 `packages/shared/src/order.types.ts`가 소유한다.
+- Firestore 원문에는 공개 타입 외 `reservationId`, `clientOrderPayloadHash`, `marketingConsent` 등 내부 필드가 존재할 수 있으므로 raw document를 공개 DTO와 동일시하지 않는다.
+- legacy 주문과 `schemaVersion: 2` 회차 주문이 공존하므로 한 흐름의 규칙을 다른 흐름에 자동 적용하지 않는다.
 
 ## 2. 주문 상태
-
-현재 `OrderStatus`:
 
 ```ts
 type OrderStatus =
@@ -37,22 +36,22 @@ type OrderStatus =
   | 'REVIEWED'
 ```
 
-과거 spec에 없던 `DELIVERY_HELD`는 현재 공통 상태다. 회차 직배송의 배송 실패·재배송 흐름에서 사용한다.
+`DELIVERY_HELD`는 회차 직배송의 배송 실패·재배송 흐름에서 사용하는 현재 공통 상태다.
 
-## 3. 현재 역할별 FSM
+## 3. 역할별 FSM
 
-`apps/api/src/orders/orders.helpers.ts` 기준 일반 상태 전이 허용 목록:
+`orders.helpers.ts`의 일반 전이 허용 목록은 다음과 같다. 이 목록은 **필요조건일 뿐 충분조건이 아니다**. service/lifecycle의 소유권·delivery method·결제·회차 불변식을 추가로 통과해야 한다.
 
 ### Seller
 
 - `ACCEPTED → PREPARING`
 - `CONFIRMED → PREPARING`
-- `PREPARING → DELIVERED` — parcel 등 실제 lifecycle guard를 추가로 통과해야 함
+- `PREPARING → DELIVERED` — 실제 lifecycle에서 parcel 조건 추가
 - `PREPARING → DELIVERY_HELD`
 - `DELIVERING → DELIVERY_HELD`
 - `DELIVERY_HELD → PREPARING`
 - `DELIVERY_HELD → CANCELLED`
-- seller 취소 허용 상태: `ACCEPTED`, `CONFIRMED`, `PREPARING`
+- seller 취소 기본 허용 상태: `ACCEPTED`, `CONFIRMED`, `PREPARING`
 
 ### Driver
 
@@ -70,13 +69,13 @@ type OrderStatus =
 
 ### Admin
 
-현재 helper는 seller와 driver 전환을 합친 범위 및 seller 취소 가능 상태를 허용한다. 단, endpoint 소유권·delivery method·회차 상태 등 service/lifecycle의 추가 guard는 그대로 적용된다.
+helper 수준에서는 seller·driver 전이의 합집합과 seller 취소 가능 상태를 허용한다. 실제 endpoint별 추가 불변식은 별도 확인한다.
 
-FSM 표만 보고 상태를 직접 Firestore에서 수정하지 않는다.
+FSM 표를 근거로 Firestore 주문 상태를 직접 수정하지 않는다.
 
-## 4. 배송 보류와 재배송
+## 4. 배송 보류·재배송 계약
 
-`DELIVERY_HELD` snapshot은 shared 타입에서 다음 핵심 필드를 가진다.
+`DeliveryHoldSnapshot`의 핵심 필드:
 
 ```ts
 {
@@ -96,132 +95,66 @@ FSM 표만 보고 상태를 직접 Firestore에서 수정하지 않는다.
 }
 ```
 
-`HoldDeliveryDto`는 reason code, reason message, 책임 여부, 선택적 재배송비·다음 연락/배송 시각을 검증한다. 실제 책임 판정과 허용 전이는 lifecycle service를 따른다.
+현재 제품·운영 계약:
 
-재배송 알림 연결:
+- `WEATHER`는 고객 책임 유료 재배송으로 취급하지 않는다.
+- 고객 책임 첫 배송 실패에서 양수 `redeliveryFee`가 요구되면 주문자 본인이 `POST /stores/:storeId/orders/:orderId/redelivery-fee`로 `REDELIVERY_FEE` charge를 생성·결제한다.
+- 같은 보류에 대해 중복 charge를 만들지 않는다.
+- **유료 재배송비가 요구된 보류는 연결 charge가 `PAID`임을 서버가 확인한 뒤에만 배송을 다시 시작할 수 있어야 한다.** 운영 정본은 명시적으로 `결제 전 재배송 금지`를 요구한다.
+- 유료 재배송까지 다시 실패하면 자동 환불을 추측하지 않고 `REDELIVERY_FAILED` 운영 이슈로 이관한다.
+
+알림 연결:
 
 - `PREPARING|DELIVERING → DELIVERY_HELD` → `ORDER_DELIVERY_HELD`
 - `DELIVERY_HELD → PREPARING` → `ORDER_REDELIVERY_PAYMENT_REQUESTED`
 - `DELIVERY_HELD → DELIVERING` → `ORDER_REDELIVERY_SCHEDULED`
 
-알림 본문과 ALIGO provider 계약은 `docs/specs/api/notifications.md`가 소유한다.
+알림 템플릿·provider 계약은 `docs/specs/api/notifications.md`가 소유한다.
 
-## 5. 공통 주문 데이터
+### 재배송비 결제 전 배송 재개 — `IMPLEMENTATION FINDING` P0
 
-현재 `Order` 공통 타입의 주요 필드:
+2026-08-24 현재 제품 계약과 실제 구현을 대조하면 위 결제 게이트가 서버에서 강제되지 않는다.
 
-```ts
-{
-  id: string
-  orderNumber?: string
-  schemaVersion?: 1 | 2
-  storeId: string
-  userId: string
-  productId: string
-  quantity: number
-  saleType: 'normal' | 'group'
-  status: OrderStatus
-  deliveryMethod: 'direct' | 'hub' | 'parcel'
-  deliveryFee: number
-  deliveryAddress: DeliveryAddress
-  isMetropolitan: boolean
-  hubId: string | null
-  pickupCode: string | null
-  totalAmount: number
-  requestedDeliveryDate: string | null
-  preparedAt: string | null
-  cancelReason: string | null
-  groupBuyConsent: GroupBuyConsent | null
+직접 근거:
 
-  roundId?: string | null
-  roundName?: string | null
-  orderItems?: OrderItemSnapshot[]
-  acquisition?: OrderAcquisitionSnapshot | null
-  deliveryHold?: DeliveryHoldSnapshot | null
-  deliveryPhone?: string | null
-  deliveryPhotoIds?: string[]
+- `docs/specs/ops/mvp-sales-round-runbook.md`는 첫 고객 사유 실패를 `재배송비 1건 생성·결제. 결제 전 재배송 금지`로 규정한다.
+- `OrderChargePaymentService` 자체는 `PAID` 상태·금액·charge/order 연결과 환불 멱등성을 직접 검증한다.
+- 그러나 `orders.helpers.ts`는 driver의 `DELIVERY_HELD → DELIVERING`을 허용하고, `OrdersLifecycleService`/`RoundOrderLifecycleService`는 해당 전환 직전에 연결 `orderCharges/{redeliveryChargeId}.status === 'PAID'`를 확인하지 않는다.
+- driver `board/[orderId]/page.tsx`도 회차 직배송 `DELIVERY_HELD`이면 charge 상태를 확인하지 않고 항상 `배송 재개` CTA를 노출해 `DELIVERING` 전환을 호출한다.
+- 현재 회귀 테스트는 charge 생성·결제·환불 자체는 고정하지만 미결제/실패 charge에서 배송 재개를 거부하는 서버 회귀를 고정하지 않는다.
 
-  createdAt: string
-  updatedAt: string
+판정:
 
-  productName?: string
-  buyerName?: string
-  address?: string
-  buyerPhone?: string | null
-  sellerPhone?: string | null
-  hubName?: string | null
-  hubAddress?: string | null
-}
-```
+- `OrderChargePaymentService`의 **재배송비 결제·환불 하위 계약은 `VERIFIED`**다.
+- 그러나 **유료 재배송비 결제 완료를 배송 재개 전제조건으로 강제하는 주문 lifecycle 계약은 P0 `IMPLEMENTATION FINDING`**이다.
+- UI에서 버튼을 숨기는 것만으로 완료하지 않는다. API 직접 호출에서도 fail-closed여야 한다.
 
-이 문서에 Firestore 내부 필드를 별도 복제하지 않는다. 새 공개 필드를 추가하면 shared 타입을 먼저 확인한다.
+actual release SHA 전 완료 조건:
 
-**주의:** 실제 `orders` Firestore 문서에는 shared `Order` 공개 타입 외에 `clientOrderPayloadHash`, `reservationId`, `marketingConsent` 등 내부 처리 필드가 함께 존재할 수 있다. raw Firestore document read를 공개 DTO와 동일한 것으로 취급하지 않는다.
+- 고객 책임이고 `redeliveryFee > 0`인 현재 보류가 유료 재배송 대상인지 서버에서 판정한다.
+- `DELIVERY_HELD → DELIVERING` 직전에 주문의 현재 `redeliveryChargeId`와 현재 보류의 `heldAt` 연계를 확인한다.
+- 연결 charge가 존재하고 `type === 'REDELIVERY_FEE'`, 같은 order/store/user에 속하며 `status === 'PAID'`일 때만 유료 재배송 재개를 허용한다.
+- `PENDING|FAILED|REFUNDED|missing|mismatched` charge에서는 주문·held counter·알림 side effect 없이 전환을 거부한다.
+- 판매자/시스템 책임 또는 재배송비가 없는 보류는 불필요한 결제 요구 없이 기존 정책대로 해소 가능해야 한다.
+- 이미 결제된 같은 보류의 정상 배송 재개는 한 번만 수렴한다.
+- driver UI도 charge 상태를 명시적으로 표현하되 UI 방어를 서버 불변식의 대체물로 사용하지 않는다.
+- 직접 unit/integration 회귀와 회차 E2E에 `미결제 재개 거부 → 결제 완료 → 재개 성공`을 포함한다.
 
-## 6. 주문 생성 입력
+추적: `docs/BACKLOG.md`의 `ORDER-REDELIVERY-PAID-RESUME-GATE`.
 
-현재 `CreateOrderDto`는 legacy와 회차 주문을 함께 수용한다.
+## 5. 주문 생성 입력
 
-주요 필드:
+`CreateOrderDto`는 legacy와 회차 주문을 함께 수용한다. 주요 입력은 상품·수량·판매형태·배송방식·배송주소·배송 연락처이며 회차 주문은 `roundId`, `roundItems`, 선택적 마케팅 동의·유입 snapshot을 추가로 가진다.
 
-```ts
-{
-  clientOrderRequestId?: string
-  productId: string
-  quantity: number
-  saleType: 'normal' | 'group'
-  deliveryMethod: 'direct' | 'hub' | 'parcel'
-  hubId?: string
-  deliveryAddress: {
-    address: string
-    addressDetail: string
-    zipCode: string
-  }
-  deliveryPhone: string
-  requestedDeliveryDate?: string
-  groupBuyConsent?: {
-    agreed: boolean
-    agreedAt: string
-  }
-  roundId?: string
-  roundItems?: Array<{
-    roundItemId: string
-    quantity: number
-  }>
-  marketingConsent?: {
-    agreed: boolean
-    channels: Array<'alimtalk' | 'sms'>
-    copyVersion: string
-    agreedAt?: string
-  }
-  acquisition?: {
-    source: 'carrot' | 'direct' | 'unknown'
-    campaign?: string | null
-    content?: string | null
-    landingUrl?: string | null
-    capturedAt: string
-  }
-}
-```
+DTO 형식 통과가 주문 가능성을 의미하지 않는다. 상품·회차·배송지역·한도·가격·소유권·판매모드·멱등성 검증을 service에서 추가로 통과해야 한다.
 
-DTO 형식 통과가 실제 주문 가능성을 의미하지 않는다. 상품·회차·배송지역·한도·소유권·판매모드·가격·멱등성 등 service 검증을 추가로 통과해야 한다.
+## 6. 현재 API endpoint
 
-## 7. 현재 API endpoint
-
-모든 endpoint는 현재 `JwtAuthGuard` 아래에서 동작하며 세부 권한은 service에서 추가 검증한다.
-
-### Consumer 자기 주문
+모든 보호 endpoint는 `JwtAuthGuard`와 service ownership 검사를 함께 사용한다.
 
 ```text
-GET /orders
-GET /orders/:orderId
-```
-
-현재 인증 사용자의 주문만 조회하는 진입점이다.
-
-### Store 주문
-
-```text
+GET   /orders
+GET   /orders/:orderId
 POST  /stores/:storeId/orders/validate-cart
 POST  /stores/:storeId/orders
 GET   /stores/:storeId/orders
@@ -236,165 +169,108 @@ PATCH /stores/:storeId/orders/:orderId/pickup-confirm
 PATCH /stores/:storeId/orders/:orderId/hub-confirm
 ```
 
-`GET /stores/:storeId/orders`의 현재 controller query는 `userId?`, `status?`, `saleType?`다. 과거 문서의 `driverId` query를 현재 공개 controller 계약으로 사용하지 않는다.
+## 7. 권한 검증 상태
 
-## 7A. 역할·소유권 검증 상태
-
-문서 정합성 기준은 `docs/DOCUMENT_CONSISTENCY.md`를 따른다. API service의 권한과 실제 frontend가 사용하는 direct Firestore read를 별개의 신뢰 경계로 검증한다.
+판정 기준은 `docs/DOCUMENT_CONSISTENCY.md`를 따른다.
 
 ### API 조회 권한 — `VERIFIED`
 
-`OrdersQueryService`와 `orders-query.service.spec.ts`가 직접 대조된다.
+`OrdersQueryService`와 직접 테스트가 다음을 고정한다.
 
-- consumer: 요청 query의 `userId`와 무관하게 자신의 주문만 목록 조회하며 타인 상세는 거부한다.
-- seller: `stores/{storeId}.ownerId === requesterId`인 스토어의 목록·상세만 허용한다.
-- driver: API 경로에서는 `order.driverId === requesterId`로 배정된 주문의 목록·상세만 허용한다.
-- admin: 스토어 주문 전체 조회를 허용한다.
-- storeId 없는 단건 조회도 seller 소유권과 driver 배정을 다시 검증한다.
-- 회차 직배송 완료 사진 URL도 주문 조회 권한을 통과한 뒤에만 생성한다.
-
-이 판정은 **API 계층에 한정**된다. 현재 seller/driver 앱의 실제 주문 read 전체를 `VERIFIED`라는 뜻이 아니다.
+- consumer: 자기 주문만 조회
+- seller: 실제 store owner만 해당 store 주문 조회
+- driver: API 경로에서는 배정된 `driverId` 주문만 조회
+- admin: 운영 범위 조회
+- storeId 없는 상세에서도 seller ownership·driver assignment 재검증
 
 ### Direct Firestore 주문 read — `IMPLEMENTATION FINDING` P0
 
-2026-08-24 현재 `firestore.rules`와 seller/driver frontend를 대조한 결과 API 권한보다 넓은 client read 경로가 존재한다.
+실제 seller/driver frontend는 API 외 raw Firestore read를 사용한다.
 
-현재 구현:
+- current `firestore.rules`는 `role == 'driver'`이면 주문의 배정·store·상태와 무관하게 read를 허용한다.
+- driver 보드의 미배정 `PREPARING` direct/hub discovery 자체는 현재 제품 흐름에 필요하다.
+- 그러나 임의 주문 원문 read와 역할에 불필요한 내부/동의/유입 필드 노출까지 허용할 근거는 아니다.
 
-- `firestore.rules`의 `orders/{orderId}`는 seller에게 `resource.data.storeId == request.auth.token.storeId`, admin에게 role 기반 read를 허용한다.
-- 같은 rule은 **`request.auth.token.role == 'driver'`이면 주문의 `driverId`, 상태, store와 무관하게 read를 허용**한다.
-- driver `board/_client.tsx`는 `PREPARING` + `direct|hub` 주문을 raw Firestore query로 discovery한다. 미배정 수거 후보 discovery 자체는 현재 제품 흐름에 사용된다.
-- driver 주문 상세 `board/[orderId]/page.tsx`는 `orders/{orderId}`를 raw Firestore `onSnapshot()`으로 직접 읽는다.
-- seller `useOrders.ts`도 자신의 store 주문을 raw Firestore document 형태로 직접 구독한다.
-- 회차 order 원문은 배송 수행 필드 외에 `acquisition`, `marketingConsent`, `clientOrderPayloadHash`, `reservationId` 등 역할별 업무에 반드시 필요한 것으로 입증되지 않은 필드를 포함할 수 있다.
-- `tests/firestore/firestore-rules.test.mjs`는 현재 driver가 다른 store 주문을 직접 읽는 동작을 성공 케이스로 고정하고 있다.
+actual release SHA 전에는 discovery 최소 필드, assigned detail 최소 필드, seller 최소 필드와 Rules/앱 회귀를 함께 고정한다.
 
-따라서 다음 두 계약은 현재 `VERIFIED`가 아니다.
+추적: `ORDER-DIRECT-READ-AUTHORIZATION-AND-MINIMIZATION`.
 
-1. **driver read authorization** — 임의 driver가 배정되지 않은 일반/완료/타-driver 주문 원문을 읽지 못한다는 보장.
-2. **seller/driver data minimization** — 역할 수행에 필요한 고객·배송 필드만 제공된다는 보장.
+### 상태 변경 authorization — `IMPLEMENTED / UNVERIFIED`
 
-미배정 `PREPARING` direct/hub 주문을 모든 driver에게 보여주는 discovery 의도와, 모든 주문 원문을 role 하나로 읽게 하는 현재 rule을 동일시하지 않는다.
+구현은 seller store ownership, driver assignment, consumer order ownership을 검사하고 미배정 `PREPARING → DELIVERING` first-claim을 별도 허용한다.
 
-actual release SHA 확정 전 최소 완료 조건:
+현재 부족한 직접 회귀:
 
-- driver의 미배정 수거 후보 discovery 목적·대상 상태·deliveryMethod·허용 필드를 명시한다.
-- 임의 driver가 다른 기사 배정 주문, 완료 주문, 기타 임의 order ID 원문을 직접 읽지 못하게 한다.
-- 배정 이후 driver 상세는 배송 수행에 필요한 최소 필드만 제공한다.
-- seller도 업무에 불필요한 `marketingConsent`, `acquisition` 등 고객 행동·동의 메타데이터와 내부 처리 필드를 raw order read로 받지 않도록 한다.
-- Firestore Rules는 위 read 경계를 직접 강제한다. Rules만으로 field minimization이 불가능하면 API DTO, 별도 safe projection, 민감/내부 필드 분리 등 동등한 구조를 사용한다.
-- `tests/firestore/firestore-rules.test.mjs`의 broad driver 성공 기대를 제거하고 discovery 허용, assigned detail 허용, 비담당/임의 read 거부를 직접 테스트한다.
-- seller/driver frontend 정상 보드·상세 흐름과 회차 first-claim을 회귀 검증한다.
+- 타-store seller status/delivery-hold mutation 거부
+- 비담당 driver assigned-order mutation 거부
+- first-claim 외 미배정 driver mutation 거부
+- 거부 요청에서 order write·notification·refund·settlement side effect 0
 
-추적: `docs/BACKLOG.md`의 `ORDER-DIRECT-READ-AUTHORIZATION-AND-MINIMIZATION`.
+추적: `ORDER-MUTATION-AUTHORIZATION-COVERAGE`.
 
-### 상태 변경 권한 — `IMPLEMENTED / UNVERIFIED`
+## 8. 회차 주문 취소
 
-`OrdersLifecycleService.assertOrderActionAccess()`의 현재 구현은 다음과 같다.
+회차 취소는 단순 `status=CANCELLED` write가 아니다.
 
-- admin: 일반 action ownership guard 통과.
-- seller: 해당 `storeId`의 실제 `ownerId`와 requester가 일치해야 변경 가능.
-- driver: 이미 `driverId`가 있으면 해당 기사만 변경 가능.
-- driver 첫 수거: `driverId`가 없고 주문이 `PREPARING`이며 요청 전이가 `DELIVERING`일 때만 최초 claim을 허용하고 이후 `driverId`를 기록한다.
-- consumer: 자신의 주문에 대해서만 action access를 통과하며 실제 허용 전이는 consumer FSM이 추가 제한한다.
+- cancellation claim/retry state
+- 본 결제 환불
+- paid 재배송비/추가 charge 환불
+- checkout reservation·round/item capacity 반환
+- `DELIVERY_HELD` counter 정합화
+- order cancellation 확정
+- settlement 취소
 
-현재 직접 검증된 근거에는 consumer의 위장 `DELIVERY_HELD` 요청 거부, 정상 seller/driver 회차 흐름, 배송사진 타인 접근 거부가 포함된다.
+관리자 강제 환불이 이 orchestration을 우회하는 현재 문제는 `docs/specs/api/admin.md`와 `ADMIN-FORCE-REFUND-CONSISTENCY`를 따른다.
 
-그러나 2026-08-24 문서 감사 기준으로 다음 mutation authorization 거부 시나리오를 직접 고정하는 회귀 테스트는 확인되지 않았다.
+## 9. 배송 사진
 
-- 다른 스토어의 seller가 `PATCH .../status` 또는 `delivery-hold`를 시도하는 경우
-- 이미 다른 기사에게 배정된 주문을 비담당 driver가 변경하는 경우
-- 미배정 주문에서 허용된 최초 `PREPARING → DELIVERING` 이외의 driver action이 거부되는 경우
-- 위 거부 요청에서 주문·알림·환불·정산 side effect가 발생하지 않는지 확인
-
-권한은 P0 계약이므로 위 직접 회귀가 추가되기 전 상태 변경 authorization 전체를 `VERIFIED`로 표현하지 않는다. 추적: `docs/BACKLOG.md`의 `ORDER-MUTATION-AUTHORIZATION-COVERAGE`.
-
-## 8. 배송 사진
-
-회차 직배송의 현재 정본 사진 경로는 단순 `photoUrl` 첨부가 아니라 서버가 파일을 수신·보관하고 완료 처리하는 전용 API다.
+회차 직배송 완료는 서버 비공개 사진 API를 사용한다.
 
 ```text
 POST /stores/:storeId/orders/:orderId/delivery-photos
 GET  /stores/:storeId/orders/:orderId/delivery-photos/:photoId/url
 ```
 
-업로드 계약:
+- 담당 기사만 회차 직배송 `DELIVERING` 주문에 JPEG를 업로드할 수 있다.
+- 최대 5 MiB.
+- 사진은 서버가 비공개 Storage 경로에 저장하고 주문에 연결한다.
+- 직접배송은 사진 연결 없이 `DELIVERED`로 완료할 수 없다.
+- read URL은 주문 권한 검증 뒤 단기 signed URL로 발급한다.
 
-- multipart field: `photo`
-- `idempotencyKey` 필요
-- 파일 1개
-- 최대 5 MiB
-- 세부 content type·권한·상태 전이는 `DeliveryPhotosService`와 회차 직배송 spec을 따른다.
-
-`PATCH .../delivery-photo`의 `photoUrl` 경로가 controller에 남아 있다는 이유로 회차 직배송에서 공개 Firebase URL 업로드를 정본으로 사용하지 않는다.
-
-## 9. 알림 연결
-
-현재 FSM helper의 주요 알림 매핑:
-
-| 전이 | 템플릿 |
-|---|---|
-| `ACCEPTED → PREPARING` | `ORDER_PREPARING` |
-| `CONFIRMED → PREPARING` | `GROUP_PREPARING` |
-| `PREPARING → DELIVERING` | `ORDER_DELIVERING` |
-| `PREPARING → DELIVERED` | `ORDER_DELIVERED` |
-| `PREPARING → DELIVERY_HELD` | `ORDER_DELIVERY_HELD` |
-| `DELIVERING → HUB_ARRIVED` | `ORDER_HUB_ARRIVED` |
-| `DELIVERING → DELIVERED` | `ORDER_DELIVERED` |
-| `DELIVERING → DELIVERY_HELD` | `ORDER_DELIVERY_HELD` |
-| `DELIVERY_HELD → PREPARING` | `ORDER_REDELIVERY_PAYMENT_REQUESTED` |
-| `DELIVERY_HELD → DELIVERING` | `ORDER_REDELIVERY_SCHEDULED` |
-
-주문 생성/결제 확정/취소 시 발생하는 추가 알림은 해당 service와 notifications spec을 따른다.
+상세는 `DeliveryPhotosService`, `StorageService`, 관련 Rules/tests가 정본이다.
 
 ## 10. Legacy 공동구매
 
-legacy 공동구매에는 `RECRUITING`, `CONFIRMED`, `GROUP_*` 알림, `groupProductConfig` 기반 자동 확정·미달 환불 흐름이 남아 있다.
+legacy 공동구매의 `RECRUITING`, `CONFIRMED`, `GROUP_*` 알림과 자동 확정·미달 환불 흐름은 회차 직배송과 별개로 유지한다. 회차 출시를 위해 legacy 상태를 임의 삭제하지 않는다.
 
-이 흐름은 회차 직배송과 별개다.
+## 11. 결제 연결
 
-- 회차 출시를 위해 legacy 공동구매 상태를 제거하지 않는다.
-- `targetQuantity`, `minQuantity`, deadline 동작의 현재 정본은 실제 product/group service를 확인한다.
-- 과거 설계의 “스케줄러 또는 Firestore trigger” 같은 미확정 표현을 현행 계약으로 사용하지 않는다.
+회차 주문의 본 결제 finalization·timeout·늦은 결제·환불 정본은 `docs/specs/api/payments.md`다.
 
-## 11. 결제와 `PENDING`
+재배송비 결제 하위 계약이 `VERIFIED`라는 사실은 **주문 lifecycle이 결제 완료 전 재배송을 차단한다는 보장으로 확장하지 않는다.** 두 계약은 별도로 검증한다.
 
-과거 spec의 “PortOne webhook 미수신 15분이면 주문 자동 삭제” 설명을 모든 주문 유형의 현행 계약으로 사용하지 않는다.
+## 12. 검증 진입점
 
-회차 주문에는 예약·결제 최종화·늦은 결제 수렴·한도 반환/재확보가 별도 구현돼 있다. 결제 상태 전환과 timeout 정본은 다음을 함께 확인한다.
-
-- `docs/specs/api/payments.md`
-- `docs/specs/mvp-sales-round-direct-delivery.md`
-- `apps/api/src/payments/**`
-- `apps/api/src/orders/round-order-lifecycle.service.ts`
-
-## 12. 검증 원칙
-
-주문 계약 변경 시 최소 확인:
+주문 변경 시 최소 확인:
 
 - `packages/shared/src/order.types.ts`
-- `apps/api/src/orders/dto/*`
-- `apps/api/src/orders/orders.controller.ts`
 - `apps/api/src/orders/orders.helpers.ts`
+- `apps/api/src/orders/orders.controller.ts`
+- `apps/api/src/orders/orders-query.service.ts`
 - `apps/api/src/orders/*lifecycle*`
-- `apps/api/src/orders/orders-query.service.spec.ts`
-- `firestore.rules`
-- `tests/firestore/firestore-rules.test.mjs`
-- seller/driver의 raw Firestore order read 사용처
+- `apps/api/src/orders/order-charges.service.ts`
+- `apps/api/src/payments/order-charge-payment.service.ts`
 - 관련 unit/spec tests
-- `apps/e2e`의 영향 시나리오
-- 회차 변경이면 `docs/specs/mvp-sales-round-direct-delivery.md`
+- `firestore.rules`, `tests/firestore/firestore-rules.test.mjs`
+- seller/driver raw Firestore 사용처
+- 회차 변경이면 `docs/specs/mvp-sales-round-direct-delivery.md`와 운영 runbook
 
-권한·개인정보 계약은 `docs/DOCUMENT_CONSISTENCY.md`에 따라 API 테스트만 통과했다고 시스템 전체를 `VERIFIED` 처리하지 않는다. client SDK + Rules 우회 경로와 역할별 필드 최소화까지 함께 확인한다.
-
-상태 전이·권한·결제·환불을 문서 예시만 보고 운영 데이터에 직접 적용하지 않는다.
+권한·금전 불변식은 UI 동작만으로 `VERIFIED` 처리하지 않는다. API 직접 호출, 동시성, 실패 side effect를 포함한 서버 증거가 필요하다.
 
 ## 변경 이력
 
 | 날짜 | 내용 |
 |---|---|
-| 2026-08-24 | API 조회 authorization과 direct Firestore read를 분리하고 broad driver read·raw order 최소화 부재를 P0 IMPLEMENTATION FINDING으로 명시 |
-| 2026-08-24 | API 조회 authorization은 VERIFIED, mutation authorization은 직접 거부 회귀 부족으로 IMPLEMENTED / UNVERIFIED 분리 |
-| 2026-08-23 | `DELIVERY_HELD`, 회차 snapshot, 현재 endpoint/FSM, 재배송·배송사진·알림 계약에 맞춰 전면 정합화 |
-| 2026-04-23 | legacy 공동구매 수량 용어 반영 |
-| 2026-03-26 | 초기 orders 설계 초안 |
+| 2026-08-24 | 재배송비 결제 전 배송 재개 금지 계약과 현재 서버/UI 우회 경로를 P0로 정합화; direct Firestore read·mutation coverage current finding 유지 |
+| 2026-08-24 | direct Firestore read authorization·역할별 최소화 P0 반영 |
+| 2026-08-23 | 현행 endpoint/FSM/회차·legacy 공존 계약으로 전면 정합화 |


### PR DESCRIPTION
## 변경
- 운영 계약의 `결제 전 재배송 금지`와 실제 주문 lifecycle/driver UI를 대조해 `ORDER-REDELIVERY-PAID-RESUME-GATE` P0 등록
- `OrderChargePaymentService`의 결제·환불 하위 계약 `VERIFIED`와 주문 재개 gate 미검증을 명확히 분리
- orders current spec → Backlog → memory → 활성 PLAN/HANDOFF로 영향 기반 전파
- current 문서는 역할에 맞게 압축해 중복 상태 복제를 줄임

## 직접 근거
- runbook: 첫 고객 사유 실패는 재배송비 1건 생성·결제, `결제 전 재배송 금지`
- `orders.helpers.ts`: driver `DELIVERY_HELD → DELIVERING` 허용
- `OrdersLifecycleService`/`RoundOrderLifecycleService`: 재개 직전 연결 charge `PAID` 확인 없음
- driver `board/[orderId]/page.tsx`: 회차 직배송 `DELIVERY_HELD`이면 charge 상태와 무관하게 `배송 재개` CTA 노출·PATCH
- existing tests: charge 생성·PAID 검증·환불 멱등성은 직접 고정하지만 미결제 재개 거부는 없음

## 판정
- 재배송비 결제·환불 하위 계약: VERIFIED 유지
- 유료 재배송비 결제 완료를 배송 재개 전제조건으로 강제: P0 IMPLEMENTATION FINDING

## 완료 방향
- 현재 hold↔charge 연계, type/order/store/user, `PAID` 검증을 서버 transition boundary에서 fail-closed
- `PENDING|FAILED|REFUNDED|missing|mismatched` side effect 0 거부
- `미결제 재개 거부 → 결제 완료 → 재개 성공` unit/integration/E2E

## 범위
- docs-only
- 코드/운영 데이터/provider/production 변경 없음