### PR TITLE
docs: PROJECT_MAP 정합성 판정 계층 수정

### DIFF
--- a/docs/PROJECT_MAP.md
+++ b/docs/PROJECT_MAP.md
@@ -11,6 +11,7 @@ Task를 시작할 때 필요한 문서만 연다.
 | 현재 Git 상태·활성 작업·외부 차단 요인 | `docs/memory.md` |
 | 저장소 영역·Context 경로 | 이 문서 |
 | 문서 전체 분류 | `docs/README.md` |
+| 문서 정합성 판정 | `docs/DOCUMENT_CONSISTENCY.md` |
 | API 계약 | `docs/specs/api/README.md` → 직접 관련 current spec |
 | Frontend 계약/역사 계획 구분 | `docs/specs/frontend/README.md` |
 | Ops 계약 | `docs/specs/ops/README.md` |
@@ -22,7 +23,7 @@ Task를 시작할 때 필요한 문서만 연다.
 | 장애 해결 이력 | `docs/TROUBLESHOOTING.md` |
 | 환경·배포 URL | `docs/URLS.md` + 필요 시 외부 재검증 |
 
-동작 계약이 충돌하면 현재 `main`의 코드·설정·테스트를 기준으로 current spec을 고친다. 운영·작업 상태가 충돌하면 직접 재검증 결과 → `docs/memory.md` → 활성 HANDOFF·PLAN → 역사 자료 순으로 판정한다.
+동작 계약이 충돌하면 `docs/DOCUMENT_CONSISTENCY.md`의 Spec·Code·Test 판정을 적용한다. 현재 `main` 코드가 current spec 또는 안전 계약과 어긋나면 문서를 코드에 맞춰 조용히 고치지 않고 `IMPLEMENTATION FINDING` 여부를 판단한다. 운영·작업 상태가 충돌하면 직접 재검증 결과 → `docs/memory.md` → 활성 HANDOFF·PLAN → 역사 자료 순으로 판정한다.
 
 ## 2. 구조 기준선
 


### PR DESCRIPTION
## 문제
`docs/PROJECT_MAP.md`가 동작 계약 충돌 시 현재 코드·설정·테스트를 기준으로 current spec을 고친다고 적고 있어, `docs/DOCUMENT_CONSISTENCY.md`의 핵심 원칙과 충돌했다.

금전·권한·개인정보·운영 안전 계약에서는 코드가 current spec을 위반한 implementation finding일 수 있으므로 코드에 문서를 자동 정렬하면 안 된다.

## 변경
- `docs/DOCUMENT_CONSISTENCY.md`를 PROJECT_MAP의 정본 라우팅에 명시
- Spec·Code·Test 판정 적용을 명확화
- 코드와 current spec/안전 계약 충돌 시 `IMPLEMENTATION FINDING` 여부를 먼저 판단하도록 수정

## 범위
- docs-only
- 진행 상태/코드/배포/provider 변경 없음