### PR TITLE
docs: 재배송비 payment-request 상태머신 P0 보강

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -20,170 +20,130 @@
 
 ### P0 — PAYMENT-FINALIZATION-PAID-GUARD
 
-`PaymentFinalizationService.finalizePaidOrder()`가 전달받은 PortOne 결제의 `status === 'PAID'`를 자체 강제하지 않는다.
+`PaymentFinalizationService.finalizePaidOrder()`가 provider `status === 'PAID'`를 boundary 자체에서 강제하지 않는다.
 
-현재 방어:
-
-- [x] scheduler는 원격 `PAID`일 때만 finalization 호출
-- [x] webhook은 `Transaction.Paid`에서 원격 결제 재조회
-- [x] 금액 불일치 처리 존재
-
-남음:
-
-- [ ] finalization boundary에서 비`PAID` 차단
-- [ ] `PENDING|FAILED|CANCELLED` 직접 거부 회귀
+- [ ] finalization boundary 비`PAID` 차단
+- [ ] `PENDING|FAILED|CANCELLED` 직접 거부
 - [ ] `PAID` legacy/group/round 정상 회귀
-- [ ] 금액 불일치·reservation/race 회귀 유지
+- [ ] 금액 불일치·reservation/race 회귀
 - [ ] 수정 SHA `main` 통합
 
 정본: `docs/specs/api/payments.md`.
 
 ### P0 — ORDER-REDELIVERY-PAID-RESUME-GATE
 
-2026-08-24 감사에서 **유료 재배송비 결제 전 배송 재개 금지**라는 운영 계약이 서버와 driver UI에서 강제되지 않음을 확인했다.
+운영 계약은 고객 책임 첫 배송 실패의 유료 재배송에 **`결제 전 재배송 금지`**를 요구한다. 2026-08-24 추가 감사에서 이 문제는 단순 driver resume guard 누락이 아니라 **결제 요청·hold 해소·배송 재개 상태머신 전체 불일치**임을 확인했다.
 
-현재 구현·증거:
+현재 직접 근거:
 
-- [x] 운영 runbook은 첫 고객 사유 실패를 `재배송비 1건 생성·결제. 결제 전 재배송 금지`로 명시
-- [x] `OrderChargePaymentService`는 charge 자체의 `PAID` 상태·금액·order 연결과 환불 멱등성을 직접 검증
-- [x] `orders.helpers.ts`는 driver `DELIVERY_HELD → DELIVERING`을 허용
-- [x] `OrdersLifecycleService`/`RoundOrderLifecycleService`는 해당 전환 직전에 현재 `redeliveryChargeId`의 charge `PAID` 여부를 확인하지 않음
-- [x] driver 주문 상세은 회차 직배송 `DELIVERY_HELD`이면 charge 상태와 무관하게 `배송 재개` CTA를 노출하고 `DELIVERING` PATCH 호출
-- [x] 현재 테스트는 charge 생성·결제·환불은 검증하지만 `미결제 재배송 재개 거부`를 직접 고정하지 않음
+- [x] `OrderChargePaymentService`의 charge `PAID` 검증·금액/연결 검증·환불 멱등성은 직접 테스트됨
+- [x] driver `DELIVERY_HELD → DELIVERING` 전환은 charge `PAID`를 확인하지 않음
+- [x] driver UI는 `DELIVERY_HELD` 회차 주문에 charge 상태와 무관하게 `배송 재개` CTA 노출
+- [x] seller `DELIVERY_HELD → PREPARING`은 고객 책임+양수 재배송비 주문에서도 현재 테스트가 정상 성공으로 고정
+- [x] 위 seller 전환은 hold `resolvedAt` 기록 + `heldOrderCount` 감소
+- [x] 현재 notification map은 이 전환을 `ORDER_REDELIVERY_PAYMENT_REQUESTED` 발송 시점으로 사용
+- [x] 그러나 `OrderChargesService.createRedeliveryFeeCharge()`는 현재 order status가 `DELIVERY_HELD`여야 charge 생성 가능
+- [x] consumer `canPayRedeliveryFee`도 현재 status가 `DELIVERY_HELD`일 때만 true
+- [x] 따라서 `PREPARING`으로 옮긴 뒤 결제 요청 알림이 가면 소비자 charge 생성/UI가 사라짐
+- [x] 이후 `PREPARING → DELIVERING`에는 과거 paid-required hold의 미결제를 확인하는 durable guard가 없음
 
 판정:
 
-- 재배송비 **결제·환불 하위 계약 자체는 `VERIFIED`**다.
-- 하지만 **결제 완료를 배송 재개 전제조건으로 강제하는 주문 lifecycle은 P0 `IMPLEMENTATION FINDING`**이다.
-- UI 버튼 조건만 수정해서 닫지 않는다. API 직접 호출에서도 fail-closed여야 한다.
+- charge 결제·환불 **하위 계약은 `VERIFIED`**.
+- 유료 재배송 **주문 상태머신 전체는 P0 `IMPLEMENTATION FINDING`**.
+- `DELIVERY_HELD → DELIVERING` 한 경로만 막아서는 `PREPARING` 우회가 남으므로 완료가 아니다.
 
-남음:
+남음 — 불변식:
 
-- [ ] 고객 책임 + `redeliveryFee > 0`인 현재 보류를 유료 재배송 대상으로 서버 판정
-- [ ] 현재 `redeliveryChargeId`가 현재 hold(`heldAt`)에 연결된 charge인지 검증
-- [ ] charge type/order/store/user 일치 + `status === 'PAID'`일 때만 `DELIVERY_HELD → DELIVERING` 허용
-- [ ] `PENDING|FAILED|REFUNDED|missing|mismatched`이면 order/counter/notification side effect 0으로 거부
-- [ ] 판매자/시스템 책임 또는 재배송비 없는 보류는 불필요한 결제 요구 없이 기존 정책대로 해소
-- [ ] driver UI에 charge 상태·대기 사유 표현
-- [ ] `미결제 재개 거부 → 결제 완료 → 재개 성공` unit/integration/E2E 직접 회귀
+- [ ] 고객 책임+양수 재배송비 hold의 `payment required`가 결제 완료 전 사라지지 않음
+- [ ] payment-request 알림 시점에도 consumer charge 생성/결제 UI·endpoint가 actionable
+- [ ] current hold↔charge를 `heldAt` 또는 동등 durable key로 연결
+- [ ] charge type/order/store/user 일치 + `PAID`일 때만 모든 실제 delivery-start 경로 허용
+- [ ] `PENDING|FAILED|REFUNDED|missing|mismatched`는 side effect 0 거부
+- [ ] `DELIVERY_HELD → DELIVERING`과 `DELIVERY_HELD → PREPARING → DELIVERING` 모두 동일 paid gate 적용
+- [ ] seller가 `PREPARING` 결제요청 구조를 유지한다면 durable payment-required marker와 consumer 결제 가능성을 상태 변경 뒤에도 보존; 아니면 결제 완료 전 hold를 해소하지 않는 구조로 변경
+- [ ] hold 해소·`heldOrderCount` 감소 시점을 payment completion/재개 정책과 명시적으로 일치
+- [ ] 판매자/시스템 책임·무료 재배송 정상 흐름 유지
+- [ ] seller/driver 동시 요청에서 hold 해소·counter 감소·scheduled 알림이 한 번만 수렴
+
+필수 회귀:
+
+- [ ] payment-request 알림 뒤 consumer payment CTA/endpoint 유지
+- [ ] charge 없음/PENDING/FAILED/REFUNDED direct resume 거부
+- [ ] 결제 전 seller `PREPARING` 전환을 정책대로 허용/거부 직접 고정
+- [ ] `PREPARING` 경유 미결제 `DELIVERING` 거부
+- [ ] `PAID` 뒤 한 번 정상 재개
+- [ ] 무료/판매자책임 재배송 정상 회귀
 - [ ] 변경 SHA `main` 통합
 
-정본: `docs/specs/api/orders.md`, 운영 증거: `docs/specs/ops/mvp-sales-round-runbook.md`.
+정본: `docs/specs/api/orders.md`; 운영 근거: `docs/specs/ops/mvp-sales-round-runbook.md`.
 
 ### P0 — ADMIN-FORCE-REFUND-CONSISTENCY
 
-`AdminService.forceRefund()`가 정상 cancellation orchestration의 금전·capacity·정산 후속효과를 우회한다.
+admin refund가 정상 cancellation의 추가 charge·capacity·held counter·settlement 후속효과를 우회한다.
 
-확인됨:
-
-- [x] admin 경로는 `CANCELLED`만 거부하고 본 결제 환불 뒤 주문을 직접 `CANCELLED` write
-- [x] 정상 회차 취소는 본 결제+paid 추가 charge 환불, retry state, reservation/counter 반환, held counter, settlement 취소 수행
-- [x] admin 경로는 추가 charge, reservation/capacity, held counter, settlement를 처리하지 않음
-- [x] 완료/리뷰/정산 생성 주문도 `CANCELLED`가 아니면 별도 상태 제한 없이 진입 가능
-
-남음:
-
-- [ ] admin 환불 허용 상태 fail-closed 정의
-- [ ] 정상 회차 cancellation orchestration 재사용 또는 동등 단일 orchestration
-- [ ] 본 결제+paid 재배송비 중복 없는 환불
-- [ ] reservation/round/item counter·held counter 정확한 반환
+- [ ] admin 환불 허용 상태 fail-closed
+- [ ] 정상 cancellation orchestration 재사용 또는 동등 단일 orchestration
+- [ ] 본 결제+paid 추가 charge 중복 없는 환불
+- [ ] reservation/round/item/held counter 반환
 - [ ] pending/confirmed settlement 취소
-- [ ] paid settlement 환불의 별도 회계 조정/운영 예외 정책
-- [ ] provider 성공/local 실패 재시도와 동시 실행 수렴
-- [ ] 상태·settlement·charge 조합 직접 회귀
-- [ ] 변경 SHA `main` 통합
+- [ ] paid settlement 별도 회계 조정/operation issue 정책
+- [ ] provider 성공/local 실패 재시도·동시 실행 수렴
+- [ ] 직접 회귀 후 `main` 통합
 
 정본: `docs/specs/api/admin.md`, `docs/specs/api/settlements.md`.
 
 ### P0 — ORDER-DIRECT-READ-AUTHORIZATION-AND-MINIMIZATION
 
-API 주문 조회 authorization보다 seller/driver 실제 raw Firestore read 경계가 넓다.
+API authorization보다 seller/driver raw Firestore read 경계가 넓다.
 
-확인됨:
-
-- [x] API driver 상세은 assigned `driverId` 제한과 직접 테스트 존재
-- [x] current Rules는 `role == driver`이면 주문을 배정/store/status와 무관하게 read 허용
-- [x] driver 보드·상세, seller 목록이 raw `orders`를 직접 사용
-- [x] raw order에 역할에 불필요한 내부/유입/동의 metadata가 존재할 수 있음
-
-남음:
-
-- [ ] 미배정 `PREPARING` direct/hub discovery의 최소 대상·필드 정의
+- [ ] 미배정 `PREPARING` direct/hub discovery 최소 대상·필드 정의
 - [ ] arbitrary/타-driver/완료 주문 raw read 차단
-- [ ] assigned driver·seller 최소 필드 projection/DTO 또는 동등 분리
+- [ ] assigned driver·seller 최소 projection/DTO 또는 동등 분리
 - [ ] broad driver rule 제거
-- [ ] Rules 및 앱 정상/거부 회귀
-- [ ] 변경 SHA `main` 통합
+- [ ] Rules + 앱 정상/거부 회귀
+- [ ] `main` 통합
 
-법적 문구를 넓혀 현재 broad read를 정당화하지 않는다. 정본: `docs/specs/api/orders.md`.
+정본: `docs/specs/api/orders.md`.
 
 ### P0 — AUTH-DRIVER-APPROVAL-AND-SESSION-REVOCATION
 
-driver 관리자 승인 계약과 실제 Kakao 가입 경로가 충돌하며 suspension/role/store 변경 뒤 stale session/claims 수렴도 불완전하다.
+신규/legacy driver 자동 승인 경로와 stale session/claims 수렴 문제가 있다.
 
-확인됨:
-
-- [x] admin approval endpoint와 driver app `driverApproved` gate 존재
-- [x] 신규 Kakao `targetRole: driver`가 `driverApproved: true`로 즉시 생성될 수 있음
-- [x] 기존 승인 필드 누락 driver도 로그인 side effect로 자동 승인
-- [x] refresh가 authoritative user 문서를 재조회하지 않고 기존 `role/storeId` claims 재사용
-- [x] Firebase custom token도 현재 API JWT claims 사용
-
-남음:
-
-- [ ] 신규/legacy 자동 승인 제거
-- [ ] 과거 계정 migration은 별도 감사 가능한 절차로 분리
-- [ ] 승인 전/후 앱·API·Firebase 직접 회귀
-- [ ] suspension/role/store/approval 변경의 revocation window/SLA 결정
-- [ ] refresh/current claims authoritative user 상태 검증
+- [ ] 신규/legacy 로그인 side-effect 자동 승인 제거
+- [ ] 과거 계정 migration 별도 감사 절차
+- [ ] 승인 전/후 앱·API·Firebase 회귀
+- [ ] suspension/role/store/approval revocation SLA 결정
+- [ ] refresh/current claims authoritative state 검증
 - [ ] Firebase stale claims 재발급 차단
 - [ ] logout/rotation 포함 회귀
-- [ ] 변경 SHA `main` 통합
+- [ ] `main` 통합
 
-`ORDER-DIRECT-READ-AUTHORIZATION-AND-MINIMIZATION`과 결합 검증한다. 정본: `docs/specs/api/auth.md`.
+정본: `docs/specs/api/auth.md`.
 
 ### P0 — ORDER-MUTATION-AUTHORIZATION-COVERAGE
 
-`OrdersLifecycleService.assertOrderActionAccess()`의 권한 구현은 있으나 핵심 거부 회귀가 부족하다.
-
-현재 구현:
-
-- [x] seller store ownership
-- [x] assigned driver ownership
-- [x] 미배정 `PREPARING → DELIVERING` first claim
-- [x] consumer order ownership
-
-남음:
+상태 변경 ownership guard는 구현돼 있으나 핵심 거부 회귀가 부족하다.
 
 - [ ] 타-store seller status/delivery-hold 403
 - [ ] 비담당 driver assigned-order mutation 403
 - [ ] first-claim 외 미배정 driver mutation 거부
-- [ ] first claim 정확한 `driverId` 기록
-- [ ] 거부된 mutation side effect 0
-- [ ] 필요한 admin 허용 범위 직접 고정
-- [ ] 변경 SHA `main` 통합
+- [ ] first claim 정확한 `driverId`
+- [ ] 거부 side effect 0
+- [ ] 필요한 admin 허용 범위 고정
+- [ ] `main` 통합
 
 정본: `docs/specs/api/orders.md`.
 
 ### P0 — DEPLOY-SAFETY-MAIN-PROTECTION
 
-repo-side production auto-deploy 차단은 완료됐지만 GitHub `main` 자체 보호는 아직 비활성이다.
+repo-side production auto-deploy 차단은 완료. GitHub 관리자 레벨 보호는 남음.
 
-완료:
-
-- [x] PR #30 세 프런트 `main` Vercel Git auto-deploy 차단
-- [x] docs-only Preview sync/E2E 제외
-- [x] `AGENTS.md` direct-main 금지
-- [x] deployment safety CI
-- [x] PR #31 pure docs/Markdown Vercel build skip
-
-남음:
-
-- [ ] Issue #32 ruleset/branch protection
+- [ ] Issue #32
 - [ ] PR required
-- [ ] `Deployment safety guard / verify` required check
-- [ ] force push·branch deletion 차단
-- [ ] 재조회에서 `protected=true` 또는 동등 enforcement 확인
+- [ ] `Deployment safety guard / verify` required
+- [ ] force push·branch delete 차단
+- [ ] 재조회에서 enforcement 확인
 
 ---
 
@@ -191,22 +151,9 @@ repo-side production auto-deploy 차단은 완료됐지만 GitHub `main` 자체 
 
 ### P0 — ALIGO 회차 알림 템플릿 8종 최종 승인
 
-- [ ] `ORDER_ACCEPTED`
-- [ ] `ORDER_PREPARING`
-- [ ] `ORDER_DELIVERING`
-- [ ] `ORDER_DELIVERY_HELD`
-- [ ] `ORDER_REDELIVERY_PAYMENT_REQUESTED`
-- [ ] `ORDER_REDELIVERY_SCHEDULED`
-- [ ] `ORDER_DELIVERED`
-- [ ] `ORDER_CANCELLED`
+`ORDER_ACCEPTED`, `ORDER_PREPARING`, `ORDER_DELIVERING`, `ORDER_DELIVERY_HELD`, `ORDER_REDELIVERY_PAYMENT_REQUESTED`, `ORDER_REDELIVERY_SCHEDULED`, `ORDER_DELIVERED`, `ORDER_CANCELLED`.
 
-마지막 provider 확인 기준:
-
-- 8종 등록·심사 요청 완료
-- 8종 모두 `검수중`
-- 실제 알림톡·SMS 발송 0건
-
-상태는 재개 시 provider에서 다시 조회한다.
+마지막 provider 확인: 8종 등록·심사 요청 완료, 전부 `검수중`, 실제 발송 0건. 재개 시 직접 재조회한다.
 
 ---
 
@@ -214,24 +161,20 @@ repo-side production auto-deploy 차단은 완료됐지만 GitHub `main` 자체 
 
 ### P0 — 실제 알림 검증
 
-- [ ] 승인 실제 `tpl_code` 8종 ↔ 내부 논리 코드 1:1 검사
-- [ ] 별도 승인 후 격리 수신자 실제 알림톡 정상 발송
-- [ ] 별도 승인 후 SMS fallback 실제 검증
+- [ ] 승인 `tpl_code` 8종 ↔ 내부 논리 코드 1:1
+- [ ] 별도 승인 후 격리 실제 알림톡
+- [ ] 별도 승인 후 SMS fallback
 
-### P0 — 판매 활성화 법적 문서 재정합화
+### P0 — 판매 활성화 legal 재정합화
 
-현재 production `/terms`, `/privacy`는 2026-08-19 비판매 상태를 전제로 한다.
-
-- [ ] 주문 성립·취소·환불·배송·재배송비·배송 보류 실제 정책 반영
-- [ ] 재배송비 결제 전 배송 재개 금지와 결제/환불 실제 구현 일치 확인
-- [ ] PortOne·결제사업자 개인정보 처리 역할 검수
-- [ ] ALIGO 고객 전화번호·메시지 처리 고지
-- [ ] order direct-read 최소화 해결 후 seller/driver 고객정보 접근 설명
-- [ ] 시행일·이전 버전 관리
-- [ ] `legal-documents.test.mjs` 갱신
-- [ ] 법적 변경을 release SHA에 포함
-
-정본: `docs/specs/legal/README.md`.
+- [ ] 주문 성립·취소·환불·배송·재배송비·보류 실제 정책
+- [ ] 재배송 payment-required 상태머신과 결제 전 재개 금지 계약 반영
+- [ ] PortOne/PG 개인정보 처리
+- [ ] ALIGO 전화번호·메시지 처리
+- [ ] order direct-read 최소화 뒤 seller/driver 접근 설명
+- [ ] 시행일·이전 버전
+- [ ] legal tests
+- [ ] release SHA 포함
 
 ### P0 — 출시 후보 검증·운영 준비
 
@@ -242,16 +185,13 @@ repo-side production auto-deploy 차단은 완료됐지만 GitHub `main` 자체 
 - [ ] `AUTH-DRIVER-APPROVAL-AND-SESSION-REVOCATION`
 - [ ] `ORDER-MUTATION-AUTHORIZATION-COVERAGE`
 - [ ] Issue #32
-- [ ] 법적 페이지 포함 actual release SHA 확정
-- [ ] exact SHA 원격 E2E chromium 26 + mobile 26 = 52 + cleanup
-- [ ] 운영 Firebase indexes/Rules read-only 재조회
-- [ ] 별도 승인 후 production ALIGO 설정
-- [ ] production exact-SHA deploy/promotion 절차 확정
-- [ ] 별도 `Task 3.1 승인`
-- [ ] 동일 exact SHA로 API + consumer/seller/driver production 배포
-- [ ] deployment metadata SHA 확인
-- [ ] 운영 smoke
-- [ ] 첫 회차 DRAFT 검수 → SCHEDULED
+- [ ] legal 포함 actual release SHA
+- [ ] exact SHA E2E 52 + cleanup
+- [ ] 운영 Firebase read-only 재조회
+- [ ] 승인 후 production ALIGO 설정
+- [ ] exact-SHA deployment 절차 + Task 3.1 별도 승인
+- [ ] 동일 SHA production + metadata 검증 + smoke
+- [ ] 첫 회차 SCHEDULED
 - [ ] 최종 출시 판정·rollback dry-run
 - [ ] 최종 승인 후 `salesMode: round_direct`
 - [ ] 초기 두 회차 모니터링·Closeout
@@ -260,73 +200,47 @@ repo-side production auto-deploy 차단은 완료됐지만 GitHub `main` 자체 
 
 ---
 
-## LATER — 출시 후 품질·운영 개선
+## LATER
 
 ### NOTIFICATION-RETRY-POLICY
-- [ ] backoff·일시/영구 오류 분류
-- [ ] timeout·rate limit 처리
-- [ ] 중복 SMS 방지·재시작 멱등성
-- [ ] 구조화 관측 지표
+- [ ] backoff·오류 분류·rate limit·중복 SMS·관측 지표
 
 ### API-LINT-BASELINE
-- [ ] auth `any` 제거
-- [ ] spec mock 타입 정리
-- [ ] `lint:check` / `lint:fix` 분리
+- [ ] auth `any`, spec mock 타입, lint command 분리
 
 ### LOCAL-DEV-FULLSTACK
-- [ ] API 3000 / consumer 3001 / seller 3002 / driver 3003 launcher
-- [ ] seller·driver local CORS 계약
-- [ ] 기존 `dev.bat` frontend-only 유지 여부
+- [ ] API/consumer/seller/driver launcher·CORS·`dev.bat` 정책
 
 ### LOAD-TEST-FORMAL
-- [ ] production 분리 staging/equivalent
-- [ ] 재개 트리거
-- [ ] `baseline → launch → growth → spike → soak`
-- [ ] k6 plan 재검증
+- [ ] staging/equivalent, 재개 트리거, baseline→soak, k6 plan
 
 ### Seller/Admin
-- [ ] ADMIN-STORES-T7 판매자 상세
-- [ ] ADMIN-STORES-T8 플랫폼 기본 수수료율
-- [ ] 준비 물량 공동구매 주문 포함 재설계
-- [ ] 필요 시 정산 UX 검증
+- [ ] ADMIN-STORES-T7/T8, 준비 물량 공동구매 재설계, 필요 시 정산 UX
 
 ### Driver/배송
-- [ ] Kakao Maps SDK 재평가
-- [ ] 밀크런 경로 프리뷰 필요 시 구현
-- [ ] 플랫폼형 드라이버 전 실시간 GPS 추적 보류
+- [ ] Kakao Maps·밀크런 preview 재평가, 플랫폼형 전 GPS 보류
 
-### 인프라 복원력
-- [ ] Railway 단일 장애점 재평가
-- [ ] backend contingency 비교
-
-### 확장 트리거
-- [ ] 다중 판매자 Phase 2
-- [ ] 실제 협력 거점 계약 시 hub 운영
-- [ ] 필요 시 `hub_staff`
-- [ ] 외부 드라이버 정산
-- [ ] 플랫폼형 드라이버
-- [ ] 결제수단 확장 재평가
+### 인프라/확장
+- [ ] Railway contingency, 다중 판매자, hub_staff, 외부 driver 정산, 결제수단 확장
 
 ---
 
 ## STALE_OR_SUPERSEDED
 
-현재 상태를 재검증하기 전 다음 과거 전제를 실행하지 않는다.
-
-- 네이버페이 “승인 메일 대기 / 채널키만 넣으면 즉시 활성화”
-- 과거 BUG-03 Firestore 공개 read/Firebase Custom Token 가정
-- 과거 운영 DB reset/visual cleanup 지시
+- 네이버페이 과거 승인 대기 전제
+- 과거 BUG-03 공개 read/Custom Token 가정
+- 운영 DB reset/visual cleanup 지시
 - 2026-05 Railway outage 상태
-- PR #11 OPEN/Draft·병합 금지 표현
+- PR #11 OPEN/Draft 표현
 - ALIGO 8종 “미등록” 표현
-- `main` merge가 자동 production 배포를 해야 한다는 전제
+- `main` merge가 auto-production이어야 한다는 전제
 
 ## 관리 원칙
 
-1. 완료 이력을 장문으로 누적하지 않는다.
+1. 완료 이력을 장문 누적하지 않는다.
 2. 현재 행동 가능한 미완료만 유지한다.
 3. 외부 상태는 직접 재조회 뒤 갱신한다.
-4. 체크박스는 production 변경 승인으로 간주하지 않는다.
-5. 우선순위 충돌 시 `docs/memory.md`와 활성 HANDOFF·PLAN을 우선한다.
-6. repository 변경은 branch+PR로 수행한다.
-7. `VERIFIED` 승격은 `docs/DOCUMENT_CONSISTENCY.md`를 따른다.
+4. 체크박스는 production 승인 아님.
+5. 우선순위 충돌 시 memory + 활성 HANDOFF/PLAN 우선.
+6. repository 변경은 branch+PR.
+7. `VERIFIED` 승격은 `docs/DOCUMENT_CONSISTENCY.md` 기준.

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -2,98 +2,86 @@
 
 # 프로젝트 현재 상태
 
-> 현재 작업 판단에 필요한 최소 상태만 유지한다. 완료 이력과 상세 Acceptance Criteria는 Git history·REPORT·`docs/BACKLOG.md`·current spec을 사용한다.
+> 현재 작업 판단에 필요한 최소 상태만 유지한다. 상세 Acceptance Criteria는 `docs/BACKLOG.md`와 current spec을 사용한다.
 
 ## 검증 기준
 
-- Git·GitHub 직접 재검증: `2026-08-24 KST`
+- Git·GitHub: `2026-08-24 KST`
 - Vercel 배포 안전 증거: `2026-08-23 KST`
-- ALIGO 상태: 마지막 provider 확인 `2026-08-23`
+- ALIGO 마지막 provider 상태: `2026-08-23`
 - 운영 상태 변경은 별도 승인 없이 수행하지 않는다.
 
 ## Git·배포 기준선
 
 - 저장소: `booker-lab/greenhub`
-- 기본 브랜치: `main`
-- `main` HEAD는 작업 시작 시 GitHub에서 직접 재조회한다.
+- 기본 브랜치: `main`; HEAD는 작업 시작 시 직접 재조회한다.
 - 회차 직배송 기능 통합 기준 SHA: `e55f25914cc7d01576fbd4639583daaf0fe6385e`
-- PR #30/#31로 세 프런트의 `main` Vercel Git production auto-deploy와 pure-doc build를 repo-side에서 차단했다.
-- docs-only `main` 변경은 Preview sync/일반 E2E에서 제외된다.
-- `AGENTS.md`와 deployment safety CI가 branch+PR 원칙을 강제한다.
-- GitHub `main` 자체는 마지막 재조회에서 `protected=false`; Issue #32가 남아 있다.
+- PR #30/#31로 세 프런트의 `main` Vercel Git auto-production과 pure-doc build를 repo-side 차단했다.
+- docs-only main 변경은 Preview sync/일반 E2E 제외.
+- `AGENTS.md` + deployment safety CI가 branch+PR 원칙을 소유한다.
+- GitHub `main` 자체 보호는 Issue #32가 남아 있다.
 
-**`main` merge는 production 배포 승인이 아니다.** production은 검증된 exact release SHA + 별도 승인 절차를 사용한다.
+`main` merge는 production 배포 승인이 아니다. production은 검증된 exact release SHA + 별도 승인 절차를 사용한다.
 
 ## 제품 현재 상태
 
-- 회차 직배송 MVP 구현은 `main`에 통합됐다.
-- consumer 구매, seller 회차·주문, driver 직배송, 결제·환불·재배송비·보류·사진·운영 예외 흐름이 존재한다.
+- 회차 직배송 MVP는 `main` 통합 완료.
+- consumer 구매, seller 회차·주문, driver 직배송, 결제·환불·재배송비·보류·사진·운영 예외 흐름 존재.
 - 카카오 비즈니스 채널 승인 완료.
-- 운영 Firebase rules/indexes는 기존 준비에서 반영 완료 상태이나 출시 전 read-only 재조회가 필요하다.
-- production 회차 배포·첫 운영 회차·`salesMode` 전환은 미실행.
+- 운영 Firebase rules/indexes는 출시 전 read-only 재조회 필요.
+- production 회차 배포·첫 운영 회차·`salesMode` 전환 미실행.
 - 판매 모드: `legacy`.
 
 ## 현재 확인된 출시 P0
 
-### 1. 재배송비 결제 전 배송 재개 가드
+### 1. 재배송비 결제·재개 상태머신
 
-운영 계약은 고객 책임 첫 배송 실패에서 유료 재배송비가 있으면 **결제 전 재배송 금지**를 요구한다.
+운영 계약은 고객 책임 유료 재배송에서 `결제 전 재배송 금지`를 요구한다.
 
-현재:
+2026-08-24 추가 감사에서 다음 두 우회/불일치가 확인됐다.
 
-- `OrderChargePaymentService`의 charge 결제·환불 하위 계약은 직접 회귀로 `VERIFIED`다.
-- 하지만 driver `DELIVERY_HELD → DELIVERING` 서버 전환은 연결 charge의 `PAID` 상태를 확인하지 않는다.
-- driver 상세 UI도 회차 직배송 `DELIVERY_HELD`이면 charge 상태와 무관하게 `배송 재개` 버튼을 노출한다.
+- driver `DELIVERY_HELD → DELIVERING`: charge `PAID` 확인 없음 + UI `배송 재개` 항상 노출.
+- seller `DELIVERY_HELD → PREPARING`: 고객 책임+양수 재배송비에서도 현재 테스트가 정상 성공으로 고정하며 hold를 해소하고 held counter를 줄임. 이 전환이 `ORDER_REDELIVERY_PAYMENT_REQUESTED` 알림을 만들지만 charge 생성 API와 consumer 결제 UI는 `status === DELIVERY_HELD`를 요구하므로 전환 뒤 결제가 불가능해진다. 이후 `PREPARING → DELIVERING`도 과거 미결제 hold를 확인하지 않는다.
 
-따라서 **`ORDER-REDELIVERY-PAID-RESUME-GATE` = P0 `IMPLEMENTATION FINDING`**이다. API 직접 호출에서 미결제/실패/환불/불일치 charge를 fail-closed하고 `미결제 거부 → 결제 완료 → 정상 재개`를 직접 검증해야 한다.
+따라서 **`ORDER-REDELIVERY-PAID-RESUME-GATE`는 단순 PAID guard가 아니라 P0 재배송 상태머신 `IMPLEMENTATION FINDING`**이다.
+
+완료 시 payment-required 상태는 결제 전 사라지지 않아야 하며, payment-request 알림 뒤 consumer 결제가 실제 가능해야 하고, `HELD→DELIVERING` 및 `HELD→PREPARING→DELIVERING` 등 모든 배송 시작 경로가 동일 PAID gate를 통과해야 한다.
 
 정본: `docs/specs/api/orders.md`, `docs/BACKLOG.md`, 운영 근거 `docs/specs/ops/mvp-sales-round-runbook.md`.
 
-### 2. 관리자 강제 환불 lifecycle 일관성
+### 2. 관리자 강제 환불 lifecycle
 
-`AdminService.forceRefund()`는 본 결제 환불 뒤 주문을 직접 `CANCELLED`로 write하며 정상 회차 cancellation의 추가 charge, reservation/capacity, held counter, settlement 후속효과를 재사용하지 않는다.
+admin refund는 본 결제 환불 뒤 주문을 직접 `CANCELLED` write하며 정상 cancellation의 추가 charge·reservation/capacity·held counter·settlement 후속효과를 재사용하지 않는다.
 
-따라서 **`ADMIN-FORCE-REFUND-CONSISTENCY` = P0 `IMPLEMENTATION FINDING`**이다. paid settlement 환불은 별도 회계 조정 정책도 필요하다.
+**`ADMIN-FORCE-REFUND-CONSISTENCY` = P0 IMPLEMENTATION FINDING**.
 
-정본: `docs/specs/api/admin.md`, `docs/specs/api/settlements.md`, `docs/BACKLOG.md`.
+### 3. Driver 승인·세션 권한
 
-### 3. Driver 승인·세션 권한 수명주기
+신규/legacy driver 자동 승인 경로와 refresh/Firebase stale claims 수렴 문제가 있다.
 
-- 신규 Kakao `targetRole: driver`가 `driverApproved: true`로 생성될 수 있다.
-- 승인 필드 누락 기존 driver도 로그인 side effect로 자동 승인된다.
-- refresh는 authoritative user 상태를 재조회하지 않고 stale `role/storeId` claims를 재사용한다.
-
-따라서 **관리자 승인 게이트는 P0 `IMPLEMENTATION FINDING`**, suspension/role/store/approval 변경의 세션 수렴은 **P0 `DECISION REQUIRED` + remediation**이다.
-
-정본: `docs/specs/api/auth.md`, `docs/specs/api/admin.md`, `docs/BACKLOG.md`.
+**관리자 승인 gate = P0 IMPLEMENTATION FINDING**, suspension/role/store/approval revocation = **P0 DECISION REQUIRED + remediation**.
 
 ### 4. 주문 direct Firestore read·개인정보 최소화
 
-API driver read는 배정 주문으로 제한되지만 current Firestore Rules는 `role == driver`이면 주문을 배정/store/status와 무관하게 read 허용하며 seller/driver 앱은 raw order document를 사용한다.
+API driver read는 배정 경계가 있으나 current Rules는 driver role에 broad order read를 허용하며 seller/driver frontend는 raw document를 사용한다.
 
-따라서 API read만 `VERIFIED`이며 **시스템 전체 driver read authorization + seller/driver data minimization은 P0 `IMPLEMENTATION FINDING`**이다.
-
-정본: `docs/specs/api/orders.md`, `docs/specs/legal/README.md`, `docs/BACKLOG.md`.
+**시스템 전체 driver read authorization + seller/driver data minimization = P0 IMPLEMENTATION FINDING**.
 
 ### 5. 결제 finalization provider 상태 방어
 
-`PaymentFinalizationService.finalizePaidOrder()`가 비`PAID` provider 입력을 boundary 자체에서 차단하지 않는다. caller 방어는 있지만 최종화 불변식 전체는 보장되지 않는다.
+`finalizePaidOrder()` boundary가 비`PAID` provider 입력을 자체 차단하지 않는다.
 
-따라서 **`PAYMENT-FINALIZATION-PAID-GUARD` = P0**다.
-
-정본: `docs/specs/api/payments.md`, `docs/BACKLOG.md`.
+**`PAYMENT-FINALIZATION-PAID-GUARD` = P0**.
 
 ### 6. 주문 mutation authorization 회귀
 
-seller store ownership, driver assignment, consumer ownership guard는 구현돼 있으나 타-store seller·비담당 driver·first-claim 외 action과 거부 side-effect 0의 직접 테스트가 부족하다.
+ownership guard는 구현돼 있으나 타-store seller·비담당 driver·first-claim 외 action과 거부 side-effect 0 직접 회귀가 부족하다.
 
-따라서 **`ORDER-MUTATION-AUTHORIZATION-COVERAGE` = `IMPLEMENTED / UNVERIFIED` + P0 `COVERAGE GAP`**다.
-
-정본: `docs/specs/api/orders.md`, `docs/BACKLOG.md`.
+**`ORDER-MUTATION-AUTHORIZATION-COVERAGE` = IMPLEMENTED / UNVERIFIED + P0 COVERAGE GAP**.
 
 ### 7. GitHub main protection
 
-repo-side 배포 방어는 완료됐지만 GitHub 관리자 레벨의 PR required / required check / force-push·delete 차단은 Issue #32가 남아 있다.
+repo-side 배포 방어는 완료. GitHub 관리자 레벨 PR required/required check/force-push·delete 차단은 Issue #32가 남아 있다.
 
 ## ALIGO 상태
 
@@ -103,57 +91,47 @@ repo-side 배포 방어는 완료됐지만 GitHub 관리자 레벨의 PR require
 - 회차 알림 템플릿 8종 등록·심사 요청 완료.
 - 8종 모두 `검수중`.
 - 실제 알림톡·SMS 발송 0건.
-- production ALIGO 자격 증명 4개·`ALIGO_TEMPLATE_CODES_JSON` 미반영.
+- production ALIGO 자격 증명·매핑 미반영.
 
-새 작업에서 현재성이 필요하면 provider에서 다시 조회한다.
+현재성이 필요하면 provider에서 다시 조회한다.
 
-## 판매 활성화 법적 상태
+## 판매 활성화 legal 상태
 
-- production `/privacy`, `/terms`는 2026-08-19 비판매 상태 기준이다.
-- 실제 판매 전 주문·취소·환불·재배송비·보류, PortOne/결제사업자, ALIGO, seller/driver 개인정보 접근을 재정합화해야 한다.
-- `ORDER-DIRECT-READ-AUTHORIZATION-AND-MINIMIZATION` 해결 전에 broad read를 법적 문구로 정당화하지 않는다.
-- `ORDER-REDELIVERY-PAID-RESUME-GATE`와 `ADMIN-FORCE-REFUND-CONSISTENCY` 해결 결과를 실제 재배송비·환불 약관에 반영한다.
+- production `/privacy`, `/terms`는 2026-08-19 비판매 상태 기준.
+- 실제 판매 전 주문·취소·환불·재배송비·보류, PortOne/PG, ALIGO, seller/driver 개인정보 접근을 재정합화해야 한다.
+- broad read를 legal 문구로 정당화하지 않는다.
+- 재배송 payment-required 상태머신과 admin refund 실제 정책을 legal의 재배송비·환불 설명에 반영한다.
 
 ## 검증 상태
 
 - 마지막 전체 원격 회차 E2E 역사 증거: SHA `6e0fc9d4cec08073ed2504208cc8bb1ea395ee7d`, run `32351887404`.
-- chromium 26 + mobile 26 = 52, 양쪽 fixture cleanup 성공.
-- 과거 run을 현재 release SHA 증거로 확장하지 않는다.
-- 모든 출시 P0와 법적 변경을 포함한 actual release SHA에서 52건+cleanup을 다시 통과해야 한다.
+- chromium 26 + mobile 26 = 52, 양쪽 cleanup 성공.
+- 과거 run을 현재 release 증거로 확장하지 않는다.
+- 모든 P0·legal 변경을 포함한 actual release SHA에서 다시 52+cleanup 필요.
 
 ## 활성 문서
 
-- 문서 라우팅: `docs/README.md`
+- 라우팅: `docs/README.md`
 - 정합성 기준: `docs/DOCUMENT_CONSISTENCY.md`
 - 작업 규칙: `AGENTS.md`
 - Context router: `docs/PROJECT_MAP.md`
-- 현재 상태 SSOT: 이 문서
-- 미완료 SSOT: `docs/BACKLOG.md`
-- 재개 순서: `docs/plans/HANDOFF_mvp_round_direct_aligo_review_pause.md`
+- 상태 SSOT: 이 문서
+- 미완료: `docs/BACKLOG.md`
+- 재개: `docs/plans/HANDOFF_mvp_round_direct_aligo_review_pause.md`
 - 출시 의존성: `docs/plans/PLAN_mvp_round_direct_launch_blockers.md`
 - 배포 안전: `docs/plans/PLAN_deployment_safety_guards_20260823.md`
-- 판매 활성화 legal gate: `docs/specs/legal/README.md`
+- legal gate: `docs/specs/legal/README.md`
 
 ## 승인 경계
 
-명시적 승인 없이 다음을 수행하지 않는다.
-
-- ALIGO 템플릿 변경·등록·실제 발송
-- production 자격 증명·환경 변수·Firebase/운영 데이터 변경
-- Railway/Vercel production 배포·rollback
-- 운영 회차 생성·상태 변경·`salesMode` 전환
-- 실제 결제·환불
-
-비밀값과 고객 개인정보 원문은 문서·로그·Git에 기록하지 않는다.
+명시적 승인 없이 ALIGO 실제 발송/설정, production 환경변수·Firebase·운영 데이터 변경, Railway/Vercel production 배포·rollback, 운영 회차/`salesMode`, 실제 결제·환불을 실행하지 않는다.
 
 ## 다음 작업
 
-1. `ORDER-REDELIVERY-PAID-RESUME-GATE` 구현·직접 회귀·`main` 통합.
-2. 나머지 P0 코드/권한/환불 게이트를 ALIGO 심사와 병렬 해결.
-3. Issue #32 관리자 설정.
-4. ALIGO 심사 결과 재조회.
-5. 승인 뒤 실제 알림톡 → SMS fallback.
-6. 모든 P0 결과 기준으로 판매 활성화 legal docs/test 재정합화.
-7. actual release SHA 고정 → 원격 E2E 52+cleanup → 운영 Firebase 재조회.
-8. 별도 승인 후 ALIGO production 설정·exact-SHA production deploy.
-9. 첫 회차 검수 → 최종 승인 → `salesMode: round_direct`.
+1. `ORDER-REDELIVERY-PAID-RESUME-GATE`를 **상태머신 전체** 기준으로 구현·직접 회귀·`main` 통합.
+2. 나머지 P0를 ALIGO 심사와 병렬 해결.
+3. Issue #32.
+4. ALIGO 상태 재조회 → 승인 뒤 실제 알림톡/SMS fallback.
+5. P0 결과 기준 legal 재정합화.
+6. actual release SHA → E2E 52+cleanup → Firebase 재조회 → 승인된 production 설정/배포.
+7. 첫 회차 검수 → 최종 승인 → `salesMode: round_direct`.

--- a/docs/plans/HANDOFF_mvp_round_direct_aligo_review_pause.md
+++ b/docs/plans/HANDOFF_mvp_round_direct_aligo_review_pause.md
@@ -2,21 +2,20 @@
 
 # 회차 직배송 MVP — ALIGO 심사 대기 인계
 
-> 현재 재개 지점만 관리한다. 상세 상태는 `docs/memory.md`, 미완료 Acceptance Criteria는 `docs/BACKLOG.md`, 실행 의존성은 `docs/plans/PLAN_mvp_round_direct_launch_blockers.md`를 따른다.
+> 현재 재개 지점만 관리한다. 상세 상태는 `docs/memory.md`, Acceptance Criteria는 `docs/BACKLOG.md`, 의존성은 `docs/plans/PLAN_mvp_round_direct_launch_blockers.md`를 따른다.
 
 ## 현재 상태 — 2026-08-24 KST
 
 - 회차 직배송 MVP `main` 통합 완료.
-- 카카오 비즈니스 채널, ALIGO 발신 프로필·`senderkey`, 회차 알림 템플릿 8종 등록·심사 요청 완료.
-- 마지막 provider 확인 기준 8종 모두 `검수중`.
-- 실제 알림톡·SMS 발송 0건.
+- 카카오 비즈니스 채널, ALIGO 발신 프로필·senderkey, 회차 알림 템플릿 8종 등록·심사 요청 완료.
+- 마지막 provider 확인: 8종 모두 `검수중`, 실제 발송 0건.
 - production ALIGO 설정 미반영.
 - 첫 운영 회차 미생성, `salesMode=legacy`.
-- `main` merge는 production 승인/배포가 아니며 exact release SHA + 별도 승인 절차를 사용한다.
+- production은 exact release SHA + 별도 승인 절차를 사용한다.
 
-현재 외부 차단점은 **ALIGO 8종 provider 심사 완료**다. 재개 시 provider 상태를 직접 다시 확인한다.
+현재 외부 차단점은 ALIGO 8종 심사 완료다. 재개 시 provider 상태를 다시 확인한다.
 
-ALIGO 심사와 병렬로 해결할 출시 P0:
+병렬 출시 P0:
 
 1. `ORDER-REDELIVERY-PAID-RESUME-GATE`
 2. `AUTH-DRIVER-APPROVAL-AND-SESSION-REVOCATION`
@@ -24,134 +23,105 @@ ALIGO 심사와 병렬로 해결할 출시 P0:
 4. `PAYMENT-FINALIZATION-PAID-GUARD`
 5. `ORDER-MUTATION-AUTHORIZATION-COVERAGE`
 6. `ADMIN-FORCE-REFUND-CONSISTENCY`
-7. Issue #32 `main` protection/ruleset
+7. Issue #32
 
-## P0 재개 포인터
+## 최우선 재개 — 재배송비 상태머신
 
-### 1. 유료 재배송비 결제 전 배송 재개
+운영 불변식은 **고객 책임 유료 재배송비를 결제하기 전에 실제 배송을 다시 시작하지 않는다**는 것이다.
 
-운영 runbook은 고객 책임 첫 배송 실패의 유료 재배송에 **결제 전 재배송 금지**를 요구한다.
+현재는 두 문제가 결합돼 있다.
 
-현재:
+### A. direct resume 우회
 
-- charge 생성·결제·환불 자체는 직접 회귀가 있어 `VERIFIED`.
-- 하지만 server lifecycle은 `DELIVERY_HELD → DELIVERING` 전에 연결 charge `PAID`를 확인하지 않는다.
-- driver 상세도 charge 상태와 무관하게 `배송 재개` CTA를 노출한다.
+`DELIVERY_HELD → DELIVERING`이 charge `PAID` 확인 없이 가능하며 driver UI도 결제 상태와 무관하게 `배송 재개`를 노출한다.
 
-완료 방향:
+### B. seller PREPARING 경유 dead-end/우회
 
-- 현재 hold ↔ current `redeliveryChargeId` 연계 확인
-- `REDELIVERY_FEE`, order/store/user 일치, `PAID`일 때만 유료 재배송 재개
-- `PENDING|FAILED|REFUNDED|missing|mismatched` side-effect 0 거부
-- 재배송비 없는 판매자/시스템 책임 보류는 기존 정책 유지
-- UI 상태 표현 + `미결제 거부 → 결제 → 재개 성공` 직접 E2E
+- 고객 책임+양수 재배송비 hold도 seller가 `DELIVERY_HELD → PREPARING` 가능.
+- 이 전환은 hold를 해소하고 `heldOrderCount`를 줄이며 `ORDER_REDELIVERY_PAYMENT_REQUESTED`를 발생시키는 현재 경로다.
+- 그러나 charge 생성 API와 consumer 결제 CTA는 현재 status `DELIVERY_HELD`를 요구한다.
+- 따라서 payment-request 알림 뒤 실제 결제가 불가능할 수 있다.
+- 이후 `PREPARING → DELIVERING`에도 과거 미결제 hold를 확인하는 durable gate가 없다.
 
-정본: `docs/specs/api/orders.md`, `docs/BACKLOG.md`; 운영 근거: `docs/specs/ops/mvp-sales-round-runbook.md`.
+완료 시 반드시:
 
-### 2. Driver 승인·세션 권한
+- payment-required 정보가 결제 전 사라지지 않고,
+- payment-request 알림 뒤 consumer가 실제 결제할 수 있으며,
+- current hold↔charge가 durable하게 연결되고,
+- `PAID` 전 모든 delivery-start 경로가 side-effect 0으로 거부되고,
+- PAID 뒤 정상 한 번만 재개되며,
+- hold resolve/held counter/알림이 race에서도 한 번만 수렴해야 한다.
 
-- 신규 Kakao `targetRole: driver`와 승인 필드 누락 기존 driver의 자동 승인 경로 제거.
-- suspension/role/store/approval 변경 뒤 refresh/Firebase claims가 정의된 revocation window 안에 authoritative state로 수렴하도록 보정.
-- broad driver Firestore read P0와 결합 회귀.
-
-정본: `docs/specs/api/auth.md`, `docs/specs/api/admin.md`, `docs/BACKLOG.md`.
-
-### 3. 주문 direct read·데이터 최소화
-
-- 필요한 미배정 `PREPARING` direct/hub discovery는 유지.
-- arbitrary raw order read와 역할에 불필요한 내부/동의/유입 필드 노출 제거.
-- Rules + projection/API + seller/driver 정상 흐름을 함께 검증.
-
-정본: `docs/specs/api/orders.md`, `docs/specs/legal/README.md`, `docs/BACKLOG.md`.
-
-### 4. 결제 finalization `PAID` guard
-
-- `finalizePaidOrder()` boundary가 비`PAID` 입력을 자체 차단하도록 보정.
-- `PENDING|FAILED|CANCELLED` 거부와 `PAID` legacy/group/round 정상 회귀.
-
-정본: `docs/specs/api/payments.md`, `docs/BACKLOG.md`.
-
-### 5. 주문 mutation authorization 회귀
-
-- 타-store seller, 비담당 driver, first-claim 외 미배정 driver action을 직접 거부 테스트로 고정.
-- 거부 side-effect 0 포함.
+단순 driver 버튼 숨김 또는 `HELD→DELIVERING` 한 경로 guard만으로 닫지 않는다.
 
 정본: `docs/specs/api/orders.md`, `docs/BACKLOG.md`.
 
-### 6. Admin 강제 환불 lifecycle
+## 나머지 P0 포인터
 
-- admin 본 결제 환불 + 주문 직접 `CANCELLED` write를 정상 cancellation 금전·capacity·settlement 불변식과 수렴시킨다.
-- paid settlement 환불은 별도 회계 조정 정책이 필요하다.
+- Driver 승인·session revocation: `docs/specs/api/auth.md`
+- Order direct read·minimization: `docs/specs/api/orders.md`, legal gate
+- Payment finalization: `docs/specs/api/payments.md`
+- Order mutation authorization: `docs/specs/api/orders.md`
+- Admin force-refund: `docs/specs/api/admin.md`, `docs/specs/api/settlements.md`
+- GitHub main protection: Issue #32 / deployment safety plan
 
-정본: `docs/specs/api/admin.md`, `docs/specs/api/settlements.md`, `docs/BACKLOG.md`.
+## 지금 하지 말 것
 
-### 7. GitHub `main` protection
+- 심사 중 ALIGO 템플릿 중복 등록·임의 수정
+- 승인 전 실제 알림톡/SMS
+- secret/실제 tpl_code/개인정보 Git 기록
+- direct `main`
+- main merge를 production 승인으로 해석
+- 승인 없는 production/Firebase/운영 회차/`salesMode`
+- P0를 UI·legal 문구만으로 정상화
+- P0 전 actual release SHA 확정
 
-- repo-side production auto-deploy 차단은 완료.
-- Issue #32에서 PR required, safety required check, force-push/delete 차단 필요.
+## 병렬 가능 작업
 
-정본: `docs/plans/PLAN_deployment_safety_guards_20260823.md`.
+1. 재배송 payment-request/hold-resolution/resume 상태머신 구현·회귀
+2. driver 승인/session revocation
+3. order direct read 최소화
+4. payment finalization PAID boundary
+5. order mutation 거부 회귀
+6. admin force-refund lifecycle
+7. Issue #32
+8. read-only 문서/코드 감사
+9. ALIGO 상태 조회
 
-## 지금 하지 말아야 할 작업
+## ALIGO 승인 뒤
 
-- 심사 중 ALIGO 템플릿 중복 등록·임의 수정.
-- 승인 전 실제 알림톡·SMS 발송.
-- secret, 실제 `tpl_code`, 고객 개인정보 원문 Git/문서 기록.
-- direct `main` commit/push.
-- `main` merge를 production 배포 승인으로 해석.
-- 별도 승인 없는 production 배포·Firebase 운영 변경·운영 회차 생성·`salesMode` 변경.
-- P0 구현 결함을 UI·legal·운영 문구만으로 정당화.
-- P0가 `main`에 포함되기 전 actual release SHA 확정.
+1. P0 6개 + Issue #32 완료 확인
+2. ALIGO 8종 상태 재확인
+3. provider code 1:1 검사
+4. 승인 후 격리 알림톡
+5. 승인 후 SMS fallback
+6. 실제 재배송/환불/read-minimization 기준 legal 재정합화
+7. actual release SHA
+8. exact SHA E2E 52+cleanup
+9. 운영 Firebase read-only
+10. 승인 후 production ALIGO 설정
+11. exact-SHA deployment 절차
+12. 별도 Task 3.1 승인 뒤 production
+13. metadata SHA + smoke
+14. 첫 회차 → 최종 판정 → `round_direct`
 
-## 지금 병렬로 할 수 있는 작업
+## 완료 체크
 
-1. 유료 재배송비 `PAID` resume guard 구현·회귀·통합.
-2. driver 승인·세션 revocation 구현·회귀·통합.
-3. 주문 direct read 최소화 구현·Rules/frontend 회귀·통합.
-4. payment finalization `PAID` guard 구현·회귀·통합.
-5. 주문 mutation authorization 거부 회귀·통합.
-6. admin force-refund lifecycle 정합화·회귀·통합.
-7. Issue #32 관리자 설정.
-8. read-only 문서/코드 정합성 감사.
-9. ALIGO provider 심사 상태 조회.
-
-## ALIGO 승인 뒤 재개 순서
-
-1. 위 P0 6개와 Issue #32 완료 확인.
-2. ALIGO 8종 승인/수정요청/반려 재확인.
-3. 승인 `tpl_code` 8종 ↔ 내부 논리 코드 1:1 검사.
-4. 별도 승인 후 격리 실제 알림톡 정상 발송.
-5. 별도 승인 후 SMS fallback 실제 검증.
-6. 실제 재배송비/환불/read-minimization 결과를 기준으로 판매 활성화 legal docs/test 재정합화.
-7. 모든 P0·legal 변경 포함 actual release SHA 확정.
-8. exact SHA 원격 E2E 52 + cleanup.
-9. 운영 Firebase read-only 재조회.
-10. 별도 승인 후 production ALIGO 설정.
-11. exact-SHA deploy/promotion 절차 확정.
-12. 사용자의 별도 `Task 3.1 승인` 뒤 production 배포.
-13. provider metadata SHA 대조 → 운영 smoke.
-14. 첫 회차 검수 → 최종 출시 판정 → `salesMode: round_direct`.
-
-## 재개 완료 조건
-
-- [x] 회차 직배송 코드 `main` 통합
-- [x] 카카오 비즈니스 채널 승인
-- [x] ALIGO 발신 프로필·senderkey 준비
-- [x] ALIGO 템플릿 8종 등록·심사 요청
-- [x] repo-side `main` auto-production 차단
-- [ ] 유료 재배송비 `PAID` resume gate + 직접 회귀 + `main`
-- [ ] driver 승인·세션/claims revocation + 직접 회귀 + `main`
-- [ ] 주문 direct read 최소화 + Rules/frontend 회귀 + `main`
-- [ ] payment finalization `PAID` guard + 회귀 + `main`
-- [ ] 주문 mutation authorization 거부 회귀 + `main`
-- [ ] admin force-refund lifecycle + 회귀 + `main`
+- [x] MVP main 통합
+- [x] 카카오 채널 승인
+- [x] ALIGO sender profile/senderkey
+- [x] 8종 등록·심사 요청
+- [x] repo-side main auto-production 차단
+- [ ] 재배송 payment-required 상태머신 + 직접 회귀 + main
+- [ ] driver 승인/session revocation
+- [ ] order direct read 최소화
+- [ ] payment finalization PAID
+- [ ] order mutation coverage
+- [ ] admin force-refund
 - [ ] Issue #32
-- [ ] ALIGO 8종 최종 승인
-- [ ] 실제 알림톡 정상 발송
-- [ ] SMS fallback
-- [ ] 판매 활성화 legal
-- [ ] actual release SHA E2E 52+cleanup
-- [ ] production ALIGO 설정
-- [ ] Task 3.1 별도 승인
-
-미완료 게이트를 건너뛰어 production 배포 또는 `salesMode` 전환을 진행하지 않는다.
+- [ ] ALIGO 8종 승인
+- [ ] 실제 알림톡/SMS fallback
+- [ ] legal
+- [ ] release SHA E2E 52+cleanup
+- [ ] production ALIGO
+- [ ] Task 3.1 승인

--- a/docs/plans/PLAN_mvp_round_direct_launch_blockers.md
+++ b/docs/plans/PLAN_mvp_round_direct_launch_blockers.md
@@ -2,285 +2,161 @@
 
 # Project Blueprint: 회차 직배송 MVP 출시 차단 요소 해소
 
-> 실행 순서·의존성·승인 게이트만 관리한다. 현재 상태는 `docs/memory.md`, 세부 Acceptance Criteria는 `docs/BACKLOG.md`, 도메인 계약은 current spec을 따른다.
+> 실행 순서·의존성·승인 게이트만 관리한다. 상태는 `docs/memory.md`, 세부 Acceptance Criteria는 `docs/BACKLOG.md`, 도메인 계약은 current spec을 따른다.
 
-## 문서 메타
+## 메타
 
-- 작성일: 2026-07-28
 - 최종 정합화: 2026-08-24 KST
 - 상태: `paused_external_review`
-- Priority: P0
-- 외부 차단점: ALIGO 회차 알림 템플릿 8종 provider 심사 완료
+- 외부 차단점: ALIGO 8종 provider 심사 완료
 - 상태 SSOT: `docs/memory.md`
-- 재개 지점: `docs/plans/HANDOFF_mvp_round_direct_aligo_review_pause.md`
-- 미완료 상세: `docs/BACKLOG.md`
-- 인증: `docs/specs/api/auth.md`
-- 주문: `docs/specs/api/orders.md`
-- 결제: `docs/specs/api/payments.md`
-- 정산: `docs/specs/api/settlements.md`
-- 관리자: `docs/specs/api/admin.md`
-- legal: `docs/specs/legal/README.md`
-- 배포 안전: `docs/plans/PLAN_deployment_safety_guards_20260823.md`
+- 재개: `docs/plans/HANDOFF_mvp_round_direct_aligo_review_pause.md`
+- 미완료: `docs/BACKLOG.md`
 
-## 현재 출시 게이트
+## 출시 게이트
 
 | ID | 게이트 | 상태 |
 |---|---|---|
 | 0A | GitHub `main` protection/ruleset | 미완료 — Issue #32 |
-| 0B | 결제 finalization 비`PAID` 최종 차단 | 미완료 — P0 |
-| 0C | 주문 mutation authorization 직접 거부 회귀 | 미완료 — P0 COVERAGE GAP |
-| 0D | 주문 direct Firestore read·데이터 최소화 | 미완료 — P0 IMPLEMENTATION FINDING |
-| 0E | driver 승인 + 세션/claims revocation | 미완료 — P0 IMPLEMENTATION FINDING / DECISION REQUIRED |
-| 0F | admin 강제 환불 lifecycle 정합성 | 미완료 — P0 IMPLEMENTATION FINDING |
-| 0G | 유료 재배송비 `PAID` 전 배송 재개 차단 | 미완료 — P0 IMPLEMENTATION FINDING |
-| 1 | ALIGO 8종 provider 최종 승인 | 검수중 |
-| 2 | 실제 알림톡 정상 발송 | 미실행 |
-| 3 | SMS fallback 실제 검증 | 미실행 |
-| 4 | 판매 활성화 legal 재정합화 | 미실행 |
-| 5 | actual release SHA 확정 | 미실행 |
-| 6 | exact SHA 원격 E2E 52건+cleanup | 미실행 |
+| 0B | payment finalization 비`PAID` 차단 | 미완료 — P0 |
+| 0C | order mutation authorization 직접 거부 회귀 | 미완료 — P0 GAP |
+| 0D | order direct Firestore read·최소화 | 미완료 — P0 FINDING |
+| 0E | driver 승인 + session/claims revocation | 미완료 — P0 FINDING/DECISION |
+| 0F | admin force-refund lifecycle | 미완료 — P0 FINDING |
+| 0G | 유료 재배송 payment-request/hold-resolution/resume 상태머신 | 미완료 — P0 FINDING |
+| 1 | ALIGO 8종 최종 승인 | 검수중 |
+| 2 | 실제 알림톡 | 미실행 |
+| 3 | SMS fallback | 미실행 |
+| 4 | 판매 활성화 legal | 미실행 |
+| 5 | actual release SHA | 미실행 |
+| 6 | exact SHA E2E 52+cleanup | 미실행 |
 | 7 | 운영 Firebase 재조회 | 미실행 |
 | 8 | 운영 ALIGO 설정 | 미실행 |
-| 9 | exact-SHA production 배포 | 미실행 — 별도 Task 3.1 승인 |
-| 10 | 첫 회차 검수 | 미실행 |
-| 11 | 최종 출시 판정 | 미실행 |
-| 12 | `salesMode: round_direct` | 미실행 |
+| 9 | exact-SHA production | 별도 승인 필요 |
+| 10~12 | 첫 회차 → 최종 판정 → `round_direct` | 미실행 |
 
-## Agent Completion Contract
+## Completion Contract
 
-1. repository 변경은 최신 `main` 기반 목적별 branch+PR로 통합한다.
-2. direct `main` commit/push 금지.
-3. Task 0A~0G는 ALIGO 심사와 병렬 수행 가능.
-4. P0 구현 결함을 문서 문구만 바꿔 정상화하지 않는다.
-5. `IMPLEMENTED / UNVERIFIED`, `COVERAGE GAP`, `IMPLEMENTATION FINDING`, P0 `DECISION REQUIRED`는 완료가 아니다.
-6. 비밀값·고객 개인정보·사진 원본·서명 URL을 증거에 남기지 않는다.
-7. actual release SHA는 Task 0A~0G와 legal gate 해결 뒤에만 확정한다.
-8. exact release SHA E2E 52+cleanup 전 production 배포 금지.
-9. `main` merge·빈 commit·재-push를 production 트리거로 사용하지 않는다.
-10. production은 exact SHA/artifact + 별도 승인 게이트를 사용한다.
-11. provider metadata SHA 불일치 시 traffic/domain 전환 금지.
-12. ALIGO 실제 발송 실패 시 알림 없는 출시를 임의 승인하지 않는다.
-13. 첫 회차가 검수된 `SCHEDULED`가 아니면 `salesMode` 전환 금지.
-14. 금전 게이트는 UI 조건이 아니라 서버 boundary에서 fail-closed여야 한다.
+1. repository 변경은 최신 `main` 기반 branch+PR.
+2. direct `main` 금지.
+3. 0A~0G는 ALIGO 심사와 병렬 가능.
+4. P0를 문서/UI 변경만으로 완료 처리하지 않는다.
+5. 금전·권한 불변식은 server boundary + 직접 거부/정상 회귀가 필요하다.
+6. actual release SHA는 0A~0G + legal 해결 뒤 고정한다.
+7. exact SHA E2E 52+cleanup 전 production 금지.
+8. production은 exact SHA/artifact + 별도 승인.
+9. provider metadata SHA 불일치 시 traffic 전환 금지.
+10. 첫 회차 `SCHEDULED` 전 `salesMode` 전환 금지.
 
-## Phase 0 — 출시 전 코드·권한·금전 안전성
+## Phase 0 — 코드·권한·금전 안전성
 
-### Task 0.1 — 회차 직배송 코드 `main` 통합
-- Status: done
-- Evidence: PR #11, 기능 통합 SHA `e55f25914cc7d01576fbd4639583daaf0fe6385e`.
+### Task 0.1 — 회차 직배송 `main` 통합
+- Status: done — PR #11
 
-### Task 0.2 — `main` 자동 production deploy 분리
-- Status: done
-- Evidence: PR #30, PR #31.
+### Task 0.2 — main auto-production 분리
+- Status: done — PR #30/#31
 
-### Task 0.3 — GitHub `main` protection/ruleset
-- Dependency: 없음
-- Required: PR required, `Deployment safety guard / verify`, force-push/delete 차단
+### Task 0.3 — GitHub main protection
+- Required: PR required, deployment safety required check, force-push/delete 차단
 - Tracking: Issue #32
 - Status: todo_admin
 
-### Task 0.4 — 결제 finalization `PAID` 최종 방어
-- Dependency: 없음
-- Goal: finalization boundary가 비`PAID` provider 상태 자체 차단
-- Verify: `PENDING|FAILED|CANCELLED|PAID`, 금액 불일치, legacy/group/round
+### Task 0.4 — Payment finalization PAID boundary
 - Backlog: `PAYMENT-FINALIZATION-PAID-GUARD`
 - Status: todo_code
 
-### Task 0.5 — 주문 mutation authorization 직접 회귀
-- Dependency: 없음
-- Goal: 타-store seller, 비담당 driver, first-claim과 거부 side-effect 0 직접 고정
+### Task 0.5 — Order mutation authorization coverage
 - Backlog: `ORDER-MUTATION-AUTHORIZATION-COVERAGE`
 - Status: todo_test
 
-### Task 0.6 — 주문 direct Firestore read·데이터 최소화
-- Dependency: 없음
-- Goal: 필요한 discovery는 유지하고 arbitrary raw read와 불필요 필드 노출 제거
-- Verify: Rules + discovery/assigned detail + 타주문/타store 거부
+### Task 0.6 — Order direct read·minimization
 - Backlog: `ORDER-DIRECT-READ-AUTHORIZATION-AND-MINIMIZATION`
 - Status: todo_code_security
 
-### Task 0.7 — Driver 승인·세션/claims revocation
-- Dependency: 없음
-- Goal: 관리자 승인 전 driver 권한 차단 + suspension/role/store/approval의 정의된 revocation window 보장
-- Coupling: Task 0.6 broad driver read와 결합 회귀
+### Task 0.7 — Driver approval·session revocation
 - Backlog: `AUTH-DRIVER-APPROVAL-AND-SESSION-REVOCATION`
+- Coupling: Task 0.6
 - Status: todo_code_security
 
-### Task 0.8 — Admin 강제 환불 lifecycle 정합화
-- Dependency: 없음
-- Goal: admin refund가 정상 cancellation의 본 결제/추가 charge/capacity/held counter/settlement 불변식과 수렴
-- Required: 허용 상태 fail-closed, paid settlement 별도 회계 정책, provider-success/local-failure 재시도, 동시 실행 수렴
+### Task 0.8 — Admin force-refund lifecycle
 - Backlog: `ADMIN-FORCE-REFUND-CONSISTENCY`
+- Goal: 본 결제·추가 charge·capacity·held counter·settlement 불변식 수렴 + paid settlement 정책
 - Status: todo_code_financial
 
-### Task 0.9 — 유료 재배송비 결제 완료 전 배송 재개 차단
-- Dependency: 없음
-- Goal: 고객 책임 유료 재배송은 현재 hold에 연결된 `REDELIVERY_FEE` charge가 `PAID`일 때만 `DELIVERY_HELD → DELIVERING` 허용
-- Required:
-  - 현재 hold와 `redeliveryChargeId` 연계 검증
-  - charge type/order/store/user 일치 검증
-  - `PENDING|FAILED|REFUNDED|missing|mismatched` fail-closed + side effect 0
-  - 재배송비 없는 판매자/시스템 책임 보류는 불필요한 결제 gate 없음
-  - driver UI charge 상태 표현
-  - `미결제 거부 → 결제 완료 → 재개 성공` unit/integration/E2E
+### Task 0.9 — 유료 재배송 상태머신 정합화
+- Backlog: `ORDER-REDELIVERY-PAID-RESUME-GATE`
 - Contract: `docs/specs/api/orders.md`
 - Operational evidence: `docs/specs/ops/mvp-sales-round-runbook.md`
-- Backlog: `ORDER-REDELIVERY-PAID-RESUME-GATE`
+- Goal: `결제 전 재배송 금지`와 payment-request 흐름을 실제 상태머신에서 동시에 만족
+- Required:
+  - paid-required hold의 payment-required 정보가 결제 전 사라지지 않음
+  - payment-request 알림 뒤 consumer charge 생성/UI·endpoint actionable
+  - current hold↔charge durable linkage
+  - `REDELIVERY_FEE` + order/store/user + `PAID` 검증
+  - 모든 delivery-start 경로(`HELD→DELIVERING`, `HELD→PREPARING→DELIVERING` 포함) 동일 gate
+  - `PENDING|FAILED|REFUNDED|missing|mismatch` side effect 0
+  - hold resolve/held counter 감소 시점을 결제·재개 계약과 일치
+  - 무료/판매자책임 흐름 정상 유지
+  - seller/driver race 한 번만 수렴
+- Required tests:
+  - payment request 뒤 consumer 결제 가능
+  - 미결제 direct resume 거부
+  - seller PREPARING 정책 직접 고정
+  - PREPARING 경유 미결제 배송 시작 거부
+  - PAID 뒤 정상 1회 재개
 - Status: todo_code_financial
 
-## Phase 1 — ALIGO 알림 게이트
+## Phase 1 — ALIGO
 
-### Task 1.1 — 발신 프로필·코드 매핑 기반
-- Status: done
+1. 8종 승인 (`blocked_external_review`)
+2. provider code 1:1 검사
+3. 승인 후 격리 실제 알림톡
+4. 승인 후 SMS fallback
 
-### Task 1.2 — 템플릿 8종 최종 승인
-- Current: `docs/memory.md`
-- Status: blocked_external_review
+## Phase 2 — legal·release SHA
 
-### Task 1.3 — 승인 `tpl_code` 1:1 매핑 검사
-- Dependency: Task 1.2
-- Status: todo
+### Task 2.1 — 판매 활성화 legal
+- Dependency: ALIGO 실제 검증 + Task 0.6 + 0.8 + 0.9
+- Required: 주문/환불/재배송비/보류 실제 상태머신, 개인정보 처리, ALIGO, seller/driver 최소 접근, legal tests
 
-### Task 1.4 — 격리 실제 알림톡 정상 발송 [승인 게이트]
-- Dependency: Task 1.3
-- Status: todo
+### Task 2.2 — actual release SHA
+- Dependency: Task 0.3~0.9 + 2.1
 
-### Task 1.5 — SMS fallback 실제 검증 [승인 게이트]
-- Dependency: Task 1.4
-- Status: todo
-
-## Phase 2 — 판매 공개 계약·release SHA
-
-### Task 2.1 — 판매 활성화 legal 재정합화
-- Dependency: Task 1.5, Task 0.6, Task 0.8, Task 0.9
-- Required: 주문·취소·환불·배송·재배송비·보류, PortOne/PG, ALIGO, seller/driver 최소 접근, 시행일·이전 버전, legal tests
-- Status: todo
-
-### Task 2.2 — actual release SHA 확정
-- Dependency: Task 0.3~0.9, Task 2.1
-- Goal: 운영 대상 단 하나의 exact `main` SHA 고정
-- Status: todo
-
-### Task 2.3 — exact SHA 전체 원격 회차 E2E
-- Dependency: Task 2.2
-- Goal: chromium 26 + mobile 26 = 52, unexpected/skipped/flaky 0, 양쪽 cleanup 성공
-- Status: todo
+### Task 2.3 — exact SHA E2E
+- Goal: chromium 26 + mobile 26 = 52, cleanup success
 
 ### Task 2.4 — 운영 Firebase read-only 재조회
-- Dependency: Task 2.3
-- Status: todo
 
-### Task 2.5 — 운영 ALIGO 변수·매핑 반영 [승인 게이트]
-- Dependency: Task 1.5, Task 2.3
-- Status: todo
+### Task 2.5 — 운영 ALIGO 설정 [승인]
 
-## Phase 3 — exact-SHA production 배포
+## Phase 3 — production
 
-### Task 3.0 — production deploy/promotion 절차 확정
-- Dependency: Task 2.3
-- Goal: exact SHA/artifact 기반 명시적 배포와 사후 SHA 검증
-- Status: todo
+- Task 3.0 exact-SHA deploy/promotion 절차
+- Task 3.1 API production — **별도 사용자 승인 필수**
+- Task 3.2 세 frontend 동일 SHA production
+- Task 3.3 smoke
+- Task 3.4 오류 관찰
 
-### Task 3.1 — API production 배포 [별도 승인 게이트]
-- Dependency: Task 0.3, Task 2.3, Task 2.4, Task 2.5, Task 3.0
-- 사용자의 별도 `Task 3.1 승인` 없이는 실행하지 않는다.
-- Status: todo
+## Phase 4~7
 
-### Task 3.2 — consumer·seller·driver production 배포 [승인 게이트]
-- Dependency: Task 3.1
-- Status: todo
+- 첫 회차 `DRAFT` → 검수 → `SCHEDULED`
+- 운영 역할/비상 연락 확인
+- rollback dry-run
+- 최종 출시 판정
+- 최종 승인 뒤 `salesMode: round_direct`
+- 전환 smoke
+- 외부 유입 공개
+- 첫 두 회차 모니터링 → Closeout
 
-### Task 3.3 — 운영 smoke
-- Dependency: Task 3.2
-- 확인: health, Kakao auth, legacy, 회차 read, `/privacy`, `/terms`
-- Status: todo
+## 최종 완료 기준
 
-### Task 3.4 — 배포 후 오류 관찰
-- Dependency: Task 3.3
-- Status: todo
-
-## Phase 4 — 첫 회차
-
-### Task 4.1 — 첫 회차 `DRAFT` 생성 [승인 게이트]
-- Dependency: Task 3.4
-- Status: todo
-
-### Task 4.2 — 일정·지역·상품·가격·한도 검수
-- Dependency: Task 4.1
-- Status: todo
-
-### Task 4.3 — `SCHEDULED` 전환 [승인 게이트]
-- Dependency: Task 4.2
-- Status: todo
-
-## Phase 5 — 최종 출시 판정
-
-### Task 5.1 — 운영 역할·비상 연락·승인자 확인
-- Dependency: Task 4.3
-- Status: todo
-
-### Task 5.2 — 전환·rollback dry-run
-- Dependency: Task 5.1
-- Status: todo
-
-### Task 5.3 — 최종 출시 판정
-- Dependency: Task 5.2
-- 대조: exact SHA, Task 0A~0G, Firebase, ALIGO, legal, 첫 회차, 운영 예외, rollback
-- Status: todo
-
-## Phase 6 — 판매 모드 전환
-
-### Task 6.1 — `round_direct` 전환 [최종 승인 게이트]
-- Dependency: Task 5.3 승인
-- Status: todo
-
-### Task 6.2 — 전환 직후 smoke·rollback 판정
-- Dependency: Task 6.1
-- Status: todo
-
-### Task 6.3 — 외부 유입 링크 공개 [승인 게이트]
-- Dependency: Task 6.2
-- Status: todo
-
-## Phase 7 — 초기 안정화
-
-### Task 7.1 — 첫 두 회차 집중 모니터링
-- Dependency: Task 6.3
-- Status: todo
-
-### Task 7.2 — 출시 Closeout
-- Dependency: Task 7.1
-- Status: todo
-
-## Completion Criteria
-
-- Task 0A~0G가 직접 테스트 증거와 함께 `main`에 포함됨.
-- 유료 재배송비 결제 완료 전 배송 재개가 서버에서 fail-closed되고 정상 결제 뒤 재개 회귀가 포함됨.
-- admin 환불이 정상 cancellation 금전·capacity·settlement 불변식과 수렴하거나 명시적 별도 정책으로 검증됨.
+- Task 0A~0G 직접 증거와 함께 `main` 포함.
+- 유료 재배송 payment request가 실제 결제 가능한 상태를 유지하고, 결제 전 모든 배송 시작 경로가 fail-closed.
+- admin refund·payment finalization·권한/개인정보 P0 해결.
 - Issue #32 완료.
-- ALIGO 8종 승인 + 실제 알림톡/SMS fallback 검증.
-- 판매 활성화 legal docs/test 정합화.
-- actual release SHA E2E 52+cleanup 성공.
-- 운영 Firebase·ALIGO 설정 확인.
+- ALIGO 승인+실발송/fallback.
+- legal 정합화.
+- actual release SHA E2E 52+cleanup.
+- 운영 Firebase/ALIGO 확인.
 - exact SHA production metadata 일치.
-- 첫 회차 `SCHEDULED`.
-- 최종 승인 뒤 `round_direct` 전환·smoke 또는 rollback 성공.
-
-## 현재 Closeout Roll-up
-
-- 코드 통합: 완료
-- payment finalization P0: 미완료
-- redelivery paid-before-resume P0: 미완료
-- admin force-refund P0: 미완료
-- order direct-read P0: 미완료
-- auth approval/revocation P0: 미완료
-- order mutation coverage P0: 미완료
-- repo-side production auto-deploy 분리: 완료
-- GitHub `main` protection: 미완료 — Issue #32
-- ALIGO 8종 승인: 검수중
-- 실제 알림 발송: 미실행
-- legal: 미실행
-- actual release SHA/E2E: 미실행
-- production 설정/배포: 미실행
-- 첫 회차: 미생성
-- `salesMode`: `legacy`
+- 첫 회차 `SCHEDULED` 후 최종 승인·전환.

--- a/docs/specs/api/orders.md
+++ b/docs/specs/api/orders.md
@@ -13,10 +13,10 @@
 
 `orders`는 consumer·seller·driver가 공유하는 핵심 도메인이다.
 
-- 주문 생성·검증·상태 전이·취소·재배송비·배송 보류·배송 사진 완료 같은 write는 NestJS API가 소유한다.
+- 주문 생성·상태 전이·취소·재배송비·보류·사진 완료 write는 NestJS API가 소유한다.
 - 공개 주문 타입은 `packages/shared/src/order.types.ts`가 소유한다.
-- Firestore 원문에는 공개 타입 외 `reservationId`, `clientOrderPayloadHash`, `marketingConsent` 등 내부 필드가 존재할 수 있으므로 raw document를 공개 DTO와 동일시하지 않는다.
-- legacy 주문과 `schemaVersion: 2` 회차 주문이 공존하므로 한 흐름의 규칙을 다른 흐름에 자동 적용하지 않는다.
+- Firestore 원문에는 `reservationId`, `clientOrderPayloadHash`, `marketingConsent` 등 공개 DTO 외 내부 필드가 존재할 수 있다.
+- legacy와 `schemaVersion: 2` 회차 주문이 공존하므로 한 흐름의 규칙을 다른 흐름에 자동 적용하지 않는다.
 
 ## 2. 주문 상태
 
@@ -36,17 +36,17 @@ type OrderStatus =
   | 'REVIEWED'
 ```
 
-`DELIVERY_HELD`는 회차 직배송의 배송 실패·재배송 흐름에서 사용하는 현재 공통 상태다.
+`DELIVERY_HELD`는 회차 직배송 배송 실패·재배송 흐름의 현재 상태다.
 
 ## 3. 역할별 FSM
 
-`orders.helpers.ts`의 일반 전이 허용 목록은 다음과 같다. 이 목록은 **필요조건일 뿐 충분조건이 아니다**. service/lifecycle의 소유권·delivery method·결제·회차 불변식을 추가로 통과해야 한다.
+`orders.helpers.ts`의 전이 허용 목록은 **필요조건일 뿐 충분조건이 아니다**. service/lifecycle의 소유권·delivery method·결제·회차 불변식을 추가로 통과해야 한다.
 
 ### Seller
 
 - `ACCEPTED → PREPARING`
 - `CONFIRMED → PREPARING`
-- `PREPARING → DELIVERED` — 실제 lifecycle에서 parcel 조건 추가
+- `PREPARING → DELIVERED` — 실제 lifecycle의 parcel 조건 추가
 - `PREPARING → DELIVERY_HELD`
 - `DELIVERING → DELIVERY_HELD`
 - `DELIVERY_HELD → PREPARING`
@@ -71,11 +71,11 @@ type OrderStatus =
 
 helper 수준에서는 seller·driver 전이의 합집합과 seller 취소 가능 상태를 허용한다. 실제 endpoint별 추가 불변식은 별도 확인한다.
 
-FSM 표를 근거로 Firestore 주문 상태를 직접 수정하지 않는다.
+FSM 표만 근거로 Firestore 주문 상태를 직접 수정하지 않는다.
 
 ## 4. 배송 보류·재배송 계약
 
-`DeliveryHoldSnapshot`의 핵심 필드:
+`DeliveryHoldSnapshot` 핵심 필드:
 
 ```ts
 {
@@ -95,62 +95,86 @@ FSM 표를 근거로 Firestore 주문 상태를 직접 수정하지 않는다.
 }
 ```
 
-현재 제품·운영 계약:
+현재 제품·운영 불변식:
 
 - `WEATHER`는 고객 책임 유료 재배송으로 취급하지 않는다.
-- 고객 책임 첫 배송 실패에서 양수 `redeliveryFee`가 요구되면 주문자 본인이 `POST /stores/:storeId/orders/:orderId/redelivery-fee`로 `REDELIVERY_FEE` charge를 생성·결제한다.
-- 같은 보류에 대해 중복 charge를 만들지 않는다.
-- **유료 재배송비가 요구된 보류는 연결 charge가 `PAID`임을 서버가 확인한 뒤에만 배송을 다시 시작할 수 있어야 한다.** 운영 정본은 명시적으로 `결제 전 재배송 금지`를 요구한다.
-- 유료 재배송까지 다시 실패하면 자동 환불을 추측하지 않고 `REDELIVERY_FAILED` 운영 이슈로 이관한다.
+- 고객 책임 첫 배송 실패에 양수 재배송비가 필요하면 주문자 본인이 `REDELIVERY_FEE` charge를 생성·결제한다.
+- 같은 hold에 charge를 중복 생성하지 않는다.
+- **유료 재배송은 결제 완료 전 실제 배송을 다시 시작하면 안 된다.**
+- 결제 요청 알림을 받은 동안 소비자가 실제 결제 endpoint/UI를 사용할 수 있어야 한다.
+- 유료 재배송까지 실패하면 자동 환불을 추측하지 않고 `REDELIVERY_FAILED` 운영 이슈로 이관한다.
 
-알림 연결:
+현재 알림 매핑:
 
 - `PREPARING|DELIVERING → DELIVERY_HELD` → `ORDER_DELIVERY_HELD`
 - `DELIVERY_HELD → PREPARING` → `ORDER_REDELIVERY_PAYMENT_REQUESTED`
 - `DELIVERY_HELD → DELIVERING` → `ORDER_REDELIVERY_SCHEDULED`
 
-알림 템플릿·provider 계약은 `docs/specs/api/notifications.md`가 소유한다.
+이 매핑은 현재 코드 사실이며, 아래 P0가 해결되기 전 **정상 재배송 상태머신의 보장으로 해석하지 않는다.**
 
-### 재배송비 결제 전 배송 재개 — `IMPLEMENTATION FINDING` P0
+### 재배송비 결제·재개 상태머신 — `IMPLEMENTATION FINDING` P0
 
-2026-08-24 현재 제품 계약과 실제 구현을 대조하면 위 결제 게이트가 서버에서 강제되지 않는다.
+2026-08-24 감사에서 단순 PAID guard 누락을 넘어 상태머신 자체가 결제 요청 흐름과 충돌함을 확인했다.
 
-직접 근거:
+#### 경로 A — driver 직접 재개 우회
 
-- `docs/specs/ops/mvp-sales-round-runbook.md`는 첫 고객 사유 실패를 `재배송비 1건 생성·결제. 결제 전 재배송 금지`로 규정한다.
-- `OrderChargePaymentService` 자체는 `PAID` 상태·금액·charge/order 연결과 환불 멱등성을 직접 검증한다.
-- 그러나 `orders.helpers.ts`는 driver의 `DELIVERY_HELD → DELIVERING`을 허용하고, `OrdersLifecycleService`/`RoundOrderLifecycleService`는 해당 전환 직전에 연결 `orderCharges/{redeliveryChargeId}.status === 'PAID'`를 확인하지 않는다.
-- driver `board/[orderId]/page.tsx`도 회차 직배송 `DELIVERY_HELD`이면 charge 상태를 확인하지 않고 항상 `배송 재개` CTA를 노출해 `DELIVERING` 전환을 호출한다.
-- 현재 회귀 테스트는 charge 생성·결제·환불 자체는 고정하지만 미결제/실패 charge에서 배송 재개를 거부하는 서버 회귀를 고정하지 않는다.
+- `orders.helpers.ts`는 `DELIVERY_HELD → DELIVERING`을 허용한다.
+- lifecycle은 해당 전환 직전에 현재 `redeliveryChargeId`의 charge `PAID`를 확인하지 않는다.
+- driver 상세도 회차 직배송 `DELIVERY_HELD`이면 charge 상태와 무관하게 `배송 재개` CTA를 노출한다.
 
-판정:
+결과: 유료 재배송비가 미결제여도 직접 배송 재개가 가능할 수 있다.
 
-- `OrderChargePaymentService`의 **재배송비 결제·환불 하위 계약은 `VERIFIED`**다.
-- 그러나 **유료 재배송비 결제 완료를 배송 재개 전제조건으로 강제하는 주문 lifecycle 계약은 P0 `IMPLEMENTATION FINDING`**이다.
-- UI에서 버튼을 숨기는 것만으로 완료하지 않는다. API 직접 호출에서도 fail-closed여야 한다.
+#### 경로 B — seller `PREPARING` 경유 결제 불가·우회
 
-actual release SHA 전 완료 조건:
+현재 직접 테스트는 고객 책임+양수 재배송비인 `DELIVERY_HELD` 주문을 seller가 `PREPARING`으로 전환하는 것을 정상 성공으로 고정한다. 이 전환은 hold를 `resolvedAt`으로 닫고 회차 `heldOrderCount`도 감소시킨다.
 
-- 고객 책임이고 `redeliveryFee > 0`인 현재 보류가 유료 재배송 대상인지 서버에서 판정한다.
-- `DELIVERY_HELD → DELIVERING` 직전에 주문의 현재 `redeliveryChargeId`와 현재 보류의 `heldAt` 연계를 확인한다.
-- 연결 charge가 존재하고 `type === 'REDELIVERY_FEE'`, 같은 order/store/user에 속하며 `status === 'PAID'`일 때만 유료 재배송 재개를 허용한다.
-- `PENDING|FAILED|REFUNDED|missing|mismatched` charge에서는 주문·held counter·알림 side effect 없이 전환을 거부한다.
-- 판매자/시스템 책임 또는 재배송비가 없는 보류는 불필요한 결제 요구 없이 기존 정책대로 해소 가능해야 한다.
-- 이미 결제된 같은 보류의 정상 배송 재개는 한 번만 수렴한다.
-- driver UI도 charge 상태를 명시적으로 표현하되 UI 방어를 서버 불변식의 대체물로 사용하지 않는다.
-- 직접 unit/integration 회귀와 회차 E2E에 `미결제 재개 거부 → 결제 완료 → 재개 성공`을 포함한다.
+하지만 동시에:
+
+- `OrderChargesService.createRedeliveryFeeCharge()`는 주문이 **현재 `DELIVERY_HELD`**여야 charge를 만들 수 있다.
+- consumer `canPayRedeliveryFee`도 **현재 status가 `DELIVERY_HELD`**일 때만 true다.
+- 즉 seller `DELIVERY_HELD → PREPARING` 뒤 `ORDER_REDELIVERY_PAYMENT_REQUESTED` 알림이 나가더라도 소비자 결제 endpoint/UI는 더 이상 actionable하지 않다.
+- 이후 `PREPARING → DELIVERING`에는 과거 paid-required hold의 미결제 상태를 확인하는 durable guard가 없다.
+
+결과: `결제 요청 알림 → 실제 결제 불가`라는 unreachable flow와 `PREPARING` 경유 미결제 배송 시작 우회가 동시에 존재한다.
+
+#### 판정
+
+- `OrderChargePaymentService`의 charge **결제·환불 하위 계약은 `VERIFIED`**다.
+- 그러나 **유료 재배송 주문 상태머신 전체는 P0 `IMPLEMENTATION FINDING`**이다.
+- 단순히 driver `DELIVERY_HELD → DELIVERING` 한 경로에만 `PAID` 조건을 추가하면 seller `PREPARING` 경유 우회가 남으므로 완료가 아니다.
+
+#### actual release SHA 전 완료 조건
+
+구현 형태는 선택할 수 있지만 다음 불변식은 모두 필요하다.
+
+1. 고객 책임+양수 재배송비가 요구된 hold에서 `payment required` 상태가 결제 완료 전 사라지지 않는다.
+2. 결제 요청 알림 시점에도 소비자가 charge 생성/결제 UI와 endpoint를 실제 사용할 수 있다.
+3. 현재 hold와 현재 charge의 연계를 `heldAt` 또는 동등 durable key로 검증한다.
+4. charge는 `REDELIVERY_FEE`, 같은 order/store/user, `status === 'PAID'`일 때만 유료 재배송 배송 시작을 허용한다.
+5. `PENDING|FAILED|REFUNDED|missing|mismatched`이면 모든 배송 시작 경로를 side effect 0으로 거부한다.
+6. **`DELIVERY_HELD → DELIVERING`뿐 아니라 `DELIVERY_HELD → PREPARING → DELIVERING` 등 paid-required hold 이후의 모든 delivery-start 경로를 동일하게 gate한다.**
+7. seller가 결제 요청을 위해 `PREPARING`으로 옮기는 구조를 유지한다면 `payment required` marker/charge linkage가 상태 변경 후에도 durable하게 남고 consumer 결제가 계속 가능해야 한다. 그렇지 않으면 결제 완료 전 hold를 해소하지 않는 구조로 변경한다.
+8. 결제 완료 시점과 hold 해소/held counter 감소 시점을 하나의 명시적 계약으로 결정하고 race에서 음수·중복 해소가 없어야 한다.
+9. 판매자/시스템 책임 또는 재배송비 없는 hold는 불필요한 결제 gate 없이 기존 정책대로 해소 가능해야 한다.
+10. UI는 결제 대기/완료를 표현하되 서버 불변식의 대체물이 아니다.
+
+필수 직접 회귀:
+
+- 고객 책임 유료 hold → payment request 알림 뒤 consumer 결제 CTA/endpoint가 계속 actionable
+- charge 없음/PENDING/FAILED/REFUNDED에서 driver direct resume 거부
+- seller가 결제 전 `PREPARING`으로 전환할 수 있는지 정책대로 직접 고정
+- `PREPARING` 경유에서도 미결제 `DELIVERING` 진입 거부
+- `PAID` 뒤 정상 한 번 재개 성공
+- seller/driver 동시 요청에서 한 번만 hold 해소·counter 감소·scheduled 알림
+- 판매자 책임/무료 재배송 정상 회귀
 
 추적: `docs/BACKLOG.md`의 `ORDER-REDELIVERY-PAID-RESUME-GATE`.
 
-## 5. 주문 생성 입력
+## 5. 주문 생성
 
-`CreateOrderDto`는 legacy와 회차 주문을 함께 수용한다. 주요 입력은 상품·수량·판매형태·배송방식·배송주소·배송 연락처이며 회차 주문은 `roundId`, `roundItems`, 선택적 마케팅 동의·유입 snapshot을 추가로 가진다.
+`CreateOrderDto`는 legacy와 회차 주문을 함께 수용한다. DTO 통과만으로 주문 가능하지 않으며 상품·회차·배송지역·한도·가격·소유권·판매모드·멱등성을 service에서 검증한다.
 
-DTO 형식 통과가 주문 가능성을 의미하지 않는다. 상품·회차·배송지역·한도·가격·소유권·판매모드·멱등성 검증을 service에서 추가로 통과해야 한다.
-
-## 6. 현재 API endpoint
-
-모든 보호 endpoint는 `JwtAuthGuard`와 service ownership 검사를 함께 사용한다.
+## 6. 주요 API
 
 ```text
 GET   /orders
@@ -171,87 +195,50 @@ PATCH /stores/:storeId/orders/:orderId/hub-confirm
 
 ## 7. 권한 검증 상태
 
-판정 기준은 `docs/DOCUMENT_CONSISTENCY.md`를 따른다.
-
 ### API 조회 권한 — `VERIFIED`
 
-`OrdersQueryService`와 직접 테스트가 다음을 고정한다.
-
-- consumer: 자기 주문만 조회
-- seller: 실제 store owner만 해당 store 주문 조회
-- driver: API 경로에서는 배정된 `driverId` 주문만 조회
-- admin: 운영 범위 조회
-- storeId 없는 상세에서도 seller ownership·driver assignment 재검증
+- consumer: 자기 주문만
+- seller: 실제 store owner만 해당 store
+- driver: API 경로는 assigned `driverId` 주문만
+- admin: 운영 범위
 
 ### Direct Firestore 주문 read — `IMPLEMENTATION FINDING` P0
 
-실제 seller/driver frontend는 API 외 raw Firestore read를 사용한다.
-
-- current `firestore.rules`는 `role == 'driver'`이면 주문의 배정·store·상태와 무관하게 read를 허용한다.
-- driver 보드의 미배정 `PREPARING` direct/hub discovery 자체는 현재 제품 흐름에 필요하다.
-- 그러나 임의 주문 원문 read와 역할에 불필요한 내부/동의/유입 필드 노출까지 허용할 근거는 아니다.
-
-actual release SHA 전에는 discovery 최소 필드, assigned detail 최소 필드, seller 최소 필드와 Rules/앱 회귀를 함께 고정한다.
+current Rules는 `role == driver`이면 주문의 배정/store/status와 무관하게 read를 허용하고 seller/driver frontend는 raw order를 사용한다. 필요한 discovery는 유지하되 arbitrary read와 불필요 필드를 최소화해야 한다.
 
 추적: `ORDER-DIRECT-READ-AUTHORIZATION-AND-MINIMIZATION`.
 
 ### 상태 변경 authorization — `IMPLEMENTED / UNVERIFIED`
 
-구현은 seller store ownership, driver assignment, consumer order ownership을 검사하고 미배정 `PREPARING → DELIVERING` first-claim을 별도 허용한다.
-
-현재 부족한 직접 회귀:
-
-- 타-store seller status/delivery-hold mutation 거부
-- 비담당 driver assigned-order mutation 거부
-- first-claim 외 미배정 driver mutation 거부
-- 거부 요청에서 order write·notification·refund·settlement side effect 0
+seller ownership, driver assignment, consumer ownership guard는 구현돼 있으나 타-store seller·비담당 driver·first-claim 외 미배정 driver action과 거부 side-effect 0의 직접 회귀가 부족하다.
 
 추적: `ORDER-MUTATION-AUTHORIZATION-COVERAGE`.
 
 ## 8. 회차 주문 취소
 
-회차 취소는 단순 `status=CANCELLED` write가 아니다.
+회차 취소는 단순 `CANCELLED` write가 아니다.
 
 - cancellation claim/retry state
 - 본 결제 환불
 - paid 재배송비/추가 charge 환불
-- checkout reservation·round/item capacity 반환
-- `DELIVERY_HELD` counter 정합화
-- order cancellation 확정
+- reservation·round/item capacity 반환
+- held counter 정합화
+- 주문 취소
 - settlement 취소
 
-관리자 강제 환불이 이 orchestration을 우회하는 현재 문제는 `docs/specs/api/admin.md`와 `ADMIN-FORCE-REFUND-CONSISTENCY`를 따른다.
+admin force-refund 우회는 `ADMIN-FORCE-REFUND-CONSISTENCY`를 따른다.
 
 ## 9. 배송 사진
 
-회차 직배송 완료는 서버 비공개 사진 API를 사용한다.
+회차 직배송 사진은 담당 기사가 서버 API로 비공개 Storage에 업로드하며 사진 연결 없이 직접배송 `DELIVERED` 완료를 허용하지 않는다. read URL은 주문 권한 검증 뒤 단기 signed URL로 발급한다.
 
-```text
-POST /stores/:storeId/orders/:orderId/delivery-photos
-GET  /stores/:storeId/orders/:orderId/delivery-photos/:photoId/url
-```
+## 10. 결제 연결
 
-- 담당 기사만 회차 직배송 `DELIVERING` 주문에 JPEG를 업로드할 수 있다.
-- 최대 5 MiB.
-- 사진은 서버가 비공개 Storage 경로에 저장하고 주문에 연결한다.
-- 직접배송은 사진 연결 없이 `DELIVERED`로 완료할 수 없다.
-- read URL은 주문 권한 검증 뒤 단기 signed URL로 발급한다.
+본 결제 finalization·timeout·늦은 결제·환불 정본은 `docs/specs/api/payments.md`다.
 
-상세는 `DeliveryPhotosService`, `StorageService`, 관련 Rules/tests가 정본이다.
+재배송비 charge 하위 계약 `VERIFIED`를 **재배송 상태머신 전체 `VERIFIED`로 확장하지 않는다.**
 
-## 10. Legacy 공동구매
-
-legacy 공동구매의 `RECRUITING`, `CONFIRMED`, `GROUP_*` 알림과 자동 확정·미달 환불 흐름은 회차 직배송과 별개로 유지한다. 회차 출시를 위해 legacy 상태를 임의 삭제하지 않는다.
-
-## 11. 결제 연결
-
-회차 주문의 본 결제 finalization·timeout·늦은 결제·환불 정본은 `docs/specs/api/payments.md`다.
-
-재배송비 결제 하위 계약이 `VERIFIED`라는 사실은 **주문 lifecycle이 결제 완료 전 재배송을 차단한다는 보장으로 확장하지 않는다.** 두 계약은 별도로 검증한다.
-
-## 12. 검증 진입점
-
-주문 변경 시 최소 확인:
+## 11. 검증 진입점
 
 - `packages/shared/src/order.types.ts`
 - `apps/api/src/orders/orders.helpers.ts`
@@ -260,17 +247,19 @@ legacy 공동구매의 `RECRUITING`, `CONFIRMED`, `GROUP_*` 알림과 자동 확
 - `apps/api/src/orders/*lifecycle*`
 - `apps/api/src/orders/order-charges.service.ts`
 - `apps/api/src/payments/order-charge-payment.service.ts`
-- 관련 unit/spec tests
-- `firestore.rules`, `tests/firestore/firestore-rules.test.mjs`
-- seller/driver raw Firestore 사용처
-- 회차 변경이면 `docs/specs/mvp-sales-round-direct-delivery.md`와 운영 runbook
+- `apps/consumer/src/app/mypage/orders/[id]/**`
+- `apps/driver/src/app/board/[orderId]/**`
+- 관련 unit/spec/E2E
+- `firestore.rules`와 Rules tests
+- 회차 변경 시 제품 spec·운영 runbook
 
-권한·금전 불변식은 UI 동작만으로 `VERIFIED` 처리하지 않는다. API 직접 호출, 동시성, 실패 side effect를 포함한 서버 증거가 필요하다.
+권한·금전 불변식은 UI 동작만으로 `VERIFIED` 처리하지 않는다.
 
 ## 변경 이력
 
 | 날짜 | 내용 |
 |---|---|
-| 2026-08-24 | 재배송비 결제 전 배송 재개 금지 계약과 현재 서버/UI 우회 경로를 P0로 정합화; direct Firestore read·mutation coverage current finding 유지 |
-| 2026-08-24 | direct Firestore read authorization·역할별 최소화 P0 반영 |
-| 2026-08-23 | 현행 endpoint/FSM/회차·legacy 공존 계약으로 전면 정합화 |
+| 2026-08-24 | 재배송 P0를 단순 PAID resume guard에서 payment-request/hold-resolution/`PREPARING` 우회까지 포함한 상태머신 결함으로 보강 |
+| 2026-08-24 | 유료 재배송비 결제 전 배송 재개 금지 P0 최초 반영 |
+| 2026-08-24 | direct Firestore read authorization·최소화 P0 반영 |
+| 2026-08-23 | 현행 endpoint/FSM/회차·legacy 공존 계약으로 정합화 |


### PR DESCRIPTION
## 변경
- PR #46의 `ORDER-REDELIVERY-PAID-RESUME-GATE`를 단일 resume guard에서 payment-request/hold-resolution/resume 전체 상태머신 P0로 보강
- seller `DELIVERY_HELD → PREPARING` 경유 dead-end 및 미결제 배송 시작 우회까지 Acceptance Criteria에 포함
- orders current spec, Backlog, memory, 활성 PLAN/HANDOFF의 현재 역할에 맞게 전파

## 추가 직접 근거
- 기존 flow test는 고객 책임+재배송비 주문의 seller `DELIVERY_HELD → PREPARING`을 정상 성공으로 고정하고 hold resolve + held counter 감소까지 검증
- 해당 전환은 `ORDER_REDELIVERY_PAYMENT_REQUESTED` 알림 매핑을 사용
- `OrderChargesService.createRedeliveryFeeCharge()`는 current order status `DELIVERY_HELD`를 요구
- consumer `canPayRedeliveryFee`도 current status `DELIVERY_HELD`에서만 true
- 따라서 seller가 PREPARING으로 옮기면 결제 요청 알림 뒤 실제 charge 생성/UI가 사라질 수 있음
- 이후 `PREPARING → DELIVERING`에는 과거 paid-required hold의 미결제를 확인하는 durable gate가 없음

## 판정
- charge 결제·환불 하위 계약: VERIFIED 유지
- 유료 재배송 주문 상태머신 전체: P0 IMPLEMENTATION FINDING

## 완료 불변식
- payment-required 정보는 PAID 전 사라지지 않음
- payment-request 알림 뒤 consumer payment endpoint/UI가 actionable
- HELD→DELIVERING과 HELD→PREPARING→DELIVERING 등 모든 delivery-start 경로 동일 PAID gate
- hold resolve/held counter 감소와 결제·재개 시점 일치
- seller/driver race에서 한 번만 수렴

## 범위
- docs-only
- 코드/운영 데이터/provider/production 변경 없음