### PR TITLE
docs: Auth/Admin P0 검증 정합화

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -127,6 +127,42 @@ admin refund가 정상 cancellation의 추가 charge·capacity·held counter·se
 
 정본: `docs/specs/api/admin.md`, `docs/specs/api/settlements.md`.
 
+### P0 — ADMIN-PRIVILEGED-MUTATION-COVERAGE
+
+`AdminController` class-level `JwtAuthGuard + RolesGuard + @Roles('admin')`와 고위험 mutation 구현은 존재하지만 서버 authorization 및 admin settlement 지급 상태 전이의 직접 회귀가 충분하지 않다.
+
+현재 직접 근거:
+
+- [x] admin controller 전체에 JWT + admin role guard 구현
+- [x] `RolesGuard`는 request JWT role과 required metadata를 비교
+- [x] `AdminService.markAsPaid()`는 transaction에서 fresh settlement status를 재확인하고 `confirmed → paid`를 구현
+- [x] Playwright admin 테스트는 비로그인 UI redirect와 admin read smoke를 확인
+- [x] 현재 `apps/api/src/admin`에 전용 controller/service `*.spec.ts` 없음
+- [x] 확인한 API E2E에서 admin high-impact mutation의 direct role-denial coverage 없음
+
+판정:
+
+- admin guard 및 mutation 구현은 `IMPLEMENTED`.
+- privileged mutation authorization + settlement pay transition은 `UNVERIFIED`.
+- 권한·금전 상태 경계이므로 P0 `COVERAGE GAP`으로 둔다.
+
+남음:
+
+- [ ] 실제 HTTP admin mutation의 unauthenticated 401
+- [ ] consumer/seller/driver의 admin mutation 403
+- [ ] invalid role에서 service 호출·Firestore/payment side effect 0
+- [ ] admin 정상 요청은 service validation/허용 경계까지 도달
+- [ ] `markAsPaid`: missing settlement 거부
+- [ ] `markAsPaid`: `pending|cancelled|paid` 거부
+- [ ] `markAsPaid`: `confirmed → paid` 정상 성공 + timestamps
+- [ ] 동시 지급/race에서 transaction fresh-read 기준 한 번만 수렴
+- [ ] 실제 guard를 mock으로 우회하지 않는 controller/API integration 증거
+- [ ] 회귀 SHA `main` 통합
+
+`ADMIN-FORCE-REFUND-CONSISTENCY`의 lifecycle 구현 결함과는 별도다. force-refund 구현을 고쳤더라도 admin role boundary와 다른 privileged mutation coverage가 없으면 이 항목은 닫히지 않는다.
+
+정본: `docs/specs/api/admin.md`, `docs/specs/api/settlements.md`; 증거: `docs/reports/REPORT_auth_orders_admin_verification_audit_20260824.md`.
+
 ### P0 — ORDER-DIRECT-READ-AUTHORIZATION-AND-MINIMIZATION
 
 API authorization보다 seller/driver raw Firestore read 경계가 넓다.
@@ -142,18 +178,33 @@ API authorization보다 seller/driver raw Firestore read 경계가 넓다.
 
 ### P0 — AUTH-DRIVER-APPROVAL-AND-SESSION-REVOCATION
 
-신규/legacy driver 자동 승인 경로와 stale session/claims 수렴 문제가 있다.
+관리자 승인 전 driver 권한을 얻을 수 있는 복수 경로와 stale session/claims 수렴 문제가 있다.
 
-- [ ] 신규/legacy 로그인 side-effect 자동 승인 제거
+현재 확인된 approval bypass:
+
+- [x] 신규 Kakao `targetRole: driver`가 `driverApproved: true`로 즉시 생성됨
+- [x] 기존 `driverApproved === undefined` driver가 Kakao 로그인 중 자동 승인됨
+- [x] 공개 `POST /auth/register`가 `role: driver`를 허용하고 seller와 달리 invite/approval gate 없이 driver user 생성 가능
+- [x] 공개 `POST /auth/login`이 `driverApproved` 확인 없이 저장된 `role: driver`로 JWT 발급
+- [x] Firebase custom token은 현재 JWT role/storeId claim을 사용
+
+이 P0는 `ORDER-DIRECT-READ-AUTHORIZATION-AND-MINIMIZATION`과 결합해서 완료 판단한다. broad driver Firestore read가 남아 있는 동안 self-issued/stale driver claim의 영향이 커질 수 있다.
+
+남음:
+
+- [ ] 공개 registration이 관리자 승인 전 usable driver authorization을 만들지 못함
+- [ ] email login이 미승인 driver에게 driver JWT를 발급하지 않음
+- [ ] 미승인 driver의 Firebase driver claim 발급 거부
+- [ ] 신규/legacy Kakao 로그인 side-effect 자동 승인 제거
 - [ ] 과거 계정 migration 별도 감사 절차
-- [ ] 승인 전/후 앱·API·Firebase 회귀
+- [ ] admin 승인 전/후 email/Kakao 앱·API·Firebase 직접 회귀
 - [ ] suspension/role/store/approval revocation SLA 결정
 - [ ] refresh/current claims authoritative state 검증
 - [ ] Firebase stale claims 재발급 차단
 - [ ] logout/rotation 포함 회귀
 - [ ] `main` 통합
 
-정본: `docs/specs/api/auth.md`.
+정본: `docs/specs/api/auth.md`; 증거: `docs/reports/REPORT_auth_orders_admin_verification_audit_20260824.md`.
 
 ### P0 — ORDER-MUTATION-AUTHORIZATION-COVERAGE
 
@@ -216,6 +267,7 @@ repo-side production auto-deploy 차단은 완료. GitHub 관리자 레벨 보�
 - [ ] `PAYMENT-WEBHOOK-SIGNATURE-COVERAGE`
 - [ ] `ORDER-REDELIVERY-PAID-RESUME-GATE`
 - [ ] `ADMIN-FORCE-REFUND-CONSISTENCY`
+- [ ] `ADMIN-PRIVILEGED-MUTATION-COVERAGE`
 - [ ] `ORDER-DIRECT-READ-AUTHORIZATION-AND-MINIMIZATION`
 - [ ] `AUTH-DRIVER-APPROVAL-AND-SESSION-REVOCATION`
 - [ ] `ORDER-MUTATION-AUTHORIZATION-COVERAGE`

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -34,46 +34,64 @@
 
 ## 현재 확인된 출시 P0
 
-### 1. 재배송비 결제·재개 상태머신
+### 1. Driver 승인·세션 권한 — 최우선 security coupling
+
+관리자 승인 전 driver 권한을 얻을 수 없어야 하지만 현재 세 경로가 확인됐다.
+
+- 공개 email `POST /auth/register`가 `role: driver`를 허용하고 승인 gate 없이 driver user 생성 가능.
+- 공개 `POST /auth/login`은 `driverApproved`를 확인하지 않고 `role=driver` JWT 발급.
+- Kakao는 신규 driver를 `driverApproved: true`로 만들고 legacy 승인 필드 누락 driver도 로그인 중 자동 승인.
+
+refresh/Firebase custom claims는 authoritative user 상태를 재검증하지 않는 stale authorization 문제도 있다.
+
+**관리자 승인 gate = P0 IMPLEMENTATION FINDING**, suspension/role/store/approval revocation = **P0 DECISION REQUIRED + remediation**.
+
+이 P0는 broad driver Firestore read가 남아 있는 `ORDER-DIRECT-READ-AUTHORIZATION-AND-MINIMIZATION`과 결합 위험이 크므로 우선 함께 닫는다.
+
+정본: `docs/specs/api/auth.md`; 증거: `docs/reports/REPORT_auth_orders_admin_verification_audit_20260824.md`.
+
+### 2. 주문 direct Firestore read·개인정보 최소화
+
+API driver read는 배정 경계가 있고 직접 테스트로 `VERIFIED`지만 current Rules는 driver role에 broad order read를 허용하며 seller/driver frontend는 raw document를 사용한다.
+
+**시스템 전체 driver read authorization + seller/driver data minimization = P0 IMPLEMENTATION FINDING**.
+
+API query authorization 자체는 `VERIFIED`를 유지하며 direct Firestore 경계와 혼동하지 않는다.
+
+### 3. 재배송비 결제·재개 상태머신
 
 운영 계약은 고객 책임 유료 재배송에서 `결제 전 재배송 금지`를 요구한다.
 
-2026-08-24 추가 감사에서 다음 두 우회/불일치가 확인됐다.
+2026-08-24 감사에서 다음 두 우회/불일치가 확인됐다.
 
 - driver `DELIVERY_HELD → DELIVERING`: charge `PAID` 확인 없음 + UI `배송 재개` 항상 노출.
-- seller `DELIVERY_HELD → PREPARING`: 고객 책임+양수 재배송비에서도 현재 테스트가 정상 성공으로 고정하며 hold를 해소하고 held counter를 줄임. 이 전환이 `ORDER_REDELIVERY_PAYMENT_REQUESTED` 알림을 만들지만 charge 생성 API와 consumer 결제 UI는 `status === DELIVERY_HELD`를 요구하므로 전환 뒤 결제가 불가능해진다. 이후 `PREPARING → DELIVERING`도 과거 미결제 hold를 확인하지 않는다.
+- seller `DELIVERY_HELD → PREPARING`: 고객 책임+양수 재배송비에서도 성공하며 hold를 해소하지만, charge 생성 API와 consumer 결제 UI는 `status === DELIVERY_HELD`를 요구해 payment-request 뒤 결제 dead-end가 가능하다. 이후 `PREPARING → DELIVERING`도 과거 미결제 hold를 확인하지 않는다.
 
-따라서 **`ORDER-REDELIVERY-PAID-RESUME-GATE`는 단순 PAID guard가 아니라 P0 재배송 상태머신 `IMPLEMENTATION FINDING`**이다.
-
-완료 시 payment-required 상태는 결제 전 사라지지 않아야 하며, payment-request 알림 뒤 consumer 결제가 실제 가능해야 하고, `HELD→DELIVERING` 및 `HELD→PREPARING→DELIVERING` 등 모든 배송 시작 경로가 동일 PAID gate를 통과해야 한다.
+따라서 **`ORDER-REDELIVERY-PAID-RESUME-GATE` = P0 재배송 상태머신 `IMPLEMENTATION FINDING`**이다.
 
 정본: `docs/specs/api/orders.md`, `docs/BACKLOG.md`, 운영 근거 `docs/specs/ops/mvp-sales-round-runbook.md`.
 
-### 2. 관리자 강제 환불 lifecycle
+### 4. 관리자 강제 환불 lifecycle
 
 admin refund는 본 결제 환불 뒤 주문을 직접 `CANCELLED` write하며 정상 cancellation의 추가 charge·reservation/capacity·held counter·settlement 후속효과를 재사용하지 않는다.
 
 **`ADMIN-FORCE-REFUND-CONSISTENCY` = P0 IMPLEMENTATION FINDING**.
 
-### 3. Driver 승인·세션 권한
+### 5. Admin privileged mutation coverage
 
-신규/legacy driver 자동 승인 경로와 refresh/Firebase stale claims 수렴 문제가 있다.
+`AdminController`의 JWT + admin role guard와 `markAsPaid()` transaction 구현은 존재한다. 그러나 admin 전용 server unit/API E2E가 없고 현재 Playwright admin 테스트는 UI redirect/read smoke 중심이라 high-impact mutation의 non-admin 직접 거부·side-effect 0 및 settlement 지급 상태/race를 직접 고정하지 않는다.
 
-**관리자 승인 gate = P0 IMPLEMENTATION FINDING**, suspension/role/store/approval revocation = **P0 DECISION REQUIRED + remediation**.
+**`ADMIN-PRIVILEGED-MUTATION-COVERAGE` = IMPLEMENTED / UNVERIFIED + P0 COVERAGE GAP**.
 
-### 4. 주문 direct Firestore read·개인정보 최소화
+정본: `docs/specs/api/admin.md`, `docs/specs/api/settlements.md`; 증거: `docs/reports/REPORT_auth_orders_admin_verification_audit_20260824.md`.
 
-API driver read는 배정 경계가 있으나 current Rules는 driver role에 broad order read를 허용하며 seller/driver frontend는 raw document를 사용한다.
-
-**시스템 전체 driver read authorization + seller/driver data minimization = P0 IMPLEMENTATION FINDING**.
-
-### 5. 결제 finalization provider 상태 방어
+### 6. 결제 finalization provider 상태 방어
 
 `finalizePaidOrder()` boundary가 비`PAID` provider 입력을 자체 차단하지 않는다.
 
-**`PAYMENT-FINALIZATION-PAID-GUARD` = P0**.
+**`PAYMENT-FINALIZATION-PAID-GUARD` = P0 IMPLEMENTATION FINDING**.
 
-### 6. PortOne webhook signature 검증 coverage
+### 7. PortOne webhook signature 검증 coverage
 
 webhook signature 구현은 raw body + id/timestamp/signature, timestamp ±5분, HMAC SHA-256 timing-safe 검증을 사용한다. 그러나 현재 회차 E2E의 signature verifier는 mock이며 real verifier의 valid HMAC 성공·non-empty invalid HMAC 거부·body/id/timestamp 변조 거부를 직접 고정한 증거가 부족하다.
 
@@ -81,13 +99,13 @@ webhook signature 구현은 raw body + id/timestamp/signature, timestamp ±5분,
 
 정본: `docs/specs/api/payments.md`; 증거: `docs/reports/REPORT_payment_webhook_signature_coverage_20260824.md`.
 
-### 7. 주문 mutation authorization 회귀
+### 8. 주문 mutation authorization 회귀
 
 ownership guard는 구현돼 있으나 타-store seller·비담당 driver·first-claim 외 action과 거부 side-effect 0 직접 회귀가 부족하다.
 
 **`ORDER-MUTATION-AUTHORIZATION-COVERAGE` = IMPLEMENTED / UNVERIFIED + P0 COVERAGE GAP**.
 
-### 8. GitHub main protection
+### 9. GitHub main protection
 
 repo-side 배포 방어는 완료. GitHub 관리자 레벨 PR required/required check/force-push·delete 차단은 Issue #32가 남아 있다.
 
@@ -136,10 +154,11 @@ repo-side 배포 방어는 완료. GitHub 관리자 레벨 PR required/required 
 
 ## 다음 작업
 
-1. `ORDER-REDELIVERY-PAID-RESUME-GATE`를 **상태머신 전체** 기준으로 구현·직접 회귀·`main` 통합.
-2. `PAYMENT-WEBHOOK-SIGNATURE-COVERAGE`를 포함한 나머지 P0를 ALIGO 심사와 병렬 해결.
-3. Issue #32.
-4. ALIGO 상태 재조회 → 승인 뒤 실제 알림톡/SMS fallback.
-5. P0 결과 기준 legal 재정합화.
-6. actual release SHA → E2E 52+cleanup → Firebase 재조회 → 승인된 production 설정/배포.
-7. 첫 회차 검수 → 최종 승인 → `salesMode: round_direct`.
+1. `AUTH-DRIVER-APPROVAL-AND-SESSION-REVOCATION` + `ORDER-DIRECT-READ-AUTHORIZATION-AND-MINIMIZATION` 결합 위험을 최우선으로 해결·직접 회귀·`main` 통합.
+2. `ORDER-REDELIVERY-PAID-RESUME-GATE` 상태머신 전체 구현·직접 회귀.
+3. `ADMIN-PRIVILEGED-MUTATION-COVERAGE`, webhook coverage, payment finalization, admin refund, order mutation 등 나머지 P0를 ALIGO 심사와 병렬 해결.
+4. Issue #32.
+5. ALIGO 상태 재조회 → 승인 뒤 실제 알림톡/SMS fallback.
+6. P0 결과 기준 legal 재정합화.
+7. actual release SHA → E2E 52+cleanup → Firebase 재조회 → 승인된 production 설정/배포.
+8. 첫 회차 검수 → 최종 승인 → `salesMode: round_direct`.

--- a/docs/plans/HANDOFF_mvp_round_direct_aligo_review_pause.md
+++ b/docs/plans/HANDOFF_mvp_round_direct_aligo_review_pause.md
@@ -17,16 +17,43 @@
 
 병렬 출시 P0:
 
-1. `ORDER-REDELIVERY-PAID-RESUME-GATE`
-2. `AUTH-DRIVER-APPROVAL-AND-SESSION-REVOCATION`
-3. `ORDER-DIRECT-READ-AUTHORIZATION-AND-MINIMIZATION`
+1. `AUTH-DRIVER-APPROVAL-AND-SESSION-REVOCATION`
+2. `ORDER-DIRECT-READ-AUTHORIZATION-AND-MINIMIZATION`
+3. `ORDER-REDELIVERY-PAID-RESUME-GATE`
 4. `PAYMENT-FINALIZATION-PAID-GUARD`
 5. `ORDER-MUTATION-AUTHORIZATION-COVERAGE`
 6. `ADMIN-FORCE-REFUND-CONSISTENCY`
-7. `PAYMENT-WEBHOOK-SIGNATURE-COVERAGE`
-8. Issue #32
+7. `ADMIN-PRIVILEGED-MUTATION-COVERAGE`
+8. `PAYMENT-WEBHOOK-SIGNATURE-COVERAGE`
+9. Issue #32
 
-## 최우선 재개 — 재배송비 상태머신
+## 최우선 재개 — Driver 승인 + direct read 결합 위험
+
+운영 불변식은 **관리자 승인 전 driver 권한을 얻을 수 없고, driver가 필요한 최소 주문만 접근한다**는 것이다.
+
+2026-08-24 감사에서 Kakao 자동승인 외에 공개 email 경로를 추가 확인했다.
+
+- `POST /auth/register`는 `role: driver`를 허용한다.
+- seller와 달리 driver registration에는 invite/approval gate가 없다.
+- `POST /auth/login`은 `driverApproved`를 확인하지 않고 저장된 `role=driver`로 JWT를 발급한다.
+- 신규 Kakao driver도 `driverApproved: true`로 생성되고 legacy 승인 필드 누락 driver도 로그인 중 자동 승인된다.
+- Firebase custom token은 현재 JWT role/storeId를 claims로 사용한다.
+- 동시에 current Firestore Rules에는 broad driver order read P0가 남아 있다.
+
+따라서 frontend에서 일반 driver credentials UI를 숨기는 것만으로 해결되지 않는다. **API authorization boundary + Firebase claim + Rules read 경계를 함께 fail-closed**해야 한다.
+
+완료 시 반드시:
+
+- public registration이 승인 전 usable driver authorization을 만들지 않고,
+- 미승인 email/Kakao driver가 driver JWT/Firebase claim을 얻지 못하며,
+- login side-effect 자동 승인이 제거되고,
+- refresh/custom-token이 authoritative approval/role/store 상태로 수렴하며,
+- driver direct Firestore read가 필요한 최소 대상·필드로 제한되고,
+- 승인 전/후 API/Firebase/Rules 직접 회귀가 존재해야 한다.
+
+정본: `docs/specs/api/auth.md`, `docs/specs/api/orders.md`, `docs/BACKLOG.md`.
+
+## 다음 핵심 재개 — 재배송비 상태머신
 
 운영 불변식은 **고객 책임 유료 재배송비를 결제하기 전에 실제 배송을 다시 시작하지 않는다**는 것이다.
 
@@ -59,12 +86,11 @@
 
 ## 나머지 P0 포인터
 
-- Driver 승인·session revocation: `docs/specs/api/auth.md`
-- Order direct read·minimization: `docs/specs/api/orders.md`, legal gate
 - Payment finalization: `docs/specs/api/payments.md`
 - Payment webhook signature coverage: `docs/specs/api/payments.md`, `docs/reports/REPORT_payment_webhook_signature_coverage_20260824.md`
 - Order mutation authorization: `docs/specs/api/orders.md`
 - Admin force-refund: `docs/specs/api/admin.md`, `docs/specs/api/settlements.md`
+- Admin privileged mutation coverage: `docs/specs/api/admin.md`, `docs/specs/api/settlements.md`, `docs/reports/REPORT_auth_orders_admin_verification_audit_20260824.md`
 - GitHub main protection: Issue #32 / deployment safety plan
 
 ## 지금 하지 말 것
@@ -75,30 +101,31 @@
 - direct `main`
 - main merge를 production 승인으로 해석
 - 승인 없는 production/Firebase/운영 회차/`salesMode`
-- P0를 UI·legal 문구만으로 정상화
+- P0를 frontend 버튼 숨김·UI redirect·legal 문구만으로 정상화
 - P0 전 actual release SHA 확정
 
 ## 병렬 가능 작업
 
-1. 재배송 payment-request/hold-resolution/resume 상태머신 구현·회귀
-2. driver 승인/session revocation
-3. order direct read 최소화
+1. driver public register/login + Kakao approval gate + refresh/custom claims
+2. order direct read 최소화/Rules 회귀
+3. 재배송 payment-request/hold-resolution/resume 상태머신 구현·회귀
 4. payment finalization PAID boundary
 5. order mutation 거부 회귀
 6. admin force-refund lifecycle
-7. webhook signature real-verifier 회귀
-8. Issue #32
-9. read-only 문서/코드 감사
-10. ALIGO 상태 조회
+7. admin privileged mutation + settlement pay 직접 회귀
+8. webhook signature real-verifier 회귀
+9. Issue #32
+10. read-only 문서/코드 감사
+11. ALIGO 상태 조회
 
 ## ALIGO 승인 뒤
 
-1. P0 7개 + Issue #32 완료 확인
+1. P0 8개 + Issue #32 완료 확인
 2. ALIGO 8종 상태 재확인
 3. provider code 1:1 검사
 4. 승인 후 격리 알림톡
 5. 승인 후 SMS fallback
-6. 실제 재배송/환불/read-minimization 기준 legal 재정합화
+6. 실제 재배송/환불/read-minimization/auth 결과 기준 legal 재정합화
 7. actual release SHA
 8. exact SHA E2E 52+cleanup
 9. 운영 Firebase read-only
@@ -115,12 +142,13 @@
 - [x] ALIGO sender profile/senderkey
 - [x] 8종 등록·심사 요청
 - [x] repo-side main auto-production 차단
-- [ ] 재배송 payment-required 상태머신 + 직접 회귀 + main
-- [ ] driver 승인/session revocation
+- [ ] driver approval/session revocation + public register/login gate
 - [ ] order direct read 최소화
+- [ ] 재배송 payment-required 상태머신 + 직접 회귀 + main
 - [ ] payment finalization PAID
 - [ ] order mutation coverage
 - [ ] admin force-refund
+- [ ] admin privileged mutation + settlement pay coverage
 - [ ] webhook signature real-verifier coverage
 - [ ] Issue #32
 - [ ] ALIGO 8종 승인

--- a/docs/plans/PLAN_mvp_round_direct_launch_blockers.md
+++ b/docs/plans/PLAN_mvp_round_direct_launch_blockers.md
@@ -18,13 +18,14 @@
 | ID | 게이트 | 상태 |
 |---|---|---|
 | 0A | GitHub `main` protection/ruleset | 미완료 — Issue #32 |
-| 0B | payment finalization 비`PAID` 차단 | 미완료 — P0 |
+| 0B | payment finalization 비`PAID` 차단 | 미완료 — P0 FINDING |
 | 0C | order mutation authorization 직접 거부 회귀 | 미완료 — P0 GAP |
 | 0D | order direct Firestore read·최소화 | 미완료 — P0 FINDING |
 | 0E | driver 승인 + session/claims revocation | 미완료 — P0 FINDING/DECISION |
 | 0F | admin force-refund lifecycle | 미완료 — P0 FINDING |
 | 0G | 유료 재배송 payment-request/hold-resolution/resume 상태머신 | 미완료 — P0 FINDING |
 | 0H | payment webhook real-signature coverage | 미완료 — P0 COVERAGE GAP |
+| 0I | admin privileged mutation authorization + settlement pay coverage | 미완료 — P0 COVERAGE GAP |
 | 1 | ALIGO 8종 최종 승인 | 검수중 |
 | 2 | 실제 알림톡 | 미실행 |
 | 3 | SMS fallback | 미실행 |
@@ -40,15 +41,17 @@
 
 1. repository 변경은 최신 `main` 기반 branch+PR.
 2. direct `main` 금지.
-3. 0A~0H는 ALIGO 심사와 병렬 가능.
+3. 0A~0I는 ALIGO 심사와 병렬 가능.
 4. P0를 문서/UI 변경만으로 완료 처리하지 않는다.
-5. 금전·권한 불변식은 server boundary + 직접 거부/정상 회귀가 필요하다.
-6. webhook auth는 mock E2E만으로 `VERIFIED` 처리하지 않고 real verifier의 valid/invalid 양방향 증거가 필요하다.
-7. actual release SHA는 0A~0H + legal 해결 뒤 고정한다.
-8. exact SHA E2E 52+cleanup 전 production 금지.
-9. production은 exact SHA/artifact + 별도 승인.
-10. provider metadata SHA 불일치 시 traffic 전환 금지.
-11. 첫 회차 `SCHEDULED` 전 `salesMode` 전환 금지.
+5. 금전·권한 불변식은 server boundary + 직접 거부/정상/동시성 회귀가 필요하다.
+6. driver 관리자 승인 계약은 public register/login, Kakao, refresh, Firebase claims까지 하나의 authorization lifecycle로 검증한다.
+7. admin role boundary는 UI redirect만으로 `VERIFIED` 처리하지 않는다.
+8. webhook auth는 mock E2E만으로 `VERIFIED` 처리하지 않고 real verifier의 valid/invalid 양방향 증거가 필요하다.
+9. actual release SHA는 0A~0I + legal 해결 뒤 고정한다.
+10. exact SHA E2E 52+cleanup 전 production 금지.
+11. production은 exact SHA/artifact + 별도 승인.
+12. provider metadata SHA 불일치 시 traffic 전환 금지.
+13. 첫 회차 `SCHEDULED` 전 `salesMode` 전환 금지.
 
 ## Phase 0 — 코드·권한·금전 안전성
 
@@ -77,7 +80,17 @@
 
 ### Task 0.7 — Driver approval·session revocation
 - Backlog: `AUTH-DRIVER-APPROVAL-AND-SESSION-REVOCATION`
-- Coupling: Task 0.6
+- Priority: highest security coupling with Task 0.6
+- Current bypasses:
+  - public email `register(role=driver) → login` can issue driver JWT without approval
+  - new Kakao driver auto-approved
+  - legacy missing approval flag auto-approved during login
+  - refresh/custom-token can preserve stale authorization claims
+- Required:
+  - public registration cannot create usable driver authorization pre-approval
+  - unapproved email/Kakao driver cannot receive driver JWT/Firebase claim
+  - login-side automatic approval removed
+  - authoritative refresh/claim revocation policy + direct pre/post approval tests
 - Status: todo_code_security
 
 ### Task 0.8 — Admin force-refund lifecycle
@@ -122,6 +135,20 @@
   - duplicate webhook 멱등 회귀 유지
 - Status: todo_test_security
 
+### Task 0.11 — Admin privileged mutation coverage
+- Backlog: `ADMIN-PRIVILEGED-MUTATION-COVERAGE`
+- Contract: `docs/specs/api/admin.md`, `docs/specs/api/settlements.md`
+- Evidence: `docs/reports/REPORT_auth_orders_admin_verification_audit_20260824.md`
+- Goal: admin role server boundary와 settlement 지급 금전 상태 전이를 직접 검증
+- Required:
+  - unauthenticated admin mutation 401
+  - consumer/seller/driver admin mutation 403 + side effect 0
+  - admin happy path/service validation 도달
+  - settlement missing/invalid states 거부, `confirmed → paid` 성공
+  - transaction fresh-read + concurrent pay 한 번만 수렴
+  - 실제 guard를 mock으로 우회하지 않는 integration 증거
+- Status: todo_test_security_financial
+
 ## Phase 1 — ALIGO
 
 1. 8종 승인 (`blocked_external_review`)
@@ -132,11 +159,11 @@
 ## Phase 2 — legal·release SHA
 
 ### Task 2.1 — 판매 활성화 legal
-- Dependency: ALIGO 실제 검증 + Task 0.6 + 0.8 + 0.9
+- Dependency: ALIGO 실제 검증 + Task 0.6 + 0.7 + 0.8 + 0.9
 - Required: 주문/환불/재배송비/보류 실제 상태머신, 개인정보 처리, ALIGO, seller/driver 최소 접근, legal tests
 
 ### Task 2.2 — actual release SHA
-- Dependency: Task 0.3~0.10 + 2.1
+- Dependency: Task 0.3~0.11 + 2.1
 
 ### Task 2.3 — exact SHA E2E
 - Goal: chromium 26 + mobile 26 = 52, cleanup success
@@ -166,9 +193,12 @@
 
 ## 최종 완료 기준
 
-- Task 0A~0H 직접 증거와 함께 `main` 포함.
+- Task 0A~0I 직접 증거와 함께 `main` 포함.
+- 승인 전 public email/Kakao driver authorization과 stale Firebase claims 우회 해결.
+- driver 권한과 order direct-read 최소화가 결합 위험 없이 fail-closed.
 - 유료 재배송 payment request가 실제 결제 가능한 상태를 유지하고, 결제 전 모든 배송 시작 경로가 fail-closed.
 - webhook signature valid/invalid real-verifier evidence 포함.
+- admin privileged mutation role boundary + settlement pay 직접 증거 포함.
 - admin refund·payment finalization·권한/개인정보 P0 해결.
 - Issue #32 완료.
 - ALIGO 승인+실발송/fallback.

--- a/docs/reports/REPORT_auth_orders_admin_verification_audit_20260824.md
+++ b/docs/reports/REPORT_auth_orders_admin_verification_audit_20260824.md
@@ -1,0 +1,142 @@
+<!-- Language: ko -->
+
+# REPORT — Auth / Orders / Admin 검증 정합성 감사
+
+> 날짜: 2026-08-24 KST
+> 기준 `main`: `abde4dea6cd0d63ce89a66e2d9d293e1f7fea0bf`
+> 범위: `auth.md` → `orders.md` → `admin.md` Spec·Code·Test 삼각 검증
+> 판정 기준: `docs/DOCUMENT_CONSISTENCY.md`
+
+## 요약 판정
+
+| 영역 | 판정 | 결과 |
+|---|---|---|
+| Auth driver approval | P0 `IMPLEMENTATION FINDING` 범위 확대 | 공개 email register/login 우회 추가 확인 |
+| Orders API query authorization | `VERIFIED` 유지 | consumer/seller/driver/admin 직접 정상·거부 회귀 존재 |
+| Orders mutation authorization | 기존 P0 `COVERAGE GAP` 유지 | 이번 감사에서 새 판정 없음 |
+| Orders direct Firestore read | 기존 P0 `IMPLEMENTATION FINDING` 유지 | 이번 감사에서 새 판정 없음 |
+| Admin server privileged mutations | `IMPLEMENTED / UNVERIFIED` + P0 `COVERAGE GAP` | 실제 guard 구현은 있으나 직접 서버 거부 회귀 부족 |
+| Admin settlement `confirmed → paid` | `IMPLEMENTED / UNVERIFIED` + P0 `COVERAGE GAP` | transaction 구현은 있으나 직접 상태/race 회귀 미확인 |
+| Admin force-refund lifecycle | 기존 P0 `IMPLEMENTATION FINDING` 유지 | 별도 remediation 항목 유지 |
+
+## 1. Auth — driver 관리자 승인 우회 범위 확대
+
+의도된 계약은 **관리자 승인 전 driver 권한을 얻을 수 없어야 한다**는 것이다.
+
+기존 감사에서 Kakao 경로 두 개가 이미 확인돼 있었다.
+
+1. 신규 Kakao `targetRole: driver`가 `driverApproved: true`로 즉시 생성됨.
+2. 기존 driver의 `driverApproved === undefined`가 로그인 side effect로 `true`가 됨.
+
+이번 감사에서 별도의 공개 email 경로를 추가 확인했다.
+
+- `RegisterDto.role`은 `consumer | seller | driver`를 허용한다.
+- `POST /auth/register`는 공개 endpoint다.
+- `AuthService.register()`는 seller에만 invite gate를 적용하며 driver는 `role: driver`로 바로 생성할 수 있다.
+- 이 email driver 문서에는 `driverApproved: true`가 필요하지 않다.
+- `POST /auth/login`도 공개 endpoint다.
+- `AuthService.login()`은 password와 `suspended`를 확인한 뒤 `driverApproved`를 확인하지 않고 저장된 `role`로 JWT를 발급한다.
+- `GET /auth/firebase-token`은 현재 JWT의 `role/storeId`를 Firebase custom claims로 전달한다.
+
+따라서 **익명 사용자가 공개 register→login 경로로 관리자 승인 없이 `role=driver` API JWT를 획득할 수 있는 구현 경로**가 존재한다.
+
+이 문제는 `ORDER-DIRECT-READ-AUTHORIZATION-AND-MINIMIZATION`과 결합 위험이 있다. 현재 broad driver Firestore read가 남아 있으므로 self-issued driver 권한이 Firebase custom claim까지 이어지면 개인정보/주문 접근 위험이 확대될 수 있다.
+
+판정:
+
+- 기존 `AUTH-DRIVER-APPROVAL-AND-SESSION-REVOCATION`의 **driver approval P0 `IMPLEMENTATION FINDING` 범위를 email register/login까지 확대**한다.
+- 새 P0 ID를 별도로 만들지 않는다.
+- stale refresh/custom claims 문제는 같은 umbrella 아래 기존 `DECISION REQUIRED + remediation`을 유지한다.
+
+현재 직접 테스트는 Kakao identity·role mismatch·suspended login 일부를 고정하지만, `register(role=driver) → login` 승인 전 거부를 고정하지 않는다.
+
+## 2. Orders — API query `VERIFIED` 유지
+
+`OrdersQueryService`와 `orders-query.service.spec.ts`를 대조했다.
+
+직접 회귀가 다음을 고정한다.
+
+- consumer 목록은 요청 필터 위조와 무관하게 자기 주문만 반환.
+- consumer는 타 소비자 주문 상세 거부.
+- seller는 소유하지 않은 store 목록·상세 거부.
+- driver는 배정 주문만 목록·상세 허용, 비배정 상세 거부.
+- admin은 store 주문 목록 허용.
+- storeId 없는 상세에서도 seller ownership과 driver assignment를 검증.
+- 완료 주문 delivery photo URL도 authorization 뒤 생성하며 실패 시 공개 URL로 우회하지 않음.
+
+따라서 `docs/specs/api/orders.md`의 **API 조회 authorization = `VERIFIED`** 판정은 과대보장이 아니며 유지한다.
+
+단, 이 판정은 API service 경계에 한정한다. raw Firestore direct read P0와 mutation authorization coverage P0를 덮지 않는다.
+
+## 3. Admin — privileged mutation coverage gap
+
+`AdminController`에는 class-level로 다음이 구현돼 있다.
+
+```text
+JwtAuthGuard
+RolesGuard
+@Roles('admin')
+```
+
+또한 `RolesGuard`는 handler/class metadata의 role과 request JWT role을 비교한다.
+
+그러나 현재 `apps/api/src/admin`에는 controller/service 전용 `*.spec.ts`가 없고, API E2E에도 admin mutation을 직접 다루는 전용 spec을 확인하지 못했다.
+
+Playwright admin 테스트는 다음 정도를 확인한다.
+
+- 비로그인 admin UI가 로그인으로 redirect.
+- admin 세션에서 admin store 화면 렌더.
+- 운영 DB 보호를 위해 archive/restore 같은 mutation은 실제 호출하지 않음.
+
+따라서 UI route redirect를 NestJS admin API role boundary의 직접 증거로 확장하지 않는다.
+
+고위험 admin mutation 예:
+
+- 주문 강제 환불
+- settlement 지급 처리
+- 사용자/driver 정지·driver 승인
+- store commission/archive/restore
+
+판정:
+
+- server admin guard **구현은 존재**한다.
+- high-impact mutation의 unauthenticated/non-admin 직접 거부와 side-effect 0은 **`IMPLEMENTED / UNVERIFIED` + P0 `COVERAGE GAP`**으로 둔다.
+- 별도 추적 ID: `ADMIN-PRIVILEGED-MUTATION-COVERAGE`.
+
+## 4. Admin settlement 지급 처리
+
+`AdminService.markAsPaid()`는 transaction 안에서 fresh settlement를 다시 읽고:
+
+- missing → 거부
+- 이미 `paid` → 거부
+- `confirmed` 외 → 거부
+- `confirmed` → `paid`
+- `paidAt`, `updatedAt` 기록
+
+을 구현한다.
+
+하지만 admin/settlements 전용 service test가 없고 seller settlements Playwright는 UI 날짜·탭 smoke 중심이라 위 금전 상태 전이를 직접 고정하지 않는다.
+
+따라서 **코드 구현을 `VERIFIED`로 승격하지 않는다.** `ADMIN-PRIVILEGED-MUTATION-COVERAGE` 완료 시 최소 다음을 직접 고정한다.
+
+- missing settlement 거부
+- `pending|cancelled|paid` 거부
+- `confirmed → paid` 정상 성공
+- transaction 재조회/race에서 한 번만 수렴
+- invalid role/invalid state side effect 0
+- 실제 controller guard와 service 조합에서 admin만 mutation 도달
+
+## 5. 문서 전파 원칙
+
+- Auth 기술 계약: `docs/specs/api/auth.md`
+- Admin 권한·mutation 계약: `docs/specs/api/admin.md`
+- Admin settlement 금전 상태 계약: `docs/specs/api/settlements.md`
+- 미완료 Acceptance Criteria: `docs/BACKLOG.md`
+- 현재 출시 상태: `docs/memory.md`
+- 실행 순서/재개 지점: 활성 PLAN/HANDOFF
+
+Orders의 이미 검증된 API query 계약은 변경하지 않는다. 검증된 항목을 새 finding 때문에 함께 낮추는 것은 정합성 원칙에 맞지 않는다.
+
+## 범위 경계
+
+이번 감사에서 코드, 테스트, Firebase Rules, provider, production, 운영 데이터는 변경하지 않았다.

--- a/docs/specs/api/admin.md
+++ b/docs/specs/api/admin.md
@@ -27,6 +27,16 @@ seller 앱의 admin UI도 세션 role을 추가로 확인하지만 API 권한의
 
 admin role을 어떤 운영 절차로 부여하는지는 계정 보안 정책이다. 과거 문서의 “Firestore 콘솔에서 직접 role을 바꾸는 것이 유일한 정식 방법”을 현행 운영 지침으로 사용하지 않는다. 실제 관리자 권한 부여는 별도 승인된 관리 절차로 수행한다.
 
+### 검증 상태 — privileged mutation boundary
+
+위 class-level guard **구현은 존재**한다. 그러나 2026-08-24 감사에서 `apps/api/src/admin`에 controller/service 전용 `*.spec.ts`가 없고, 현재 확인한 API E2E도 admin mutation의 unauthenticated/non-admin 거부와 side-effect 0을 직접 고정하지 않는 것을 확인했다.
+
+현재 Playwright admin 테스트는 비로그인 admin UI redirect와 admin 화면 read smoke 중심이며 운영 DB 보호를 위해 archive/restore 같은 mutation을 실제 수행하지 않는다. 이 UI 증거를 NestJS admin API role boundary 전체의 직접 검증으로 확장하지 않는다.
+
+따라서 고위험 admin mutation authorization은 **`IMPLEMENTED / UNVERIFIED` + P0 `COVERAGE GAP`**으로 둔다.
+
+추적: `docs/BACKLOG.md`의 `ADMIN-PRIVILEGED-MUTATION-COVERAGE`; 증거: `docs/reports/REPORT_auth_orders_admin_verification_audit_20260824.md`.
+
 ## 2. 접근 URL
 
 UI 진입점:
@@ -109,7 +119,7 @@ PATCH /admin/users/:userId/status
 
 현재 신규 로그인은 suspended 사용자를 거부하지만, **기존 세션의 refresh·JWT·Firebase custom claims가 언제 무효화되는지는 별도 auth P0**다. `suspended: true` write 성공만으로 기존 세션이 즉시 차단됐다고 기록하지 않는다.
 
-정본: `docs/specs/api/auth.md`의 `AUTH-SESSION-CLAIM-REVOCATION`.
+정본: `docs/specs/api/auth.md`의 `AUTH-DRIVER-APPROVAL-AND-SESSION-REVOCATION`.
 
 ## 5. 주문 관리
 
@@ -201,12 +211,28 @@ GET /admin/settlements?storeId=<storeId>&from=<date>&to=<date>
 PATCH /admin/settlements/:settlementId/pay
 ```
 
+현재 구현:
+
 - `confirmed`만 `paid`로 전환
 - 이미 `paid`면 거부
+- `confirmed` 외 상태 거부
 - transaction 안에서 status 재확인
 - `paidAt`, `updatedAt` 기록
 
-상세 정산 상태 계약은 `docs/specs/api/settlements.md`가 정본이다.
+### 검증 상태 — `IMPLEMENTED / UNVERIFIED`
+
+금전 상태 전이 구현은 있으나 이번 감사에서 `markAsPaid()`의 직접 service/API 회귀를 확인하지 못했다. seller settlement Playwright는 UI 날짜·탭 smoke 중심이며 admin 지급 mutation의 증거가 아니다.
+
+다음이 직접 고정되기 전에는 지급 상태 전이를 `VERIFIED`로 승격하지 않는다.
+
+- settlement 없음 거부
+- `pending|cancelled|paid` 거부
+- `confirmed → paid` 정상 성공
+- transaction 재조회와 동시 요청에서 한 번만 수렴
+- invalid state/invalid role side effect 0
+- 실제 controller guard + service 조합에서 admin만 도달
+
+이 공백은 `ADMIN-PRIVILEGED-MUTATION-COVERAGE` P0가 소유한다. 상세 정산 상태 계약은 `docs/specs/api/settlements.md`가 정본이다.
 
 ## 7. Driver 관리
 
@@ -234,9 +260,13 @@ PATCH /admin/drivers/:userId/approve
 - `role === driver` 확인
 - `driverApproved: true`
 
-이 endpoint가 존재한다는 사실과 **관리자 승인만이 driver 권한을 부여하는 유일한 경로라는 보장**은 현재 동일하지 않다. 2026-08-24 감사에서 `AuthService.kakaoLogin()`이 신규 `targetRole: driver` 사용자를 `driverApproved: true`로 생성하고, 기존 승인 필드 누락 driver도 로그인 시 자동 승인하는 경로를 확인했다.
+이 endpoint가 존재한다는 사실과 **관리자 승인만이 driver 권한을 부여하는 유일한 경로라는 보장**은 현재 동일하지 않다. 2026-08-24 감사에서 다음 우회를 확인했다.
 
-따라서 현재 driver 승인 게이트는 P0 `IMPLEMENTATION FINDING`이며, admin 승인 UI/API만 보고 `VERIFIED`로 판단하지 않는다. 정본과 완료 조건: `docs/specs/api/auth.md`의 `DRIVER-APPROVAL-GATE-BYPASS`.
+- 신규 Kakao `targetRole: driver`가 `driverApproved: true`로 생성됨
+- 기존 승인 필드 누락 driver가 Kakao 로그인 중 자동 승인됨
+- 공개 email `POST /auth/register`가 `role: driver`를 생성할 수 있고 이어지는 `POST /auth/login`이 `driverApproved` 확인 없이 `role=driver` JWT를 발급함
+
+따라서 현재 driver 승인 게이트는 P0 `IMPLEMENTATION FINDING`이며, admin 승인 UI/API만 보고 `VERIFIED`로 판단하지 않는다. 정본과 완료 조건: `docs/specs/api/auth.md` 및 Backlog `AUTH-DRIVER-APPROVAL-AND-SESSION-REVOCATION`.
 
 ### 정지/복구
 
@@ -333,10 +363,12 @@ Storage write/read 권한은 현재 `storage.rules`를 정본으로 확인한다
 - admin 주문 목록: 최대 200건, pagination 없음
 - admin 정산 목록: 최대 500건, pagination 없음
 - driver 목록: 최대 100건 read 후 메모리 필터
+- admin privileged mutation의 서버 authorization + side-effect 0 직접 회귀는 `ADMIN-PRIVILEGED-MUTATION-COVERAGE` 해결 전 `VERIFIED`가 아님
+- admin settlement 지급 전이는 `ADMIN-PRIVILEGED-MUTATION-COVERAGE` 해결 전 `VERIFIED`가 아님
 - admin 강제 환불은 `ADMIN-FORCE-REFUND-CONSISTENCY` 해결 전 주문 취소 lifecycle과 동일한 P0 안전 계약으로 사용하지 않음
 - store 수수료 설정과 settlement 생성의 `PLATFORM_FEE_RATE` 관계는 단일 정책으로 완전히 통합돼 있지 않을 수 있으므로 변경 전 코드 재검증 필요
-- driver 관리자 승인 게이트는 `DRIVER-APPROVAL-GATE-BYPASS` 해결 전 `VERIFIED`가 아님
-- 사용자/driver `suspended` flag의 기존 세션 enforcement는 `AUTH-SESSION-CLAIM-REVOCATION` 해결 전 `VERIFIED`가 아님
+- driver 관리자 승인 게이트는 `AUTH-DRIVER-APPROVAL-AND-SESSION-REVOCATION` 해결 전 `VERIFIED`가 아님
+- 사용자/driver `suspended` flag의 기존 세션 enforcement는 같은 auth P0 해결 전 `VERIFIED`가 아님
 - admin actions의 통합 감사 로그 범위는 operation/audit 구현을 확인해야 하며 단순 endpoint 존재만으로 완전한 감사 추적을 보장하지 않는다.
 
 이 제한을 해소할 필요가 생기면 `docs/BACKLOG.md`에 현재 작업으로 승격한 뒤 별도 설계를 수행한다.
@@ -348,16 +380,21 @@ admin 변경 시 최소 확인:
 - `apps/api/src/admin/admin.controller.ts`
 - `apps/api/src/admin/admin.service.ts`
 - `apps/api/src/admin/dto/admin.dto.ts`
+- `apps/api/src/common/guards/roles.guard.ts`
 - `apps/seller/src/app/admin/**`
 - `apps/seller/src/hooks/useAdmin.ts`
 - auth/orders/payments/settlements 관련 spec
 - `RoundOrderLifecycleService`와 `OrderCapacityService`
 - paid redelivery charge refund path
-- 관련 unit/E2E
+- 관련 unit/API E2E/Playwright
+
+admin role boundary는 UI redirect만으로 `VERIFIED` 처리하지 않는다. 실제 HTTP 경계에서 unauthenticated 401, consumer/seller/driver 403, admin 허용과 거부 side-effect 0을 직접 고정한다.
 
 환불처럼 금전·주문·capacity·정산을 함께 변경하는 작업은 provider 환불 성공만으로 완료 판정하지 않는다. 모든 local side effect와 실패 재시도·race를 직접 검증한다.
 
-승인·정지처럼 권한 수명주기에 영향을 주는 변경은 admin endpoint의 Firestore write 성공만 검사하지 않고 auth refresh/custom-token 및 실제 접근 차단까지 검증한다.
+settlement 지급처럼 금전 상태를 변경하는 admin mutation은 정상·잘못된 상태·동시 요청을 직접 회귀한다.
+
+승인·정지처럼 권한 수명주기에 영향을 주는 변경은 admin endpoint의 Firestore write 성공만 검사하지 않고 auth register/login/refresh/custom-token 및 실제 접근 차단까지 검증한다.
 
 실제 환불·계정 권한 변경·운영 데이터 변경은 문서 정합성 검토 범위에서 실행하지 않는다.
 
@@ -365,6 +402,8 @@ admin 변경 시 최소 확인:
 
 | 날짜 | 내용 |
 |---|---|
+| 2026-08-24 | admin privileged mutation 서버 authorization과 settlement 지급 상태 전이의 직접 회귀 부재를 `ADMIN-PRIVILEGED-MUTATION-COVERAGE` P0로 분리 |
+| 2026-08-24 | 공개 email driver register/login 우회를 driver 승인 P0에 연결 |
 | 2026-08-24 | admin force refund가 정상 회차 취소의 재배송비·reservation/counter·settlement 후속효과를 우회하는 구조를 P0 IMPLEMENTATION FINDING으로 정합화 |
 | 2026-08-24 | driver 승인 자동 우회와 suspension 기존 세션 revocation을 auth P0와 연결하고 admin write 자체를 권한 enforcement 완료로 보지 않도록 정합화 |
 | 2026-08-23 | canonical URL, archive/restore, 현재 정산·드라이버·초대 계약, 위험한 수동 권한 부여 지침을 현행화 |

--- a/docs/specs/api/auth.md
+++ b/docs/specs/api/auth.md
@@ -56,7 +56,7 @@ driver credentials는 더 좁게 제한한다.
 - API 응답 role이 `driver`
 - `driverApproved === true`
 
-따라서 이메일/비밀번호 endpoint가 존재한다고 해서 production 일반 로그인 경로로 노출하지 않는다.
+따라서 이메일/비밀번호 endpoint가 존재한다고 해서 production 일반 로그인 경로로 노출하지 않는다. **다만 frontend가 일반 credentials UI를 노출하지 않는다는 사실은 공개 NestJS `register/login` endpoint 자체의 권한 안전성을 대신하지 않는다.**
 
 ## 4. 역할
 
@@ -78,7 +78,7 @@ NestJS JWT payload의 현재 계약:
 
 `storeId`는 seller/admin에서 존재할 수 있고 consumer/driver는 일반적으로 `null` 또는 미설정이다. 단순 역할만으로 모든 store 데이터 접근을 허용하지 않으며 endpoint/service와 Firebase Rules의 소유권·배정 검사를 추가로 적용해야 한다.
 
-## 5. Kakao 역할 진입과 Driver 승인
+## 5. 역할 진입과 Driver 승인
 
 `KakaoLoginDto.targetRole` 허용값:
 
@@ -92,6 +92,12 @@ consumer | seller | driver
 - seller: `seller|admin`
 - driver: `driver|admin`
 
+공개 `RegisterDto.role`도 현재 다음을 허용한다.
+
+```text
+consumer | seller | driver
+```
+
 ### 의도된 Driver 계약
 
 현재 admin/API/UI 구조에는 별도의 driver 승인 상태가 존재한다.
@@ -100,28 +106,36 @@ consumer | seller | driver
 - `PATCH /admin/drivers/:userId/approve`
 - driver 앱 callback은 실제 role이 `driver`일 때 `driverApproved === true`를 요구한다.
 
-따라서 **관리자 승인 전 driver 권한을 획득할 수 없다는 계약**을 current 안전 계약으로 사용한다. role 승격·driver 승인·스토어 소유권을 단순 OAuth targetRole 요청만으로 자동 부여하지 않는다.
+따라서 **관리자 승인 전 driver 권한을 획득할 수 없다는 계약**을 current 안전 계약으로 사용한다. role 승격·driver 승인·스토어 소유권을 OAuth targetRole, 공개 가입 role, 또는 stale token payload만으로 자동 부여하지 않는다.
 
-### 현재 구현 불일치 — `IMPLEMENTATION FINDING` P0
+### 현재 구현 불일치 — Driver approval P0 `IMPLEMENTATION FINDING`
 
-2026-08-24 `AuthService.kakaoLogin()`을 직접 대조한 결과 위 계약과 충돌하는 두 경로가 존재한다.
+2026-08-24 직접 대조에서 위 계약과 충돌하는 세 경로가 확인됐다.
 
-1. 기존 사용자 role이 `driver`이고 `driverApproved` 필드가 `undefined`이면 로그인 중 `driverApproved: true`를 자동 기록한다.
+1. 기존 Kakao 사용자 role이 `driver`이고 `driverApproved` 필드가 `undefined`이면 로그인 중 `driverApproved: true`를 자동 기록한다.
 2. Kakao 사용자 매핑이 없는 신규 사용자가 `targetRole: driver`를 요청하면 신규 user를 `role: driver`, `driverApproved: true`로 즉시 생성한다.
+3. 공개 `POST /auth/register`는 `role: driver`를 허용하고 seller와 달리 invite/approval gate 없이 driver user를 만들 수 있다. 이어지는 공개 `POST /auth/login`은 `driverApproved`를 확인하지 않고 저장된 `role: driver`로 API JWT를 발급한다.
 
-즉 driver 앱 callback이 승인 flag를 확인하더라도 **API가 그 flag를 로그인 과정에서 스스로 true로 만들 수 있어 관리자 승인 게이트의 독립성이 보장되지 않는다.** `auth.service.spec.ts`는 Kakao identity·role mismatch·suspended login은 검증하지만 신규 driver가 승인 없이 생성되지 않는다는 회귀를 현재 직접 고정하지 않는다.
+즉 driver 앱 callback이 승인 flag를 확인하더라도 **API authorization boundary 자체에서 관리자 승인 게이트의 독립성이 보장되지 않는다.** 특히 email register→login 경로는 frontend Credentials provider 노출 여부와 무관하게 API에 직접 호출 가능하다.
 
-이 항목은 `DRIVER-APPROVAL-GATE-BYPASS` P0로 추적한다. 실제 구현을 정당화하기 위해 “driver는 Kakao 가입 즉시 승인”으로 문서를 바꾸지 않는다.
+`GET /auth/firebase-token`은 현재 JWT의 `role/storeId`로 Firebase custom claims를 생성하므로, 승인 없이 발급된 driver JWT가 Firebase role claim으로 이어질 수 있다. 이 문제는 broad driver order read가 남아 있는 `ORDER-DIRECT-READ-AUTHORIZATION-AND-MINIMIZATION`과 결합 위험이 있다.
+
+현재 `auth.service.spec.ts`는 Kakao identity·role mismatch·suspended login 일부는 검증하지만 `register(role=driver) → login` 승인 전 거부와 신규 driver 승인 게이트를 직접 고정하지 않는다.
+
+추적 umbrella: `docs/BACKLOG.md`의 `AUTH-DRIVER-APPROVAL-AND-SESSION-REVOCATION`. 기술 finding 이름으로 `DRIVER-APPROVAL-GATE-BYPASS`를 사용할 수 있으나 별도 완료 항목으로 중복 추적하지 않는다.
 
 최소 완료 조건:
 
+- 공개 registration이 관리자 승인 전 usable driver authorization을 만들지 못함
+- email login이 미승인 driver에게 driver JWT를 발급하지 않음
+- 미승인 driver JWT/세션에서 Firebase driver custom claim을 발급하지 않음
 - 신규 Kakao identity의 `targetRole: driver`가 관리자 승인 없이 `driverApproved: true` 권한을 만들지 못함
 - 기존 `driverApproved` 누락 계정을 로그인 시 자동 승인하지 않음
 - 과거 계정 migration이 필요하면 로그인 side effect가 아닌 명시적·감사 가능한 migration/관리 절차로 분리
-- admin 승인 전 driver 앱 정상 진입·driver API/Firestore 권한 획득 거부
-- admin 승인 후 정상 driver 로그인 유지
+- admin 승인 전 driver 앱·driver API·Firestore 권한 획득 거부
+- admin 승인 후 email/Kakao의 허용된 정상 driver 로그인 유지
 - consumer/seller/admin role 진입 회귀 없음
-- 직접 unit/API/E2E 회귀로 승인 전/후 경계를 고정
+- register/login/Kakao + API/Firebase claim의 승인 전/후 직접 unit/integration/E2E 회귀
 
 ## 6. Access / Refresh token과 권한 변경 수렴
 
@@ -174,7 +188,9 @@ POST /auth/refresh
 주의:
 
 - `/auth/login`과 `/auth/register`는 API 기능으로 존재하지만 현재 세 앱의 production 일반 이메일 로그인 provider라는 뜻은 아니다.
-- 일반 사용자에게 credentials 인증을 노출하려면 별도 제품·보안 결정이 필요하다.
+- **이 두 endpoint가 공개라는 사실 자체는 현재 보안 경계다. UI 미노출을 authorization control로 취급하지 않는다.**
+- 현재 `role: driver` register→login 승인 우회는 P0 implementation finding이다.
+- 일반 사용자에게 credentials 인증을 제품 기능으로 노출하려면 별도 제품·보안 결정이 필요하다.
 
 ### 인증 사용자
 
@@ -235,7 +251,7 @@ interface SavedAddress {
 
 `GET /auth/firebase-token`은 현재 API JWT 사용자에게 Firebase client용 custom token을 발급하는 경로다. 현재 controller는 `CurrentUser()`의 `sub/role/storeId`를 그대로 `AuthService.getFirebaseToken()`에 전달하고, service는 그 값으로 Firebase custom claims를 만든다.
 
-따라서 이 경로의 안전성은 API JWT claims의 현재성에 의존한다. `AUTH-SESSION-CLAIM-REVOCATION`이 해결되기 전에는 **정지·role/store 변경 이후 Firebase claims가 즉시 현재 상태와 일치한다고 가정하지 않는다.**
+따라서 이 경로의 안전성은 API JWT claims의 현재성에 의존한다. `AUTH-DRIVER-APPROVAL-AND-SESSION-REVOCATION`이 해결되기 전에는 **미승인 driver·정지·role/store 변경 이후 Firebase claims가 authoritative user 상태와 일치한다고 가정하지 않는다.**
 
 특히 Firestore Rules가 `role`/`storeId` claims를 데이터 접근의 근거로 사용하므로 auth claim lifecycle과 Rules authorization을 별개의 문제로 분리하지 않는다.
 
@@ -261,8 +277,9 @@ interface SavedAddress {
 - Kakao identity는 서버에서 access token으로 재검증한다.
 - password hash, refresh token, JWT, OAuth token, E2E shared secret을 문서·로그에 기록하지 않는다.
 - Credentials provider는 E2E gate를 제거한 채 production 로그인으로 열지 않는다.
-- role/storeId/driver approval은 client targetRole 또는 stale token payload만으로 최종 결정하지 않는다.
-- driver 관리자 승인 게이트를 로그인 side effect로 자동 충족시키지 않는다.
+- **공개 register/login endpoint는 frontend UI 미노출을 보안 통제로 간주하지 않는다.**
+- role/storeId/driver approval은 client targetRole, registration role 또는 stale token payload만으로 최종 결정하지 않는다.
+- driver 관리자 승인 게이트를 가입·로그인 side effect로 자동 충족시키지 않는다.
 - 계정 정지·role/store 변경이 refresh/custom-token 경로에서 무기한 과거 권한으로 유지되지 않도록 한다.
 - 타인 주문·스토어 접근은 endpoint/service와 Firebase Rules의 소유권 검사를 통과해야 한다.
 - driver E2E allowlist와 secret을 실제 운영 driver 인증 모델로 사용하지 않는다.
@@ -274,6 +291,7 @@ interface SavedAddress {
 
 - `apps/api/src/auth/auth.controller.ts`
 - `apps/api/src/auth/auth.service.ts`
+- `apps/api/src/auth/dto/register.dto.ts`
 - `apps/api/src/auth/strategies/jwt.strategy.ts`
 - `apps/api/src/auth/types/jwt-payload.type.ts`
 - `apps/api/src/common/guards/*`
@@ -284,12 +302,13 @@ interface SavedAddress {
 - 관련 auth unit/E2E tests
 - OAuth URL 변경이면 `docs/URLS.md`, `docs/specs/ops/preview-auth-url-policy.md`
 
-권한·정지·승인 계약은 `docs/DOCUMENT_CONSISTENCY.md`에 따라 로그인 성공 테스트만으로 `VERIFIED` 처리하지 않는다. 신규 가입, 승인 전/후, suspension, refresh, Firebase custom claims까지 수명주기를 직접 검증한다.
+권한·정지·승인 계약은 `docs/DOCUMENT_CONSISTENCY.md`에 따라 로그인 성공 테스트만으로 `VERIFIED` 처리하지 않는다. 공개 가입, 승인 전/후, suspension, refresh, Firebase custom claims까지 수명주기를 직접 검증한다.
 
 ## 변경 이력
 
 | 날짜 | 내용 |
 |---|---|
+| 2026-08-24 | 공개 email `register(role=driver) → login`이 승인 없이 driver JWT를 발급할 수 있는 추가 P0 우회를 반영하고 Kakao/refresh/Firebase claim과 하나의 driver authorization lifecycle로 정합화 |
 | 2026-08-24 | 신규/legacy driver 자동 승인 경로를 P0 IMPLEMENTATION FINDING으로 분리하고, 정지·role/store 변경의 refresh/custom-token stale claims를 P0 revocation 결정·remediation으로 명시 |
 | 2026-08-23 | Kakao 운영 OAuth, E2E 전용 Credentials, driver approval, refresh/custom-token 현행 계약에 맞춰 전면 정합화 |
 | 2026-07-01 | Kakao access token 서버 검증 계약 보강 |

--- a/docs/specs/api/settlements.md
+++ b/docs/specs/api/settlements.md
@@ -199,7 +199,9 @@ GET /stores/:storeId/settlements/summary?date=<date>
 
 ## 9. Admin 정산 API
 
-admin controller 전체는 `JwtAuthGuard + RolesGuard + @Roles('admin')`으로 보호된다.
+admin controller 전체에는 `JwtAuthGuard + RolesGuard + @Roles('admin')` 구현이 적용된다.
+
+2026-08-24 감사 기준 이 privileged mutation server boundary의 직접 거부 회귀는 충분하지 않아 `ADMIN-PRIVILEGED-MUTATION-COVERAGE` P0 `COVERAGE GAP`으로 추적한다. UI redirect를 서버 authorization 전체의 직접 증거로 사용하지 않는다.
 
 ### 목록
 
@@ -215,7 +217,7 @@ store/date filter를 지원하며 `settledAt DESC`, 최대 500건을 조회한�
 PATCH /admin/settlements/:settlementId/pay
 ```
 
-`markAsPaid()`의 현재 계약:
+`markAsPaid()`의 현재 구현:
 
 - settlement 없음 → not found
 - 이미 `paid` → 거부
@@ -223,7 +225,23 @@ PATCH /admin/settlements/:settlementId/pay
 - transaction에서 status 재확인 후 `paid`
 - `paidAt`, `updatedAt` 기록
 
-즉, `pending → paid` 직접 전환은 허용하지 않는다.
+즉 코드상 `pending → paid` 직접 전환은 허용하지 않는다.
+
+### 검증 상태 — `IMPLEMENTED / UNVERIFIED` + P0 `COVERAGE GAP`
+
+이번 감사에서 `apps/api/src/admin`에 전용 service/controller spec을 확인하지 못했고, seller settlements Playwright는 UI 날짜·탭 smoke 중심이다. 따라서 위 금전 상태 전이 구현을 `VERIFIED`로 승격하지 않는다.
+
+`ADMIN-PRIVILEGED-MUTATION-COVERAGE` 완료 시 최소 다음을 직접 고정한다.
+
+- missing settlement 거부
+- `pending|cancelled|paid` 거부
+- `confirmed → paid` 정상 성공
+- transaction에서 fresh status 재확인
+- 동시 지급 요청이 한 번만 안정적으로 수렴
+- invalid state/invalid role side effect 0
+- 실제 controller guard + service 조합에서 admin만 mutation에 도달
+
+증거: `docs/reports/REPORT_auth_orders_admin_verification_audit_20260824.md`.
 
 ## 10. 인덱스
 
@@ -253,6 +271,7 @@ seller/admin UI는 공통 `SettlementStatus`, `STATUS_LABEL`, `STATUS_COLOR`를 
 - 정상 취소/환불 경합에서 pending/confirmed settlement가 `cancelled`로 수렴
 - `paid` settlement 이후 환불은 별도 회계 정책을 따름
 - admin 강제 환불도 `ADMIN-FORCE-REFUND-CONSISTENCY` 해결 후 같은 회계 불변식에 수렴
+- admin 지급은 `ADMIN-PRIVILEGED-MUTATION-COVERAGE` 해결 후 direct status/race 증거를 포함
 
 출시 상태 자체는 `docs/memory.md`와 활성 출시 PLAN을 따른다.
 
@@ -266,19 +285,23 @@ seller/admin UI는 공통 `SettlementStatus`, `STATUS_LABEL`, `STATUS_COLOR`를 
 - `apps/api/src/settlements/dto/query-settlements.dto.ts`
 - `apps/api/src/admin/admin.controller.ts`
 - `apps/api/src/admin/admin.service.ts`
+- `apps/api/src/common/guards/roles.guard.ts`
 - `apps/api/src/orders/round-order-lifecycle.service.ts`
 - payment/redelivery refund paths
 - fee calculator / aggregator tests
 - seller/admin settlement UI
-- 관련 E2E
+- 관련 unit/API E2E/Playwright
 - `firestore.indexes.json`
 
 금전 환불과 정산이 연결되는 변경은 payment provider 성공뿐 아니라 주문 상태, reservation/capacity, 재배송비, settlement 상태, 실패 재시도와 race를 함께 검증한다.
+
+admin 지급 상태 전이는 코드의 transaction 존재만으로 `VERIFIED` 처리하지 않고 정상·거부·동시성·authorization 경계를 직접 검증한다.
 
 ## 변경 이력
 
 | 날짜 | 내용 |
 |---|---|
+| 2026-08-24 | admin `confirmed → paid` 구현과 직접 검증 증거를 분리해 `ADMIN-PRIVILEGED-MUTATION-COVERAGE` P0 COVERAGE GAP에 연결 |
 | 2026-08-24 | admin force refund가 `cancelSettlement()` 및 정상 취소 lifecycle을 우회하는 P0 정산 불일치를 명시 |
 | 2026-08-23 | 자동 confirm, transaction 멱등성, paid 역전 방지, admin 지급 API, 현재 조회/권한 계약으로 정합화 |
 | 2026-03-28 | 초기 settlements 설계 초안 |


### PR DESCRIPTION
## 감사 범위
`auth.md → orders.md → admin.md`를 `docs/DOCUMENT_CONSISTENCY.md` 기준으로 Spec·Code·Test 삼각 검증했습니다.

## 핵심 finding

### 1. Driver approval P0 범위 확대
기존 Kakao 자동승인 외에 공개 email 경로를 추가 확인했습니다.

- `RegisterDto.role`이 `driver` 허용
- public `POST /auth/register`는 seller와 달리 driver invite/approval gate 없음
- public `POST /auth/login`은 `driverApproved` 확인 없이 `role=driver` JWT 발급
- Firebase custom token은 현재 JWT role/storeId를 claims로 사용

따라서 `AUTH-DRIVER-APPROVAL-AND-SESSION-REVOCATION` 범위를 public register/login까지 확대합니다. broad driver Firestore read P0와 결합 위험이 있어 활성 HANDOFF의 최우선 재개도 이 두 security boundary로 조정합니다.

### 2. Orders API query `VERIFIED` 유지
`orders-query.service.spec.ts`가 consumer/seller/driver/admin 정상·거부 경계를 직접 고정하므로 API query authorization은 `VERIFIED`를 유지합니다.

기존 direct Firestore read P0와 mutation coverage P0는 그대로 유지합니다.

### 3. Admin privileged mutation P0 coverage gap 신규
`AdminController`의 JWT/admin role guard와 `markAsPaid()` transaction 구현은 존재하지만:

- `apps/api/src/admin` 전용 controller/service spec 없음
- 확인한 API E2E에 high-impact admin mutation direct role-denial 없음
- Playwright admin 테스트는 UI redirect/read smoke 중심
- settlement pay의 invalid state / confirmed success / race 직접 회귀 없음

따라서 `ADMIN-PRIVILEGED-MUTATION-COVERAGE`를 `IMPLEMENTED / UNVERIFIED + P0 COVERAGE GAP`으로 추가합니다.

## 문서 변경
- `docs/specs/api/auth.md`
- `docs/specs/api/admin.md`
- `docs/specs/api/settlements.md`
- `docs/BACKLOG.md`
- `docs/memory.md`
- 활성 PLAN/HANDOFF
- evidence report 추가

## 범위 경계
- docs-only
- Orders current spec은 변경 없음
- 코드/테스트/Firebase Rules/provider/production/운영 데이터 변경 없음
