### PR TITLE
docs: PortOne webhook signature P0 coverage 정합화

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -30,53 +30,75 @@
 
 정본: `docs/specs/api/payments.md`.
 
-### P0 — ORDER-REDELIVERY-PAID-RESUME-GATE
+### P0 — PAYMENT-WEBHOOK-SIGNATURE-COVERAGE
 
-운영 계약은 고객 책임 첫 배송 실패의 유료 재배송에 **`결제 전 재배송 금지`**를 요구한다. 2026-08-24 추가 감사에서 이 문제는 단순 driver resume guard 누락이 아니라 **결제 요청·hold 해소·배송 재개 상태머신 전체 불일치**임을 확인했다.
+PortOne webhook 인증 구현은 존재하지만 금융 상태 변경 경계에 필요한 cryptographic 양방향 회귀가 충분하지 않다.
 
-현재 직접 근거:
+현재 구현·증거:
 
-- [x] `OrderChargePaymentService`의 charge `PAID` 검증·금액/연결 검증·환불 멱등성은 직접 테스트됨
-- [x] driver `DELIVERY_HELD → DELIVERING` 전환은 charge `PAID`를 확인하지 않음
-- [x] driver UI는 `DELIVERY_HELD` 회차 주문에 charge 상태와 무관하게 `배송 재개` CTA 노출
-- [x] seller `DELIVERY_HELD → PREPARING`은 고객 책임+양수 재배송비 주문에서도 현재 테스트가 정상 성공으로 고정
-- [x] 위 seller 전환은 hold `resolvedAt` 기록 + `heldOrderCount` 감소
-- [x] 현재 notification map은 이 전환을 `ORDER_REDELIVERY_PAYMENT_REQUESTED` 발송 시점으로 사용
-- [x] 그러나 `OrderChargesService.createRedeliveryFeeCharge()`는 현재 order status가 `DELIVERY_HELD`여야 charge 생성 가능
-- [x] consumer `canPayRedeliveryFee`도 현재 status가 `DELIVERY_HELD`일 때만 true
-- [x] 따라서 `PREPARING`으로 옮긴 뒤 결제 요청 알림이 가면 소비자 charge 생성/UI가 사라짐
-- [x] 이후 `PREPARING → DELIVERING`에는 과거 paid-required hold의 미결제를 확인하는 durable guard가 없음
+- [x] production bootstrap은 `rawBody: true`
+- [x] controller는 raw body + `webhook-id` + `webhook-timestamp` + `webhook-signature` 요구
+- [x] `PORTONE_WEBHOOK_SECRET` 필수
+- [x] timestamp ±5분
+- [x] HMAC SHA-256 + timing-safe compare 구현
+- [x] missing signature/secret, stale timestamp 단위 거부 테스트
+- [x] HTTP E2E에서 webhook header 없는 요청 401
+- [x] signed-flow fixture에서 controller webhook 경로 실행
+
+현재 공백:
+
+- 회차 E2E fixture의 `verifyWebhookSignature`는 mock이므로 실제 HMAC 검증 성공 증거가 아님
+- 실제 verifier의 valid signature 성공 테스트가 없음
+- 필수 header를 모두 채운 non-empty invalid signature 직접 거부 테스트가 없음
+- body/id/timestamp 변조에 동일 signature가 거부되는 직접 테스트가 없음
+- actual controller + real verifier 조합에서 invalid signature가 `PaymentsService.handleWebhook()`에 도달하지 않는 통합 증거가 없음
 
 판정:
 
-- charge 결제·환불 **하위 계약은 `VERIFIED`**.
-- 유료 재배송 **주문 상태머신 전체는 P0 `IMPLEMENTATION FINDING`**.
-- `DELIVERY_HELD → DELIVERING` 한 경로만 막아서는 `PREPARING` 우회가 남으므로 완료가 아니다.
+- 구현을 결함으로 단정하지 않는다.
+- 금융 인증 경계이므로 **`IMPLEMENTED / PARTIALLY VERIFIED` + P0 `COVERAGE GAP`**으로 둔다.
 
-남음 — 불변식:
+남음:
 
-- [ ] 고객 책임+양수 재배송비 hold의 `payment required`가 결제 완료 전 사라지지 않음
-- [ ] payment-request 알림 시점에도 consumer charge 생성/결제 UI·endpoint가 actionable
-- [ ] current hold↔charge를 `heldAt` 또는 동등 durable key로 연결
-- [ ] charge type/order/store/user 일치 + `PAID`일 때만 모든 실제 delivery-start 경로 허용
-- [ ] `PENDING|FAILED|REFUNDED|missing|mismatched`는 side effect 0 거부
-- [ ] `DELIVERY_HELD → DELIVERING`과 `DELIVERY_HELD → PREPARING → DELIVERING` 모두 동일 paid gate 적용
-- [ ] seller가 `PREPARING` 결제요청 구조를 유지한다면 durable payment-required marker와 consumer 결제 가능성을 상태 변경 뒤에도 보존; 아니면 결제 완료 전 hold를 해소하지 않는 구조로 변경
-- [ ] hold 해소·`heldOrderCount` 감소 시점을 payment completion/재개 정책과 명시적으로 일치
-- [ ] 판매자/시스템 책임·무료 재배송 정상 흐름 유지
-- [ ] seller/driver 동시 요청에서 hold 해소·counter 감소·scheduled 알림이 한 번만 수렴
+- [ ] 고정 secret/id/timestamp/raw body의 valid HMAC이 실제 `PortoneClient.verifyWebhookSignature()` 통과
+- [ ] non-empty invalid HMAC 거부
+- [ ] raw body 1 byte 변조 거부
+- [ ] webhook-id 변조 거부
+- [ ] signed timestamp 변조/허용창 경계 거부·허용 고정
+- [ ] real verifier를 사용하는 controller integration에서 valid request만 `PaymentsService.handleWebhook()` 도달
+- [ ] invalid request에서 주문/payment/orderCharge/capacity side effect 0
+- [ ] 기존 duplicate webhook 멱등 회귀 유지
+- [ ] 회귀 SHA `main` 통합
 
-필수 회귀:
+정본: `docs/specs/api/payments.md`.
 
-- [ ] payment-request 알림 뒤 consumer payment CTA/endpoint 유지
-- [ ] charge 없음/PENDING/FAILED/REFUNDED direct resume 거부
-- [ ] 결제 전 seller `PREPARING` 전환을 정책대로 허용/거부 직접 고정
-- [ ] `PREPARING` 경유 미결제 `DELIVERING` 거부
-- [ ] `PAID` 뒤 한 번 정상 재개
-- [ ] 무료/판매자책임 재배송 정상 회귀
-- [ ] 변경 SHA `main` 통합
+### P0 — ORDER-REDELIVERY-PAID-RESUME-GATE
 
-정본: `docs/specs/api/orders.md`; 운영 근거: `docs/specs/ops/mvp-sales-round-runbook.md`.
+운영 계약은 고객 책임 유료 재배송에서 `결제 전 재배송 금지`를 요구하지만 payment-request/hold-resolution/resume 상태머신이 이 불변식과 충돌한다.
+
+현재 확인:
+
+- [x] charge 결제·환불 하위 계약은 직접 테스트됨
+- [x] `DELIVERY_HELD → DELIVERING`에 charge `PAID` server gate 없음
+- [x] driver UI도 charge 상태와 무관하게 `배송 재개` 노출
+- [x] 고객 책임+양수 재배송비 hold도 seller `DELIVERY_HELD → PREPARING` 성공이 테스트로 고정
+- [x] 이 전환은 hold resolve + held counter 감소 + payment-request 알림을 발생시킴
+- [x] charge 생성 API와 consumer payment CTA는 현재 `DELIVERY_HELD`를 요구해 PREPARING 전환 뒤 결제 dead-end 가능
+- [x] 이후 `PREPARING → DELIVERING`에도 과거 paid-required hold의 durable gate 없음
+
+남음:
+
+- [ ] payment-required 정보가 PAID 전 사라지지 않음
+- [ ] payment-request 알림 뒤 consumer 결제 UI/endpoint actionable
+- [ ] current hold↔charge durable linkage
+- [ ] `REDELIVERY_FEE` + order/store/user + `PAID` 검증
+- [ ] 모든 delivery-start 경로 동일 paid gate
+- [ ] invalid charge state side effect 0
+- [ ] hold resolve/held counter 감소 시점 명시·race 수렴
+- [ ] 무료/판매자책임 흐름 유지
+- [ ] 직접 unit/integration/E2E + `main`
+
+정본: `docs/specs/api/orders.md`.
 
 ### P0 — ADMIN-FORCE-REFUND-CONSISTENCY
 
@@ -89,7 +111,7 @@ admin refund가 정상 cancellation의 추가 charge·capacity·held counter·se
 - [ ] pending/confirmed settlement 취소
 - [ ] paid settlement 별도 회계 조정/operation issue 정책
 - [ ] provider 성공/local 실패 재시도·동시 실행 수렴
-- [ ] 직접 회귀 후 `main` 통합
+- [ ] 직접 회귀 + `main`
 
 정본: `docs/specs/api/admin.md`, `docs/specs/api/settlements.md`.
 
@@ -97,27 +119,27 @@ admin refund가 정상 cancellation의 추가 charge·capacity·held counter·se
 
 API authorization보다 seller/driver raw Firestore read 경계가 넓다.
 
-- [ ] 미배정 `PREPARING` direct/hub discovery 최소 대상·필드 정의
+- [ ] 미배정 `PREPARING` direct/hub discovery 최소 대상·필드
 - [ ] arbitrary/타-driver/완료 주문 raw read 차단
 - [ ] assigned driver·seller 최소 projection/DTO 또는 동등 분리
 - [ ] broad driver rule 제거
 - [ ] Rules + 앱 정상/거부 회귀
-- [ ] `main` 통합
+- [ ] `main`
 
 정본: `docs/specs/api/orders.md`.
 
 ### P0 — AUTH-DRIVER-APPROVAL-AND-SESSION-REVOCATION
 
-신규/legacy driver 자동 승인 경로와 stale session/claims 수렴 문제가 있다.
+신규/legacy driver 자동 승인과 stale session/claims 수렴 문제가 있다.
 
-- [ ] 신규/legacy 로그인 side-effect 자동 승인 제거
+- [ ] 로그인 side-effect 자동 승인 제거
 - [ ] 과거 계정 migration 별도 감사 절차
 - [ ] 승인 전/후 앱·API·Firebase 회귀
-- [ ] suspension/role/store/approval revocation SLA 결정
-- [ ] refresh/current claims authoritative state 검증
+- [ ] suspension/role/store/approval revocation SLA
+- [ ] refresh authoritative state 검증
 - [ ] Firebase stale claims 재발급 차단
-- [ ] logout/rotation 포함 회귀
-- [ ] `main` 통합
+- [ ] logout/rotation 회귀
+- [ ] `main`
 
 정본: `docs/specs/api/auth.md`.
 
@@ -131,13 +153,13 @@ API authorization보다 seller/driver raw Firestore read 경계가 넓다.
 - [ ] first claim 정확한 `driverId`
 - [ ] 거부 side effect 0
 - [ ] 필요한 admin 허용 범위 고정
-- [ ] `main` 통합
+- [ ] `main`
 
 정본: `docs/specs/api/orders.md`.
 
 ### P0 — DEPLOY-SAFETY-MAIN-PROTECTION
 
-repo-side production auto-deploy 차단은 완료. GitHub 관리자 레벨 보호는 남음.
+repo-side production auto-deploy 차단은 완료. GitHub 관리자 레벨 보호는 남아 있다.
 
 - [ ] Issue #32
 - [ ] PR required
@@ -168,7 +190,7 @@ repo-side production auto-deploy 차단은 완료. GitHub 관리자 레벨 보�
 ### P0 — 판매 활성화 legal 재정합화
 
 - [ ] 주문 성립·취소·환불·배송·재배송비·보류 실제 정책
-- [ ] 재배송 payment-required 상태머신과 결제 전 재개 금지 계약 반영
+- [ ] 재배송 payment-required 상태머신
 - [ ] PortOne/PG 개인정보 처리
 - [ ] ALIGO 전화번호·메시지 처리
 - [ ] order direct-read 최소화 뒤 seller/driver 접근 설명
@@ -179,6 +201,7 @@ repo-side production auto-deploy 차단은 완료. GitHub 관리자 레벨 보�
 ### P0 — 출시 후보 검증·운영 준비
 
 - [ ] `PAYMENT-FINALIZATION-PAID-GUARD`
+- [ ] `PAYMENT-WEBHOOK-SIGNATURE-COVERAGE`
 - [ ] `ORDER-REDELIVERY-PAID-RESUME-GATE`
 - [ ] `ADMIN-FORCE-REFUND-CONSISTENCY`
 - [ ] `ORDER-DIRECT-READ-AUTHORIZATION-AND-MINIMIZATION`

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -32,73 +32,85 @@
 
 ### P0 — PAYMENT-WEBHOOK-SIGNATURE-COVERAGE
 
-PortOne webhook 인증 구현은 존재하지만 금융 상태 변경 경계에 필요한 cryptographic 양방향 회귀가 충분하지 않다.
+PortOne webhook signature 구현은 존재하지만 금융 상태 변경 경계에 필요한 real-verifier cryptographic 양방향 회귀가 충분하지 않다.
 
-현재 구현·증거:
+현재 직접 근거:
 
 - [x] production bootstrap은 `rawBody: true`
-- [x] controller는 raw body + `webhook-id` + `webhook-timestamp` + `webhook-signature` 요구
-- [x] `PORTONE_WEBHOOK_SECRET` 필수
-- [x] timestamp ±5분
-- [x] HMAC SHA-256 + timing-safe compare 구현
-- [x] missing signature/secret, stale timestamp 단위 거부 테스트
+- [x] controller는 raw body + `webhook-id` + `webhook-timestamp` + `webhook-signature`를 요구
+- [x] verifier는 `PORTONE_WEBHOOK_SECRET`, timestamp ±5분, HMAC SHA-256, timing-safe compare 사용
+- [x] missing signature/secret, stale timestamp 거부 테스트 존재
 - [x] HTTP E2E에서 webhook header 없는 요청 401
-- [x] signed-flow fixture에서 controller webhook 경로 실행
-
-현재 공백:
-
-- 회차 E2E fixture의 `verifyWebhookSignature`는 mock이므로 실제 HMAC 검증 성공 증거가 아님
-- 실제 verifier의 valid signature 성공 테스트가 없음
-- 필수 header를 모두 채운 non-empty invalid signature 직접 거부 테스트가 없음
-- body/id/timestamp 변조에 동일 signature가 거부되는 직접 테스트가 없음
-- actual controller + real verifier 조합에서 invalid signature가 `PaymentsService.handleWebhook()`에 도달하지 않는 통합 증거가 없음
+- [x] 회차 E2E fixture는 controller webhook 경로를 실행하지만 `verifyWebhookSignature`는 mock
 
 판정:
 
-- 구현을 결함으로 단정하지 않는다.
-- 금융 인증 경계이므로 **`IMPLEMENTED / PARTIALLY VERIFIED` + P0 `COVERAGE GAP`**으로 둔다.
+- webhook signature 구현은 `IMPLEMENTED`.
+- 현재 직접 증거는 `PARTIALLY VERIFIED`.
+- 금융 인증 경계이므로 P0 `COVERAGE GAP`으로 추적한다.
+- 구현 결함으로 단정하지 않는다.
 
 남음:
 
-- [ ] 고정 secret/id/timestamp/raw body의 valid HMAC이 실제 `PortoneClient.verifyWebhookSignature()` 통과
-- [ ] non-empty invalid HMAC 거부
-- [ ] raw body 1 byte 변조 거부
+- [ ] known secret/id/timestamp/raw body의 valid HMAC이 실제 `PortoneClient.verifyWebhookSignature()` 통과
+- [ ] 필수 header를 모두 채운 non-empty invalid HMAC 거부
+- [ ] 동일 signature에서 raw body 1 byte 변조 거부
 - [ ] webhook-id 변조 거부
-- [ ] signed timestamp 변조/허용창 경계 거부·허용 고정
-- [ ] real verifier를 사용하는 controller integration에서 valid request만 `PaymentsService.handleWebhook()` 도달
-- [ ] invalid request에서 주문/payment/orderCharge/capacity side effect 0
+- [ ] signed timestamp 변조 및 허용창 경계 거부·허용 고정
+- [ ] actual controller + real verifier에서 invalid request가 `PaymentsService.handleWebhook()`에 도달하지 않음
+- [ ] invalid request의 주문/payment/orderCharge/capacity side effect 0
 - [ ] 기존 duplicate webhook 멱등 회귀 유지
 - [ ] 회귀 SHA `main` 통합
 
-정본: `docs/specs/api/payments.md`.
+정본: `docs/specs/api/payments.md`; 증거: `docs/reports/REPORT_payment_webhook_signature_coverage_20260824.md`.
 
 ### P0 — ORDER-REDELIVERY-PAID-RESUME-GATE
 
-운영 계약은 고객 책임 유료 재배송에서 `결제 전 재배송 금지`를 요구하지만 payment-request/hold-resolution/resume 상태머신이 이 불변식과 충돌한다.
+운영 계약은 고객 책임 첫 배송 실패의 유료 재배송에 **`결제 전 재배송 금지`**를 요구한다. 2026-08-24 추가 감사에서 이 문제는 단순 driver resume guard 누락이 아니라 **결제 요청·hold 해소·배송 재개 상태머신 전체 불일치**임을 확인했다.
 
-현재 확인:
+현재 직접 근거:
 
-- [x] charge 결제·환불 하위 계약은 직접 테스트됨
-- [x] `DELIVERY_HELD → DELIVERING`에 charge `PAID` server gate 없음
-- [x] driver UI도 charge 상태와 무관하게 `배송 재개` 노출
-- [x] 고객 책임+양수 재배송비 hold도 seller `DELIVERY_HELD → PREPARING` 성공이 테스트로 고정
-- [x] 이 전환은 hold resolve + held counter 감소 + payment-request 알림을 발생시킴
-- [x] charge 생성 API와 consumer payment CTA는 현재 `DELIVERY_HELD`를 요구해 PREPARING 전환 뒤 결제 dead-end 가능
-- [x] 이후 `PREPARING → DELIVERING`에도 과거 paid-required hold의 durable gate 없음
+- [x] `OrderChargePaymentService`의 charge `PAID` 검증·금액/연결 검증·환불 멱등성은 직접 테스트됨
+- [x] driver `DELIVERY_HELD → DELIVERING` 전환은 charge `PAID`를 확인하지 않음
+- [x] driver UI는 `DELIVERY_HELD` 회차 주문에 charge 상태와 무관하게 `배송 재개` CTA 노출
+- [x] seller `DELIVERY_HELD → PREPARING`은 고객 책임+양수 재배송비 주문에서도 현재 테스트가 정상 성공으로 고정
+- [x] 위 seller 전환은 hold `resolvedAt` 기록 + `heldOrderCount` 감소
+- [x] 현재 notification map은 이 전환을 `ORDER_REDELIVERY_PAYMENT_REQUESTED` 발송 시점으로 사용
+- [x] 그러나 `OrderChargesService.createRedeliveryFeeCharge()`는 현재 order status가 `DELIVERY_HELD`여야 charge 생성 가능
+- [x] consumer `canPayRedeliveryFee`도 현재 status가 `DELIVERY_HELD`일 때만 true
+- [x] 따라서 `PREPARING`으로 옮긴 뒤 결제 요청 알림이 가면 소비자 charge 생성/UI가 사라짐
+- [x] 이후 `PREPARING → DELIVERING`에는 과거 paid-required hold의 미결제를 확인하는 durable guard가 없음
 
-남음:
+판정:
 
-- [ ] payment-required 정보가 PAID 전 사라지지 않음
-- [ ] payment-request 알림 뒤 consumer 결제 UI/endpoint actionable
-- [ ] current hold↔charge durable linkage
-- [ ] `REDELIVERY_FEE` + order/store/user + `PAID` 검증
-- [ ] 모든 delivery-start 경로 동일 paid gate
-- [ ] invalid charge state side effect 0
-- [ ] hold resolve/held counter 감소 시점 명시·race 수렴
-- [ ] 무료/판매자책임 흐름 유지
-- [ ] 직접 unit/integration/E2E + `main`
+- charge 결제·환불 **하위 계약은 `VERIFIED`**.
+- 유료 재배송 **주문 상태머신 전체는 P0 `IMPLEMENTATION FINDING`**.
+- `DELIVERY_HELD → DELIVERING` 한 경로만 막아서는 `PREPARING` 우회가 남으므로 완료가 아니다.
 
-정본: `docs/specs/api/orders.md`.
+남음 — 불변식:
+
+- [ ] 고객 책임+양수 재배송비 hold의 `payment required`가 결제 완료 전 사라지지 않음
+- [ ] payment-request 알림 시점에도 consumer charge 생성/결제 UI·endpoint가 actionable
+- [ ] current hold↔charge를 `heldAt` 또는 동등 durable key로 연결
+- [ ] charge type/order/store/user 일치 + `PAID`일 때만 모든 실제 delivery-start 경로 허용
+- [ ] `PENDING|FAILED|REFUNDED|missing|mismatched`는 side effect 0 거부
+- [ ] `DELIVERY_HELD → DELIVERING`과 `DELIVERY_HELD → PREPARING → DELIVERING` 모두 동일 paid gate 적용
+- [ ] seller가 `PREPARING` 결제요청 구조를 유지한다면 durable payment-required marker와 consumer 결제 가능성을 상태 변경 뒤에도 보존; 아니면 결제 완료 전 hold를 해소하지 않는 구조로 변경
+- [ ] hold 해소·`heldOrderCount` 감소 시점을 payment completion/재개 정책과 명시적으로 일치
+- [ ] 판매자/시스템 책임·무료 재배송 정상 흐름 유지
+- [ ] seller/driver 동시 요청에서 hold 해소·counter 감소·scheduled 알림이 한 번만 수렴
+
+필수 회귀:
+
+- [ ] payment-request 알림 뒤 consumer payment CTA/endpoint 유지
+- [ ] charge 없음/PENDING/FAILED/REFUNDED direct resume 거부
+- [ ] 결제 전 seller `PREPARING` 전환을 정책대로 허용/거부 직접 고정
+- [ ] `PREPARING` 경유 미결제 `DELIVERING` 거부
+- [ ] `PAID` 뒤 한 번 정상 재개
+- [ ] 무료/판매자책임 재배송 정상 회귀
+- [ ] 변경 SHA `main` 통합
+
+정본: `docs/specs/api/orders.md`; 운영 근거: `docs/specs/ops/mvp-sales-round-runbook.md`.
 
 ### P0 — ADMIN-FORCE-REFUND-CONSISTENCY
 
@@ -111,7 +123,7 @@ admin refund가 정상 cancellation의 추가 charge·capacity·held counter·se
 - [ ] pending/confirmed settlement 취소
 - [ ] paid settlement 별도 회계 조정/operation issue 정책
 - [ ] provider 성공/local 실패 재시도·동시 실행 수렴
-- [ ] 직접 회귀 + `main`
+- [ ] 직접 회귀 후 `main` 통합
 
 정본: `docs/specs/api/admin.md`, `docs/specs/api/settlements.md`.
 
@@ -119,27 +131,27 @@ admin refund가 정상 cancellation의 추가 charge·capacity·held counter·se
 
 API authorization보다 seller/driver raw Firestore read 경계가 넓다.
 
-- [ ] 미배정 `PREPARING` direct/hub discovery 최소 대상·필드
+- [ ] 미배정 `PREPARING` direct/hub discovery 최소 대상·필드 정의
 - [ ] arbitrary/타-driver/완료 주문 raw read 차단
 - [ ] assigned driver·seller 최소 projection/DTO 또는 동등 분리
 - [ ] broad driver rule 제거
 - [ ] Rules + 앱 정상/거부 회귀
-- [ ] `main`
+- [ ] `main` 통합
 
 정본: `docs/specs/api/orders.md`.
 
 ### P0 — AUTH-DRIVER-APPROVAL-AND-SESSION-REVOCATION
 
-신규/legacy driver 자동 승인과 stale session/claims 수렴 문제가 있다.
+신규/legacy driver 자동 승인 경로와 stale session/claims 수렴 문제가 있다.
 
-- [ ] 로그인 side-effect 자동 승인 제거
+- [ ] 신규/legacy 로그인 side-effect 자동 승인 제거
 - [ ] 과거 계정 migration 별도 감사 절차
 - [ ] 승인 전/후 앱·API·Firebase 회귀
-- [ ] suspension/role/store/approval revocation SLA
-- [ ] refresh authoritative state 검증
+- [ ] suspension/role/store/approval revocation SLA 결정
+- [ ] refresh/current claims authoritative state 검증
 - [ ] Firebase stale claims 재발급 차단
-- [ ] logout/rotation 회귀
-- [ ] `main`
+- [ ] logout/rotation 포함 회귀
+- [ ] `main` 통합
 
 정본: `docs/specs/api/auth.md`.
 
@@ -153,13 +165,13 @@ API authorization보다 seller/driver raw Firestore read 경계가 넓다.
 - [ ] first claim 정확한 `driverId`
 - [ ] 거부 side effect 0
 - [ ] 필요한 admin 허용 범위 고정
-- [ ] `main`
+- [ ] `main` 통합
 
 정본: `docs/specs/api/orders.md`.
 
 ### P0 — DEPLOY-SAFETY-MAIN-PROTECTION
 
-repo-side production auto-deploy 차단은 완료. GitHub 관리자 레벨 보호는 남아 있다.
+repo-side production auto-deploy 차단은 완료. GitHub 관리자 레벨 보호는 남음.
 
 - [ ] Issue #32
 - [ ] PR required
@@ -190,7 +202,7 @@ repo-side production auto-deploy 차단은 완료. GitHub 관리자 레벨 보�
 ### P0 — 판매 활성화 legal 재정합화
 
 - [ ] 주문 성립·취소·환불·배송·재배송비·보류 실제 정책
-- [ ] 재배송 payment-required 상태머신
+- [ ] 재배송 payment-required 상태머신과 결제 전 재개 금지 계약 반영
 - [ ] PortOne/PG 개인정보 처리
 - [ ] ALIGO 전화번호·메시지 처리
 - [ ] order direct-read 최소화 뒤 seller/driver 접근 설명

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -16,16 +16,16 @@
 - 저장소: `booker-lab/greenhub`
 - 기본 브랜치: `main`; HEAD는 작업 시작 시 직접 재조회한다.
 - 회차 직배송 기능 통합 기준 SHA: `e55f25914cc7d01576fbd4639583daaf0fe6385e`
-- PR #30/#31로 세 프런트의 `main` Vercel Git auto-production과 pure-doc build를 repo-side 차단했다.
+- PR #30/#31로 세 프런트 `main`의 Vercel Git auto-production과 pure-doc build를 repo-side 차단했다.
 - docs-only main 변경은 Preview sync/일반 E2E 제외.
 - `AGENTS.md` + deployment safety CI가 branch+PR 원칙을 소유한다.
-- GitHub `main` 자체 보호는 Issue #32가 남아 있다.
+- GitHub `main` 관리자 보호는 Issue #32가 남아 있다.
 
 `main` merge는 production 배포 승인이 아니다. production은 검증된 exact release SHA + 별도 승인 절차를 사용한다.
 
 ## 제품 현재 상태
 
-- 회차 직배송 MVP는 `main` 통합 완료.
+- 회차 직배송 MVP `main` 통합 완료.
 - consumer 구매, seller 회차·주문, driver 직배송, 결제·환불·재배송비·보류·사진·운영 예외 흐름 존재.
 - 카카오 비즈니스 채널 승인 완료.
 - 운영 Firebase rules/indexes는 출시 전 read-only 재조회 필요.
@@ -34,52 +34,65 @@
 
 ## 현재 확인된 출시 P0
 
-### 1. 재배송비 결제·재개 상태머신
+### 1. PortOne webhook signature 검증 coverage
 
-운영 계약은 고객 책임 유료 재배송에서 `결제 전 재배송 금지`를 요구한다.
+webhook은 raw body + id/timestamp/signature를 요구하고 HMAC SHA-256 timing-safe 검증, ±5분 timestamp 제한이 구현돼 있다. production bootstrap도 `rawBody: true`다.
 
-2026-08-24 추가 감사에서 다음 두 우회/불일치가 확인됐다.
+현재 증거:
 
-- driver `DELIVERY_HELD → DELIVERING`: charge `PAID` 확인 없음 + UI `배송 재개` 항상 노출.
-- seller `DELIVERY_HELD → PREPARING`: 고객 책임+양수 재배송비에서도 현재 테스트가 정상 성공으로 고정하며 hold를 해소하고 held counter를 줄임. 이 전환이 `ORDER_REDELIVERY_PAYMENT_REQUESTED` 알림을 만들지만 charge 생성 API와 consumer 결제 UI는 `status === DELIVERY_HELD`를 요구하므로 전환 뒤 결제가 불가능해진다. 이후 `PREPARING → DELIVERING`도 과거 미결제 hold를 확인하지 않는다.
+- missing signature/secret, stale timestamp 단위 거부 테스트
+- HTTP E2E의 header 없는 webhook 401
+- controller 경로 E2E
 
-따라서 **`ORDER-REDELIVERY-PAID-RESUME-GATE`는 단순 PAID guard가 아니라 P0 재배송 상태머신 `IMPLEMENTATION FINDING`**이다.
+그러나 회차 E2E의 `verifyWebhookSignature`는 mock이며 **real verifier의 valid HMAC 성공과 non-empty invalid HMAC 거부를 직접 고정한 회귀가 없다.**
 
-완료 시 payment-required 상태는 결제 전 사라지지 않아야 하며, payment-request 알림 뒤 consumer 결제가 실제 가능해야 하고, `HELD→DELIVERING` 및 `HELD→PREPARING→DELIVERING` 등 모든 배송 시작 경로가 동일 PAID gate를 통과해야 한다.
+따라서 구현 결함으로 단정하지 않고 **`PAYMENT-WEBHOOK-SIGNATURE-COVERAGE` = `IMPLEMENTED / PARTIALLY VERIFIED` + P0 `COVERAGE GAP`**으로 둔다.
 
-정본: `docs/specs/api/orders.md`, `docs/BACKLOG.md`, 운영 근거 `docs/specs/ops/mvp-sales-round-runbook.md`.
+정본: `docs/specs/api/payments.md`, `docs/BACKLOG.md`.
 
-### 2. 관리자 강제 환불 lifecycle
+### 2. 재배송비 결제·재개 상태머신
+
+운영 계약은 고객 책임 유료 재배송에 `결제 전 재배송 금지`를 요구한다.
+
+현재:
+
+- direct `DELIVERY_HELD → DELIVERING`에 charge PAID gate 없음.
+- seller `DELIVERY_HELD → PREPARING`은 유료 hold에서도 성공하며 hold를 해소하지만, charge 생성 API·consumer 결제 CTA는 current `DELIVERY_HELD`를 요구해 payment-request 뒤 결제 dead-end 가능.
+- 이후 `PREPARING → DELIVERING`에도 durable paid-required guard 없음.
+
+따라서 **`ORDER-REDELIVERY-PAID-RESUME-GATE` = P0 상태머신 `IMPLEMENTATION FINDING`**.
+
+### 3. 관리자 강제 환불 lifecycle
 
 admin refund는 본 결제 환불 뒤 주문을 직접 `CANCELLED` write하며 정상 cancellation의 추가 charge·reservation/capacity·held counter·settlement 후속효과를 재사용하지 않는다.
 
 **`ADMIN-FORCE-REFUND-CONSISTENCY` = P0 IMPLEMENTATION FINDING**.
 
-### 3. Driver 승인·세션 권한
+### 4. Driver 승인·세션 권한
 
 신규/legacy driver 자동 승인 경로와 refresh/Firebase stale claims 수렴 문제가 있다.
 
 **관리자 승인 gate = P0 IMPLEMENTATION FINDING**, suspension/role/store/approval revocation = **P0 DECISION REQUIRED + remediation**.
 
-### 4. 주문 direct Firestore read·개인정보 최소화
+### 5. 주문 direct Firestore read·개인정보 최소화
 
 API driver read는 배정 경계가 있으나 current Rules는 driver role에 broad order read를 허용하며 seller/driver frontend는 raw document를 사용한다.
 
 **시스템 전체 driver read authorization + seller/driver data minimization = P0 IMPLEMENTATION FINDING**.
 
-### 5. 결제 finalization provider 상태 방어
+### 6. 결제 finalization provider 상태 방어
 
 `finalizePaidOrder()` boundary가 비`PAID` provider 입력을 자체 차단하지 않는다.
 
-**`PAYMENT-FINALIZATION-PAID-GUARD` = P0**.
+**`PAYMENT-FINALIZATION-PAID-GUARD` = P0 IMPLEMENTATION FINDING**.
 
-### 6. 주문 mutation authorization 회귀
+### 7. 주문 mutation authorization 회귀
 
 ownership guard는 구현돼 있으나 타-store seller·비담당 driver·first-claim 외 action과 거부 side-effect 0 직접 회귀가 부족하다.
 
 **`ORDER-MUTATION-AUTHORIZATION-COVERAGE` = IMPLEMENTED / UNVERIFIED + P0 COVERAGE GAP**.
 
-### 7. GitHub main protection
+### 8. GitHub main protection
 
 repo-side 배포 방어는 완료. GitHub 관리자 레벨 PR required/required check/force-push·delete 차단은 Issue #32가 남아 있다.
 
@@ -100,7 +113,7 @@ repo-side 배포 방어는 완료. GitHub 관리자 레벨 PR required/required 
 - production `/privacy`, `/terms`는 2026-08-19 비판매 상태 기준.
 - 실제 판매 전 주문·취소·환불·재배송비·보류, PortOne/PG, ALIGO, seller/driver 개인정보 접근을 재정합화해야 한다.
 - broad read를 legal 문구로 정당화하지 않는다.
-- 재배송 payment-required 상태머신과 admin refund 실제 정책을 legal의 재배송비·환불 설명에 반영한다.
+- 재배송 상태머신·admin refund 실제 정책을 legal의 재배송비·환불 설명에 반영한다.
 
 ## 검증 상태
 
@@ -128,10 +141,11 @@ repo-side 배포 방어는 완료. GitHub 관리자 레벨 PR required/required 
 
 ## 다음 작업
 
-1. `ORDER-REDELIVERY-PAID-RESUME-GATE`를 **상태머신 전체** 기준으로 구현·직접 회귀·`main` 통합.
-2. 나머지 P0를 ALIGO 심사와 병렬 해결.
-3. Issue #32.
-4. ALIGO 상태 재조회 → 승인 뒤 실제 알림톡/SMS fallback.
-5. P0 결과 기준 legal 재정합화.
-6. actual release SHA → E2E 52+cleanup → Firebase 재조회 → 승인된 production 설정/배포.
-7. 첫 회차 검수 → 최종 승인 → `salesMode: round_direct`.
+1. P0 금융/권한 코드·coverage 게이트를 ALIGO 심사와 병렬 해결.
+2. 우선 금융 경계: webhook signature real-verifier coverage, finalization PAID boundary, 재배송 상태머신, admin refund lifecycle.
+3. 권한 경계: driver approval/revocation, order direct read 최소화, mutation coverage.
+4. Issue #32.
+5. ALIGO 상태 재조회 → 승인 뒤 실제 알림톡/SMS fallback.
+6. P0 결과 기준 legal 재정합화.
+7. actual release SHA → E2E 52+cleanup → Firebase 재조회 → 승인된 production 설정/배포.
+8. 첫 회차 검수 → 최종 승인 → `salesMode: round_direct`.

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -16,16 +16,16 @@
 - 저장소: `booker-lab/greenhub`
 - 기본 브랜치: `main`; HEAD는 작업 시작 시 직접 재조회한다.
 - 회차 직배송 기능 통합 기준 SHA: `e55f25914cc7d01576fbd4639583daaf0fe6385e`
-- PR #30/#31로 세 프런트 `main`의 Vercel Git auto-production과 pure-doc build를 repo-side 차단했다.
+- PR #30/#31로 세 프런트의 `main` Vercel Git auto-production과 pure-doc build를 repo-side 차단했다.
 - docs-only main 변경은 Preview sync/일반 E2E 제외.
 - `AGENTS.md` + deployment safety CI가 branch+PR 원칙을 소유한다.
-- GitHub `main` 관리자 보호는 Issue #32가 남아 있다.
+- GitHub `main` 자체 보호는 Issue #32가 남아 있다.
 
 `main` merge는 production 배포 승인이 아니다. production은 검증된 exact release SHA + 별도 승인 절차를 사용한다.
 
 ## 제품 현재 상태
 
-- 회차 직배송 MVP `main` 통합 완료.
+- 회차 직배송 MVP는 `main` 통합 완료.
 - consumer 구매, seller 회차·주문, driver 직배송, 결제·환불·재배송비·보류·사진·운영 예외 흐름 존재.
 - 카카오 비즈니스 채널 승인 완료.
 - 운영 Firebase rules/indexes는 출시 전 read-only 재조회 필요.
@@ -34,57 +34,52 @@
 
 ## 현재 확인된 출시 P0
 
-### 1. PortOne webhook signature 검증 coverage
+### 1. 재배송비 결제·재개 상태머신
 
-webhook은 raw body + id/timestamp/signature를 요구하고 HMAC SHA-256 timing-safe 검증, ±5분 timestamp 제한이 구현돼 있다. production bootstrap도 `rawBody: true`다.
+운영 계약은 고객 책임 유료 재배송에서 `결제 전 재배송 금지`를 요구한다.
 
-현재 증거:
+2026-08-24 추가 감사에서 다음 두 우회/불일치가 확인됐다.
 
-- missing signature/secret, stale timestamp 단위 거부 테스트
-- HTTP E2E의 header 없는 webhook 401
-- controller 경로 E2E
+- driver `DELIVERY_HELD → DELIVERING`: charge `PAID` 확인 없음 + UI `배송 재개` 항상 노출.
+- seller `DELIVERY_HELD → PREPARING`: 고객 책임+양수 재배송비에서도 현재 테스트가 정상 성공으로 고정하며 hold를 해소하고 held counter를 줄임. 이 전환이 `ORDER_REDELIVERY_PAYMENT_REQUESTED` 알림을 만들지만 charge 생성 API와 consumer 결제 UI는 `status === DELIVERY_HELD`를 요구하므로 전환 뒤 결제가 불가능해진다. 이후 `PREPARING → DELIVERING`도 과거 미결제 hold를 확인하지 않는다.
 
-그러나 회차 E2E의 `verifyWebhookSignature`는 mock이며 **real verifier의 valid HMAC 성공과 non-empty invalid HMAC 거부를 직접 고정한 회귀가 없다.**
+따라서 **`ORDER-REDELIVERY-PAID-RESUME-GATE`는 단순 PAID guard가 아니라 P0 재배송 상태머신 `IMPLEMENTATION FINDING`**이다.
 
-따라서 구현 결함으로 단정하지 않고 **`PAYMENT-WEBHOOK-SIGNATURE-COVERAGE` = `IMPLEMENTED / PARTIALLY VERIFIED` + P0 `COVERAGE GAP`**으로 둔다.
+완료 시 payment-required 상태는 결제 전 사라지지 않아야 하며, payment-request 알림 뒤 consumer 결제가 실제 가능해야 하고, `HELD→DELIVERING` 및 `HELD→PREPARING→DELIVERING` 등 모든 배송 시작 경로가 동일 PAID gate를 통과해야 한다.
 
-정본: `docs/specs/api/payments.md`, `docs/BACKLOG.md`.
+정본: `docs/specs/api/orders.md`, `docs/BACKLOG.md`, 운영 근거 `docs/specs/ops/mvp-sales-round-runbook.md`.
 
-### 2. 재배송비 결제·재개 상태머신
-
-운영 계약은 고객 책임 유료 재배송에 `결제 전 재배송 금지`를 요구한다.
-
-현재:
-
-- direct `DELIVERY_HELD → DELIVERING`에 charge PAID gate 없음.
-- seller `DELIVERY_HELD → PREPARING`은 유료 hold에서도 성공하며 hold를 해소하지만, charge 생성 API·consumer 결제 CTA는 current `DELIVERY_HELD`를 요구해 payment-request 뒤 결제 dead-end 가능.
-- 이후 `PREPARING → DELIVERING`에도 durable paid-required guard 없음.
-
-따라서 **`ORDER-REDELIVERY-PAID-RESUME-GATE` = P0 상태머신 `IMPLEMENTATION FINDING`**.
-
-### 3. 관리자 강제 환불 lifecycle
+### 2. 관리자 강제 환불 lifecycle
 
 admin refund는 본 결제 환불 뒤 주문을 직접 `CANCELLED` write하며 정상 cancellation의 추가 charge·reservation/capacity·held counter·settlement 후속효과를 재사용하지 않는다.
 
 **`ADMIN-FORCE-REFUND-CONSISTENCY` = P0 IMPLEMENTATION FINDING**.
 
-### 4. Driver 승인·세션 권한
+### 3. Driver 승인·세션 권한
 
 신규/legacy driver 자동 승인 경로와 refresh/Firebase stale claims 수렴 문제가 있다.
 
 **관리자 승인 gate = P0 IMPLEMENTATION FINDING**, suspension/role/store/approval revocation = **P0 DECISION REQUIRED + remediation**.
 
-### 5. 주문 direct Firestore read·개인정보 최소화
+### 4. 주문 direct Firestore read·개인정보 최소화
 
 API driver read는 배정 경계가 있으나 current Rules는 driver role에 broad order read를 허용하며 seller/driver frontend는 raw document를 사용한다.
 
 **시스템 전체 driver read authorization + seller/driver data minimization = P0 IMPLEMENTATION FINDING**.
 
-### 6. 결제 finalization provider 상태 방어
+### 5. 결제 finalization provider 상태 방어
 
 `finalizePaidOrder()` boundary가 비`PAID` provider 입력을 자체 차단하지 않는다.
 
-**`PAYMENT-FINALIZATION-PAID-GUARD` = P0 IMPLEMENTATION FINDING**.
+**`PAYMENT-FINALIZATION-PAID-GUARD` = P0**.
+
+### 6. PortOne webhook signature 검증 coverage
+
+webhook signature 구현은 raw body + id/timestamp/signature, timestamp ±5분, HMAC SHA-256 timing-safe 검증을 사용한다. 그러나 현재 회차 E2E의 signature verifier는 mock이며 real verifier의 valid HMAC 성공·non-empty invalid HMAC 거부·body/id/timestamp 변조 거부를 직접 고정한 증거가 부족하다.
+
+**`PAYMENT-WEBHOOK-SIGNATURE-COVERAGE` = IMPLEMENTED / PARTIALLY VERIFIED + P0 COVERAGE GAP**. 구현 결함으로 단정하지 않는다.
+
+정본: `docs/specs/api/payments.md`; 증거: `docs/reports/REPORT_payment_webhook_signature_coverage_20260824.md`.
 
 ### 7. 주문 mutation authorization 회귀
 
@@ -113,7 +108,7 @@ repo-side 배포 방어는 완료. GitHub 관리자 레벨 PR required/required 
 - production `/privacy`, `/terms`는 2026-08-19 비판매 상태 기준.
 - 실제 판매 전 주문·취소·환불·재배송비·보류, PortOne/PG, ALIGO, seller/driver 개인정보 접근을 재정합화해야 한다.
 - broad read를 legal 문구로 정당화하지 않는다.
-- 재배송 상태머신·admin refund 실제 정책을 legal의 재배송비·환불 설명에 반영한다.
+- 재배송 payment-required 상태머신과 admin refund 실제 정책을 legal의 재배송비·환불 설명에 반영한다.
 
 ## 검증 상태
 
@@ -141,11 +136,10 @@ repo-side 배포 방어는 완료. GitHub 관리자 레벨 PR required/required 
 
 ## 다음 작업
 
-1. P0 금융/권한 코드·coverage 게이트를 ALIGO 심사와 병렬 해결.
-2. 우선 금융 경계: webhook signature real-verifier coverage, finalization PAID boundary, 재배송 상태머신, admin refund lifecycle.
-3. 권한 경계: driver approval/revocation, order direct read 최소화, mutation coverage.
-4. Issue #32.
-5. ALIGO 상태 재조회 → 승인 뒤 실제 알림톡/SMS fallback.
-6. P0 결과 기준 legal 재정합화.
-7. actual release SHA → E2E 52+cleanup → Firebase 재조회 → 승인된 production 설정/배포.
-8. 첫 회차 검수 → 최종 승인 → `salesMode: round_direct`.
+1. `ORDER-REDELIVERY-PAID-RESUME-GATE`를 **상태머신 전체** 기준으로 구현·직접 회귀·`main` 통합.
+2. `PAYMENT-WEBHOOK-SIGNATURE-COVERAGE`를 포함한 나머지 P0를 ALIGO 심사와 병렬 해결.
+3. Issue #32.
+4. ALIGO 상태 재조회 → 승인 뒤 실제 알림톡/SMS fallback.
+5. P0 결과 기준 legal 재정합화.
+6. actual release SHA → E2E 52+cleanup → Firebase 재조회 → 승인된 production 설정/배포.
+7. 첫 회차 검수 → 최종 승인 → `salesMode: round_direct`.

--- a/docs/plans/HANDOFF_mvp_round_direct_aligo_review_pause.md
+++ b/docs/plans/HANDOFF_mvp_round_direct_aligo_review_pause.md
@@ -13,60 +13,59 @@
 - 첫 운영 회차 미생성, `salesMode=legacy`.
 - production은 exact release SHA + 별도 승인 절차를 사용한다.
 
-현재 외부 차단점은 ALIGO 8종 심사 완료다. 재개 시 provider 상태를 다시 확인한다.
+현재 외부 차단점은 ALIGO 8종 심사 완료다. 재개 시 provider 상태를 다시 확인한다. 단, 출시 P0는 심사와 병렬 진행 가능하다.
 
 병렬 출시 P0:
 
-1. `PAYMENT-WEBHOOK-SIGNATURE-COVERAGE`
-2. `PAYMENT-FINALIZATION-PAID-GUARD`
-3. `ORDER-REDELIVERY-PAID-RESUME-GATE`
-4. `ADMIN-FORCE-REFUND-CONSISTENCY`
-5. `AUTH-DRIVER-APPROVAL-AND-SESSION-REVOCATION`
-6. `ORDER-DIRECT-READ-AUTHORIZATION-AND-MINIMIZATION`
-7. `ORDER-MUTATION-AUTHORIZATION-COVERAGE`
+1. `ORDER-REDELIVERY-PAID-RESUME-GATE`
+2. `AUTH-DRIVER-APPROVAL-AND-SESSION-REVOCATION`
+3. `ORDER-DIRECT-READ-AUTHORIZATION-AND-MINIMIZATION`
+4. `PAYMENT-FINALIZATION-PAID-GUARD`
+5. `ORDER-MUTATION-AUTHORIZATION-COVERAGE`
+6. `ADMIN-FORCE-REFUND-CONSISTENCY`
+7. `PAYMENT-WEBHOOK-SIGNATURE-COVERAGE`
 8. Issue #32
 
-## 최우선 재개 포인터
+## 최우선 재개 — 재배송비 상태머신
 
-### 1. PortOne webhook signature coverage
+운영 불변식은 **고객 책임 유료 재배송비를 결제하기 전에 실제 배송을 다시 시작하지 않는다**는 것이다.
 
-구현은 raw body + webhook headers + timestamp ±5분 + HMAC SHA-256 timing-safe 검증을 사용한다. production bootstrap도 `rawBody: true`다.
+현재는 두 문제가 결합돼 있다.
 
-현재는 missing signature/secret/stale timestamp 단위 거부와 unsigned HTTP 401 증거가 있지만, **real verifier의 valid HMAC 성공과 non-empty invalid HMAC 거부가 직접 고정되지 않았다.** 회차 E2E의 signature verifier는 mock이다.
+### A. direct resume 우회
 
-완료:
+`DELIVERY_HELD → DELIVERING`이 charge `PAID` 확인 없이 가능하며 driver UI도 결제 상태와 무관하게 `배송 재개`를 노출한다.
 
-- valid HMAC real verifier 성공
-- invalid non-empty HMAC 거부
-- body/id/timestamp mutation 거부
-- actual controller + real verifier에서 invalid request가 service에 도달하지 않음
-- side effect 0
+### B. seller PREPARING 경유 dead-end/우회
 
-정본: `docs/specs/api/payments.md`, `docs/BACKLOG.md`.
+- 고객 책임+양수 재배송비 hold도 seller가 `DELIVERY_HELD → PREPARING` 가능.
+- 이 전환은 hold를 해소하고 `heldOrderCount`를 줄이며 `ORDER_REDELIVERY_PAYMENT_REQUESTED`를 발생시키는 현재 경로다.
+- 그러나 charge 생성 API와 consumer 결제 CTA는 현재 status `DELIVERY_HELD`를 요구한다.
+- 따라서 payment-request 알림 뒤 실제 결제가 불가능할 수 있다.
+- 이후 `PREPARING → DELIVERING`에도 과거 미결제 hold를 확인하는 durable gate가 없다.
 
-### 2. Payment finalization PAID boundary
+완료 시 반드시:
 
-`finalizePaidOrder()`가 비`PAID` provider 입력을 boundary 자체에서 차단하도록 보정하고 `PENDING|FAILED|CANCELLED|PAID`를 직접 고정한다.
+- payment-required 정보가 결제 전 사라지지 않고,
+- payment-request 알림 뒤 consumer가 실제 결제할 수 있으며,
+- current hold↔charge가 durable하게 연결되고,
+- `PAID` 전 모든 delivery-start 경로가 side-effect 0으로 거부되고,
+- PAID 뒤 정상 한 번만 재개되며,
+- hold resolve/held counter/알림이 race에서도 한 번만 수렴해야 한다.
 
-### 3. 유료 재배송 상태머신
+단순 driver 버튼 숨김 또는 `HELD→DELIVERING` 한 경로 guard만으로 닫지 않는다.
 
-`결제 전 재배송 금지`와 payment-request 후 실제 consumer 결제 가능성을 동시에 만족해야 한다. direct resume와 seller PREPARING 경유 우회를 모두 닫는다.
+정본: `docs/specs/api/orders.md`, `docs/BACKLOG.md`.
 
-### 4. Admin force-refund
+## 나머지 P0 포인터
 
-정상 cancellation의 본 결제·추가 charge·capacity·held counter·settlement 불변식과 수렴하고 paid settlement 별도 회계 정책을 정의한다.
-
-### 5~7. 권한 P0
-
-- driver 승인/session revocation
-- order direct read/minimization
-- order mutation authorization coverage
-
-세부는 Backlog/current spec을 따른다.
-
-### 8. GitHub main protection
-
-Issue #32: PR required + deployment safety required check + force-push/delete 차단.
+- Driver 승인·session revocation: `docs/specs/api/auth.md`
+- Order direct read·minimization: `docs/specs/api/orders.md`, legal gate
+- Payment finalization: `docs/specs/api/payments.md`
+- Payment webhook signature coverage: `docs/specs/api/payments.md`, `docs/reports/REPORT_payment_webhook_signature_coverage_20260824.md`
+- Order mutation authorization: `docs/specs/api/orders.md`
+- Admin force-refund: `docs/specs/api/admin.md`, `docs/specs/api/settlements.md`
+- GitHub main protection: Issue #32 / deployment safety plan
 
 ## 지금 하지 말 것
 
@@ -81,13 +80,13 @@ Issue #32: PR required + deployment safety required check + force-push/delete �
 
 ## 병렬 가능 작업
 
-1. webhook signature real-verifier 회귀
-2. payment finalization PAID boundary
-3. 재배송 상태머신
-4. admin force-refund lifecycle
-5. driver approval/session revocation
-6. order direct read 최소화
-7. order mutation 거부 회귀
+1. 재배송 payment-request/hold-resolution/resume 상태머신 구현·회귀
+2. driver 승인/session revocation
+3. order direct read 최소화
+4. payment finalization PAID boundary
+5. order mutation 거부 회귀
+6. admin force-refund lifecycle
+7. webhook signature real-verifier 회귀
 8. Issue #32
 9. read-only 문서/코드 감사
 10. ALIGO 상태 조회
@@ -99,7 +98,7 @@ Issue #32: PR required + deployment safety required check + force-push/delete �
 3. provider code 1:1 검사
 4. 승인 후 격리 알림톡
 5. 승인 후 SMS fallback
-6. 실제 P0 해결 결과 기준 legal 재정합화
+6. 실제 재배송/환불/read-minimization 기준 legal 재정합화
 7. actual release SHA
 8. exact SHA E2E 52+cleanup
 9. 운영 Firebase read-only
@@ -116,13 +115,13 @@ Issue #32: PR required + deployment safety required check + force-push/delete �
 - [x] ALIGO sender profile/senderkey
 - [x] 8종 등록·심사 요청
 - [x] repo-side main auto-production 차단
-- [ ] webhook real-signature coverage + main
-- [ ] payment finalization PAID + main
-- [ ] 재배송 payment-required 상태머신 + main
-- [ ] admin force-refund lifecycle + main
-- [ ] driver approval/session revocation + main
-- [ ] order direct read 최소화 + main
-- [ ] order mutation coverage + main
+- [ ] 재배송 payment-required 상태머신 + 직접 회귀 + main
+- [ ] driver 승인/session revocation
+- [ ] order direct read 최소화
+- [ ] payment finalization PAID
+- [ ] order mutation coverage
+- [ ] admin force-refund
+- [ ] webhook signature real-verifier coverage
 - [ ] Issue #32
 - [ ] ALIGO 8종 승인
 - [ ] 실제 알림톡/SMS fallback

--- a/docs/plans/HANDOFF_mvp_round_direct_aligo_review_pause.md
+++ b/docs/plans/HANDOFF_mvp_round_direct_aligo_review_pause.md
@@ -17,53 +17,56 @@
 
 병렬 출시 P0:
 
-1. `ORDER-REDELIVERY-PAID-RESUME-GATE`
-2. `AUTH-DRIVER-APPROVAL-AND-SESSION-REVOCATION`
-3. `ORDER-DIRECT-READ-AUTHORIZATION-AND-MINIMIZATION`
-4. `PAYMENT-FINALIZATION-PAID-GUARD`
-5. `ORDER-MUTATION-AUTHORIZATION-COVERAGE`
-6. `ADMIN-FORCE-REFUND-CONSISTENCY`
-7. Issue #32
+1. `PAYMENT-WEBHOOK-SIGNATURE-COVERAGE`
+2. `PAYMENT-FINALIZATION-PAID-GUARD`
+3. `ORDER-REDELIVERY-PAID-RESUME-GATE`
+4. `ADMIN-FORCE-REFUND-CONSISTENCY`
+5. `AUTH-DRIVER-APPROVAL-AND-SESSION-REVOCATION`
+6. `ORDER-DIRECT-READ-AUTHORIZATION-AND-MINIMIZATION`
+7. `ORDER-MUTATION-AUTHORIZATION-COVERAGE`
+8. Issue #32
 
-## 최우선 재개 — 재배송비 상태머신
+## 최우선 재개 포인터
 
-운영 불변식은 **고객 책임 유료 재배송비를 결제하기 전에 실제 배송을 다시 시작하지 않는다**는 것이다.
+### 1. PortOne webhook signature coverage
 
-현재는 두 문제가 결합돼 있다.
+구현은 raw body + webhook headers + timestamp ±5분 + HMAC SHA-256 timing-safe 검증을 사용한다. production bootstrap도 `rawBody: true`다.
 
-### A. direct resume 우회
+현재는 missing signature/secret/stale timestamp 단위 거부와 unsigned HTTP 401 증거가 있지만, **real verifier의 valid HMAC 성공과 non-empty invalid HMAC 거부가 직접 고정되지 않았다.** 회차 E2E의 signature verifier는 mock이다.
 
-`DELIVERY_HELD → DELIVERING`이 charge `PAID` 확인 없이 가능하며 driver UI도 결제 상태와 무관하게 `배송 재개`를 노출한다.
+완료:
 
-### B. seller PREPARING 경유 dead-end/우회
+- valid HMAC real verifier 성공
+- invalid non-empty HMAC 거부
+- body/id/timestamp mutation 거부
+- actual controller + real verifier에서 invalid request가 service에 도달하지 않음
+- side effect 0
 
-- 고객 책임+양수 재배송비 hold도 seller가 `DELIVERY_HELD → PREPARING` 가능.
-- 이 전환은 hold를 해소하고 `heldOrderCount`를 줄이며 `ORDER_REDELIVERY_PAYMENT_REQUESTED`를 발생시키는 현재 경로다.
-- 그러나 charge 생성 API와 consumer 결제 CTA는 현재 status `DELIVERY_HELD`를 요구한다.
-- 따라서 payment-request 알림 뒤 실제 결제가 불가능할 수 있다.
-- 이후 `PREPARING → DELIVERING`에도 과거 미결제 hold를 확인하는 durable gate가 없다.
+정본: `docs/specs/api/payments.md`, `docs/BACKLOG.md`.
 
-완료 시 반드시:
+### 2. Payment finalization PAID boundary
 
-- payment-required 정보가 결제 전 사라지지 않고,
-- payment-request 알림 뒤 consumer가 실제 결제할 수 있으며,
-- current hold↔charge가 durable하게 연결되고,
-- `PAID` 전 모든 delivery-start 경로가 side-effect 0으로 거부되고,
-- PAID 뒤 정상 한 번만 재개되며,
-- hold resolve/held counter/알림이 race에서도 한 번만 수렴해야 한다.
+`finalizePaidOrder()`가 비`PAID` provider 입력을 boundary 자체에서 차단하도록 보정하고 `PENDING|FAILED|CANCELLED|PAID`를 직접 고정한다.
 
-단순 driver 버튼 숨김 또는 `HELD→DELIVERING` 한 경로 guard만으로 닫지 않는다.
+### 3. 유료 재배송 상태머신
 
-정본: `docs/specs/api/orders.md`, `docs/BACKLOG.md`.
+`결제 전 재배송 금지`와 payment-request 후 실제 consumer 결제 가능성을 동시에 만족해야 한다. direct resume와 seller PREPARING 경유 우회를 모두 닫는다.
 
-## 나머지 P0 포인터
+### 4. Admin force-refund
 
-- Driver 승인·session revocation: `docs/specs/api/auth.md`
-- Order direct read·minimization: `docs/specs/api/orders.md`, legal gate
-- Payment finalization: `docs/specs/api/payments.md`
-- Order mutation authorization: `docs/specs/api/orders.md`
-- Admin force-refund: `docs/specs/api/admin.md`, `docs/specs/api/settlements.md`
-- GitHub main protection: Issue #32 / deployment safety plan
+정상 cancellation의 본 결제·추가 charge·capacity·held counter·settlement 불변식과 수렴하고 paid settlement 별도 회계 정책을 정의한다.
+
+### 5~7. 권한 P0
+
+- driver 승인/session revocation
+- order direct read/minimization
+- order mutation authorization coverage
+
+세부는 Backlog/current spec을 따른다.
+
+### 8. GitHub main protection
+
+Issue #32: PR required + deployment safety required check + force-push/delete 차단.
 
 ## 지금 하지 말 것
 
@@ -78,24 +81,25 @@
 
 ## 병렬 가능 작업
 
-1. 재배송 payment-request/hold-resolution/resume 상태머신 구현·회귀
-2. driver 승인/session revocation
-3. order direct read 최소화
-4. payment finalization PAID boundary
-5. order mutation 거부 회귀
-6. admin force-refund lifecycle
-7. Issue #32
-8. read-only 문서/코드 감사
-9. ALIGO 상태 조회
+1. webhook signature real-verifier 회귀
+2. payment finalization PAID boundary
+3. 재배송 상태머신
+4. admin force-refund lifecycle
+5. driver approval/session revocation
+6. order direct read 최소화
+7. order mutation 거부 회귀
+8. Issue #32
+9. read-only 문서/코드 감사
+10. ALIGO 상태 조회
 
 ## ALIGO 승인 뒤
 
-1. P0 6개 + Issue #32 완료 확인
+1. P0 7개 + Issue #32 완료 확인
 2. ALIGO 8종 상태 재확인
 3. provider code 1:1 검사
 4. 승인 후 격리 알림톡
 5. 승인 후 SMS fallback
-6. 실제 재배송/환불/read-minimization 기준 legal 재정합화
+6. 실제 P0 해결 결과 기준 legal 재정합화
 7. actual release SHA
 8. exact SHA E2E 52+cleanup
 9. 운영 Firebase read-only
@@ -112,12 +116,13 @@
 - [x] ALIGO sender profile/senderkey
 - [x] 8종 등록·심사 요청
 - [x] repo-side main auto-production 차단
-- [ ] 재배송 payment-required 상태머신 + 직접 회귀 + main
-- [ ] driver 승인/session revocation
-- [ ] order direct read 최소화
-- [ ] payment finalization PAID
-- [ ] order mutation coverage
-- [ ] admin force-refund
+- [ ] webhook real-signature coverage + main
+- [ ] payment finalization PAID + main
+- [ ] 재배송 payment-required 상태머신 + main
+- [ ] admin force-refund lifecycle + main
+- [ ] driver approval/session revocation + main
+- [ ] order direct read 최소화 + main
+- [ ] order mutation coverage + main
 - [ ] Issue #32
 - [ ] ALIGO 8종 승인
 - [ ] 실제 알림톡/SMS fallback

--- a/docs/plans/PLAN_mvp_round_direct_launch_blockers.md
+++ b/docs/plans/PLAN_mvp_round_direct_launch_blockers.md
@@ -2,7 +2,7 @@
 
 # Project Blueprint: 회차 직배송 MVP 출시 차단 요소 해소
 
-> 실행 순서·의존성·승인 게이트만 관리한다. 상태는 `docs/memory.md`, 세부 Acceptance Criteria는 `docs/BACKLOG.md`, 도메인 계약은 current spec을 따른다.
+> 실행 순서·의존성·승인 게이트만 관리한다. 상태는 `docs/memory.md`, 상세 Acceptance Criteria는 `docs/BACKLOG.md`, 도메인 계약은 current spec을 따른다.
 
 ## 메타
 
@@ -18,12 +18,13 @@
 | ID | 게이트 | 상태 |
 |---|---|---|
 | 0A | GitHub `main` protection/ruleset | 미완료 — Issue #32 |
-| 0B | payment finalization 비`PAID` 차단 | 미완료 — P0 |
-| 0C | order mutation authorization 직접 거부 회귀 | 미완료 — P0 GAP |
-| 0D | order direct Firestore read·최소화 | 미완료 — P0 FINDING |
-| 0E | driver 승인 + session/claims revocation | 미완료 — P0 FINDING/DECISION |
-| 0F | admin force-refund lifecycle | 미완료 — P0 FINDING |
-| 0G | 유료 재배송 payment-request/hold-resolution/resume 상태머신 | 미완료 — P0 FINDING |
+| 0B | payment finalization 비`PAID` boundary | 미완료 — P0 FINDING |
+| 0C | payment webhook real-signature coverage | 미완료 — P0 COVERAGE GAP |
+| 0D | order mutation authorization coverage | 미완료 — P0 GAP |
+| 0E | order direct Firestore read·minimization | 미완료 — P0 FINDING |
+| 0F | driver approval + session/claims revocation | 미완료 — P0 FINDING/DECISION |
+| 0G | admin force-refund lifecycle | 미완료 — P0 FINDING |
+| 0H | 유료 재배송 payment-request/hold-resolution/resume 상태머신 | 미완료 — P0 FINDING |
 | 1 | ALIGO 8종 최종 승인 | 검수중 |
 | 2 | 실제 알림톡 | 미실행 |
 | 3 | SMS fallback | 미실행 |
@@ -39,14 +40,15 @@
 
 1. repository 변경은 최신 `main` 기반 branch+PR.
 2. direct `main` 금지.
-3. 0A~0G는 ALIGO 심사와 병렬 가능.
+3. 0A~0H는 ALIGO 심사와 병렬 가능.
 4. P0를 문서/UI 변경만으로 완료 처리하지 않는다.
-5. 금전·권한 불변식은 server boundary + 직접 거부/정상 회귀가 필요하다.
-6. actual release SHA는 0A~0G + legal 해결 뒤 고정한다.
-7. exact SHA E2E 52+cleanup 전 production 금지.
-8. production은 exact SHA/artifact + 별도 승인.
-9. provider metadata SHA 불일치 시 traffic 전환 금지.
-10. 첫 회차 `SCHEDULED` 전 `salesMode` 전환 금지.
+5. 금전·권한 불변식은 server boundary + 직접 정상/거부/동시성 증거가 필요하다.
+6. webhook auth는 mock E2E만으로 `VERIFIED` 처리하지 않고 real verifier의 valid/invalid 양방향 증거를 요구한다.
+7. actual release SHA는 0A~0H + legal 해결 뒤 고정한다.
+8. exact SHA E2E 52+cleanup 전 production 금지.
+9. production은 exact SHA/artifact + 별도 승인.
+10. provider metadata SHA 불일치 시 traffic 전환 금지.
+11. 첫 회차 `SCHEDULED` 전 `salesMode` 전환 금지.
 
 ## Phase 0 — 코드·권한·금전 안전성
 
@@ -65,45 +67,47 @@
 - Backlog: `PAYMENT-FINALIZATION-PAID-GUARD`
 - Status: todo_code
 
-### Task 0.5 — Order mutation authorization coverage
+### Task 0.5 — Payment webhook signature real-verifier coverage
+- Backlog: `PAYMENT-WEBHOOK-SIGNATURE-COVERAGE`
+- Goal: 구현된 HMAC verifier를 실제 cryptographic positive/negative path와 controller raw-body 경계에서 직접 고정
+- Required:
+  - known valid signature 성공
+  - non-empty invalid signature 거부
+  - body/id/timestamp mutation 거부
+  - controller + real verifier에서 invalid request가 service에 도달하지 않음
+  - invalid request side effect 0
+  - duplicate webhook 멱등 회귀 유지
+- Status: todo_test_security
+
+### Task 0.6 — Order mutation authorization coverage
 - Backlog: `ORDER-MUTATION-AUTHORIZATION-COVERAGE`
 - Status: todo_test
 
-### Task 0.6 — Order direct read·minimization
+### Task 0.7 — Order direct read·minimization
 - Backlog: `ORDER-DIRECT-READ-AUTHORIZATION-AND-MINIMIZATION`
 - Status: todo_code_security
 
-### Task 0.7 — Driver approval·session revocation
+### Task 0.8 — Driver approval·session revocation
 - Backlog: `AUTH-DRIVER-APPROVAL-AND-SESSION-REVOCATION`
-- Coupling: Task 0.6
+- Coupling: Task 0.7
 - Status: todo_code_security
 
-### Task 0.8 — Admin force-refund lifecycle
+### Task 0.9 — Admin force-refund lifecycle
 - Backlog: `ADMIN-FORCE-REFUND-CONSISTENCY`
 - Goal: 본 결제·추가 charge·capacity·held counter·settlement 불변식 수렴 + paid settlement 정책
 - Status: todo_code_financial
 
-### Task 0.9 — 유료 재배송 상태머신 정합화
+### Task 0.10 — 유료 재배송 상태머신 정합화
 - Backlog: `ORDER-REDELIVERY-PAID-RESUME-GATE`
-- Contract: `docs/specs/api/orders.md`
-- Operational evidence: `docs/specs/ops/mvp-sales-round-runbook.md`
-- Goal: `결제 전 재배송 금지`와 payment-request 흐름을 실제 상태머신에서 동시에 만족
+- Goal: `결제 전 재배송 금지`와 payment-request 결제 가능성을 동시에 보장
 - Required:
-  - paid-required hold의 payment-required 정보가 결제 전 사라지지 않음
-  - payment-request 알림 뒤 consumer charge 생성/UI·endpoint actionable
+  - payment-required 상태 PAID 전 보존
+  - payment-request 뒤 consumer payment actionable
   - current hold↔charge durable linkage
-  - `REDELIVERY_FEE` + order/store/user + `PAID` 검증
-  - 모든 delivery-start 경로(`HELD→DELIVERING`, `HELD→PREPARING→DELIVERING` 포함) 동일 gate
-  - `PENDING|FAILED|REFUNDED|missing|mismatch` side effect 0
-  - hold resolve/held counter 감소 시점을 결제·재개 계약과 일치
-  - 무료/판매자책임 흐름 정상 유지
-  - seller/driver race 한 번만 수렴
-- Required tests:
-  - payment request 뒤 consumer 결제 가능
-  - 미결제 direct resume 거부
-  - seller PREPARING 정책 직접 고정
-  - PREPARING 경유 미결제 배송 시작 거부
-  - PAID 뒤 정상 1회 재개
+  - 모든 delivery-start 경로 PAID gate
+  - invalid charge state side effect 0
+  - hold resolve/held counter timing·race 수렴
+  - 무료/판매자책임 흐름 유지
 - Status: todo_code_financial
 
 ## Phase 1 — ALIGO
@@ -116,11 +120,11 @@
 ## Phase 2 — legal·release SHA
 
 ### Task 2.1 — 판매 활성화 legal
-- Dependency: ALIGO 실제 검증 + Task 0.6 + 0.8 + 0.9
-- Required: 주문/환불/재배송비/보류 실제 상태머신, 개인정보 처리, ALIGO, seller/driver 최소 접근, legal tests
+- Dependency: ALIGO 실제 검증 + Task 0.7 + 0.9 + 0.10
+- Required: 주문/환불/재배송/보류 실제 상태머신, PortOne/PG, ALIGO, seller/driver 최소 접근, legal tests
 
 ### Task 2.2 — actual release SHA
-- Dependency: Task 0.3~0.9 + 2.1
+- Dependency: Task 0.3~0.10 + 2.1
 
 ### Task 2.3 — exact SHA E2E
 - Goal: chromium 26 + mobile 26 = 52, cleanup success
@@ -144,15 +148,14 @@
 - rollback dry-run
 - 최종 출시 판정
 - 최종 승인 뒤 `salesMode: round_direct`
-- 전환 smoke
-- 외부 유입 공개
+- 전환 smoke → 외부 유입 공개
 - 첫 두 회차 모니터링 → Closeout
 
 ## 최종 완료 기준
 
-- Task 0A~0G 직접 증거와 함께 `main` 포함.
-- 유료 재배송 payment request가 실제 결제 가능한 상태를 유지하고, 결제 전 모든 배송 시작 경로가 fail-closed.
-- admin refund·payment finalization·권한/개인정보 P0 해결.
+- Task 0A~0H 직접 증거와 함께 `main` 포함.
+- webhook signature valid/invalid real-verifier evidence 포함.
+- payment finalization·재배송·admin refund·권한/개인정보 P0 해결.
 - Issue #32 완료.
 - ALIGO 승인+실발송/fallback.
 - legal 정합화.

--- a/docs/plans/PLAN_mvp_round_direct_launch_blockers.md
+++ b/docs/plans/PLAN_mvp_round_direct_launch_blockers.md
@@ -2,12 +2,12 @@
 
 # Project Blueprint: 회차 직배송 MVP 출시 차단 요소 해소
 
-> 실행 순서·의존성·승인 게이트만 관리한다. 상태는 `docs/memory.md`, 상세 Acceptance Criteria는 `docs/BACKLOG.md`, 도메인 계약은 current spec을 따른다.
+> 실행 순서·의존성·승인 게이트만 관리한다. 상태는 `docs/memory.md`, 세부 Acceptance Criteria는 `docs/BACKLOG.md`, 도메인 계약은 current spec을 따른다.
 
 ## 메타
 
 - 최종 정합화: 2026-08-24 KST
-- 상태: `paused_external_review`
+- 상태: `active_p0_parallel / aligo_external_review_pending`
 - 외부 차단점: ALIGO 8종 provider 심사 완료
 - 상태 SSOT: `docs/memory.md`
 - 재개: `docs/plans/HANDOFF_mvp_round_direct_aligo_review_pause.md`
@@ -18,13 +18,13 @@
 | ID | 게이트 | 상태 |
 |---|---|---|
 | 0A | GitHub `main` protection/ruleset | 미완료 — Issue #32 |
-| 0B | payment finalization 비`PAID` boundary | 미완료 — P0 FINDING |
-| 0C | payment webhook real-signature coverage | 미완료 — P0 COVERAGE GAP |
-| 0D | order mutation authorization coverage | 미완료 — P0 GAP |
-| 0E | order direct Firestore read·minimization | 미완료 — P0 FINDING |
-| 0F | driver approval + session/claims revocation | 미완료 — P0 FINDING/DECISION |
-| 0G | admin force-refund lifecycle | 미완료 — P0 FINDING |
-| 0H | 유료 재배송 payment-request/hold-resolution/resume 상태머신 | 미완료 — P0 FINDING |
+| 0B | payment finalization 비`PAID` 차단 | 미완료 — P0 |
+| 0C | order mutation authorization 직접 거부 회귀 | 미완료 — P0 GAP |
+| 0D | order direct Firestore read·최소화 | 미완료 — P0 FINDING |
+| 0E | driver 승인 + session/claims revocation | 미완료 — P0 FINDING/DECISION |
+| 0F | admin force-refund lifecycle | 미완료 — P0 FINDING |
+| 0G | 유료 재배송 payment-request/hold-resolution/resume 상태머신 | 미완료 — P0 FINDING |
+| 0H | payment webhook real-signature coverage | 미완료 — P0 COVERAGE GAP |
 | 1 | ALIGO 8종 최종 승인 | 검수중 |
 | 2 | 실제 알림톡 | 미실행 |
 | 3 | SMS fallback | 미실행 |
@@ -42,8 +42,8 @@
 2. direct `main` 금지.
 3. 0A~0H는 ALIGO 심사와 병렬 가능.
 4. P0를 문서/UI 변경만으로 완료 처리하지 않는다.
-5. 금전·권한 불변식은 server boundary + 직접 정상/거부/동시성 증거가 필요하다.
-6. webhook auth는 mock E2E만으로 `VERIFIED` 처리하지 않고 real verifier의 valid/invalid 양방향 증거를 요구한다.
+5. 금전·권한 불변식은 server boundary + 직접 거부/정상 회귀가 필요하다.
+6. webhook auth는 mock E2E만으로 `VERIFIED` 처리하지 않고 real verifier의 valid/invalid 양방향 증거가 필요하다.
 7. actual release SHA는 0A~0H + legal 해결 뒤 고정한다.
 8. exact SHA E2E 52+cleanup 전 production 금지.
 9. production은 exact SHA/artifact + 별도 승인.
@@ -67,48 +67,60 @@
 - Backlog: `PAYMENT-FINALIZATION-PAID-GUARD`
 - Status: todo_code
 
-### Task 0.5 — Payment webhook signature real-verifier coverage
-- Backlog: `PAYMENT-WEBHOOK-SIGNATURE-COVERAGE`
-- Goal: 구현된 HMAC verifier를 실제 cryptographic positive/negative path와 controller raw-body 경계에서 직접 고정
+### Task 0.5 — Order mutation authorization coverage
+- Backlog: `ORDER-MUTATION-AUTHORIZATION-COVERAGE`
+- Status: todo_test
+
+### Task 0.6 — Order direct read·minimization
+- Backlog: `ORDER-DIRECT-READ-AUTHORIZATION-AND-MINIMIZATION`
+- Status: todo_code_security
+
+### Task 0.7 — Driver approval·session revocation
+- Backlog: `AUTH-DRIVER-APPROVAL-AND-SESSION-REVOCATION`
+- Coupling: Task 0.6
+- Status: todo_code_security
+
+### Task 0.8 — Admin force-refund lifecycle
+- Backlog: `ADMIN-FORCE-REFUND-CONSISTENCY`
+- Goal: 본 결제·추가 charge·capacity·held counter·settlement 불변식 수렴 + paid settlement 정책
+- Status: todo_code_financial
+
+### Task 0.9 — 유료 재배송 상태머신 정합화
+- Backlog: `ORDER-REDELIVERY-PAID-RESUME-GATE`
+- Contract: `docs/specs/api/orders.md`
+- Operational evidence: `docs/specs/ops/mvp-sales-round-runbook.md`
+- Goal: `결제 전 재배송 금지`와 payment-request 흐름을 실제 상태머신에서 동시에 만족
 - Required:
-  - known valid signature 성공
-  - non-empty invalid signature 거부
+  - paid-required hold의 payment-required 정보가 결제 전 사라지지 않음
+  - payment-request 알림 뒤 consumer charge 생성/UI·endpoint actionable
+  - current hold↔charge durable linkage
+  - `REDELIVERY_FEE` + order/store/user + `PAID` 검증
+  - 모든 delivery-start 경로(`HELD→DELIVERING`, `HELD→PREPARING→DELIVERING` 포함) 동일 gate
+  - `PENDING|FAILED|REFUNDED|missing|mismatch` side effect 0
+  - hold resolve/held counter 감소 시점을 결제·재개 계약과 일치
+  - 무료/판매자책임 흐름 정상 유지
+  - seller/driver race 한 번만 수렴
+- Required tests:
+  - payment request 뒤 consumer 결제 가능
+  - 미결제 direct resume 거부
+  - seller PREPARING 정책 직접 고정
+  - PREPARING 경유 미결제 배송 시작 거부
+  - PAID 뒤 정상 1회 재개
+- Status: todo_code_financial
+
+### Task 0.10 — Payment webhook real-signature coverage
+- Backlog: `PAYMENT-WEBHOOK-SIGNATURE-COVERAGE`
+- Contract: `docs/specs/api/payments.md`
+- Evidence: `docs/reports/REPORT_payment_webhook_signature_coverage_20260824.md`
+- Goal: 구현된 signature verifier를 실제 cryptographic positive/negative path와 controller raw-body 경계에서 직접 고정
+- Required:
+  - known valid HMAC real-verifier 성공
+  - non-empty invalid HMAC 거부
   - body/id/timestamp mutation 거부
   - controller + real verifier에서 invalid request가 service에 도달하지 않음
   - invalid request side effect 0
   - duplicate webhook 멱등 회귀 유지
 - Status: todo_test_security
-
-### Task 0.6 — Order mutation authorization coverage
-- Backlog: `ORDER-MUTATION-AUTHORIZATION-COVERAGE`
-- Status: todo_test
-
-### Task 0.7 — Order direct read·minimization
-- Backlog: `ORDER-DIRECT-READ-AUTHORIZATION-AND-MINIMIZATION`
-- Status: todo_code_security
-
-### Task 0.8 — Driver approval·session revocation
-- Backlog: `AUTH-DRIVER-APPROVAL-AND-SESSION-REVOCATION`
-- Coupling: Task 0.7
-- Status: todo_code_security
-
-### Task 0.9 — Admin force-refund lifecycle
-- Backlog: `ADMIN-FORCE-REFUND-CONSISTENCY`
-- Goal: 본 결제·추가 charge·capacity·held counter·settlement 불변식 수렴 + paid settlement 정책
-- Status: todo_code_financial
-
-### Task 0.10 — 유료 재배송 상태머신 정합화
-- Backlog: `ORDER-REDELIVERY-PAID-RESUME-GATE`
-- Goal: `결제 전 재배송 금지`와 payment-request 결제 가능성을 동시에 보장
-- Required:
-  - payment-required 상태 PAID 전 보존
-  - payment-request 뒤 consumer payment actionable
-  - current hold↔charge durable linkage
-  - 모든 delivery-start 경로 PAID gate
-  - invalid charge state side effect 0
-  - hold resolve/held counter timing·race 수렴
-  - 무료/판매자책임 흐름 유지
-- Status: todo_code_financial
 
 ## Phase 1 — ALIGO
 
@@ -120,8 +132,8 @@
 ## Phase 2 — legal·release SHA
 
 ### Task 2.1 — 판매 활성화 legal
-- Dependency: ALIGO 실제 검증 + Task 0.7 + 0.9 + 0.10
-- Required: 주문/환불/재배송/보류 실제 상태머신, PortOne/PG, ALIGO, seller/driver 최소 접근, legal tests
+- Dependency: ALIGO 실제 검증 + Task 0.6 + 0.8 + 0.9
+- Required: 주문/환불/재배송비/보류 실제 상태머신, 개인정보 처리, ALIGO, seller/driver 최소 접근, legal tests
 
 ### Task 2.2 — actual release SHA
 - Dependency: Task 0.3~0.10 + 2.1
@@ -148,14 +160,16 @@
 - rollback dry-run
 - 최종 출시 판정
 - 최종 승인 뒤 `salesMode: round_direct`
-- 전환 smoke → 외부 유입 공개
+- 전환 smoke
+- 외부 유입 공개
 - 첫 두 회차 모니터링 → Closeout
 
 ## 최종 완료 기준
 
 - Task 0A~0H 직접 증거와 함께 `main` 포함.
+- 유료 재배송 payment request가 실제 결제 가능한 상태를 유지하고, 결제 전 모든 배송 시작 경로가 fail-closed.
 - webhook signature valid/invalid real-verifier evidence 포함.
-- payment finalization·재배송·admin refund·권한/개인정보 P0 해결.
+- admin refund·payment finalization·권한/개인정보 P0 해결.
 - Issue #32 완료.
 - ALIGO 승인+실발송/fallback.
 - legal 정합화.

--- a/docs/reports/REPORT_payment_webhook_signature_coverage_20260824.md
+++ b/docs/reports/REPORT_payment_webhook_signature_coverage_20260824.md
@@ -1,0 +1,47 @@
+<!-- Language: ko -->
+
+# REPORT — PortOne webhook signature coverage audit
+
+> 날짜: 2026-08-24 KST
+> 범위: read-only code/test evidence audit
+> 판정 기준: `docs/DOCUMENT_CONSISTENCY.md`
+
+## 판정
+
+- Webhook signature 구현: `IMPLEMENTED`
+- 현재 직접 증거: `PARTIALLY VERIFIED`
+- 출시 위험 분류: P0 `COVERAGE GAP`
+- 구현 결함으로 단정하지 않는다.
+
+## 직접 확인한 구현
+
+- `apps/api/src/main.ts`: Nest `rawBody: true`.
+- `PaymentsController`: raw body와 `webhook-id`, `webhook-timestamp`, `webhook-signature`를 요구하고 검증 실패를 audit에 기록한다.
+- `PortoneClient.verifyWebhookSignature()`: `PORTONE_WEBHOOK_SECRET`, timestamp 허용창, HMAC SHA-256, timing-safe compare를 사용한다.
+
+## 현재 직접 테스트 증거
+
+- missing signature 거부.
+- missing secret 거부.
+- stale timestamp 거부.
+- HTTP E2E에서 webhook header 없는 요청 401.
+- 회차 E2E fixture는 controller webhook 경로를 실행하지만 `verifyWebhookSignature`를 mock한다.
+
+## 미검증 핵심 경로
+
+다음은 금융 상태 변경 인증 경계에 필요한 직접 회귀가 현재 확인되지 않았다.
+
+1. known secret/id/timestamp/raw body로 만든 valid HMAC의 real verifier 성공.
+2. 필수 header를 모두 채운 non-empty invalid HMAC 거부.
+3. 동일 signature에서 raw body 1 byte 변조 거부.
+4. webhook id 변조 거부.
+5. signed timestamp 변조 및 허용창 경계 거부/허용.
+6. actual controller + real verifier 조합에서 invalid request가 `PaymentsService.handleWebhook()`에 도달하지 않음.
+7. invalid request의 주문/payment/orderCharge/capacity side effect 0.
+8. 기존 duplicate webhook 멱등 회귀 유지.
+
+## 문서 정합성 결론
+
+`docs/specs/api/payments.md`의 현재 구현 계약 자체는 유지한다. 이 보고서는 구현 계약을 축약하거나 대체하지 않고, 그 구현이 어느 수준까지 직접 검증됐는지에 대한 evidence만 분리한다.
+
+미완료 작업은 `docs/BACKLOG.md`의 `PAYMENT-WEBHOOK-SIGNATURE-COVERAGE`가 소유하며, 현재 출시 상태 요약은 `docs/memory.md`, 실행 순서는 활성 PLAN/HANDOFF가 소유한다.

--- a/docs/specs/api/payments.md
+++ b/docs/specs/api/payments.md
@@ -2,28 +2,71 @@
 
 # Payments API / Domain Spec
 
-> **최종 정합화**: 2026-08-24 KST
+> **최종 정합화**: 2026-08-24
 > **상태**: Current
 > **공통 타입 정본**: `packages/shared/src/payment.types.ts`
 > **서버 구현 정본**: `apps/api/src/payments/**`
-> **주문 연계**: `docs/specs/api/orders.md`
+> **주문 연계 계약**: `docs/specs/api/orders.md`, `docs/specs/mvp-sales-round-direct-delivery.md`
 
-## 1. 소유권
+## 1. 소유권과 범위
 
-- 결제 검증·최종화·환불·재배송비 결제는 NestJS API가 소유한다.
-- consumer의 PortOne SDK 성공 반환만으로 주문을 확정하지 않는다.
-- 본 결제는 주문 ID를 PortOne `paymentId`로 사용한다.
-- 재배송비는 본 결제와 분리된 `orderCharges`를 사용한다.
-- webhook은 중요한 수렴 경로지만 유일한 수렴 경로가 아니며, 장기 `PENDING` 주문은 scheduler가 PortOne 원격 상태를 재조회한다.
+- 결제 검증·최종화·환불·재배송비 결제 처리는 NestJS API가 소유한다.
+- consumer는 PortOne V2 SDK로 결제 UI를 시작하지만 결제 성공 여부를 클라이언트 반환값만으로 확정하지 않는다.
+- 현재 일반 진입 경로는 PortOne V2 API를 재조회한 뒤 상태·금액에 따라 주문/결제를 수렴시킨다.
+- **주의:** 현재 `main`의 `PaymentFinalizationService.finalizePaidOrder()` 자체는 전달받은 `paymentData.status === 'PAID'`를 독립적으로 재검증하지 않는다. 따라서 이 메서드를 “어떤 호출 경로에서도 비`PAID`를 차단하는 최종 보안 경계”로 문서화하면 안 된다.
+- webhook은 중요한 수렴 경로지만 유일한 수렴 경로가 아니다. 15분 이상 `PENDING` 주문도 scheduler가 PortOne을 재조회해 paid/cancel/확인필요 상태로 수렴시킨다.
+- legacy 본 결제와 회차 직배송 본 결제는 같은 payment finalization 기반을 공유하지만, 회차 주문은 `checkoutReservations`와 용량 반환·재확보 규칙을 추가로 사용한다.
+- 재배송비는 본 결제와 별개의 `orderCharges` 결제로 관리한다.
 
-## 2. 서버 비밀 설정
+## 2. PortOne V2 서버 설정
+
+현재 서버가 사용하는 비밀 설정:
 
 - `PORTONE_V2_SECRET`
 - `PORTONE_WEBHOOK_SECRET`
 
-비밀값 원문은 Git·문서·로그에 기록하지 않는다. 실제 결제수단·채널의 외부 상태는 작업 직전에 PortOne에서 재조회한다.
+client channel/store 설정은 각 frontend 환경의 현재 코드를 따른다. 실제 결제 수단의 계약·심사·활성화 상태는 외부 상태이므로 이 spec에 “현재 승인됨/대기 중”으로 고정하지 않는다. 결제 수단을 변경하는 작업은 PortOne 콘솔과 대상 환경을 직접 재조회한다.
 
-## 3. Webhook 보안 계약
+비밀값 원문은 문서·로그·Git에 기록하지 않는다.
+
+## 3. 본 결제 식별자와 기록
+
+현재 일반 본 결제는 주문 ID를 PortOne `paymentId`로 사용한다.
+
+```text
+orderId == paymentId == payments/{paymentId}.id
+```
+
+결제 성공 후 `payments/{orderId}`에는 다음 핵심 필드가 기록된다.
+
+```ts
+{
+  id: string
+  orderId: string
+  userId: string
+  storeId: string
+  amount: number
+  payMethod: string | null
+  status: 'PAID' | 'CANCELLED' | 'FAILED' | 'PENDING'
+  portonePaymentId: string
+  portoneTransactionId: string
+  refundAmount: number | null
+  refundedAt: Timestamp | null
+  refundReason: string | null
+  refundClaim?: {
+    token: string
+    expiresAt: number
+  } | null
+  createdAt: Timestamp
+  updatedAt: Timestamp
+}
+```
+
+공개 shared `Payment`에는 `refundClaim` 같은 내부 동시성 필드가 포함되지 않는다. Firestore 내부 필드와 공개 DTO를 동일시하지 않는다.
+
+`PENDING` 주문 단계에서는 본 결제 문서가 아직 없을 수 있다. 결제 성공 시 transaction 안에서 `PAID` 문서를 생성한다.
+
+## 4. Webhook 보안 계약
 
 Endpoint:
 
@@ -31,186 +74,318 @@ Endpoint:
 POST /payments/webhook/portone
 ```
 
-JWT는 사용하지 않지만 공개 무인증 endpoint가 아니다.
-
-`PaymentsController`는 다음을 요구한다.
+이 endpoint는 JWT를 사용하지 않지만 인증이 없는 endpoint가 아니다. 서버는 raw body와 다음 PortOne webhook header를 검증한다.
 
 ```text
-raw request body
 webhook-id
 webhook-timestamp
 webhook-signature
 ```
 
-`PortoneClient.verifyWebhookSignature()`의 현재 구현:
+현재 `PortoneClient.verifyWebhookSignature()` 계약:
 
-- `PORTONE_WEBHOOK_SECRET` 없으면 fail-closed
-- raw body 또는 필수 header 누락 시 fail-closed
-- timestamp ±5분 초과 시 거부
-- `webhookId.webhookTimestamp.rawBody`에 HMAC SHA-256 적용
-- `vN,<base64 signature>` 후보를 timing-safe 비교
-- 검증 실패 시 `UnauthorizedException`
-- controller는 invalid signature를 audit에 기록
+- `PORTONE_WEBHOOK_SECRET` 필요
+- raw body 필요
+- header 세 개 모두 필요
+- timestamp 허용 오차: ±5분
+- HMAC SHA-256 signature를 timing-safe 비교
+- 검증 실패 시 `401` 계열 실패
+- invalid signature는 audit에 기록
 
-`apps/api/src/main.ts`는 `NestFactory.create(AppModule, { rawBody: true })`를 사용한다.
+과거 문서의 “웹훅 인증 미적용, IP allowlist 권장만” 설명은 현행 계약이 아니다.
 
-### 검증 상태 — `IMPLEMENTED / PARTIALLY VERIFIED` + P0 `COVERAGE GAP`
+## 5. Webhook 이벤트 처리
 
-구현과 일부 직접 증거는 존재한다.
+`PaymentsService.handleWebhook()`의 현재 흐름:
 
-- `portone.client.spec.ts`: missing signature, missing secret, stale timestamp 거부
-- `mvp-sales-round.e2e-spec.ts`: webhook header 없는 요청 401
-- 같은 E2E fixture는 `rawBody: true`로 controller를 실제 HTTP 경계에서 실행
+1. `paymentId`가 `order-charge-` prefix이면 재배송비 결제 경로로 분기한다.
+2. 본 결제라면 `orders/{paymentId}`를 조회한다.
+3. `Transaction.Ready`는 상태 변경 없이 무시한다.
+4. `Transaction.Paid`가 아닌 이벤트는 아직 처리 가능한 `PENDING` 주문을 `payment_failed`로 취소·release하는 경로로 보낸다.
+5. `Transaction.Paid`이면 webhook body의 금액을 신뢰하지 않고 `GET /payments/{paymentId}`로 PortOne 원격 결제를 다시 조회한다.
+6. 현재 코드에서는 취소된 주문에 대해서만 원격 `paymentData.status !== 'PAID'`를 명시적으로 차단한 뒤 `PaymentFinalizationService.finalizePaidOrder()`에 전달한다.
 
-그러나 현재 테스트에서 확인되지 않은 핵심 암호학적 양방향 회귀가 있다.
+중복 webhook은 최종화 service의 주문 상태 검사와 transaction으로 멱등 처리한다. “PENDING 아니면 무조건 skip”보다 실제 구현의 `canFinalize()` 조건을 따른다.
 
-- 알려진 raw body/id/timestamp/secret으로 만든 **정상 HMAC signature가 실제 `PortoneClient` verifier를 통과**하는 테스트
-- 필수 header가 모두 존재하지만 **non-empty 잘못된 HMAC signature가 실제 verifier에서 거부**되는 테스트
-- raw body를 1 byte라도 변경하거나 webhook id/timestamp를 바꿨을 때 동일 signature가 거부되는 테스트
-- 실제 controller + real verifier 조합에서 invalid signature가 `PaymentsService.handleWebhook()`에 도달하지 않는 통합 테스트
+## 6. 결제 성공 최종화
 
-현재 회차 E2E fixture의 `PortoneClient.verifyWebhookSignature`는 mock이므로, `v1,contract-signature` 성공은 cryptographic verification 성공 증거가 아니다.
+`PaymentFinalizationService.finalizePaidOrder()`의 현재 구현을 설명한다.
 
-금융 상태를 변경하는 인증 경계이므로 위 핵심 양방향 증거 전에는 webhook signature contract 전체를 `VERIFIED`로 승격하지 않는다.
+### 현재 구현 한계 — provider 상태 최종 방어
 
-추적: `docs/BACKLOG.md`의 `PAYMENT-WEBHOOK-SIGNATURE-COVERAGE`.
+현재 `main`에서 이 메서드는 다음을 자체 검사한다.
 
-## 4. Webhook 이벤트 처리
+- 주문 존재 여부
+- 주문이 `canFinalize()` 가능한 상태인지
+- PortOne 금액과 주문 금액 일치 여부
+- 회차 reservation/capacity 조건
 
-본 결제의 현재 흐름:
+그러나 **전달된 `paymentData.status`가 실제 `PAID`인지 메서드 내부에서 직접 차단하지 않는다.**
 
-1. `paymentId`가 `order-charge-`이면 재배송비 결제로 분기한다.
-2. `Transaction.Ready`는 상태 변경 없이 무시한다.
-3. 그 외 non-`Paid` 이벤트는 아직 `PENDING`인 주문에 대해서만 `payment_failed` 취소/release를 적용한다.
-4. `Transaction.Paid`이면 webhook body의 금액·상태를 최종값으로 신뢰하지 않고 PortOne `GET /payments/{paymentId}`를 재조회한다.
-5. 중복 처리는 주문 상태 검사와 transaction으로 수렴한다.
+현재 일반 호출 경로의 방어는 다음과 같다.
 
-`cancelPendingOrder()`는 fresh order가 `PENDING`일 때만 적용하므로 이미 확정·완료된 주문을 non-paid webhook으로 역전하지 않는다.
+- `cleanupPendingOrders()`는 `paymentData.status === 'PAID'`일 때만 finalization을 호출한다.
+- webhook은 `Transaction.Paid` 이벤트에서 원격 결제를 재조회하지만, `PENDING` 주문에 대해 재조회 결과의 status를 finalization 직전에 다시 강제하지 않는다.
 
-## 5. 본 결제 finalization — P0 구현 finding
+따라서 원하는 불변식은 다음과 같지만, **현재 `main` 구현 완료 사실로 읽으면 안 된다.**
 
-`PaymentFinalizationService.finalizePaidOrder()`는 현재 다음을 검사한다.
+```text
+finalizePaidOrder(paymentData) accepts only paymentData.status === 'PAID'
+```
 
-- 주문 존재/처리 가능 상태
-- provider 금액과 주문 금액
-- 회차 reservation/capacity
+이 방어가 코드와 회귀 테스트로 통합되기 전까지는 `finalizePaidOrder()`를 독립적인 `PAID` 최종 보안 경계로 취급하지 않는다.
 
-그러나 전달된 `paymentData.status === 'PAID'`를 boundary 자체에서 직접 강제하지 않는다.
-
-현재 caller 방어:
-
-- scheduler는 원격 `PAID`일 때만 finalization 호출
-- webhook은 `Transaction.Paid` 이벤트에서 provider 결제를 재조회
-
-하지만 `PENDING` 주문의 webhook 경로에서 재조회 결과의 status를 finalization boundary가 최종 강제하지 않으므로 독립 불변식은 미완료다.
-
-추적: `PAYMENT-FINALIZATION-PAID-GUARD`.
-
-완료 전에는 `finalizePaidOrder()`를 독립적인 PAID 보안 경계로 문서화하지 않는다.
-
-## 6. 금액 검증·정상 확정
+### 금액 검증
 
 ```text
 PortOne payment.amount.total === orders.totalAmount
 ```
 
-불일치 시 audit → provider 환불 시도 → 주문 취소/capacity 반환으로 수렴한다.
+불일치 시:
 
-정상 확정은:
+1. `payment.amount_tampered` audit 기록
+2. PortOne 전액 환불 시도
+3. 주문을 `amount_mismatch` 사유로 `CANCELLED`
+4. 연결된 capacity/reservation 반환
 
-- normal → `ACCEPTED`
-- group → `RECRUITING`
-- `payments/{orderId}` `PAID` 기록
-- 회차 주문 reservation consume
-- 법정 retention record
-- 고객 알림 요청
+클라이언트가 보낸 금액을 최종 검증값으로 사용하지 않는다.
 
-을 수행한다.
+### 정상 결제
 
-## 7. `PENDING` timeout·늦은 결제
+호출자가 실제 `PAID` 결제만 전달했다는 전제 아래 현재 finalization은:
 
-15분 이상 `PENDING` 주문은 scheduler가 provider를 재조회한다.
+- `saleType === 'group'` → `RECRUITING`
+- 그 외 → `ACCEPTED`
+- `payments/{orderId}`를 `PAID`로 기록
+- 법정 보관용 retention record 생성
+- `ORDER_ACCEPTED` 또는 `GROUP_JOINED` 알림 요청
+
+### 회차 주문(`schemaVersion: 2`)
+
+- 정상 `PENDING` 결제는 기존 `checkoutReservation`을 transaction에서 consume한다.
+- reservation이 없으면 정상 결제 최종화를 완료하지 않는다.
+- 주문/결제/capacity가 한 transaction 경계에서 중복 적용되지 않도록 처리한다.
+
+## 7. 15분 `PENDING` 수렴
+
+`PaymentsService.cleanupPendingOrders()`는 매분 실행하며 15분보다 오래된 `PENDING` 주문을 찾는다.
+
+중요: 현재 동작은 **바로 삭제하거나 무조건 취소하지 않는다.**
+
+각 주문마다 PortOne 원격 결제를 먼저 조회한다.
 
 | 원격 결과 | 처리 |
 |---|---|
-| `PAID` | finalization 시도 |
-| 명확한 비결제 상태 | timeout 취소 |
-| `404 PAYMENT_NOT_FOUND` | timeout 취소 |
-| 인증/네트워크/기타 조회 오류 | 상태 추측 없이 `PAYMENT_LOOKUP_FAILED` 운영 이슈 |
+| `PAID` | 정상 finalization 시도 |
+| 명확한 비결제 상태 | `timeout` 취소 |
+| `404 + PAYMENT_NOT_FOUND` | `timeout` 취소 |
+| 인증/네트워크/기타 조회 오류 | 주문 상태를 추측해 취소하지 않고 `PAYMENT_LOOKUP_FAILED` 운영 이슈 기록 |
 
-회차 timeout 뒤 늦은 실제 결제는 capacity 재확보를 시도하고, 실패하면 provider 전액 환불로 수렴한다.
+legacy 비택배 주문은 취소 시 daily cap을 반환하고, `schemaVersion: 2` 회차 주문은 reservation을 `EXPIRED` 처리해 확보량을 반환한다.
 
-## 8. 본 결제 환불 — `VERIFIED`
+## 8. 늦은 결제
 
-`PaymentRefundService`는 refund claim으로 동시/재시도 중복 provider 환불을 차단한다.
+회차 주문에서는 timeout 취소 뒤 실제 PortOne 결제가 늦게 `PAID`로 확인될 수 있다.
 
-직접 테스트가 다음을 고정한다.
+현재 `canFinalize()`은 다음 주문을 다시 수렴 대상으로 허용한다.
 
-- `PAID` 미환불 결제만 claim
-- 동시 호출·완료 후 재시도에서 provider refund 1회
-- 성공 뒤 `CANCELLED` + 환불 금액/시각/사유
-- provider 실패 시 claim 해제 + `AUTO_REFUND_FAILED`
+- `PENDING`
+- `CANCELLED`이면서 `cancelReason === 'timeout'`이고 아직 late-payment refund가 확정되지 않은 주문
 
-이 하위 계약이 `VERIFIED`라는 사실은 admin 강제 환불 전체 lifecycle이 안전하다는 뜻이 아니다. 그 문제는 `ADMIN-FORCE-REFUND-CONSISTENCY`가 소유한다.
+회차(`schemaVersion: 2`) timeout 취소 주문의 늦은 결제 처리:
 
-## 9. 재배송비 charge — 하위 결제 계약 `VERIFIED`
+1. 같은 회차/상품/배송지 한도를 다시 확보하려 시도한다.
+2. 재확보 성공 → 새 reservation을 consume하며 정상 주문으로 최종화한다.
+3. 재확보 실패 → PortOne 전액 환불 후 `latePaymentRefundedAt`과 `CANCELLED` payment 기록으로 수렴한다.
 
-PortOne payment ID:
+따라서 “timeout 뒤 webhook은 무조건 무시” 또는 “timeout 주문은 무조건 삭제”는 잘못된 구현 가정이다.
+
+## 9. 환불
+
+외부에 범용 환불 endpoint를 노출하지 않는다. 주문 취소·운영 예외 등 승인된 서버 흐름이 내부 환불 service를 호출한다.
+
+`PaymentRefundService.refundByOrderId()`의 현재 계약:
+
+1. 주문에 연결된 payment를 찾는다.
+2. `PAID`이면서 아직 환불되지 않은 경우에만 refund claim을 획득한다.
+3. claim TTL은 5분이다.
+4. PortOne `/payments/{paymentId}/cancel`을 호출한다.
+5. 성공 시 payment를 `CANCELLED`, `refundAmount/refundedAt/refundReason` 기록으로 갱신한다.
+6. 법정 분쟁·고객지원 보존 record를 생성한다.
+7. 실패 시 claim을 해제하고 `AUTO_REFUND_FAILED` 운영 이슈를 생성한다.
+
+이미 `CANCELLED`, `refundedAt` 존재, 다른 유효 claim이 존재하는 경우 외부 환불을 중복 호출하지 않는다.
+
+실제 사용자 취소·판매자 취소·공동구매 취소의 상태 허용 범위는 orders lifecycle이 소유한다.
+
+## 10. 재배송비 결제
+
+재배송비는 `payments/{orderId}` 본 결제와 섞지 않고 `orderCharges`로 관리한다.
+
+PortOne payment ID 형식:
 
 ```text
 order-charge-{chargeId}
 ```
 
-지원 type:
+현재 지원 type:
 
 ```text
 REDELIVERY_FEE
 ```
 
-`OrderChargePaymentService`는 현재:
+`OrderChargePaymentService`는 webhook에서 다음을 검증한다.
 
-- charge 존재·`PENDING`
-- `REDELIVERY_FEE`
-- stored payment ID 일치
-- provider 원격 `PAID`
-- 금액 일치
-- order의 current `redeliveryChargeId`, storeId, userId 일치
+- charge 존재
+- 상태가 `PENDING`
+- type이 `REDELIVERY_FEE`
+- 저장된 `portonePaymentId`와 webhook payment ID 일치
+- PortOne 원격 상태 `PAID`
+- 원격 금액과 charge 금액 일치
+- 연결 주문의 `redeliveryChargeId`, `storeId`, `userId` 일치
 
-를 확인한다. 환불 멱등성도 직접 회귀가 있다.
+본 주문 취소 시 paid 재배송비도 별도 refund 경로로 환불할 수 있다. 본 결제와 재배송비 결제를 같은 payment record라고 가정하지 않는다.
 
-그러나 charge 하위 계약 `VERIFIED`를 **결제 전 배송 재개 차단이 보장된다는 의미로 확장하지 않는다.** 재배송 전체 상태머신은 `ORDER-REDELIVERY-PAID-RESUME-GATE`가 소유한다.
+## 10A. 결제 하위 계약 검증 상태
 
-## 10. 현재 금융 P0 요약
+판정 기준은 `docs/DOCUMENT_CONSISTENCY.md`를 따른다.
 
-| 항목 | 판정 |
-|---|---|
-| webhook signature 구현 | 구현됨 |
-| webhook signature 핵심 양방향 회귀 | **P0 COVERAGE GAP** |
-| finalization `PAID` boundary | **P0 IMPLEMENTATION FINDING** |
-| 본 결제 refund claim 멱등성 | `VERIFIED` |
-| 재배송비 charge 결제/환불 | `VERIFIED` |
-| 재배송비 payment→resume 상태머신 | 별도 P0 IMPLEMENTATION FINDING |
-| admin force-refund 전체 lifecycle | 별도 P0 IMPLEMENTATION FINDING |
+### 본 결제 finalization provider 상태 — `IMPLEMENTATION FINDING`
 
-## 11. 검증 진입점
+현재 `finalizePaidOrder()` 내부의 비`PAID` 최종 차단이 없으므로 P0 미해결 상태다. caller 방어와 기존 race/멱등 테스트가 존재하더라도 이 불변식 전체를 `VERIFIED`로 승격하지 않는다.
 
-- `apps/api/src/main.ts`
+추적: `docs/BACKLOG.md`의 `PAYMENT-FINALIZATION-PAID-GUARD`.
+
+### 본 결제 환불 멱등성 — `VERIFIED`
+
+`PaymentRefundService` 구현과 `payments.service.spec.ts`의 직접 회귀가 다음을 함께 보장한다.
+
+- `PAID`이며 미환불인 결제만 refund claim 획득
+- 동시 환불 호출과 완료 뒤 재시도에서 PortOne 외부 환불 1회
+- 성공 뒤 `CANCELLED`/환불 금액·시각 기록
+- provider 실패 시 claim 해제와 `AUTO_REFUND_FAILED` 운영 이슈
+- 법정 분쟁·고객지원 retention 기록에 provider 원문·민감정보를 복제하지 않음
+
+### 재배송비 결제·환불 — `VERIFIED`
+
+`OrderChargePaymentService` 구현과 직접 회귀가 다음을 확인한다.
+
+- `Transaction.Paid`에서 원격 결제를 재조회하고 `PAID` 상태·금액·charge/order 연결 관계 검증
+- 불일치 시 `PENDING` charge를 확정하지 않음
+- 실패 webhook 중복 시 `FAILED`로 한 번 수렴
+- paid 재배송비 환불의 동시 호출·완료 후 재시도에서 PortOne 환불 1회
+- 주문 생성 측에서는 고객 책임 배송 보류, WEATHER 제외, 양수 재배송비, 주문자 소유권을 확인
+
+이 `VERIFIED` 판정은 위 계약 범위에 한정한다. 주문 취소 전체의 상태 허용 범위와 side effect는 orders lifecycle 계약을 별도로 확인한다.
+
+## 11. 현재 조회 API
+
+### Webhook
+
+```text
+POST /payments/webhook/portone
+```
+
+PortOne provider용. JWT 없음, provider signature 검증 필수.
+
+### Payment ID 조회
+
+```text
+GET /payments/:paymentId
+```
+
+`JwtAuthGuard` 적용.
+
+현재 허용:
+
+- payment 소유 사용자
+- admin
+- 같은 store 소속 seller
+
+### Store 주문 결제 조회
+
+```text
+GET /stores/:storeId/orders/:orderId/payment
+```
+
+`JwtAuthGuard` 적용. 현재 service는 admin 또는 해당 store 소속 사용자 역할/소유권을 확인한다.
+
+범용 `POST /refund` 같은 public endpoint는 없다.
+
+## 12. PortOne client 오류 처리
+
+`PortoneClient`는 provider 실패를 `PortoneError(status, type, message)`로 보존한다.
+
+중요한 구분:
+
+- `404 + PAYMENT_NOT_FOUND`: PENDING reconciliation에서 “결제가 존재하지 않음”으로 취급 가능
+- `401`: 인증 실패이며 결제 없음으로 취급하면 안 됨
+- 네트워크/파싱/기타 provider 오류: 결제 상태를 추측하지 않고 확인 필요로 남김
+
+오류 메시지는 진단용으로 정제하며 비밀 인증 header를 로그에 출력하지 않는다.
+
+## 13. 공개 공통 타입
+
+현재 `packages/shared/src/payment.types.ts`:
+
+```ts
+export type PaymentStatus = 'PENDING' | 'PAID' | 'FAILED' | 'CANCELLED'
+export type PayMethod = 'kakaopay' | 'naverpay' | 'card'
+
+export interface Payment {
+  id: string
+  orderId: string
+  userId: string
+  storeId: string
+  amount: number
+  payMethod: PayMethod | null
+  status: PaymentStatus
+  portonePaymentId: string
+  portoneTransactionId: string
+  refundAmount: number | null
+  refundedAt: string | null
+  refundReason: string | null
+  createdAt: string
+  updatedAt: string
+}
+```
+
+주의: provider의 `method.type` 문자열과 shared `PayMethod`의 좁은 union 사이 정규화 범위를 변경할 때는 실제 service와 consumer 사용처를 함께 검토한다. 문서만 보고 provider 문자열을 가정하지 않는다.
+
+## 14. 운영 이슈 연계
+
+결제 계열 주요 운영 이슈:
+
+- `PAYMENT_LOOKUP_FAILED`: timeout reconciliation 중 원격 결제 상태를 신뢰성 있게 조회하지 못함
+- `AUTO_REFUND_FAILED`: 자동 환불 provider 호출 실패
+
+이 이슈가 열려 있으면 상태를 추측하거나 PortOne 콘솔에서 반복 환불하지 않는다. 운영 조치는 `docs/specs/ops/mvp-sales-round-runbook.md`를 따른다.
+
+## 15. 검증 원칙
+
+결제 계약 변경 시 최소 확인:
+
 - `apps/api/src/payments/payments.controller.ts`
-- `apps/api/src/payments/portone.client.ts`
+- `apps/api/src/payments/payments.service.ts`
 - `apps/api/src/payments/payment-finalization.service.ts`
 - `apps/api/src/payments/payment-refund.service.ts`
 - `apps/api/src/payments/order-charge-payment.service.ts`
-- `apps/api/src/payments/*.spec.ts`
-- `apps/api/test/mvp-sales-round*.e2e-spec.ts`
-- `apps/api/test/helpers/mvp-sales-round-fixture.ts`
-- `docs/specs/api/orders.md`
+- `apps/api/src/payments/portone.client.ts`
+- 관련 unit/e2e tests
+- `packages/shared/src/payment.types.ts`
+- 회차 결제면 `docs/specs/mvp-sales-round-direct-delivery.md`
+- 운영 예외면 runbook
 
-금융 P0는 구현 존재만으로 완료 처리하지 않고 정상·거부·동시성·실패 경로의 직접 증거를 요구한다.
+특히 finalization 안전성 변경 시 `PENDING`, `FAILED`, `CANCELLED`, `PAID`, 금액 불일치와 회차/legacy 경로를 각각 회귀 테스트로 확인한다. 문서에 적힌 원하는 불변식을 구현 완료 증거로 대신하지 않는다.
+
+실제 결제·환불은 테스트 문서에 적힌 예시만으로 실행하지 않는다. 대상 환경과 승인 범위를 확인한다.
 
 ## 변경 이력
 
 | 날짜 | 내용 |
 |---|---|
-| 2026-08-24 | webhook signature 구현과 실제 증거를 분리하고 valid/invalid cryptographic path 미검증을 P0 COVERAGE GAP으로 등록 |
-| 2026-08-24 | finalization PAID boundary current gap 정합화 |
-| 2026-08-23 | PortOne V2·환불·재배송비 현행 계약 정합화 |
+| 2026-08-24 | 문서 정합성 기준에 따라 finalization P0, 본 결제 환불, 재배송비 결제·환불의 검증 상태를 분리 |
+| 2026-08-23 | 현재 `main`의 `finalizePaidOrder()`가 provider `PAID` 상태를 자체 차단하지 않는 구현 한계를 명시하고 호출 경로 의존성을 정합화 |
+| 2026-08-23 | webhook 서명, PortOne 재조회, PENDING reconciliation, 늦은 결제 재확보/환불, refund claim, 재배송비 결제에 맞춰 전면 정합화 |
+| 2026-03-27 | PortOne V2 초기 전환 |
+| 2026-03-26 | 초기 payments 설계 초안 |

--- a/docs/specs/api/payments.md
+++ b/docs/specs/api/payments.md
@@ -2,71 +2,28 @@
 
 # Payments API / Domain Spec
 
-> **최종 정합화**: 2026-08-24
+> **최종 정합화**: 2026-08-24 KST
 > **상태**: Current
 > **공통 타입 정본**: `packages/shared/src/payment.types.ts`
 > **서버 구현 정본**: `apps/api/src/payments/**`
-> **주문 연계 계약**: `docs/specs/api/orders.md`, `docs/specs/mvp-sales-round-direct-delivery.md`
+> **주문 연계**: `docs/specs/api/orders.md`
 
-## 1. 소유권과 범위
+## 1. 소유권
 
-- 결제 검증·최종화·환불·재배송비 결제 처리는 NestJS API가 소유한다.
-- consumer는 PortOne V2 SDK로 결제 UI를 시작하지만 결제 성공 여부를 클라이언트 반환값만으로 확정하지 않는다.
-- 현재 일반 진입 경로는 PortOne V2 API를 재조회한 뒤 상태·금액에 따라 주문/결제를 수렴시킨다.
-- **주의:** 현재 `main`의 `PaymentFinalizationService.finalizePaidOrder()` 자체는 전달받은 `paymentData.status === 'PAID'`를 독립적으로 재검증하지 않는다. 따라서 이 메서드를 “어떤 호출 경로에서도 비`PAID`를 차단하는 최종 보안 경계”로 문서화하면 안 된다.
-- webhook은 중요한 수렴 경로지만 유일한 수렴 경로가 아니다. 15분 이상 `PENDING` 주문도 scheduler가 PortOne을 재조회해 paid/cancel/확인필요 상태로 수렴시킨다.
-- legacy 본 결제와 회차 직배송 본 결제는 같은 payment finalization 기반을 공유하지만, 회차 주문은 `checkoutReservations`와 용량 반환·재확보 규칙을 추가로 사용한다.
-- 재배송비는 본 결제와 별개의 `orderCharges` 결제로 관리한다.
+- 결제 검증·최종화·환불·재배송비 결제는 NestJS API가 소유한다.
+- consumer의 PortOne SDK 성공 반환만으로 주문을 확정하지 않는다.
+- 본 결제는 주문 ID를 PortOne `paymentId`로 사용한다.
+- 재배송비는 본 결제와 분리된 `orderCharges`를 사용한다.
+- webhook은 중요한 수렴 경로지만 유일한 수렴 경로가 아니며, 장기 `PENDING` 주문은 scheduler가 PortOne 원격 상태를 재조회한다.
 
-## 2. PortOne V2 서버 설정
-
-현재 서버가 사용하는 비밀 설정:
+## 2. 서버 비밀 설정
 
 - `PORTONE_V2_SECRET`
 - `PORTONE_WEBHOOK_SECRET`
 
-client channel/store 설정은 각 frontend 환경의 현재 코드를 따른다. 실제 결제 수단의 계약·심사·활성화 상태는 외부 상태이므로 이 spec에 “현재 승인됨/대기 중”으로 고정하지 않는다. 결제 수단을 변경하는 작업은 PortOne 콘솔과 대상 환경을 직접 재조회한다.
+비밀값 원문은 Git·문서·로그에 기록하지 않는다. 실제 결제수단·채널의 외부 상태는 작업 직전에 PortOne에서 재조회한다.
 
-비밀값 원문은 문서·로그·Git에 기록하지 않는다.
-
-## 3. 본 결제 식별자와 기록
-
-현재 일반 본 결제는 주문 ID를 PortOne `paymentId`로 사용한다.
-
-```text
-orderId == paymentId == payments/{paymentId}.id
-```
-
-결제 성공 후 `payments/{orderId}`에는 다음 핵심 필드가 기록된다.
-
-```ts
-{
-  id: string
-  orderId: string
-  userId: string
-  storeId: string
-  amount: number
-  payMethod: string | null
-  status: 'PAID' | 'CANCELLED' | 'FAILED' | 'PENDING'
-  portonePaymentId: string
-  portoneTransactionId: string
-  refundAmount: number | null
-  refundedAt: Timestamp | null
-  refundReason: string | null
-  refundClaim?: {
-    token: string
-    expiresAt: number
-  } | null
-  createdAt: Timestamp
-  updatedAt: Timestamp
-}
-```
-
-공개 shared `Payment`에는 `refundClaim` 같은 내부 동시성 필드가 포함되지 않는다. Firestore 내부 필드와 공개 DTO를 동일시하지 않는다.
-
-`PENDING` 주문 단계에서는 본 결제 문서가 아직 없을 수 있다. 결제 성공 시 transaction 안에서 `PAID` 문서를 생성한다.
-
-## 4. Webhook 보안 계약
+## 3. Webhook 보안 계약
 
 Endpoint:
 
@@ -74,318 +31,186 @@ Endpoint:
 POST /payments/webhook/portone
 ```
 
-이 endpoint는 JWT를 사용하지 않지만 인증이 없는 endpoint가 아니다. 서버는 raw body와 다음 PortOne webhook header를 검증한다.
+JWT는 사용하지 않지만 공개 무인증 endpoint가 아니다.
+
+`PaymentsController`는 다음을 요구한다.
 
 ```text
+raw request body
 webhook-id
 webhook-timestamp
 webhook-signature
 ```
 
-현재 `PortoneClient.verifyWebhookSignature()` 계약:
+`PortoneClient.verifyWebhookSignature()`의 현재 구현:
 
-- `PORTONE_WEBHOOK_SECRET` 필요
-- raw body 필요
-- header 세 개 모두 필요
-- timestamp 허용 오차: ±5분
-- HMAC SHA-256 signature를 timing-safe 비교
-- 검증 실패 시 `401` 계열 실패
-- invalid signature는 audit에 기록
+- `PORTONE_WEBHOOK_SECRET` 없으면 fail-closed
+- raw body 또는 필수 header 누락 시 fail-closed
+- timestamp ±5분 초과 시 거부
+- `webhookId.webhookTimestamp.rawBody`에 HMAC SHA-256 적용
+- `vN,<base64 signature>` 후보를 timing-safe 비교
+- 검증 실패 시 `UnauthorizedException`
+- controller는 invalid signature를 audit에 기록
 
-과거 문서의 “웹훅 인증 미적용, IP allowlist 권장만” 설명은 현행 계약이 아니다.
+`apps/api/src/main.ts`는 `NestFactory.create(AppModule, { rawBody: true })`를 사용한다.
 
-## 5. Webhook 이벤트 처리
+### 검증 상태 — `IMPLEMENTED / PARTIALLY VERIFIED` + P0 `COVERAGE GAP`
 
-`PaymentsService.handleWebhook()`의 현재 흐름:
+구현과 일부 직접 증거는 존재한다.
 
-1. `paymentId`가 `order-charge-` prefix이면 재배송비 결제 경로로 분기한다.
-2. 본 결제라면 `orders/{paymentId}`를 조회한다.
-3. `Transaction.Ready`는 상태 변경 없이 무시한다.
-4. `Transaction.Paid`가 아닌 이벤트는 아직 처리 가능한 `PENDING` 주문을 `payment_failed`로 취소·release하는 경로로 보낸다.
-5. `Transaction.Paid`이면 webhook body의 금액을 신뢰하지 않고 `GET /payments/{paymentId}`로 PortOne 원격 결제를 다시 조회한다.
-6. 현재 코드에서는 취소된 주문에 대해서만 원격 `paymentData.status !== 'PAID'`를 명시적으로 차단한 뒤 `PaymentFinalizationService.finalizePaidOrder()`에 전달한다.
+- `portone.client.spec.ts`: missing signature, missing secret, stale timestamp 거부
+- `mvp-sales-round.e2e-spec.ts`: webhook header 없는 요청 401
+- 같은 E2E fixture는 `rawBody: true`로 controller를 실제 HTTP 경계에서 실행
 
-중복 webhook은 최종화 service의 주문 상태 검사와 transaction으로 멱등 처리한다. “PENDING 아니면 무조건 skip”보다 실제 구현의 `canFinalize()` 조건을 따른다.
+그러나 현재 테스트에서 확인되지 않은 핵심 암호학적 양방향 회귀가 있다.
 
-## 6. 결제 성공 최종화
+- 알려진 raw body/id/timestamp/secret으로 만든 **정상 HMAC signature가 실제 `PortoneClient` verifier를 통과**하는 테스트
+- 필수 header가 모두 존재하지만 **non-empty 잘못된 HMAC signature가 실제 verifier에서 거부**되는 테스트
+- raw body를 1 byte라도 변경하거나 webhook id/timestamp를 바꿨을 때 동일 signature가 거부되는 테스트
+- 실제 controller + real verifier 조합에서 invalid signature가 `PaymentsService.handleWebhook()`에 도달하지 않는 통합 테스트
 
-`PaymentFinalizationService.finalizePaidOrder()`의 현재 구현을 설명한다.
+현재 회차 E2E fixture의 `PortoneClient.verifyWebhookSignature`는 mock이므로, `v1,contract-signature` 성공은 cryptographic verification 성공 증거가 아니다.
 
-### 현재 구현 한계 — provider 상태 최종 방어
+금융 상태를 변경하는 인증 경계이므로 위 핵심 양방향 증거 전에는 webhook signature contract 전체를 `VERIFIED`로 승격하지 않는다.
 
-현재 `main`에서 이 메서드는 다음을 자체 검사한다.
+추적: `docs/BACKLOG.md`의 `PAYMENT-WEBHOOK-SIGNATURE-COVERAGE`.
 
-- 주문 존재 여부
-- 주문이 `canFinalize()` 가능한 상태인지
-- PortOne 금액과 주문 금액 일치 여부
-- 회차 reservation/capacity 조건
+## 4. Webhook 이벤트 처리
 
-그러나 **전달된 `paymentData.status`가 실제 `PAID`인지 메서드 내부에서 직접 차단하지 않는다.**
+본 결제의 현재 흐름:
 
-현재 일반 호출 경로의 방어는 다음과 같다.
+1. `paymentId`가 `order-charge-`이면 재배송비 결제로 분기한다.
+2. `Transaction.Ready`는 상태 변경 없이 무시한다.
+3. 그 외 non-`Paid` 이벤트는 아직 `PENDING`인 주문에 대해서만 `payment_failed` 취소/release를 적용한다.
+4. `Transaction.Paid`이면 webhook body의 금액·상태를 최종값으로 신뢰하지 않고 PortOne `GET /payments/{paymentId}`를 재조회한다.
+5. 중복 처리는 주문 상태 검사와 transaction으로 수렴한다.
 
-- `cleanupPendingOrders()`는 `paymentData.status === 'PAID'`일 때만 finalization을 호출한다.
-- webhook은 `Transaction.Paid` 이벤트에서 원격 결제를 재조회하지만, `PENDING` 주문에 대해 재조회 결과의 status를 finalization 직전에 다시 강제하지 않는다.
+`cancelPendingOrder()`는 fresh order가 `PENDING`일 때만 적용하므로 이미 확정·완료된 주문을 non-paid webhook으로 역전하지 않는다.
 
-따라서 원하는 불변식은 다음과 같지만, **현재 `main` 구현 완료 사실로 읽으면 안 된다.**
+## 5. 본 결제 finalization — P0 구현 finding
 
-```text
-finalizePaidOrder(paymentData) accepts only paymentData.status === 'PAID'
-```
+`PaymentFinalizationService.finalizePaidOrder()`는 현재 다음을 검사한다.
 
-이 방어가 코드와 회귀 테스트로 통합되기 전까지는 `finalizePaidOrder()`를 독립적인 `PAID` 최종 보안 경계로 취급하지 않는다.
+- 주문 존재/처리 가능 상태
+- provider 금액과 주문 금액
+- 회차 reservation/capacity
 
-### 금액 검증
+그러나 전달된 `paymentData.status === 'PAID'`를 boundary 자체에서 직접 강제하지 않는다.
+
+현재 caller 방어:
+
+- scheduler는 원격 `PAID`일 때만 finalization 호출
+- webhook은 `Transaction.Paid` 이벤트에서 provider 결제를 재조회
+
+하지만 `PENDING` 주문의 webhook 경로에서 재조회 결과의 status를 finalization boundary가 최종 강제하지 않으므로 독립 불변식은 미완료다.
+
+추적: `PAYMENT-FINALIZATION-PAID-GUARD`.
+
+완료 전에는 `finalizePaidOrder()`를 독립적인 PAID 보안 경계로 문서화하지 않는다.
+
+## 6. 금액 검증·정상 확정
 
 ```text
 PortOne payment.amount.total === orders.totalAmount
 ```
 
-불일치 시:
+불일치 시 audit → provider 환불 시도 → 주문 취소/capacity 반환으로 수렴한다.
 
-1. `payment.amount_tampered` audit 기록
-2. PortOne 전액 환불 시도
-3. 주문을 `amount_mismatch` 사유로 `CANCELLED`
-4. 연결된 capacity/reservation 반환
+정상 확정은:
 
-클라이언트가 보낸 금액을 최종 검증값으로 사용하지 않는다.
+- normal → `ACCEPTED`
+- group → `RECRUITING`
+- `payments/{orderId}` `PAID` 기록
+- 회차 주문 reservation consume
+- 법정 retention record
+- 고객 알림 요청
 
-### 정상 결제
+을 수행한다.
 
-호출자가 실제 `PAID` 결제만 전달했다는 전제 아래 현재 finalization은:
+## 7. `PENDING` timeout·늦은 결제
 
-- `saleType === 'group'` → `RECRUITING`
-- 그 외 → `ACCEPTED`
-- `payments/{orderId}`를 `PAID`로 기록
-- 법정 보관용 retention record 생성
-- `ORDER_ACCEPTED` 또는 `GROUP_JOINED` 알림 요청
-
-### 회차 주문(`schemaVersion: 2`)
-
-- 정상 `PENDING` 결제는 기존 `checkoutReservation`을 transaction에서 consume한다.
-- reservation이 없으면 정상 결제 최종화를 완료하지 않는다.
-- 주문/결제/capacity가 한 transaction 경계에서 중복 적용되지 않도록 처리한다.
-
-## 7. 15분 `PENDING` 수렴
-
-`PaymentsService.cleanupPendingOrders()`는 매분 실행하며 15분보다 오래된 `PENDING` 주문을 찾는다.
-
-중요: 현재 동작은 **바로 삭제하거나 무조건 취소하지 않는다.**
-
-각 주문마다 PortOne 원격 결제를 먼저 조회한다.
+15분 이상 `PENDING` 주문은 scheduler가 provider를 재조회한다.
 
 | 원격 결과 | 처리 |
 |---|---|
-| `PAID` | 정상 finalization 시도 |
-| 명확한 비결제 상태 | `timeout` 취소 |
-| `404 + PAYMENT_NOT_FOUND` | `timeout` 취소 |
-| 인증/네트워크/기타 조회 오류 | 주문 상태를 추측해 취소하지 않고 `PAYMENT_LOOKUP_FAILED` 운영 이슈 기록 |
+| `PAID` | finalization 시도 |
+| 명확한 비결제 상태 | timeout 취소 |
+| `404 PAYMENT_NOT_FOUND` | timeout 취소 |
+| 인증/네트워크/기타 조회 오류 | 상태 추측 없이 `PAYMENT_LOOKUP_FAILED` 운영 이슈 |
 
-legacy 비택배 주문은 취소 시 daily cap을 반환하고, `schemaVersion: 2` 회차 주문은 reservation을 `EXPIRED` 처리해 확보량을 반환한다.
+회차 timeout 뒤 늦은 실제 결제는 capacity 재확보를 시도하고, 실패하면 provider 전액 환불로 수렴한다.
 
-## 8. 늦은 결제
+## 8. 본 결제 환불 — `VERIFIED`
 
-회차 주문에서는 timeout 취소 뒤 실제 PortOne 결제가 늦게 `PAID`로 확인될 수 있다.
+`PaymentRefundService`는 refund claim으로 동시/재시도 중복 provider 환불을 차단한다.
 
-현재 `canFinalize()`은 다음 주문을 다시 수렴 대상으로 허용한다.
+직접 테스트가 다음을 고정한다.
 
-- `PENDING`
-- `CANCELLED`이면서 `cancelReason === 'timeout'`이고 아직 late-payment refund가 확정되지 않은 주문
+- `PAID` 미환불 결제만 claim
+- 동시 호출·완료 후 재시도에서 provider refund 1회
+- 성공 뒤 `CANCELLED` + 환불 금액/시각/사유
+- provider 실패 시 claim 해제 + `AUTO_REFUND_FAILED`
 
-회차(`schemaVersion: 2`) timeout 취소 주문의 늦은 결제 처리:
+이 하위 계약이 `VERIFIED`라는 사실은 admin 강제 환불 전체 lifecycle이 안전하다는 뜻이 아니다. 그 문제는 `ADMIN-FORCE-REFUND-CONSISTENCY`가 소유한다.
 
-1. 같은 회차/상품/배송지 한도를 다시 확보하려 시도한다.
-2. 재확보 성공 → 새 reservation을 consume하며 정상 주문으로 최종화한다.
-3. 재확보 실패 → PortOne 전액 환불 후 `latePaymentRefundedAt`과 `CANCELLED` payment 기록으로 수렴한다.
+## 9. 재배송비 charge — 하위 결제 계약 `VERIFIED`
 
-따라서 “timeout 뒤 webhook은 무조건 무시” 또는 “timeout 주문은 무조건 삭제”는 잘못된 구현 가정이다.
-
-## 9. 환불
-
-외부에 범용 환불 endpoint를 노출하지 않는다. 주문 취소·운영 예외 등 승인된 서버 흐름이 내부 환불 service를 호출한다.
-
-`PaymentRefundService.refundByOrderId()`의 현재 계약:
-
-1. 주문에 연결된 payment를 찾는다.
-2. `PAID`이면서 아직 환불되지 않은 경우에만 refund claim을 획득한다.
-3. claim TTL은 5분이다.
-4. PortOne `/payments/{paymentId}/cancel`을 호출한다.
-5. 성공 시 payment를 `CANCELLED`, `refundAmount/refundedAt/refundReason` 기록으로 갱신한다.
-6. 법정 분쟁·고객지원 보존 record를 생성한다.
-7. 실패 시 claim을 해제하고 `AUTO_REFUND_FAILED` 운영 이슈를 생성한다.
-
-이미 `CANCELLED`, `refundedAt` 존재, 다른 유효 claim이 존재하는 경우 외부 환불을 중복 호출하지 않는다.
-
-실제 사용자 취소·판매자 취소·공동구매 취소의 상태 허용 범위는 orders lifecycle이 소유한다.
-
-## 10. 재배송비 결제
-
-재배송비는 `payments/{orderId}` 본 결제와 섞지 않고 `orderCharges`로 관리한다.
-
-PortOne payment ID 형식:
+PortOne payment ID:
 
 ```text
 order-charge-{chargeId}
 ```
 
-현재 지원 type:
+지원 type:
 
 ```text
 REDELIVERY_FEE
 ```
 
-`OrderChargePaymentService`는 webhook에서 다음을 검증한다.
+`OrderChargePaymentService`는 현재:
 
-- charge 존재
-- 상태가 `PENDING`
-- type이 `REDELIVERY_FEE`
-- 저장된 `portonePaymentId`와 webhook payment ID 일치
-- PortOne 원격 상태 `PAID`
-- 원격 금액과 charge 금액 일치
-- 연결 주문의 `redeliveryChargeId`, `storeId`, `userId` 일치
+- charge 존재·`PENDING`
+- `REDELIVERY_FEE`
+- stored payment ID 일치
+- provider 원격 `PAID`
+- 금액 일치
+- order의 current `redeliveryChargeId`, storeId, userId 일치
 
-본 주문 취소 시 paid 재배송비도 별도 refund 경로로 환불할 수 있다. 본 결제와 재배송비 결제를 같은 payment record라고 가정하지 않는다.
+를 확인한다. 환불 멱등성도 직접 회귀가 있다.
 
-## 10A. 결제 하위 계약 검증 상태
+그러나 charge 하위 계약 `VERIFIED`를 **결제 전 배송 재개 차단이 보장된다는 의미로 확장하지 않는다.** 재배송 전체 상태머신은 `ORDER-REDELIVERY-PAID-RESUME-GATE`가 소유한다.
 
-판정 기준은 `docs/DOCUMENT_CONSISTENCY.md`를 따른다.
+## 10. 현재 금융 P0 요약
 
-### 본 결제 finalization provider 상태 — `IMPLEMENTATION FINDING`
+| 항목 | 판정 |
+|---|---|
+| webhook signature 구현 | 구현됨 |
+| webhook signature 핵심 양방향 회귀 | **P0 COVERAGE GAP** |
+| finalization `PAID` boundary | **P0 IMPLEMENTATION FINDING** |
+| 본 결제 refund claim 멱등성 | `VERIFIED` |
+| 재배송비 charge 결제/환불 | `VERIFIED` |
+| 재배송비 payment→resume 상태머신 | 별도 P0 IMPLEMENTATION FINDING |
+| admin force-refund 전체 lifecycle | 별도 P0 IMPLEMENTATION FINDING |
 
-현재 `finalizePaidOrder()` 내부의 비`PAID` 최종 차단이 없으므로 P0 미해결 상태다. caller 방어와 기존 race/멱등 테스트가 존재하더라도 이 불변식 전체를 `VERIFIED`로 승격하지 않는다.
+## 11. 검증 진입점
 
-추적: `docs/BACKLOG.md`의 `PAYMENT-FINALIZATION-PAID-GUARD`.
-
-### 본 결제 환불 멱등성 — `VERIFIED`
-
-`PaymentRefundService` 구현과 `payments.service.spec.ts`의 직접 회귀가 다음을 함께 보장한다.
-
-- `PAID`이며 미환불인 결제만 refund claim 획득
-- 동시 환불 호출과 완료 뒤 재시도에서 PortOne 외부 환불 1회
-- 성공 뒤 `CANCELLED`/환불 금액·시각 기록
-- provider 실패 시 claim 해제와 `AUTO_REFUND_FAILED` 운영 이슈
-- 법정 분쟁·고객지원 retention 기록에 provider 원문·민감정보를 복제하지 않음
-
-### 재배송비 결제·환불 — `VERIFIED`
-
-`OrderChargePaymentService` 구현과 직접 회귀가 다음을 확인한다.
-
-- `Transaction.Paid`에서 원격 결제를 재조회하고 `PAID` 상태·금액·charge/order 연결 관계 검증
-- 불일치 시 `PENDING` charge를 확정하지 않음
-- 실패 webhook 중복 시 `FAILED`로 한 번 수렴
-- paid 재배송비 환불의 동시 호출·완료 후 재시도에서 PortOne 환불 1회
-- 주문 생성 측에서는 고객 책임 배송 보류, WEATHER 제외, 양수 재배송비, 주문자 소유권을 확인
-
-이 `VERIFIED` 판정은 위 계약 범위에 한정한다. 주문 취소 전체의 상태 허용 범위와 side effect는 orders lifecycle 계약을 별도로 확인한다.
-
-## 11. 현재 조회 API
-
-### Webhook
-
-```text
-POST /payments/webhook/portone
-```
-
-PortOne provider용. JWT 없음, provider signature 검증 필수.
-
-### Payment ID 조회
-
-```text
-GET /payments/:paymentId
-```
-
-`JwtAuthGuard` 적용.
-
-현재 허용:
-
-- payment 소유 사용자
-- admin
-- 같은 store 소속 seller
-
-### Store 주문 결제 조회
-
-```text
-GET /stores/:storeId/orders/:orderId/payment
-```
-
-`JwtAuthGuard` 적용. 현재 service는 admin 또는 해당 store 소속 사용자 역할/소유권을 확인한다.
-
-범용 `POST /refund` 같은 public endpoint는 없다.
-
-## 12. PortOne client 오류 처리
-
-`PortoneClient`는 provider 실패를 `PortoneError(status, type, message)`로 보존한다.
-
-중요한 구분:
-
-- `404 + PAYMENT_NOT_FOUND`: PENDING reconciliation에서 “결제가 존재하지 않음”으로 취급 가능
-- `401`: 인증 실패이며 결제 없음으로 취급하면 안 됨
-- 네트워크/파싱/기타 provider 오류: 결제 상태를 추측하지 않고 확인 필요로 남김
-
-오류 메시지는 진단용으로 정제하며 비밀 인증 header를 로그에 출력하지 않는다.
-
-## 13. 공개 공통 타입
-
-현재 `packages/shared/src/payment.types.ts`:
-
-```ts
-export type PaymentStatus = 'PENDING' | 'PAID' | 'FAILED' | 'CANCELLED'
-export type PayMethod = 'kakaopay' | 'naverpay' | 'card'
-
-export interface Payment {
-  id: string
-  orderId: string
-  userId: string
-  storeId: string
-  amount: number
-  payMethod: PayMethod | null
-  status: PaymentStatus
-  portonePaymentId: string
-  portoneTransactionId: string
-  refundAmount: number | null
-  refundedAt: string | null
-  refundReason: string | null
-  createdAt: string
-  updatedAt: string
-}
-```
-
-주의: provider의 `method.type` 문자열과 shared `PayMethod`의 좁은 union 사이 정규화 범위를 변경할 때는 실제 service와 consumer 사용처를 함께 검토한다. 문서만 보고 provider 문자열을 가정하지 않는다.
-
-## 14. 운영 이슈 연계
-
-결제 계열 주요 운영 이슈:
-
-- `PAYMENT_LOOKUP_FAILED`: timeout reconciliation 중 원격 결제 상태를 신뢰성 있게 조회하지 못함
-- `AUTO_REFUND_FAILED`: 자동 환불 provider 호출 실패
-
-이 이슈가 열려 있으면 상태를 추측하거나 PortOne 콘솔에서 반복 환불하지 않는다. 운영 조치는 `docs/specs/ops/mvp-sales-round-runbook.md`를 따른다.
-
-## 15. 검증 원칙
-
-결제 계약 변경 시 최소 확인:
-
+- `apps/api/src/main.ts`
 - `apps/api/src/payments/payments.controller.ts`
-- `apps/api/src/payments/payments.service.ts`
+- `apps/api/src/payments/portone.client.ts`
 - `apps/api/src/payments/payment-finalization.service.ts`
 - `apps/api/src/payments/payment-refund.service.ts`
 - `apps/api/src/payments/order-charge-payment.service.ts`
-- `apps/api/src/payments/portone.client.ts`
-- 관련 unit/e2e tests
-- `packages/shared/src/payment.types.ts`
-- 회차 결제면 `docs/specs/mvp-sales-round-direct-delivery.md`
-- 운영 예외면 runbook
+- `apps/api/src/payments/*.spec.ts`
+- `apps/api/test/mvp-sales-round*.e2e-spec.ts`
+- `apps/api/test/helpers/mvp-sales-round-fixture.ts`
+- `docs/specs/api/orders.md`
 
-특히 finalization 안전성 변경 시 `PENDING`, `FAILED`, `CANCELLED`, `PAID`, 금액 불일치와 회차/legacy 경로를 각각 회귀 테스트로 확인한다. 문서에 적힌 원하는 불변식을 구현 완료 증거로 대신하지 않는다.
-
-실제 결제·환불은 테스트 문서에 적힌 예시만으로 실행하지 않는다. 대상 환경과 승인 범위를 확인한다.
+금융 P0는 구현 존재만으로 완료 처리하지 않고 정상·거부·동시성·실패 경로의 직접 증거를 요구한다.
 
 ## 변경 이력
 
 | 날짜 | 내용 |
 |---|---|
-| 2026-08-24 | 문서 정합성 기준에 따라 finalization P0, 본 결제 환불, 재배송비 결제·환불의 검증 상태를 분리 |
-| 2026-08-23 | 현재 `main`의 `finalizePaidOrder()`가 provider `PAID` 상태를 자체 차단하지 않는 구현 한계를 명시하고 호출 경로 의존성을 정합화 |
-| 2026-08-23 | webhook 서명, PortOne 재조회, PENDING reconciliation, 늦은 결제 재확보/환불, refund claim, 재배송비 결제에 맞춰 전면 정합화 |
-| 2026-03-27 | PortOne V2 초기 전환 |
-| 2026-03-26 | 초기 payments 설계 초안 |
+| 2026-08-24 | webhook signature 구현과 실제 증거를 분리하고 valid/invalid cryptographic path 미검증을 P0 COVERAGE GAP으로 등록 |
+| 2026-08-24 | finalization PAID boundary current gap 정합화 |
+| 2026-08-23 | PortOne V2·환불·재배송비 현행 계약 정합화 |


### PR DESCRIPTION
## 변경
- PortOne webhook signature 구현과 검증 증거를 분리해 `PAYMENT-WEBHOOK-SIGNATURE-COVERAGE` P0 `COVERAGE GAP` 등록
- 구현 결함으로 오판하지 않고 real verifier의 cryptographic positive/negative path를 release 증거로 요구
- `docs/specs/api/payments.md`의 기존 Current 계약은 그대로 보존
- 상세 증거는 `docs/reports/REPORT_payment_webhook_signature_coverage_20260824.md`로 분리
- Backlog → memory → 활성 PLAN/HANDOFF에 필요한 상태·의존성만 최소 전파
- 기존 재배송 상태머신 P0의 상세 Acceptance Criteria와 최우선 재개 순서는 유지
- 활성 PLAN의 상태를 ALIGO 전체 pause로 오해하지 않도록 `active_p0_parallel / aligo_external_review_pending`으로 명확화

## 직접 근거
- production bootstrap: `rawBody: true`
- controller: raw body + webhook-id/timestamp/signature 필수, invalid signature audit
- verifier: ±5분 timestamp, HMAC SHA-256, timing-safe compare
- unit: missing signature/secret, stale timestamp 거부
- HTTP E2E: header 없는 webhook 401
- 회차 E2E fixture의 `verifyWebhookSignature`는 mock
- real verifier의 valid HMAC 성공 / non-empty invalid HMAC 거부 / body-id-timestamp mutation 거부가 직접 고정되지 않음

## 판정
- webhook signature 구현: `IMPLEMENTED`
- 핵심 양방향 cryptographic evidence: `PARTIALLY VERIFIED`
- 출시 위험: P0 `COVERAGE GAP`
- 구현 결함으로 단정하지 않음

## 완료 방향
- known valid HMAC success
- non-empty invalid HMAC rejection
- raw body/id/timestamp mutation rejection
- controller + real verifier integration에서 invalid request가 service에 도달하지 않음
- invalid request side effect 0
- duplicate webhook 멱등 회귀 유지

## 범위
- docs-only
- 코드/provider/production/운영 데이터 변경 없음