### PR TITLE
security: integrate P0 auth and payment protections

### DIFF
--- a/apps/api/src/admin/admin.service.spec.ts
+++ b/apps/api/src/admin/admin.service.spec.ts
@@ -1,0 +1,52 @@
+import type { FirestoreService } from '../firestore/firestore.service';
+import * as admin from 'firebase-admin';
+import { AdminService } from './admin.service';
+
+jest.mock('firebase-admin', () => ({
+  auth: jest.fn(),
+}));
+
+describe('AdminService driver session 보강', () => {
+  const firebaseAuth = { revokeRefreshTokens: jest.fn() };
+
+  function makeService(user: Record<string, unknown>, exists = true) {
+    const userRef = {
+      get: jest.fn().mockResolvedValue({ exists, data: () => user }),
+      update: jest.fn().mockResolvedValue(undefined),
+    };
+    const firestore = {
+      doc: jest.fn().mockReturnValue(userRef),
+      Timestamp: { now: jest.fn(() => 'now') },
+    };
+    return {
+      firestore,
+      service: new AdminService(firestore as unknown as FirestoreService, {} as never),
+      userRef,
+    };
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    firebaseAuth.revokeRefreshTokens.mockResolvedValue(undefined);
+    (admin.auth as jest.Mock).mockReturnValue(firebaseAuth);
+  });
+
+  it('driver 정지 시 Firebase refresh token을 폐기한다', async () => {
+    const { service, userRef } = makeService({ id: 'driver-1', role: 'driver' });
+
+    await expect(service.suspendDriver('driver-1', { suspended: true })).resolves.toEqual({
+      userId: 'driver-1',
+      suspended: true,
+    });
+    expect(userRef.update).toHaveBeenCalledWith({ suspended: true, updatedAt: 'now' });
+    expect(firebaseAuth.revokeRefreshTokens).toHaveBeenCalledWith('driver-1');
+  });
+
+  it('driver 정지 해제 시 refresh token 폐기를 다시 호출하지 않는다', async () => {
+    const { service } = makeService({ id: 'driver-1', role: 'driver' });
+
+    await service.suspendDriver('driver-1', { suspended: false });
+
+    expect(firebaseAuth.revokeRefreshTokens).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/admin/admin.service.ts
+++ b/apps/api/src/admin/admin.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, NotFoundException, BadRequestException } from '@nestjs/common';
+import * as admin from 'firebase-admin';
 import { v4 as uuidv4 } from 'uuid';
 import { FirestoreService } from '../firestore/firestore.service';
 import { PaymentsService } from '../payments/payments.service';
@@ -265,6 +266,9 @@ export class AdminService {
       suspended: dto.suspended,
       updatedAt: this.firestore.Timestamp.now(),
     });
+    if (dto.suspended) {
+      await admin.auth().revokeRefreshTokens(userId);
+    }
     return { userId, suspended: dto.suspended };
   }
 

--- a/apps/api/src/auth/auth.controller.spec.ts
+++ b/apps/api/src/auth/auth.controller.spec.ts
@@ -1,0 +1,236 @@
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { JwtService } from '@nestjs/jwt';
+import { Test } from '@nestjs/testing';
+import * as bcrypt from 'bcrypt';
+import request from 'supertest';
+import { App } from 'supertest/types';
+import { AuditService } from '../common/audit/audit.service';
+import { FirestoreService } from '../firestore/firestore.service';
+import { AuthController } from './auth.controller';
+import { AuthService } from './auth.service';
+import { KakaoClient } from './kakao.client';
+
+type UserRecord = Record<string, unknown>;
+type UsersQuery = {
+  where: (_field: string, _operator: string, value: string) => UsersQuery;
+  limit: () => UsersQuery;
+  get: () => Promise<{
+    empty: boolean;
+    docs: Array<{ data: () => UserRecord }>;
+  }>;
+};
+
+function makeAuthHarness() {
+  const users = new Map<string, UserRecord>();
+  const refreshTokenWrites: Array<{ path: string; data: UserRecord }> = [];
+  let emailFilter = '';
+
+  const usersQuery: UsersQuery = {
+    where: (_field: string, _operator: string, value: string) => {
+      emailFilter = value;
+      return usersQuery;
+    },
+    limit: () => usersQuery,
+    get: () => {
+      const matches = [...users.values()].filter((user) => user.email === emailFilter);
+      return Promise.resolve({
+        empty: matches.length === 0,
+        docs: matches.map((user) => ({ data: () => user })),
+      });
+    },
+  };
+
+  const firestore = {
+    collection: (path: string) => {
+      if (path === 'users') return usersQuery;
+      throw new Error(`Unexpected collection path: ${path}`);
+    },
+    doc: (path: string) => {
+      if (path.startsWith('users/')) {
+        const userId = path.slice('users/'.length);
+        return {
+          get: () => {
+            const user = users.get(userId);
+            return Promise.resolve({ exists: user !== undefined, data: () => user });
+          },
+          set: (data: UserRecord) => {
+            users.set(userId, data);
+            return Promise.resolve();
+          },
+        };
+      }
+
+      if (path.startsWith('refreshTokens/')) {
+        return {
+          set: (data: UserRecord) => {
+            refreshTokenWrites.push({ path, data });
+            return Promise.resolve();
+          },
+        };
+      }
+
+      throw new Error(`Unexpected document path: ${path}`);
+    },
+    Timestamp: { now: jest.fn(() => 'now') },
+  };
+
+  const jwt = {
+    sign: jest.fn(
+      (_payload: Record<string, unknown>, options: { secret?: string }) =>
+        options.secret === 'access-secret' ? 'access-token' : 'refresh-token',
+    ),
+    verify: jest.fn(),
+  };
+  const config = new ConfigService({
+    JWT_SECRET: 'access-secret',
+    JWT_REFRESH_SECRET: 'refresh-secret',
+    JWT_EXPIRES_IN: '1h',
+    JWT_REFRESH_EXPIRES_IN: '30d',
+  });
+  const kakaoClient = { getUser: jest.fn() };
+  const audit = { log: jest.fn().mockResolvedValue(undefined) };
+
+  return {
+    audit,
+    config,
+    firestore,
+    jwt,
+    kakaoClient,
+    refreshTokenWrites,
+    users,
+  };
+}
+
+describe('AuthController public driver approval boundary', () => {
+  let app: INestApplication<App>;
+  let harness: ReturnType<typeof makeAuthHarness>;
+
+  beforeEach(async () => {
+    harness = makeAuthHarness();
+    const module = await Test.createTestingModule({
+      controllers: [AuthController],
+      providers: [
+        AuthService,
+        { provide: FirestoreService, useValue: harness.firestore },
+        { provide: ConfigService, useValue: harness.config },
+        { provide: JwtService, useValue: harness.jwt },
+        { provide: KakaoClient, useValue: harness.kakaoClient },
+        { provide: AuditService, useValue: harness.audit },
+      ],
+    }).compile();
+
+    app = module.createNestApplication();
+    app.useGlobalPipes(new ValidationPipe({ whitelist: true, forbidNonWhitelisted: true }));
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await app?.close();
+  });
+
+  it('public register→login keeps a driver approval-pending and rejects before token issuance', async () => {
+    const email = 'pending-driver@example.com';
+    const password = 'password-123';
+
+    const registration = await request(app.getHttpServer())
+      .post('/auth/register')
+      .send({ email, password, name: '신청 기사', role: 'driver' })
+      .expect(201);
+
+    const userId = (registration.body as { userId: string }).userId;
+    expect(harness.users.get(userId)).toEqual(
+      expect.objectContaining({ role: 'driver', driverApproved: false }),
+    );
+
+    await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({ email, password })
+      .expect(403);
+
+    expect(harness.jwt.sign).not.toHaveBeenCalled();
+    expect(harness.refreshTokenWrites).toHaveLength(0);
+  });
+
+  it('public registration rejects a client-supplied driverApproved field', async () => {
+    await request(app.getHttpServer())
+      .post('/auth/register')
+      .send({
+        email: 'forged-driver@example.com',
+        password: 'password-123',
+        name: '위조 기사',
+        role: 'driver',
+        driverApproved: true,
+      })
+      .expect(400);
+
+    expect(harness.users.size).toBe(0);
+  });
+
+  it.each([
+    ['false', { driverApproved: false }],
+    ['missing', {}],
+  ])('public login rejects %s driver approval before token issuance', async (_label, approval) => {
+    const password = 'password-123';
+    harness.users.set('driver-1', {
+      id: 'driver-1',
+      email: 'driver@example.com',
+      name: '기사',
+      role: 'driver',
+      suspended: false,
+      passwordHash: await bcrypt.hash(password, 4),
+      ...approval,
+    });
+
+    await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({ email: 'driver@example.com', password })
+      .expect(403);
+
+    expect(harness.jwt.sign).not.toHaveBeenCalled();
+    expect(harness.refreshTokenWrites).toHaveLength(0);
+  });
+
+  it('approved driver public login issues normal access and refresh tokens', async () => {
+    const password = 'password-123';
+    harness.users.set('driver-1', {
+      id: 'driver-1',
+      email: 'driver@example.com',
+      name: '승인 기사',
+      role: 'driver',
+      driverApproved: true,
+      suspended: false,
+      passwordHash: await bcrypt.hash(password, 4),
+    });
+
+    await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({ email: 'driver@example.com', password })
+      .expect(200)
+      .expect(({ body }) => {
+        expect(body).toEqual(
+          expect.objectContaining({ accessToken: 'access-token', refreshToken: 'refresh-token' }),
+        );
+      });
+
+    expect(harness.jwt.sign).toHaveBeenCalledTimes(2);
+    expect(harness.refreshTokenWrites).toHaveLength(1);
+  });
+
+  it.each(['consumer', 'seller', 'admin'])('%s public login remains allowed', async (role) => {
+    const password = 'password-123';
+    harness.users.set(`${role}-1`, {
+      id: `${role}-1`,
+      email: `${role}@example.com`,
+      name: role,
+      role,
+      suspended: false,
+      passwordHash: await bcrypt.hash(password, 4),
+    });
+
+    await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({ email: `${role}@example.com`, password })
+      .expect(200);
+  });
+});

--- a/apps/api/src/auth/auth.service.spec.ts
+++ b/apps/api/src/auth/auth.service.spec.ts
@@ -147,5 +147,48 @@ describe('AuthService', () => {
       expect(audit.log).toHaveBeenCalledWith('auth.login.suspended', { userId: 'user-1' });
       expect(jwt.sign).not.toHaveBeenCalled();
     });
+
+    it('공개 driver 가입은 승인 대기 상태로 저장한다', async () => {
+      const { service, userRef } = makeKakaoLoginService({});
+
+      await service.register({
+        email: 'driver@example.com',
+        password: 'password-123',
+        name: '신청 기사',
+        role: 'driver',
+      } as never);
+
+      expect(userRef.set).toHaveBeenCalledWith(
+        expect.objectContaining({ role: 'driver', driverApproved: false }),
+      );
+    });
+
+    it('기존 미승인 driver를 카카오 로그인 때 자동 승인하지 않는다', async () => {
+      const { service, userRef } = makeKakaoLoginService({
+        user: { id: 'driver-1', role: 'driver', storeId: null, suspended: false },
+      });
+
+      const result = await service.kakaoLogin({
+        kakaoAccessToken: 'token',
+        targetRole: 'driver',
+      });
+
+      expect(result.user).not.toHaveProperty('driverApproved', true);
+      expect(userRef.update).not.toHaveBeenCalled();
+    });
+
+    it('신규 driver의 카카오 가입도 승인 대기로 저장한다', async () => {
+      const { service, userRef } = makeKakaoLoginService({});
+
+      const result = await service.kakaoLogin({
+        kakaoAccessToken: 'token',
+        targetRole: 'driver',
+      });
+
+      expect(result.user).toMatchObject({ role: 'driver', driverApproved: false });
+      expect(userRef.set).toHaveBeenCalledWith(
+        expect.objectContaining({ role: 'driver', driverApproved: false }),
+      );
+    });
   });
 });

--- a/apps/api/src/auth/auth.service.spec.ts
+++ b/apps/api/src/auth/auth.service.spec.ts
@@ -1,9 +1,14 @@
 import type { ConfigService } from '@nestjs/config';
 import type { JwtService } from '@nestjs/jwt';
+import * as admin from 'firebase-admin';
 import type { AuditService } from '../common/audit/audit.service';
 import type { FirestoreService } from '../firestore/firestore.service';
 import { AuthService } from './auth.service';
 import type { KakaoClient } from './kakao.client';
+
+jest.mock('firebase-admin', () => ({
+  auth: jest.fn(),
+}));
 
 describe('AuthService', () => {
   function makeKakaoLoginService(options: {
@@ -19,6 +24,10 @@ describe('AuthService', () => {
       }),
     };
     const userRef = {
+      get: jest.fn().mockResolvedValue({
+        exists: options.user !== undefined,
+        data: () => options.user,
+      }),
       set: jest.fn().mockResolvedValue(undefined),
       update: jest.fn().mockResolvedValue(undefined),
     };
@@ -189,6 +198,99 @@ describe('AuthService', () => {
       expect(userRef.set).toHaveBeenCalledWith(
         expect.objectContaining({ role: 'driver', driverApproved: false }),
       );
+    });
+  });
+
+  describe('getFirebaseToken', () => {
+    const firebaseAuth = { createCustomToken: jest.fn() };
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      firebaseAuth.createCustomToken.mockResolvedValue('firebase-custom-token');
+      (admin.auth as jest.Mock).mockReturnValue(firebaseAuth);
+    });
+
+    it('승인된 driver token에는 Rules가 기대하는 true claim을 넣는다', async () => {
+      const { service } = makeKakaoLoginService({
+        user: {
+          id: 'driver-1',
+          role: 'driver',
+          driverApproved: true,
+          suspended: false,
+        },
+      });
+
+      await expect(service.getFirebaseToken('driver-1', 'driver')).resolves.toBe(
+        'firebase-custom-token',
+      );
+      expect(firebaseAuth.createCustomToken).toHaveBeenCalledWith('driver-1', {
+        role: 'driver',
+        storeId: null,
+        driverApproved: true,
+      });
+    });
+
+    it.each([
+      ['미승인', { id: 'driver-1', role: 'driver', driverApproved: false, suspended: false }],
+      ['승인 claim 누락', { id: 'driver-1', role: 'driver', suspended: false }],
+      ['역할 불일치', { id: 'driver-1', role: 'consumer', driverApproved: true, suspended: false }],
+    ])('%s driver token 발급을 거부한다', async (_label, user) => {
+      const { service } = makeKakaoLoginService({ user });
+
+      await expect(service.getFirebaseToken('driver-1', 'driver')).rejects.toMatchObject({
+        status: 403,
+      });
+      expect(firebaseAuth.createCustomToken).not.toHaveBeenCalled();
+    });
+
+    it('정지되거나 존재하지 않는 driver token 발급을 거부한다', async () => {
+      const suspended = makeKakaoLoginService({
+        user: { id: 'driver-1', role: 'driver', driverApproved: true, suspended: true },
+      });
+      await expect(suspended.service.getFirebaseToken('driver-1', 'driver')).rejects.toMatchObject({
+        status: 401,
+      });
+
+      const missing = makeKakaoLoginService({});
+      await expect(missing.service.getFirebaseToken('driver-1', 'driver')).rejects.toMatchObject({
+        status: 401,
+      });
+      expect(firebaseAuth.createCustomToken).not.toHaveBeenCalled();
+    });
+
+    it('driver가 아닌 token에는 driverApproved claim을 넣지 않는다', async () => {
+      const { service } = makeKakaoLoginService({
+        user: { id: 'consumer-1', role: 'consumer', suspended: false },
+      });
+
+      await service.getFirebaseToken('consumer-1', 'consumer');
+
+      expect(firebaseAuth.createCustomToken).toHaveBeenCalledWith('consumer-1', {
+        role: 'consumer',
+        storeId: null,
+      });
+    });
+
+    it('승인 상태 변경은 다음 token 발급에만 반영된다', async () => {
+      const user = {
+        id: 'driver-1',
+        role: 'driver',
+        driverApproved: false,
+        suspended: false,
+      };
+      const { service } = makeKakaoLoginService({ user });
+
+      await expect(service.getFirebaseToken('driver-1', 'driver')).rejects.toMatchObject({
+        status: 403,
+      });
+      user.driverApproved = true;
+      await expect(service.getFirebaseToken('driver-1', 'driver')).resolves.toBe(
+        'firebase-custom-token',
+      );
+      user.driverApproved = false;
+      await expect(service.getFirebaseToken('driver-1', 'driver')).rejects.toMatchObject({
+        status: 403,
+      });
     });
   });
 });

--- a/apps/api/src/auth/auth.service.spec.ts
+++ b/apps/api/src/auth/auth.service.spec.ts
@@ -1,6 +1,7 @@
 import type { ConfigService } from '@nestjs/config';
 import type { JwtService } from '@nestjs/jwt';
 import * as admin from 'firebase-admin';
+import * as bcrypt from 'bcrypt';
 import type { AuditService } from '../common/audit/audit.service';
 import type { FirestoreService } from '../firestore/firestore.service';
 import { AuthService } from './auth.service';
@@ -83,7 +84,7 @@ describe('AuthService', () => {
       kakaoClient as unknown as KakaoClient,
       audit as unknown as AuditService,
     );
-    return { audit, firestore, jwt, kakaoClient, service, userRef, usersQuery };
+    return { audit, firestore, jwt, kakaoClient, refreshTokenRef, service, userRef, usersQuery };
   }
 
   describe('kakaoLogin', () => {
@@ -198,6 +199,72 @@ describe('AuthService', () => {
       expect(userRef.set).toHaveBeenCalledWith(
         expect.objectContaining({ role: 'driver', driverApproved: false }),
       );
+    });
+  });
+
+  describe('email login driver approval', () => {
+    const password = 'password-123';
+
+    async function makeEmailLoginService(overrides: Record<string, unknown> = {}) {
+      return makeKakaoLoginService({
+        user: {
+          id: 'driver-1',
+          email: 'driver@example.com',
+          name: '신청 기사',
+          role: 'driver',
+          storeId: null,
+          suspended: false,
+          passwordHash: await bcrypt.hash(password, 4),
+          ...overrides,
+        },
+      });
+    }
+
+    it.each([
+      ['false', { driverApproved: false }],
+      ['missing', {}],
+    ])('%s approval driver는 token 발급 전에 email login이 거부된다', async (_label, approval) => {
+      const { jwt, refreshTokenRef, service } = await makeEmailLoginService(approval);
+
+      await expect(service.login({ email: 'driver@example.com', password })).rejects.toMatchObject({
+        status: 403,
+      });
+      expect(jwt.sign).not.toHaveBeenCalled();
+      expect(refreshTokenRef.set).not.toHaveBeenCalled();
+    });
+
+    it('승인된 driver는 정상적으로 email login하고 access/refresh token을 발급한다', async () => {
+      const { jwt, refreshTokenRef, service } = await makeEmailLoginService({
+        driverApproved: true,
+      });
+
+      const result = await service.login({ email: 'driver@example.com', password });
+      expect(result.accessToken).toBe('access-token');
+      expect(result.refreshToken).toBe('refresh-token');
+      expect(result.user).toMatchObject({ role: 'driver', driverApproved: true });
+      expect(jwt.sign).toHaveBeenCalledTimes(2);
+      expect(refreshTokenRef.set).toHaveBeenCalledTimes(1);
+    });
+
+    it.each(['consumer', 'seller', 'admin'])('%s email login 정상 경로를 유지한다', async (role) => {
+      const { service } = await makeEmailLoginService({ role, driverApproved: undefined });
+
+      const result = await service.login({ email: 'driver@example.com', password });
+      expect(result.accessToken).toBe('access-token');
+      expect(result.refreshToken).toBe('refresh-token');
+      expect(result.user).toMatchObject({ role });
+    });
+
+    it('정지된 사용자의 기존 email login 거부를 유지한다', async () => {
+      const { jwt, service } = await makeEmailLoginService({
+        role: 'consumer',
+        suspended: true,
+      });
+
+      await expect(service.login({ email: 'driver@example.com', password })).rejects.toMatchObject({
+        status: 401,
+      });
+      expect(jwt.sign).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -77,6 +77,7 @@ export class AuthService {
       name: dto.name,
       phone: dto.phone ?? null,
       role: dto.role,
+      ...(dto.role === 'driver' ? { driverApproved: false } : {}),
       storeId: null,
       providers: ['email'],
       passwordHash,
@@ -262,13 +263,6 @@ export class AuthService {
 
     if (!snap.empty) {
       userData = snap.docs[0].data();
-      if (userData['role'] === 'driver' && userData['driverApproved'] === undefined) {
-        await this.firestore.doc(`users/${String(userData['id'])}`).update({
-          driverApproved: true,
-          updatedAt: this.firestore.Timestamp.now(),
-        });
-        userData = { ...userData, driverApproved: true };
-      }
     } else {
       if (dto.targetRole === 'seller') {
         throw new ForbiddenException('판매자 계정은 관리자 초대로만 가입할 수 있습니다.');
@@ -283,7 +277,7 @@ export class AuthService {
         name: kakaoProfile.name,
         phone: null,
         role: newRole,
-        ...(newRole === 'driver' ? { driverApproved: true } : {}),
+        ...(newRole === 'driver' ? { driverApproved: false } : {}),
         storeId: null,
         providers: ['kakao'],
         savedAddresses: [],
@@ -368,7 +362,24 @@ export class AuthService {
   }
 
   async getFirebaseToken(userId: string, role: string, storeId?: string): Promise<string> {
-    return admin.auth().createCustomToken(userId, { role, storeId: storeId ?? null });
+    const userSnap = await this.firestore.doc(`users/${userId}`).get();
+    if (!userSnap.exists) {
+      throw new UnauthorizedException('사용자를 찾을 수 없습니다.');
+    }
+
+    const user = userSnap.data()!;
+    if (user['suspended'] === true) {
+      throw new UnauthorizedException('정지된 계정입니다. 고객센터에 문의해주세요.');
+    }
+    if (role === 'driver' && (user['role'] !== 'driver' || user['driverApproved'] !== true)) {
+      throw new ForbiddenException('승인된 드라이버만 배송 정보를 조회할 수 있습니다.');
+    }
+
+    return admin.auth().createCustomToken(userId, {
+      role,
+      storeId: storeId ?? null,
+      ...(role === 'driver' ? { driverApproved: true } : {}),
+    });
   }
 
   private async issueTokens(payload: JwtPayload) {

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -140,6 +140,10 @@ export class AuthService {
       throw new UnauthorizedException('정지된 계정입니다. 고객센터에 문의해주세요.');
     }
 
+    if (userData['role'] === 'driver' && userData['driverApproved'] !== true) {
+      throw new ForbiddenException('승인된 드라이버만 로그인할 수 있습니다.');
+    }
+
     const { accessToken, refreshToken } = await this.issueTokens({
       sub: userData['id'],
       role: userData['role'],

--- a/apps/api/src/auth/strategies/jwt.strategy.spec.ts
+++ b/apps/api/src/auth/strategies/jwt.strategy.spec.ts
@@ -1,6 +1,5 @@
 import { ForbiddenException } from '@nestjs/common';
 import type { ConfigService } from '@nestjs/config';
-import type { FirestoreService } from '../../firestore/firestore.service';
 import { JwtStrategy } from './jwt.strategy';
 
 function makeStrategy(user: Record<string, unknown> | null) {

--- a/apps/api/src/auth/strategies/jwt.strategy.spec.ts
+++ b/apps/api/src/auth/strategies/jwt.strategy.spec.ts
@@ -1,0 +1,59 @@
+import { ForbiddenException } from '@nestjs/common';
+import type { ConfigService } from '@nestjs/config';
+import type { FirestoreService } from '../../firestore/firestore.service';
+import { JwtStrategy } from './jwt.strategy';
+
+function makeStrategy(user: Record<string, unknown> | null) {
+  const firestore = {
+    doc: jest.fn().mockReturnValue({
+      get: jest.fn().mockResolvedValue({
+        exists: user !== null,
+        data: () => user,
+      }),
+    }),
+  };
+  const config = { get: jest.fn().mockReturnValue('jwt-secret') };
+  return {
+    firestore,
+    strategy: new JwtStrategy(config as unknown as ConfigService, firestore as never),
+  };
+}
+
+describe('JwtStrategy driver 승인 경계', () => {
+  it('승인된 driver만 JWT 검증을 통과한다', async () => {
+    const { strategy } = makeStrategy({
+      id: 'driver-1',
+      role: 'driver',
+      driverApproved: true,
+      suspended: false,
+    });
+
+    await expect(strategy.validate({ sub: 'driver-1', role: 'driver' })).resolves.toEqual({
+      sub: 'driver-1',
+      role: 'driver',
+    });
+  });
+
+  it.each([
+    ['승인 전', { id: 'driver-1', role: 'driver', driverApproved: false }],
+    ['승인 필드 없음', { id: 'driver-1', role: 'driver' }],
+    ['정지됨', { id: 'driver-1', role: 'driver', driverApproved: true, suspended: true }],
+    ['역할 불일치', { id: 'driver-1', role: 'consumer', driverApproved: true }],
+  ])('%s driver는 API JWT 검증이 거부된다', async (_label, user) => {
+    const { strategy } = makeStrategy(user);
+
+    await expect(strategy.validate({ sub: 'driver-1', role: 'driver' })).rejects.toBeInstanceOf(
+      ForbiddenException,
+    );
+  });
+
+  it('driver가 아닌 역할은 승인 조회 없이 통과한다', async () => {
+    const { strategy, firestore } = makeStrategy(null);
+
+    await expect(strategy.validate({ sub: 'consumer-1', role: 'consumer' })).resolves.toEqual({
+      sub: 'consumer-1',
+      role: 'consumer',
+    });
+    expect(firestore.doc).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/auth/strategies/jwt.strategy.ts
+++ b/apps/api/src/auth/strategies/jwt.strategy.ts
@@ -1,12 +1,16 @@
-import { Injectable } from '@nestjs/common';
+import { ForbiddenException, Injectable } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import { ConfigService } from '@nestjs/config';
+import { FirestoreService } from '../../firestore/firestore.service';
 import { JwtPayload } from '../types/jwt-payload.type';
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
-  constructor(config: ConfigService) {
+  constructor(
+    config: ConfigService,
+    private readonly firestore: FirestoreService,
+  ) {
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       ignoreExpiration: false,
@@ -14,7 +18,20 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     });
   }
 
-  validate(payload: JwtPayload): JwtPayload {
+  async validate(payload: JwtPayload): Promise<JwtPayload> {
+    if (payload.role === 'driver') {
+      const userSnap = await this.firestore.doc(`users/${payload.sub}`).get();
+      const user = userSnap.data();
+      if (
+        !userSnap.exists ||
+        user?.['role'] !== 'driver' ||
+        user?.['driverApproved'] !== true ||
+        user?.['suspended'] === true
+      ) {
+        throw new ForbiddenException('승인된 드라이버만 배송 기능을 사용할 수 있습니다.');
+      }
+    }
+
     return { sub: payload.sub, role: payload.role, storeId: payload.storeId };
   }
 }

--- a/apps/api/src/driver/driver.controller.spec.ts
+++ b/apps/api/src/driver/driver.controller.spec.ts
@@ -1,0 +1,15 @@
+import { GUARDS_METADATA } from '@nestjs/common/constants';
+import { ROLES_KEY } from '../common/decorators/roles.decorator';
+import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
+import { RolesGuard } from '../common/guards/roles.guard';
+import { DriverController } from './driver.controller';
+
+describe('DriverController 권한 계약', () => {
+  it('driver 역할만 전용 주문 목록 API를 호출할 수 있다', () => {
+    const roles = Reflect.getMetadata(ROLES_KEY, DriverController) as string[];
+    const guards = Reflect.getMetadata(GUARDS_METADATA, DriverController) as unknown[];
+
+    expect(roles).toEqual(['driver']);
+    expect(guards).toEqual(expect.arrayContaining([JwtAuthGuard, RolesGuard]));
+  });
+});

--- a/apps/api/src/driver/driver.controller.ts
+++ b/apps/api/src/driver/driver.controller.ts
@@ -8,7 +8,7 @@ import type { JwtPayload } from '../auth/types/jwt-payload.type';
 
 @Controller('driver')
 @UseGuards(JwtAuthGuard, RolesGuard)
-@Roles('driver', 'seller')
+@Roles('driver')
 export class DriverController {
   constructor(private readonly driver: DriverService) {}
 

--- a/apps/api/src/driver/driver.service.spec.ts
+++ b/apps/api/src/driver/driver.service.spec.ts
@@ -1,0 +1,37 @@
+import { DriverService } from './driver.service';
+
+describe('DriverService 주문 노출 범위', () => {
+  it('미배정 수거 가능 주문과 본인 배정 주문만 반환한다', async () => {
+    const query = {
+      where: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      get: jest.fn().mockResolvedValue({
+        docs: [
+          {
+            id: 'pickup-direct',
+            data: () => ({ status: 'PREPARING', deliveryMethod: 'direct', driverId: null }),
+          },
+          {
+            id: 'pickup-parcel',
+            data: () => ({ status: 'PREPARING', deliveryMethod: 'parcel', driverId: null }),
+          },
+          {
+            id: 'assigned',
+            data: () => ({ status: 'DELIVERING', deliveryMethod: 'direct', driverId: 'driver-1' }),
+          },
+          {
+            id: 'other-driver',
+            data: () => ({ status: 'DELIVERING', deliveryMethod: 'direct', driverId: 'driver-2' }),
+          },
+        ],
+      }),
+    };
+    const firestore = { collection: jest.fn().mockReturnValue(query) };
+    const service = new DriverService(firestore as never);
+
+    await expect(service.getOrders('driver-1')).resolves.toEqual([
+      { id: 'pickup-direct', status: 'PREPARING', deliveryMethod: 'direct', driverId: null },
+      { id: 'assigned', status: 'DELIVERING', deliveryMethod: 'direct', driverId: 'driver-1' },
+    ]);
+  });
+});

--- a/apps/api/src/driver/driver.service.ts
+++ b/apps/api/src/driver/driver.service.ts
@@ -21,6 +21,15 @@ export class DriverService {
       .orderBy('preparedAt', 'asc')
       .get();
 
-    return snap.docs.map((d: any) => ({ id: d.id, ...d.data() }));
+    return snap.docs
+      .map((d: any) => ({ id: d.id, ...d.data() }))
+      .filter((order: Record<string, unknown>) => {
+        const isAssignedToRequester = order['driverId'] === driverId;
+        const isAvailablePickup =
+          order['status'] === 'PREPARING' &&
+          order['driverId'] == null &&
+          ['direct', 'hub'].includes(String(order['deliveryMethod']));
+        return isAssignedToRequester || isAvailablePickup;
+      });
   }
 }

--- a/apps/api/src/firestore/firestore-indexes.spec.ts
+++ b/apps/api/src/firestore/firestore-indexes.spec.ts
@@ -125,6 +125,7 @@ const QUERY_CONTRACTS: QueryContract[] = [
     sourcePatterns: [
       "where('status', '==', 'PREPARING')",
       "where('deliveryMethod', 'in', ['direct', 'hub'])",
+      "where('driverId', '==', null)",
       "orderBy('preparedAt', 'asc')",
     ],
     collectionGroup: 'orders',
@@ -132,6 +133,7 @@ const QUERY_CONTRACTS: QueryContract[] = [
     fields: [
       { fieldPath: 'status', order: 'ASCENDING' },
       { fieldPath: 'deliveryMethod', order: 'ASCENDING' },
+      { fieldPath: 'driverId', order: 'ASCENDING' },
       { fieldPath: 'preparedAt', order: 'ASCENDING' },
     ],
   },

--- a/apps/api/src/orders/driver-assignment.spec.ts
+++ b/apps/api/src/orders/driver-assignment.spec.ts
@@ -14,15 +14,16 @@ function makeFirestore(order: Data) {
   });
   const doc = (path: string) => ({
     path,
-    get: jest.fn(async () => {
+    get: jest.fn(() => {
       if (path === 'orders/order-1' && initialReads < 2) {
         initialReads += 1;
-        return snapshot({ ...order });
+        return Promise.resolve(snapshot({ ...order }));
       }
-      return snapshot(records.get(path) ?? null);
+      return Promise.resolve(snapshot(records.get(path) ?? null));
     }),
-    update: jest.fn(async (data: Data) => {
+    update: jest.fn((data: Data) => {
       records.set(path, { ...(records.get(path) ?? {}), ...data });
+      return Promise.resolve();
     }),
   });
 
@@ -32,8 +33,8 @@ function makeFirestore(order: Data) {
       const result = transactionQueue.then(async () => {
         const pending = new Map<string, Data>();
         const transaction = {
-          get: jest.fn(async (ref: { path: string }) =>
-            snapshot(pending.get(ref.path) ?? records.get(ref.path) ?? null),
+          get: jest.fn((ref: { path: string }) =>
+            Promise.resolve(snapshot(pending.get(ref.path) ?? records.get(ref.path) ?? null)),
           ),
           update: jest.fn((ref: { path: string }, data: Data) => {
             pending.set(ref.path, { ...(records.get(ref.path) ?? {}), ...data });

--- a/apps/api/src/orders/driver-assignment.spec.ts
+++ b/apps/api/src/orders/driver-assignment.spec.ts
@@ -1,0 +1,121 @@
+import { ConflictException, ForbiddenException } from '@nestjs/common';
+import { OrdersLifecycleService } from './orders-lifecycle.service';
+
+type Data = Record<string, unknown>;
+
+function makeFirestore(order: Data) {
+  const records = new Map<string, Data>([['orders/order-1', order]]);
+  let initialReads = 0;
+  let transactionQueue = Promise.resolve();
+
+  const snapshot = (data: Data | null) => ({
+    exists: data !== null,
+    data: () => data,
+  });
+  const doc = (path: string) => ({
+    path,
+    get: jest.fn(async () => {
+      if (path === 'orders/order-1' && initialReads < 2) {
+        initialReads += 1;
+        return snapshot({ ...order });
+      }
+      return snapshot(records.get(path) ?? null);
+    }),
+    update: jest.fn(async (data: Data) => {
+      records.set(path, { ...(records.get(path) ?? {}), ...data });
+    }),
+  });
+
+  const firestore = {
+    doc,
+    runTransaction: jest.fn((callback: (transaction: any) => Promise<unknown>) => {
+      const result = transactionQueue.then(async () => {
+        const pending = new Map<string, Data>();
+        const transaction = {
+          get: jest.fn(async (ref: { path: string }) =>
+            snapshot(pending.get(ref.path) ?? records.get(ref.path) ?? null),
+          ),
+          update: jest.fn((ref: { path: string }, data: Data) => {
+            pending.set(ref.path, { ...(records.get(ref.path) ?? {}), ...data });
+          }),
+        };
+        const value = await callback(transaction);
+        pending.forEach((data, path) => records.set(path, data));
+        return value;
+      });
+      transactionQueue = result.then(
+        () => undefined,
+        () => undefined,
+      );
+      return result;
+    }),
+    Timestamp: { now: jest.fn(() => new Date('2026-08-23T00:00:00.000Z')) },
+  };
+
+  return { firestore, records };
+}
+
+function makeService(firestore: unknown) {
+  return new OrdersLifecycleService(
+    firestore as never,
+    { sendToUser: jest.fn().mockResolvedValue(undefined) } as never,
+    { processRefundByOrderId: jest.fn() } as never,
+    { createSettlement: jest.fn(), cancelSettlement: jest.fn() } as never,
+    { releaseReservation: jest.fn() } as never,
+    {} as never,
+  );
+}
+
+describe('driver 주문 선점 경계', () => {
+  it('동시에 미배정 주문을 선점해도 한 driver만 성공한다', async () => {
+    const { firestore, records } = makeFirestore({
+      storeId: 'store-1',
+      userId: 'consumer-1',
+      status: 'PREPARING',
+      deliveryMethod: 'direct',
+      driverId: null,
+    });
+    const service = makeService(firestore);
+
+    const results = await Promise.allSettled([
+      service.updateStatus('store-1', 'order-1', 'driver-1', { status: 'DELIVERING' }, 'driver'),
+      service.updateStatus('store-1', 'order-1', 'driver-2', { status: 'DELIVERING' }, 'driver'),
+    ]);
+
+    expect(results.filter((result) => result.status === 'fulfilled')).toHaveLength(1);
+    expect(results.filter((result) => result.status === 'rejected')).toHaveLength(1);
+    expect(records.get('orders/order-1')).toMatchObject({ status: 'DELIVERING' });
+    expect(['driver-1', 'driver-2']).toContain(records.get('orders/order-1')?.['driverId']);
+    expect(results.find((result) => result.status === 'rejected')?.reason).toBeInstanceOf(
+      ConflictException,
+    );
+  });
+
+  it('다른 driver가 이미 배정된 주문을 바꾸지 못한다', async () => {
+    const { firestore } = makeFirestore({
+      storeId: 'store-1',
+      status: 'PREPARING',
+      deliveryMethod: 'direct',
+      driverId: 'driver-1',
+    });
+    const service = makeService(firestore);
+
+    await expect(
+      service.updateStatus('store-1', 'order-1', 'driver-2', { status: 'DELIVERING' }, 'driver'),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
+  it('택배 주문은 driver 선점 대상이 아니다', async () => {
+    const { firestore } = makeFirestore({
+      storeId: 'store-1',
+      status: 'PREPARING',
+      deliveryMethod: 'parcel',
+      driverId: null,
+    });
+    const service = makeService(firestore);
+
+    await expect(
+      service.updateStatus('store-1', 'order-1', 'driver-1', { status: 'DELIVERING' }, 'driver'),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+  });
+});

--- a/apps/api/src/orders/orders-lifecycle.service.ts
+++ b/apps/api/src/orders/orders-lifecycle.service.ts
@@ -1,5 +1,6 @@
 import {
   BadRequestException,
+  ConflictException,
   ForbiddenException,
   Injectable,
   NotFoundException,
@@ -186,7 +187,27 @@ export class OrdersLifecycleService {
         t.update(this.firestore.doc(`orders/${orderId}`), update);
       });
     } else {
-      await this.firestore.doc(`orders/${orderId}`).update(update);
+      const isDriverAssignment =
+        role === 'driver' && currentStatus === 'PREPARING' && nextStatus === 'DELIVERING';
+      if (isDriverAssignment) {
+        await this.firestore.runTransaction(async (transaction) => {
+          const orderRef = this.firestore.doc(`orders/${orderId}`);
+          const latestSnap = await transaction.get(orderRef);
+          if (!latestSnap.exists || latestSnap.data()?.['storeId'] !== storeId) {
+            throw new NotFoundException();
+          }
+          const latestOrder = latestSnap.data()!;
+          if (latestOrder['status'] !== 'PREPARING') {
+            throw new ConflictException('주문 상태가 변경되었습니다.');
+          }
+          if (latestOrder['driverId'] != null && latestOrder['driverId'] !== requesterId) {
+            throw new ConflictException('이미 다른 기사에게 배정된 주문입니다.');
+          }
+          transaction.update(orderRef, update);
+        });
+      } else {
+        await this.firestore.doc(`orders/${orderId}`).update(update);
+      }
     }
 
     // 판매자 강제 취소 → settlement 취소 반영
@@ -390,7 +411,12 @@ export class OrdersLifecycleService {
     }
     if (role === 'driver') {
       if (order['driverId'] === requesterId) return;
-      if (!order['driverId'] && order['status'] === 'PREPARING' && nextStatus === 'DELIVERING') {
+      if (
+        order['driverId'] == null &&
+        order['status'] === 'PREPARING' &&
+        nextStatus === 'DELIVERING' &&
+        ['direct', 'hub'].includes(String(order['deliveryMethod']))
+      ) {
         return;
       }
       throw new ForbiddenException('담당 기사만 배송 상태를 변경할 수 있습니다.');

--- a/apps/api/src/orders/round-order-lifecycle.service.ts
+++ b/apps/api/src/orders/round-order-lifecycle.service.ts
@@ -51,6 +51,14 @@ export class RoundOrderLifecycleService {
         throw new ConflictException('주문 상태가 변경되었습니다.');
       }
       if (
+        input.dto.status === 'DELIVERING' &&
+        input.expectedStatus === 'PREPARING' &&
+        order['driverId'] != null &&
+        order['driverId'] !== input.requesterId
+      ) {
+        throw new ConflictException('이미 다른 기사에게 배정된 주문입니다.');
+      }
+      if (
         input.dto.status === 'DELIVERED' &&
         order['deliveryMethod'] === 'direct' &&
         (!Array.isArray(order['deliveryPhotoIds']) || order['deliveryPhotoIds'].length === 0)

--- a/apps/api/src/orders/round-order-lifecycle.service.ts
+++ b/apps/api/src/orders/round-order-lifecycle.service.ts
@@ -34,7 +34,6 @@ export class RoundOrderLifecycleService {
       return this.cancel({
         storeId: input.storeId,
         orderId: input.orderId,
-        expectedStatus: input.expectedStatus,
         reason: input.dto.reason ?? '판매자 취소',
       });
     }
@@ -112,7 +111,6 @@ export class RoundOrderLifecycleService {
     return this.cancel({
       storeId: input.storeId,
       orderId: input.orderId,
-      expectedStatus: order['status'],
       reason: input.reason ?? '소비자 취소',
       requireOpenRound: true,
     });
@@ -124,13 +122,16 @@ export class RoundOrderLifecycleService {
     expectedStatus: OrderStatus;
     reason: string;
   }) {
-    return this.cancel(input);
+    return this.cancel({
+      storeId: input.storeId,
+      orderId: input.orderId,
+      reason: input.reason,
+    });
   }
 
   private async cancel(input: {
     storeId: string;
     orderId: string;
-    expectedStatus: OrderStatus;
     reason: string;
     requireOpenRound?: boolean;
   }) {
@@ -138,50 +139,66 @@ export class RoundOrderLifecycleService {
     if (claimed.done) return { orderId: input.orderId, status: 'CANCELLED' };
 
     if (claimed.needsRefund) {
-      try {
-        await this.payments.processRefundByOrderId(input.orderId, input.reason);
-        await this.payments.refundOrderChargesByOrderId(input.orderId, input.reason);
-      } catch (error) {
-        await this.recordCancellationState(input.orderId, 'REFUND_FAILED', input.reason);
-        throw error;
-      }
-      await this.recordCancellationState(input.orderId, 'LOCAL_PENDING', input.reason);
+      await this.processCancellationRefund(input);
     }
 
+    let localCancellation: { completed: boolean; needsRefund: boolean };
     try {
-      await this.applyLocalCancellation(input);
+      localCancellation = await this.applyLocalCancellation(input);
     } catch (error) {
       await this.recordCancellationState(input.orderId, 'LOCAL_FAILED', input.reason);
       throw error;
     }
-    await this.settlements.cancelSettlement(input.orderId);
+    if (localCancellation.needsRefund) {
+      await this.processCancellationRefund(input);
+      try {
+        localCancellation = await this.applyLocalCancellation(input);
+      } catch (error) {
+        await this.recordCancellationState(input.orderId, 'LOCAL_FAILED', input.reason);
+        throw error;
+      }
+    }
+    if (!localCancellation.completed) {
+      throw new ConflictException('환불 처리 결과를 확인할 수 없어 주문 취소를 완료하지 못했습니다.');
+    }
+
+    try {
+      await this.settlements.cancelSettlement(input.orderId);
+    } catch (error) {
+      await this.recordCancellationState(input.orderId, 'LOCAL_FAILED', input.reason);
+      throw error;
+    }
     return { orderId: input.orderId, status: 'CANCELLED' };
   }
 
   private async claimCancellation(input: {
     storeId: string;
     orderId: string;
-    expectedStatus: OrderStatus;
     reason: string;
     requireOpenRound?: boolean;
   }) {
     let result = { done: false, needsRefund: false };
     await this.firestore.runTransaction(async (tx) => {
       const orderRef = this.firestore.doc(`orders/${input.orderId}`);
+      const paymentRef = this.firestore.doc(`payments/${input.orderId}`);
       const orderSnap = await tx.get(orderRef);
       if (!orderSnap.exists || orderSnap.data()?.['storeId'] !== input.storeId) {
         throw new NotFoundException();
       }
       const order = orderSnap.data() as OrderRecord;
+      const paymentSnap = await tx.get(paymentRef);
+      const payment = paymentSnap.exists ? (paymentSnap.data() as OrderRecord) : null;
+      const paymentIsPaid = payment?.['status'] === 'PAID' && !payment['refundedAt'];
       if (order['status'] === 'CANCELLED') {
-        result = { done: true, needsRefund: false };
+        result = { done: !paymentIsPaid, needsRefund: paymentIsPaid };
         return;
       }
       const cancellationStatus = order['cancellation']?.['status'] as string | undefined;
+      if (cancellationStatus === 'REFUNDING') {
+        result = { done: false, needsRefund: paymentIsPaid };
+        return;
+      }
       if (!['LOCAL_PENDING', 'LOCAL_FAILED'].includes(cancellationStatus ?? '')) {
-        if (order['status'] !== input.expectedStatus) {
-          throw new ConflictException('주문 상태가 변경되었습니다.');
-        }
         if (
           ![
             'PENDING',
@@ -198,7 +215,7 @@ export class RoundOrderLifecycleService {
         if (cancellationStatus === 'REFUNDING') {
           throw new ConflictException('주문 취소가 이미 처리 중입니다.');
         }
-        const needsRefund = order['status'] !== 'PENDING';
+        const needsRefund = order['status'] !== 'PENDING' || paymentIsPaid;
         tx.update(orderRef, {
           cancellation: {
             status: needsRefund ? 'REFUNDING' : 'LOCAL_PENDING',
@@ -219,17 +236,60 @@ export class RoundOrderLifecycleService {
     reason: string;
   }) {
     const now = this.firestore.Timestamp.now();
+    let result = { completed: false, needsRefund: false };
     await this.firestore.runTransaction(async (tx) => {
       const orderRef = this.firestore.doc(`orders/${input.orderId}`);
+      const paymentRef = this.firestore.doc(`payments/${input.orderId}`);
       const orderSnap = await tx.get(orderRef);
       if (!orderSnap.exists || orderSnap.data()?.['storeId'] !== input.storeId) {
         throw new NotFoundException();
       }
       const order = orderSnap.data() as OrderRecord;
-      if (order['status'] === 'CANCELLED') return;
+      const paymentSnap = await tx.get(paymentRef);
+      const payment = paymentSnap.exists ? (paymentSnap.data() as OrderRecord) : null;
+      const paymentIsPaid = payment?.['status'] === 'PAID' && !payment['refundedAt'];
+      if (order['status'] === 'CANCELLED') {
+        if (paymentIsPaid) {
+          tx.update(orderRef, {
+            cancellation: {
+              status: 'REFUNDING',
+              reason: input.reason,
+              updatedAt: this.toIso(now),
+            },
+            updatedAt: now,
+          });
+          result = { completed: false, needsRefund: true };
+          return;
+        }
+        if (order['cancellation']?.['status'] !== 'COMPLETED') {
+          tx.update(orderRef, {
+            cancellation: {
+              status: 'COMPLETED',
+              reason: input.reason,
+              completedAt: this.toIso(now),
+              updatedAt: this.toIso(now),
+            },
+            updatedAt: now,
+          });
+        }
+        result = { completed: true, needsRefund: false };
+        return;
+      }
       const cancellationStatus = order['cancellation']?.['status'];
       if (!['LOCAL_PENDING', 'LOCAL_FAILED'].includes(cancellationStatus)) {
         throw new ConflictException('주문 취소 재시도 상태가 아닙니다.');
+      }
+      if (paymentIsPaid) {
+        tx.update(orderRef, {
+          cancellation: {
+            status: 'REFUNDING',
+            reason: input.reason,
+            updatedAt: this.toIso(now),
+          },
+          updatedAt: now,
+        });
+        result = { completed: false, needsRefund: true };
+        return;
       }
       if (order['reservationId']) {
         await this.capacity.releaseReservationInTransaction(tx, order['reservationId']);
@@ -251,7 +311,23 @@ export class RoundOrderLifecycleService {
         },
         updatedAt: now,
       });
+      result = { completed: true, needsRefund: false };
     });
+    return result;
+  }
+
+  private async processCancellationRefund(input: {
+    orderId: string;
+    reason: string;
+  }) {
+    try {
+      await this.payments.processRefundByOrderId(input.orderId, input.reason);
+      await this.payments.refundOrderChargesByOrderId(input.orderId, input.reason);
+    } catch (error) {
+      await this.recordCancellationState(input.orderId, 'REFUND_FAILED', input.reason);
+      throw error;
+    }
+    await this.recordCancellationState(input.orderId, 'LOCAL_PENDING', input.reason);
   }
 
   private async recordCancellationState(orderId: string, status: string, reason: string) {

--- a/apps/api/src/payments/p0-002-race.spec.ts
+++ b/apps/api/src/payments/p0-002-race.spec.ts
@@ -2,31 +2,88 @@ import { PaymentFinalizationService } from './payment-finalization.service';
 import { PaymentRefundService } from './payment-refund.service';
 import { RoundOrderLifecycleService } from '../orders/round-order-lifecycle.service';
 
-type Data = Record<string, any>;
+type Data = Record<string, unknown>;
 
-function makeSnap(data: Data | null, ref?: Data) {
+type MockDocumentRef = {
+  path: string;
+  get: () => Promise<MockSnapshot>;
+  set: (data: Data) => Promise<void>;
+  update: (data: Data) => Promise<void>;
+};
+
+type MockSnapshot = {
+  exists: boolean;
+  data(): Data | null;
+  ref?: MockDocumentRef;
+};
+
+type MockQueryDocument = {
+  id: string;
+  data(): Data;
+  ref: MockDocumentRef;
+};
+
+type MockQuery = {
+  where(field: string, op: string, value: unknown): MockQuery;
+  limit(value?: number): MockQuery;
+  get(): Promise<{ empty: boolean; docs: MockQueryDocument[] }>;
+};
+
+type MockTransaction = {
+  get(ref: MockDocumentRef): Promise<MockSnapshot>;
+  set(ref: MockDocumentRef, data: Data): void;
+  update(ref: MockDocumentRef, data: Data): void;
+};
+
+type CancellationInput = {
+  storeId: string;
+  orderId: string;
+  reason: string;
+};
+
+type CancellationLifecycleHook = {
+  applyLocalCancellation: (input: CancellationInput) => Promise<{
+    completed: boolean;
+    needsRefund: boolean;
+  }>;
+};
+
+type MockFirestore = {
+  doc(path: string): MockDocumentRef;
+  collection(name: string): MockQuery;
+  runTransaction<T>(callback: (tx: MockTransaction) => Promise<T>): Promise<T>;
+  Timestamp: { now(): Date };
+  FieldValue: { increment(value: number): { __increment: number } };
+};
+
+function makeSnap(data: Data | null, ref?: MockDocumentRef): MockSnapshot {
   return { exists: data !== null, data: () => data, ref };
 }
 
 function makeFirestore(initial: Record<string, Data>) {
-  const records = new Map(Object.entries(initial));
-  const refs = new Map<string, Data>();
-  const doc = (path: string) => {
+  const records = new Map<string, Data>(Object.entries(initial));
+  const refs = new Map<string, MockDocumentRef>();
+  const doc = (path: string): MockDocumentRef => {
     if (!refs.has(path)) {
-      refs.set(path, {
+      const ref: MockDocumentRef = {
         path,
-        get: jest.fn(async () => makeSnap(records.get(path) ?? null, refs.get(path))),
-        set: jest.fn(async (data: Data) => records.set(path, data)),
-        update: jest.fn(async (data: Data) =>
-          records.set(path, { ...(records.get(path) ?? {}), ...data }),
-        ),
-      });
+        get: jest.fn(() => Promise.resolve(makeSnap(records.get(path) ?? null, ref))),
+        set: jest.fn((data: Data) => {
+          records.set(path, data);
+          return Promise.resolve();
+        }),
+        update: jest.fn((data: Data) => {
+          records.set(path, { ...(records.get(path) ?? {}), ...data });
+          return Promise.resolve();
+        }),
+      };
+      refs.set(path, ref);
     }
-    return refs.get(path);
+    return refs.get(path)!;
   };
-  const collection = (name: string) => {
+  const collection = (name: string): MockQuery => {
     const filters: Array<[string, string, unknown]> = [];
-    const query: Data = {
+    const query: MockQuery = {
       where(field: string, op: string, value: unknown) {
         filters.push([field, op, value]);
         return query;
@@ -34,7 +91,7 @@ function makeFirestore(initial: Record<string, Data>) {
       limit() {
         return query;
       },
-      async get() {
+      get() {
         const docs = Array.from(records.entries())
           .filter(([path, data]) => {
             if (!path.startsWith(`${name}/`)) return false;
@@ -42,26 +99,30 @@ function makeFirestore(initial: Record<string, Data>) {
               op === '<' ? true : data[field] === value,
             );
           })
-          .map(([path, data]) => ({ id: path.split('/')[1], data: () => data, ref: doc(path) }));
-        return { empty: docs.length === 0, docs };
+          .map(([path, data]) => ({
+            id: path.split('/').at(-1) ?? '',
+            data: () => data,
+            ref: doc(path),
+          }));
+        return Promise.resolve({ empty: docs.length === 0, docs });
       },
     };
     return query;
   };
 
   let transactionQueue = Promise.resolve();
-  const firestore = {
+  const firestore: MockFirestore = {
     doc,
     collection,
-    runTransaction: jest.fn((callback: (tx: Data) => Promise<unknown>) => {
+    runTransaction: jest.fn(<T>(callback: (tx: MockTransaction) => Promise<T>) => {
       const result = transactionQueue.then(async () => {
         const pending = new Map<string, Data>();
-        const tx = {
-          get: jest.fn(async (ref: Data) =>
-            makeSnap(pending.get(ref.path) ?? records.get(ref.path) ?? null, ref),
+        const tx: MockTransaction = {
+          get: jest.fn((ref: MockDocumentRef) =>
+            Promise.resolve(makeSnap(pending.get(ref.path) ?? records.get(ref.path) ?? null, ref)),
           ),
-          set: jest.fn((ref: Data, data: Data) => pending.set(ref.path, data)),
-          update: jest.fn((ref: Data, data: Data) => {
+          set: jest.fn((ref: MockDocumentRef, data: Data) => pending.set(ref.path, data)),
+          update: jest.fn((ref: MockDocumentRef, data: Data) => {
             const current = pending.get(ref.path) ?? records.get(ref.path) ?? {};
             pending.set(ref.path, { ...current, ...data });
           }),
@@ -79,9 +140,7 @@ function makeFirestore(initial: Record<string, Data>) {
     Timestamp: {
       now: jest.fn(() => new Date('2026-08-23T00:00:00.000Z')),
     },
-    FieldValue: {
-      increment: jest.fn((value: number) => ({ __increment: value })),
-    },
+    FieldValue: { increment: jest.fn((value: number) => ({ __increment: value })) },
   };
   return { firestore, records };
 }
@@ -193,7 +252,7 @@ describe('P0-002 회차 취소와 결제 finalization 경합', () => {
     const readStarted = new Promise<void>((resolve) => {
       reached = resolve;
     });
-    const orderRef = (fixture.firestore as any).doc('orders/order-1');
+    const orderRef = fixture.firestore.doc('orders/order-1');
     const originalGet = orderRef.get;
     let firstRead = true;
     orderRef.get = jest.fn(async () => {
@@ -241,11 +300,14 @@ describe('P0-002 회차 취소와 결제 finalization 경합', () => {
     const applyStarted = new Promise<void>((resolve) => {
       reached = resolve;
     });
-    const originalApply = (fixture.lifecycle as any).applyLocalCancellation.bind(fixture.lifecycle);
-    (fixture.lifecycle as any).applyLocalCancellation = async (input: Data) => {
+    const lifecycleHook = fixture.lifecycle as unknown as CancellationLifecycleHook;
+    const unboundOriginalApply = lifecycleHook.applyLocalCancellation;
+    const originalApply = unboundOriginalApply.bind(
+      fixture.lifecycle,
+    ) as CancellationLifecycleHook['applyLocalCancellation'];
+    lifecycleHook.applyLocalCancellation = (input) => {
       reached();
-      await gate;
-      return originalApply(input);
+      return gate.then(() => originalApply(input));
     };
 
     const cancellation = fixture.lifecycle.cancelByConsumer({

--- a/apps/api/src/payments/p0-002-race.spec.ts
+++ b/apps/api/src/payments/p0-002-race.spec.ts
@@ -1,0 +1,337 @@
+import { PaymentFinalizationService } from './payment-finalization.service';
+import { PaymentRefundService } from './payment-refund.service';
+import { RoundOrderLifecycleService } from '../orders/round-order-lifecycle.service';
+
+type Data = Record<string, any>;
+
+function makeSnap(data: Data | null, ref?: Data) {
+  return { exists: data !== null, data: () => data, ref };
+}
+
+function makeFirestore(initial: Record<string, Data>) {
+  const records = new Map(Object.entries(initial));
+  const refs = new Map<string, Data>();
+  const doc = (path: string) => {
+    if (!refs.has(path)) {
+      refs.set(path, {
+        path,
+        get: jest.fn(async () => makeSnap(records.get(path) ?? null, refs.get(path))),
+        set: jest.fn(async (data: Data) => records.set(path, data)),
+        update: jest.fn(async (data: Data) =>
+          records.set(path, { ...(records.get(path) ?? {}), ...data }),
+        ),
+      });
+    }
+    return refs.get(path);
+  };
+  const collection = (name: string) => {
+    const filters: Array<[string, string, unknown]> = [];
+    const query: Data = {
+      where(field: string, op: string, value: unknown) {
+        filters.push([field, op, value]);
+        return query;
+      },
+      limit() {
+        return query;
+      },
+      async get() {
+        const docs = Array.from(records.entries())
+          .filter(([path, data]) => {
+            if (!path.startsWith(`${name}/`)) return false;
+            return filters.every(([field, op, value]) =>
+              op === '<' ? true : data[field] === value,
+            );
+          })
+          .map(([path, data]) => ({ id: path.split('/')[1], data: () => data, ref: doc(path) }));
+        return { empty: docs.length === 0, docs };
+      },
+    };
+    return query;
+  };
+
+  let transactionQueue = Promise.resolve();
+  const firestore = {
+    doc,
+    collection,
+    runTransaction: jest.fn((callback: (tx: Data) => Promise<unknown>) => {
+      const result = transactionQueue.then(async () => {
+        const pending = new Map<string, Data>();
+        const tx = {
+          get: jest.fn(async (ref: Data) =>
+            makeSnap(pending.get(ref.path) ?? records.get(ref.path) ?? null, ref),
+          ),
+          set: jest.fn((ref: Data, data: Data) => pending.set(ref.path, data)),
+          update: jest.fn((ref: Data, data: Data) => {
+            const current = pending.get(ref.path) ?? records.get(ref.path) ?? {};
+            pending.set(ref.path, { ...current, ...data });
+          }),
+        };
+        const value = await callback(tx);
+        for (const [path, data] of pending) records.set(path, data);
+        return value;
+      });
+      transactionQueue = result.then(
+        () => undefined,
+        () => undefined,
+      );
+      return result;
+    }),
+    Timestamp: {
+      now: jest.fn(() => new Date('2026-08-23T00:00:00.000Z')),
+    },
+    FieldValue: {
+      increment: jest.fn((value: number) => ({ __increment: value })),
+    },
+  };
+  return { firestore, records };
+}
+
+function makeOrder(overrides: Data = {}) {
+  return {
+    id: 'order-1',
+    storeId: 'store-1',
+    userId: 'user-1',
+    status: 'PENDING',
+    schemaVersion: 2,
+    roundId: 'round-1',
+    reservationId: 'reservation-1',
+    saleType: 'normal',
+    totalAmount: 100000,
+    deliveryAddress: { address: '경기도 이천시 중리천로 1' },
+    orderItems: [{ roundItemId: 'round-item-1', quantity: 1 }],
+    ...overrides,
+  };
+}
+
+function makeFixture(orderOverrides: Data = {}) {
+  const { firestore, records } = makeFirestore({
+    'orders/order-1': makeOrder(orderOverrides),
+    'saleRounds/round-1': {
+      storeId: 'store-1',
+      schedule: { orderCloseAt: '2099-08-23T00:00:00.000Z' },
+    },
+  });
+  const portone = { refund: jest.fn().mockResolvedValue(undefined) };
+  const issueWriter = { createOrMergeIssue: jest.fn().mockResolvedValue({ id: 'issue-1' }) };
+  const retention = { saveRecord: jest.fn().mockResolvedValue({}) };
+  const refunds = new PaymentRefundService(
+    firestore as never,
+    portone as never,
+    issueWriter as never,
+    retention as never,
+  );
+  const capacity = {
+    reserveCheckout: jest.fn().mockResolvedValue({ id: 'late-reservation-1' }),
+    consumeReservationInTransaction: jest.fn().mockResolvedValue({ status: 'CONSUMED' }),
+    releaseReservationInTransaction: jest.fn().mockResolvedValue({ status: 'RELEASED' }),
+  };
+  const notifications = { sendToUser: jest.fn() };
+  const finalization = new PaymentFinalizationService(
+    firestore as never,
+    portone as never,
+    notifications as never,
+    { log: jest.fn() } as never,
+    capacity as never,
+    issueWriter as never,
+    retention as never,
+    refunds,
+  );
+  const payments = {
+    processRefundByOrderId: jest.fn((orderId: string, reason: string) =>
+      refunds.refundByOrderId(orderId, reason),
+    ),
+    refundOrderChargesByOrderId: jest.fn().mockResolvedValue(undefined),
+  };
+  const settlements = { cancelSettlement: jest.fn().mockResolvedValue(undefined) };
+  const lifecycle = new RoundOrderLifecycleService(
+    firestore as never,
+    payments as never,
+    settlements as never,
+    capacity as never,
+  );
+  return { firestore, records, portone, payments, finalization, lifecycle };
+}
+
+const paidPayment = {
+  amount: { total: 100000 },
+  status: 'PAID',
+  method: { type: 'CARD' },
+  transactionId: 'tx-1',
+} as never;
+
+describe('P0-002 회차 취소와 결제 finalization 경합', () => {
+  it('cancel first: 완료된 취소 뒤 늦은 PAID를 기존 환불 경로로 수렴시킨다', async () => {
+    const fixture = makeFixture();
+
+    await fixture.lifecycle.cancelByConsumer({
+      storeId: 'store-1',
+      orderId: 'order-1',
+      userId: 'user-1',
+      reason: '소비자 취소',
+    });
+    const result = await fixture.finalization.finalizePaidOrder('order-1', paidPayment);
+
+    expect(result).toEqual({ ok: false, reason: 'cancelled_paid_refunded' });
+    expect(fixture.records.get('orders/order-1')).toMatchObject({
+      status: 'CANCELLED',
+      cancellation: { status: 'COMPLETED' },
+    });
+    expect(fixture.records.get('payments/order-1')).toMatchObject({
+      status: 'CANCELLED',
+      refundAmount: 100000,
+    });
+    expect(fixture.portone.refund).toHaveBeenCalledTimes(1);
+  });
+
+  it('payment first: 취소 요청이 시작된 뒤 결제 확정이 먼저 커밋되어도 최신 상태로 환불 취소한다', async () => {
+    const fixture = makeFixture();
+    let release!: () => void;
+    let reached!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const readStarted = new Promise<void>((resolve) => {
+      reached = resolve;
+    });
+    const orderRef = (fixture.firestore as any).doc('orders/order-1');
+    const originalGet = orderRef.get;
+    let firstRead = true;
+    orderRef.get = jest.fn(async () => {
+      const snapshot = await originalGet();
+      if (firstRead) {
+        firstRead = false;
+        reached();
+        await gate;
+      }
+      return snapshot;
+    });
+
+    const cancellation = fixture.lifecycle.cancelByConsumer({
+      storeId: 'store-1',
+      orderId: 'order-1',
+      userId: 'user-1',
+      reason: '소비자 취소',
+    });
+    await readStarted;
+
+    await expect(fixture.finalization.finalizePaidOrder('order-1', paidPayment)).resolves.toEqual({
+      ok: true,
+      status: 'ACCEPTED',
+    });
+    expect(fixture.records.get('orders/order-1')?.status).toBe('ACCEPTED');
+
+    release();
+    await cancellation;
+
+    expect(fixture.records.get('orders/order-1')).toMatchObject({
+      status: 'CANCELLED',
+      cancellation: { status: 'COMPLETED' },
+    });
+    expect(fixture.records.get('payments/order-1')).toMatchObject({ status: 'CANCELLED' });
+    expect(fixture.portone.refund).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancellation claim first: PAID가 기록되어도 로컬 취소가 최신 결제를 다시 확인한다', async () => {
+    const fixture = makeFixture();
+    let release!: () => void;
+    let reached!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const applyStarted = new Promise<void>((resolve) => {
+      reached = resolve;
+    });
+    const originalApply = (fixture.lifecycle as any).applyLocalCancellation.bind(fixture.lifecycle);
+    (fixture.lifecycle as any).applyLocalCancellation = async (input: Data) => {
+      reached();
+      await gate;
+      return originalApply(input);
+    };
+
+    const cancellation = fixture.lifecycle.cancelByConsumer({
+      storeId: 'store-1',
+      orderId: 'order-1',
+      userId: 'user-1',
+      reason: '소비자 취소',
+    });
+    await applyStarted;
+
+    await expect(fixture.finalization.finalizePaidOrder('order-1', paidPayment)).resolves.toEqual({
+      ok: false,
+      reason: 'cancelled_paid_refunded',
+    });
+    expect(fixture.records.get('orders/order-1')?.status).toBe('PENDING');
+    expect(fixture.records.get('payments/order-1')?.status).toBe('CANCELLED');
+
+    release();
+    await cancellation;
+
+    expect(fixture.records.get('orders/order-1')).toMatchObject({
+      status: 'CANCELLED',
+      cancellation: { status: 'COMPLETED' },
+    });
+    expect(fixture.records.get('payments/order-1')).toMatchObject({ status: 'CANCELLED' });
+    expect(fixture.portone.refund).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancellation claim exists: 진행 중 취소는 정상 ACCEPTED 전환을 차단한다', async () => {
+    const fixture = makeFixture({
+      cancellation: { status: 'LOCAL_PENDING', reason: '소비자 취소' },
+    });
+
+    const result = await fixture.finalization.finalizePaidOrder('order-1', paidPayment);
+
+    expect(result).toEqual({ ok: false, reason: 'cancelled_paid_refunded' });
+    expect(fixture.records.get('orders/order-1')?.status).toBe('PENDING');
+    expect(fixture.records.get('payments/order-1')?.status).toBe('CANCELLED');
+    expect(fixture.portone.refund).toHaveBeenCalledTimes(1);
+  });
+
+  it('취소 후 확인된 결제의 환불 실패는 정상 취소 완료로 숨기지 않는다', async () => {
+    const fixture = makeFixture({
+      status: 'CANCELLED',
+      cancelReason: '소비자 취소',
+      cancellation: { status: 'COMPLETED', reason: '소비자 취소' },
+    });
+    fixture.portone.refund.mockRejectedValueOnce(new Error('환불 실패'));
+
+    await expect(fixture.finalization.finalizePaidOrder('order-1', paidPayment)).rejects.toThrow(
+      '환불 실패',
+    );
+    expect(fixture.records.get('orders/order-1')).toMatchObject({
+      status: 'CANCELLED',
+      cancellation: { status: 'REFUND_FAILED' },
+    });
+    expect(fixture.records.get('payments/order-1')).toMatchObject({
+      status: 'PAID',
+      refundClaim: null,
+    });
+  });
+
+  it('normal payment: 취소 claim이 없는 PAID는 기존 ACCEPTED 전환을 유지한다', async () => {
+    const fixture = makeFixture();
+
+    const result = await fixture.finalization.finalizePaidOrder('order-1', paidPayment);
+
+    expect(result).toEqual({ ok: true, status: 'ACCEPTED' });
+    expect(fixture.records.get('orders/order-1')?.status).toBe('ACCEPTED');
+    expect(fixture.records.get('payments/order-1')?.status).toBe('PAID');
+    expect(fixture.portone.refund).not.toHaveBeenCalled();
+  });
+
+  it('normal unpaid cancellation: 결제 기록이 없으면 PortOne 환불 없이 취소한다', async () => {
+    const fixture = makeFixture();
+
+    await fixture.lifecycle.cancelByConsumer({
+      storeId: 'store-1',
+      orderId: 'order-1',
+      userId: 'user-1',
+      reason: '소비자 취소',
+    });
+
+    expect(fixture.records.get('orders/order-1')?.status).toBe('CANCELLED');
+    expect(fixture.records.has('payments/order-1')).toBe(false);
+    expect(fixture.portone.refund).not.toHaveBeenCalled();
+    expect(fixture.payments.processRefundByOrderId).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/payments/payment-finalization.service.ts
+++ b/apps/api/src/payments/payment-finalization.service.ts
@@ -6,6 +6,7 @@ import { OperationIssueWriterService } from '../operations/operation-issue-write
 import { OrderCapacityService } from '../orders/order-capacity.service';
 import { RetentionService } from '../retention/retention.service';
 import { PortoneClient } from './portone.client';
+import { PaymentRefundService } from './payment-refund.service';
 
 type PaymentData = Awaited<ReturnType<PortoneClient['getPayment']>>;
 const LATE_PAYMENT_REFUND_REASON = '결제 만료 후 회차 한도 마감';
@@ -21,6 +22,7 @@ export class PaymentFinalizationService {
     private readonly capacity: OrderCapacityService,
     private readonly issueWriter: OperationIssueWriterService,
     private readonly retention: RetentionService,
+    private readonly refunds: PaymentRefundService,
   ) {}
 
   async recordPaymentLookupFailure(orderId: string, error: unknown) {
@@ -50,7 +52,9 @@ export class PaymentFinalizationService {
     const orderSnap = await this.firestore.doc(`orders/${orderId}`).get();
     if (!orderSnap.exists) return { ok: false, reason: 'order_not_found' };
     const order = orderSnap.data() as Record<string, any>;
-    if (!this.canFinalize(order)) return { ok: true, reason: 'already_processed' };
+    if (!this.canFinalize(order) && !this.isCancellationSettlementCandidate(order)) {
+      return { ok: true, reason: 'already_processed' };
+    }
 
     if (paymentData.amount.total !== order['totalAmount']) {
       await this.audit.log('payment.amount_tampered', {
@@ -63,7 +67,11 @@ export class PaymentFinalizationService {
     }
 
     let reservationId = order['reservationId'] as string | undefined;
-    if (order['schemaVersion'] === 2 && order['status'] === 'CANCELLED') {
+    if (
+      order['schemaVersion'] === 2 &&
+      order['status'] === 'CANCELLED' &&
+      order['cancelReason'] === 'timeout'
+    ) {
       try {
         const reservation = await this.capacity.reserveCheckout({
           storeId: order['storeId'],
@@ -87,11 +95,31 @@ export class PaymentFinalizationService {
     const newStatus = order['saleType'] === 'group' ? 'RECRUITING' : 'ACCEPTED';
     const now = this.firestore.Timestamp.now();
     let applied = false;
+    let cancellationOutcome: 'REFUND' | null = null;
     await this.firestore.runTransaction(async (tx) => {
       const orderRef = this.firestore.doc(`orders/${orderId}`);
+      const paymentRef = this.firestore.doc(`payments/${orderId}`);
       const freshSnap = await tx.get(orderRef);
       if (!freshSnap.exists) return;
       const freshOrder = freshSnap.data() as Record<string, any>;
+      if (this.isCancellationSettlementCandidate(freshOrder)) {
+        const paymentSnap = await tx.get(paymentRef);
+        const payment = paymentSnap.exists ? (paymentSnap.data() as Record<string, any>) : null;
+        if (payment?.['status'] !== 'CANCELLED' && !payment?.['refundedAt']) {
+          if (payment?.['status'] !== 'PAID') {
+            await this.writePaidPaymentInTransaction(
+              tx,
+              orderId,
+              freshOrder,
+              paymentData,
+              now,
+              freshOrder['status'],
+            );
+          }
+          cancellationOutcome = 'REFUND';
+        }
+        return;
+      }
       if (!this.canFinalize(freshOrder)) return;
 
       if (freshOrder['schemaVersion'] === 2) {
@@ -103,46 +131,40 @@ export class PaymentFinalizationService {
         });
       }
       tx.update(orderRef, {
-        status: newStatus,
+        status: freshOrder['saleType'] === 'group' ? 'RECRUITING' : 'ACCEPTED',
         ...(reservationId ? { reservationId } : {}),
         updatedAt: now,
       });
-      tx.set(this.firestore.doc(`payments/${orderId}`), {
-        id: orderId,
+      const finalStatus = freshOrder['saleType'] === 'group' ? 'RECRUITING' : 'ACCEPTED';
+      await this.writePaidPaymentInTransaction(
+        tx,
         orderId,
-        userId: freshOrder['userId'],
-        storeId: freshOrder['storeId'],
-        amount: paymentData.amount.total,
-        payMethod: paymentData.method?.type ?? null,
-        status: 'PAID',
-        portonePaymentId: orderId,
-        portoneTransactionId: paymentData.transactionId,
-        refundAmount: null,
-        refundedAt: null,
-        refundReason: null,
-        refundClaim: null,
-        createdAt: now,
-        updatedAt: now,
-      });
-      await this.retention.saveRecord({
-        id: `${orderId}:payment`,
-        purpose: 'LEGAL_ORDER',
-        basisAt: this.toDate(now),
-        metadata: {
-          orderId,
-          paymentId: orderId,
-          storeId: freshOrder['storeId'],
-          userId: freshOrder['userId'],
-          recordTypes: ['PAYMENT'],
-          amount: paymentData.amount.total,
-          payMethod: paymentData.method?.type ?? null,
-          orderStatus: newStatus,
-          paymentStatus: 'PAID',
-        },
-        transaction: tx,
-      });
+        freshOrder,
+        paymentData,
+        now,
+        finalStatus,
+      );
       applied = true;
     });
+    if (cancellationOutcome === 'REFUND') {
+      try {
+        await this.refunds.refundByOrderId(
+          orderId,
+          order['cancelReason'] ?? '취소 후 확인된 결제 환불',
+        );
+      } catch (error) {
+        await this.firestore.doc(`orders/${orderId}`).update({
+          cancellation: {
+            status: 'REFUND_FAILED',
+            reason: order['cancelReason'] ?? '취소 후 확인된 결제 환불',
+            updatedAt: this.firestore.Timestamp.now(),
+          },
+          updatedAt: this.firestore.Timestamp.now(),
+        });
+        throw error;
+      }
+      return { ok: false, reason: 'cancelled_paid_refunded' };
+    }
     if (!applied) return { ok: true, reason: 'already_processed' };
 
     await this.notifications.sendToUser(
@@ -194,6 +216,58 @@ export class PaymentFinalizationService {
         order['cancelReason'] === 'timeout' &&
         !order['latePaymentRefundedAt'])
     );
+  }
+
+  private isCancellationSettlementCandidate(order: Record<string, any>) {
+    return (
+      (order['status'] === 'CANCELLED' && order['cancelReason'] !== 'timeout') ||
+      ['LOCAL_PENDING', 'LOCAL_FAILED', 'REFUNDING'].includes(order['cancellation']?.['status'])
+    );
+  }
+
+  private async writePaidPaymentInTransaction(
+    tx: any,
+    orderId: string,
+    order: Record<string, any>,
+    paymentData: PaymentData,
+    now: any,
+    orderStatus: string,
+  ) {
+    const paymentRef = this.firestore.doc(`payments/${orderId}`);
+    tx.set(paymentRef, {
+      id: orderId,
+      orderId,
+      userId: order['userId'],
+      storeId: order['storeId'],
+      amount: paymentData.amount.total,
+      payMethod: paymentData.method?.type ?? null,
+      status: 'PAID',
+      portonePaymentId: orderId,
+      portoneTransactionId: paymentData.transactionId,
+      refundAmount: null,
+      refundedAt: null,
+      refundReason: null,
+      refundClaim: null,
+      createdAt: now,
+      updatedAt: now,
+    });
+    await this.retention.saveRecord({
+      id: `${orderId}:payment`,
+      purpose: 'LEGAL_ORDER',
+      basisAt: this.toDate(now),
+      metadata: {
+        orderId,
+        paymentId: orderId,
+        storeId: order['storeId'],
+        userId: order['userId'],
+        recordTypes: ['PAYMENT'],
+        amount: paymentData.amount.total,
+        payMethod: paymentData.method?.type ?? null,
+        orderStatus,
+        paymentStatus: 'PAID',
+      },
+      transaction: tx,
+    });
   }
 
   private resolveBuyerDisplayName(order: Record<string, any>): string {

--- a/apps/api/src/payments/payment-finalization.service.ts
+++ b/apps/api/src/payments/payment-finalization.service.ts
@@ -52,6 +52,9 @@ export class PaymentFinalizationService {
     const orderSnap = await this.firestore.doc(`orders/${orderId}`).get();
     if (!orderSnap.exists) return { ok: false, reason: 'order_not_found' };
     const order = orderSnap.data() as Record<string, any>;
+    if (paymentData.status !== 'PAID') {
+      return { ok: true, reason: 'payment_not_paid' };
+    }
     if (!this.canFinalize(order) && !this.isCancellationSettlementCandidate(order)) {
       return { ok: true, reason: 'already_processed' };
     }

--- a/apps/api/src/payments/payments.service.spec.ts
+++ b/apps/api/src/payments/payments.service.spec.ts
@@ -86,6 +86,10 @@ const paymentData = {
   transactionId: 'tx-1',
 } as never;
 
+function paymentDataWithStatus(status: string, overrides: Data = {}) {
+  return { ...paymentData, status, ...overrides } as never;
+}
+
 function makeFinalization(overrides: Data = {}) {
   const order = {
     id: 'order-1',
@@ -137,6 +141,57 @@ function makeFinalization(overrides: Data = {}) {
 }
 
 describe('결제 최종화 경쟁 조건', () => {
+  it.each(['PENDING', 'FAILED', 'CANCELLED'])(
+    'PortOne 상태가 %s이면 정상 주문 finalization을 수행하지 않는다',
+    async (status) => {
+      const fixture = makeFinalization(
+        status === 'CANCELLED' ? { status: 'CANCELLED', cancelReason: '소비자 취소' } : {},
+      );
+
+      await expect(
+        fixture.service.finalizePaidOrder('order-1', paymentDataWithStatus(status)),
+      ).resolves.toEqual({ ok: true, reason: 'payment_not_paid' });
+
+      expect(fixture.records.get('orders/order-1')?.status).toBe(
+        status === 'CANCELLED' ? 'CANCELLED' : 'PENDING',
+      );
+      expect(fixture.records.has('payments/order-1')).toBe(false);
+      expect(fixture.capacity.consumeReservationInTransaction).not.toHaveBeenCalled();
+      expect(fixture.portone.refund).not.toHaveBeenCalled();
+    },
+  );
+
+  it('PAID group 결제는 기존 RECRUITING finalization을 유지한다', async () => {
+    const fixture = makeFinalization({ saleType: 'group' });
+
+    await expect(fixture.service.finalizePaidOrder('order-1', paymentData)).resolves.toEqual({
+      ok: true,
+      status: 'RECRUITING',
+    });
+
+    expect(fixture.records.get('orders/order-1')?.status).toBe('RECRUITING');
+    expect(fixture.records.get('payments/order-1')?.status).toBe('PAID');
+  });
+
+  it('PAID 금액이 주문 금액과 다르면 기존 환불 방어를 유지한다', async () => {
+    const fixture = makeFinalization();
+
+    await expect(
+      fixture.service.finalizePaidOrder(
+        'order-1',
+        paymentDataWithStatus('PAID', { amount: { total: 99999 } }),
+      ),
+    ).resolves.toEqual({ ok: false, reason: 'amount_mismatch' });
+
+    expect(fixture.portone.refund).toHaveBeenCalledWith(
+      'order-1',
+      99999,
+      '금액 위변조 감지',
+    );
+    expect(fixture.records.get('orders/order-1')?.status).toBe('CANCELLED');
+    expect(fixture.records.has('payments/order-1')).toBe(false);
+  });
+
   it('결제 조회 최종 실패를 허용된 상태 정보만 담아 운영 예외로 기록한다', async () => {
     const fixture = makeFinalization();
 

--- a/apps/api/src/payments/payments.service.spec.ts
+++ b/apps/api/src/payments/payments.service.spec.ts
@@ -112,6 +112,7 @@ function makeFinalization(overrides: Data = {}) {
   };
   const issueWriter = { createOrMergeIssue: jest.fn().mockResolvedValue({ id: 'issue-1' }) };
   const retention = { saveRecord: jest.fn().mockResolvedValue({}) };
+  const refunds = { refundByOrderId: jest.fn().mockResolvedValue(undefined) };
   const service = new PaymentFinalizationService(
     firestore as never,
     portone as never,
@@ -120,6 +121,7 @@ function makeFinalization(overrides: Data = {}) {
     capacity as never,
     issueWriter as never,
     retention as never,
+    refunds as never,
   );
   return {
     service,
@@ -130,6 +132,7 @@ function makeFinalization(overrides: Data = {}) {
     capacity,
     issueWriter,
     retention,
+    refunds,
   };
 }
 

--- a/apps/api/test/helpers/mvp-sales-round-fixture.ts
+++ b/apps/api/test/helpers/mvp-sales-round-fixture.ts
@@ -151,6 +151,7 @@ export async function createMvpSalesRoundFixture() {
     capacity,
     issueWriter,
     retention,
+    refunds,
   );
   const payments = new PaymentsService(
     firestore,

--- a/apps/api/test/helpers/mvp-sales-round-fixture.ts
+++ b/apps/api/test/helpers/mvp-sales-round-fixture.ts
@@ -82,8 +82,8 @@ function seedRecords(): Record<string, Data> {
       name: '다른 구매자',
       phone: '010-2222-2222',
     },
-    'users/driver-1': { id: 'driver-1', role: 'driver' },
-    'users/driver-2': { id: 'driver-2', role: 'driver' },
+    'users/driver-1': { id: 'driver-1', role: 'driver', driverApproved: true },
+    'users/driver-2': { id: 'driver-2', role: 'driver', driverApproved: true },
     'users/admin-1': { id: 'admin-1', role: 'admin' },
   };
 }

--- a/apps/api/test/mvp-sales-round-consistency.e2e-spec.ts
+++ b/apps/api/test/mvp-sales-round-consistency.e2e-spec.ts
@@ -132,6 +132,7 @@ describe('회차 직배송 실제 서비스 정합성', () => {
     const fixture = makeFixture();
     const payment = {
       amount: { total: 40_000 },
+      status: 'PAID',
       method: { type: 'CARD' },
       transactionId: 'transaction-1',
     };
@@ -166,6 +167,7 @@ describe('회차 직배송 실제 서비스 정합성', () => {
     const fixture = makeFixture();
     await fixture.finalization.finalizePaidOrder('order-1', {
       amount: { total: 40_000 },
+      status: 'PAID',
       method: { type: 'CARD' },
       transactionId: 'transaction-1',
     } as never);

--- a/apps/api/test/mvp-sales-round-consistency.e2e-spec.ts
+++ b/apps/api/test/mvp-sales-round-consistency.e2e-spec.ts
@@ -92,7 +92,17 @@ function makeFixture(overrides: Record<string, Data> = {}) {
   const firestore = memory.firestore as never;
   const capacity = new OrderCapacityService(firestore);
   const payments = {
-    processRefundByOrderId: jest.fn().mockResolvedValue(undefined),
+    processRefundByOrderId: jest.fn(async (orderId: string) => {
+      const paymentRef = (firestore as any).doc(`payments/${orderId}`);
+      const paymentSnap = await paymentRef.get();
+      if (paymentSnap.exists) {
+        await paymentRef.update({
+          status: 'CANCELLED',
+          refundAmount: paymentSnap.data()?.amount,
+          refundedAt: new Date(),
+        });
+      }
+    }),
     refundOrderChargesByOrderId: jest.fn().mockResolvedValue(undefined),
   };
   const settlements = { cancelSettlement: jest.fn().mockResolvedValue(undefined) };
@@ -112,6 +122,7 @@ function makeFixture(overrides: Record<string, Data> = {}) {
     capacity,
     {} as never,
     { saveRecord: jest.fn().mockResolvedValue(undefined) } as never,
+    { refundByOrderId: jest.fn().mockResolvedValue(undefined) } as never,
   );
   return { ...memory, capacity, payments, lifecycle, roundState, queries, finalization };
 }

--- a/apps/driver/src/app/board/_client.tsx
+++ b/apps/driver/src/app/board/_client.tsx
@@ -41,6 +41,7 @@ export default function BoardClient() {
       collection(db, 'orders'),
       where('status', '==', 'PREPARING'),
       where('deliveryMethod', 'in', ['direct', 'hub']),
+      where('driverId', '==', null),
       orderBy('preparedAt', 'asc'),
     );
     const unsubPreparing = onSnapshot(qPreparing, (snap) => {

--- a/apps/driver/src/app/board/board-contract.test.mjs
+++ b/apps/driver/src/app/board/board-contract.test.mjs
@@ -13,6 +13,7 @@ test('수거 대기 보드는 PREPARING의 direct와 hub만 조회하고 parcel�
     boardSource,
     /where\(\s*['"]deliveryMethod['"]\s*,\s*['"]in['"]\s*,\s*\[\s*['"]direct['"]\s*,\s*['"]hub['"]\s*\]\s*\)/,
   );
+  assert.match(boardSource, /where\(\s*['"]driverId['"]\s*,\s*['"]==['"]\s*,\s*null\s*\)/);
   assert.doesNotMatch(
     boardSource,
     /where\(\s*['"]deliveryMethod['"]\s*,\s*['"]==['"]\s*,\s*['"]direct['"]\s*\)/,

--- a/apps/driver/src/app/map/page.tsx
+++ b/apps/driver/src/app/map/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { useSession } from 'next-auth/react';
 import { useFirebaseAuth } from '@/hooks/useFirebaseAuth';
 import { db } from '@/lib/firebase';
 import { collection, query, where, onSnapshot } from 'firebase/firestore';
@@ -50,18 +51,51 @@ function nearestNeighbor(orders: Order[]): Order[] {
 }
 
 export default function MapPage() {
+  const { data: session } = useSession();
   const { firebaseReady } = useFirebaseAuth();
   const [orders, setOrders] = useState<Order[]>([]);
 
   useEffect(() => {
-    if (!firebaseReady) return;
+    const driverId = session?.user?.id;
+    if (!firebaseReady || !driverId) {
+      setOrders([]);
+      return;
+    }
 
-    const q = query(collection(db, 'orders'), where('status', 'in', ['PREPARING', 'DELIVERING']));
-    const unsub = onSnapshot(q, (snap) => {
-      setOrders(snap.docs.map((d) => ({ id: d.id, ...d.data() }) as Order));
+    let availableOrders: Order[] = [];
+    let assignedOrders: Order[] = [];
+    const publish = () => {
+      const byId = new Map<string, Order>();
+      [...availableOrders, ...assignedOrders].forEach((order) => {
+        byId.set(order.id, order);
+      });
+      setOrders([...byId.values()]);
+    };
+
+    const availableQuery = query(
+      collection(db, 'orders'),
+      where('status', '==', 'PREPARING'),
+      where('deliveryMethod', 'in', ['direct', 'hub']),
+      where('driverId', '==', null),
+    );
+    const assignedQuery = query(
+      collection(db, 'orders'),
+      where('status', '==', 'DELIVERING'),
+      where('driverId', '==', driverId),
+    );
+    const unsubscribeAvailable = onSnapshot(availableQuery, (snap) => {
+      availableOrders = snap.docs.map((d) => ({ id: d.id, ...d.data() }) as Order);
+      publish();
     });
-    return unsub;
-  }, [firebaseReady]);
+    const unsubscribeAssigned = onSnapshot(assignedQuery, (snap) => {
+      assignedOrders = snap.docs.map((d) => ({ id: d.id, ...d.data() }) as Order);
+      publish();
+    });
+    return () => {
+      unsubscribeAvailable();
+      unsubscribeAssigned();
+    };
+  }, [firebaseReady, session?.user?.id]);
 
   const sorted = nearestNeighbor(orders);
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -18,10 +18,11 @@
 
 ## INTEGRATION CANDIDATE CLOSEOUT
 
-현재 branch `codex/task-2c-r1-reg001`의 `c9d60f6` candidate는 `F-001`, `P0-001`, `P0-002`, `REG-001`, `ENV-001` 검증을 완료했다. API/consumer/seller/driver/shared, Firestore Rules, build, deployment safety evidence는 [Task 2D closeout report](plans/REPORT_task_2d_integration_closeout.md)에 고정한다.
+현재 branch `codex/task-2c-r1-reg001`의 Task 2F-B candidate는 Task 2F-A auth change `1da3dee`와 기존 `F-001`, `P0-001`, `P0-002`, `REG-001`, `ENV-001` 검증 범위를 포함한다. API/consumer/seller/driver/shared, Firestore Rules, build, deployment safety evidence는 [Task 2D closeout report](plans/REPORT_task_2d_integration_closeout.md)에 고정하고, 이번 문서는 public driver approval 하위 범위의 현재 상태만 갱신한다.
 
-- candidate 상태: `TASK_2C_REGRESSION_VERIFIED`
-- 현재 `origin/main` `256abc7`에는 candidate code가 아직 없다.
+- candidate 상태: `TASK_2F_B_PUBLICATION_CANDIDATE`
+- 현재 `origin/main` `d6185bd`에는 candidate code가 아직 없다.
+- candidate에서 public register/login approval gate, Kakao 자동승인 방지, JWT/current-user 경계를 검증했지만 `AUTH-SESSION-CLAIM-REVOCATION`은 OPEN이다.
 - [ ] candidate를 현재 `main`에 branch+PR로 통합하고 승인된 SHA를 확정
 - 최신 main의 `ORDER-REDELIVERY-PAID-RESUME-GATE` 및 기타 미완료 P0는 candidate closeout과 별도의 ACTIVE 작업이다.
 
@@ -189,31 +190,24 @@ API authorization보다 seller/driver raw Firestore read 경계가 넓다.
 
 ### P0 — AUTH-DRIVER-APPROVAL-AND-SESSION-REVOCATION
 
-관리자 승인 전 driver 권한을 얻을 수 있는 복수 경로와 stale session/claims 수렴 문제가 있다.
+관리자 승인 전 driver 권한을 얻을 수 없는지와 stale session/claims 수렴을 하나의 umbrella로 추적한다. Task 2F-B candidate는 approval-gate/current-user 하위 범위만 검증했으며, 전체 P0를 닫지 않는다.
 
-현재 확인된 approval bypass:
+Candidate에서 검증됨 (아직 `main` 미통합):
 
-- [x] 신규 Kakao `targetRole: driver`가 `driverApproved: true`로 즉시 생성됨
-- [x] 기존 `driverApproved === undefined` driver가 Kakao 로그인 중 자동 승인됨
-- [x] 공개 `POST /auth/register`가 `role: driver`를 허용하고 seller와 달리 invite/approval gate 없이 driver user 생성 가능
-- [x] 공개 `POST /auth/login`이 `driverApproved` 확인 없이 저장된 `role: driver`로 JWT 발급
-- [x] Firebase custom token은 현재 JWT role/storeId claim을 사용
+- [x] 신규 Kakao `targetRole: driver`가 `driverApproved: false`로 생성되고 자동 승인되지 않음
+- [x] 기존 `driverApproved === undefined` driver가 Kakao 로그인 중 자동 승인되지 않음
+- [x] 공개 `POST /auth/register` driver가 `driverApproved: false`로 생성되고 client approval 주입이 거부됨
+- [x] 공개 `POST /auth/login`이 false/missing approval driver에게 JWT/refresh token을 발급하지 않음
+- [x] 현재 user 기반 JWT strategy/Firebase custom-token approval·suspension 경계와 직접 register→login 회귀
 
-이 P0는 `ORDER-DIRECT-READ-AUTHORIZATION-AND-MINIMIZATION`과 결합해서 완료 판단한다. broad driver Firestore read가 남아 있는 동안 self-issued/stale driver claim의 영향이 커질 수 있다.
+남음 — `AUTH-SESSION-CLAIM-REVOCATION` OPEN 및 통합 대기:
 
-남음:
-
-- [ ] 공개 registration이 관리자 승인 전 usable driver authorization을 만들지 못함
-- [ ] email login이 미승인 driver에게 driver JWT를 발급하지 않음
-- [ ] 미승인 driver의 Firebase driver claim 발급 거부
-- [ ] 신규/legacy Kakao 로그인 side-effect 자동 승인 제거
-- [ ] 과거 계정 migration 별도 감사 절차
-- [ ] admin 승인 전/후 email/Kakao 앱·API·Firebase 직접 회귀
-- [ ] suspension/role/store/approval revocation SLA 결정
-- [ ] refresh/current claims authoritative state 검증
-- [ ] Firebase stale claims 재발급 차단
-- [ ] logout/rotation 포함 회귀
-- [ ] `main` 통합
+- [ ] candidate를 `main`에 통합
+- [ ] 과거 계정 migration을 로그인 side effect가 아닌 별도 감사 절차로 분리
+- [ ] refresh 시 authoritative user 상태 확인 및 stale role/store/approval claim 재발급 차단
+- [ ] suspension/role/store/approval revocation SLA와 access-token window 결정·구현
+- [ ] logout/rotation을 포함한 session lifecycle 회귀
+- [ ] `ORDER-DIRECT-READ-AUTHORIZATION-AND-MINIMIZATION`과 결합된 broad driver read/minimization 해결
 
 정본: `docs/specs/api/auth.md`; 증거: `docs/reports/REPORT_auth_orders_admin_verification_audit_20260824.md`.
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -16,6 +16,17 @@
 
 ---
 
+## INTEGRATION CANDIDATE CLOSEOUT
+
+현재 branch `codex/task-2c-r1-reg001`의 `c9d60f6` candidate는 `F-001`, `P0-001`, `P0-002`, `REG-001`, `ENV-001` 검증을 완료했다. API/consumer/seller/driver/shared, Firestore Rules, build, deployment safety evidence는 [Task 2D closeout report](plans/REPORT_task_2d_integration_closeout.md)에 고정한다.
+
+- candidate 상태: `TASK_2C_REGRESSION_VERIFIED`
+- 현재 `origin/main` `256abc7`에는 candidate code가 아직 없다.
+- [ ] candidate를 현재 `main`에 branch+PR로 통합하고 승인된 SHA를 확정
+- 최신 main의 `ORDER-REDELIVERY-PAID-RESUME-GATE` 및 기타 미완료 P0는 candidate closeout과 별도의 ACTIVE 작업이다.
+
+---
+
 ## ACTIVE
 
 ### P0 — PAYMENT-FINALIZATION-PAID-GUARD

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -23,6 +23,21 @@
 
 `main` merge는 production 배포 승인이 아니다. production은 검증된 exact release SHA + 별도 승인 절차를 사용한다.
 
+## Task 2C integration candidate closeout
+
+현재 workspace 기준 검증 상태와 `origin/main` 상태를 분리한다.
+
+- 현재 branch: `codex/task-2c-r1-reg001`
+- 현재 candidate HEAD: `c9d60f63af63a841f92ac56666fbafc6b49ec029`
+- candidate 기준: `TASK_2C_REGRESSION_VERIFIED`
+- `F-001`, `P0-001`, `P0-002`, `REG-001`, `ENV-001`: candidate에서 검증·종료
+- candidate 변경은 최신 main 기준으로 재구성됐지만 아직 main에 반영되지 않았다.
+- 현재 `origin/main`: `256abc705c6895a0d43936207382238be15bd976`
+- candidate와 현재 main의 merge-base: `97674e97a4f2f763f83a51a79c65012425c4a50c`
+- `origin/main`의 이후 변경은 문서-only redelivery P0 정합화이며 candidate 코드 영역과 overlap이 없다. 이 branch에서 rebase/merge하지 않았다.
+
+검증 상세는 [Task 2D integration closeout report](plans/REPORT_task_2d_integration_closeout.md)를 따른다. 아래 출시 P0 서술은 현재 main의 미통합 상태를 설명하며, candidate에서 검증된 remediation을 main 완료로 해석하지 않는다.
+
 ## 제품 현재 상태
 
 - 회차 직배송 MVP는 `main` 통합 완료.

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -23,18 +23,17 @@
 
 `main` merge는 production 배포 승인이 아니다. production은 검증된 exact release SHA + 별도 승인 절차를 사용한다.
 
-## Task 2C integration candidate closeout
+## Task 2F-B integration candidate closeout
 
 현재 workspace 기준 검증 상태와 `origin/main` 상태를 분리한다.
 
 - 현재 branch: `codex/task-2c-r1-reg001`
-- 현재 candidate HEAD: `c9d60f63af63a841f92ac56666fbafc6b49ec029`
-- candidate 기준: `TASK_2C_REGRESSION_VERIFIED`
+- Task 2F-A auth change: `1da3dee261fec6b8da8f17c1afc86e13c8cd8eaf`
+- candidate 기준: `TASK_2F_B_PUBLICATION_CANDIDATE`
 - `F-001`, `P0-001`, `P0-002`, `REG-001`, `ENV-001`: candidate에서 검증·종료
-- candidate 변경은 최신 main 기준으로 재구성됐지만 아직 main에 반영되지 않았다.
-- 현재 `origin/main`: `256abc705c6895a0d43936207382238be15bd976`
-- candidate와 현재 main의 merge-base: `97674e97a4f2f763f83a51a79c65012425c4a50c`
-- `origin/main`의 이후 변경은 문서-only redelivery P0 정합화이며 candidate 코드 영역과 overlap이 없다. 이 branch에서 rebase/merge하지 않았다.
+- candidate는 `origin/main` `d6185bd676d79214ccd4949209162900e4a69bc0` 기준이며 아직 main에 반영되지 않았다.
+- merge-base도 `d6185bd676d79214ccd4949209162900e4a69bc0`이다.
+- candidate는 public register/login approval gate, Kakao 자동승인 방지, JWT/current-user 경계를 검증한다. `AUTH-SESSION-CLAIM-REVOCATION`은 OPEN이다.
 
 검증 상세는 [Task 2D integration closeout report](plans/REPORT_task_2d_integration_closeout.md)를 따른다. 아래 출시 P0 서술은 현재 main의 미통합 상태를 설명하며, candidate에서 검증된 remediation을 main 완료로 해석하지 않는다.
 
@@ -51,15 +50,13 @@
 
 ### 1. Driver 승인·세션 권한 — 최우선 security coupling
 
-관리자 승인 전 driver 권한을 얻을 수 없어야 하지만 현재 세 경로가 확인됐다.
+관리자 승인 전 driver 권한을 얻을 수 없어야 한다. Task 2F-B candidate에서 다음 approval-gate 하위 범위가 검증됐다.
 
-- 공개 email `POST /auth/register`가 `role: driver`를 허용하고 승인 gate 없이 driver user 생성 가능.
-- 공개 `POST /auth/login`은 `driverApproved`를 확인하지 않고 `role=driver` JWT 발급.
-- Kakao는 신규 driver를 `driverApproved: true`로 만들고 legacy 승인 필드 누락 driver도 로그인 중 자동 승인.
+- public `register(role=driver)`는 `driverApproved: false`를 저장하고 client approval 주입을 거부한다.
+- public `register → login`의 false/missing approval driver는 token side effect 전에 거부된다.
+- 신규/legacy Kakao driver 자동승인이 제거됐고, JWT strategy/Firebase custom-token 경계가 current user 상태를 확인한다.
 
-refresh/Firebase custom claims는 authoritative user 상태를 재검증하지 않는 stale authorization 문제도 있다.
-
-**관리자 승인 gate = P0 IMPLEMENTATION FINDING**, suspension/role/store/approval revocation = **P0 DECISION REQUIRED + remediation**.
+**candidate approval gate/current-user boundary = VERIFIED (main 통합 대기)**. `AUTH-SESSION-CLAIM-REVOCATION`의 refresh/stale-claim/session lifecycle은 **OPEN**이며, broad driver Firestore read와 결합 위험도 남는다.
 
 이 P0는 broad driver Firestore read가 남아 있는 `ORDER-DIRECT-READ-AUTHORIZATION-AND-MINIMIZATION`과 결합 위험이 크므로 우선 함께 닫는다.
 
@@ -169,7 +166,7 @@ repo-side 배포 방어는 완료. GitHub 관리자 레벨 PR required/required 
 
 ## 다음 작업
 
-1. `AUTH-DRIVER-APPROVAL-AND-SESSION-REVOCATION` + `ORDER-DIRECT-READ-AUTHORIZATION-AND-MINIMIZATION` 결합 위험을 최우선으로 해결·직접 회귀·`main` 통합.
+1. Task 2F-B candidate PR CI/merge를 진행하고, 이후 `AUTH-SESSION-CLAIM-REVOCATION` + `ORDER-DIRECT-READ-AUTHORIZATION-AND-MINIMIZATION` 결합 위험을 해결·직접 회귀한다.
 2. `ORDER-REDELIVERY-PAID-RESUME-GATE` 상태머신 전체 구현·직접 회귀.
 3. `ADMIN-PRIVILEGED-MUTATION-COVERAGE`, webhook coverage, payment finalization, admin refund, order mutation 등 나머지 P0를 ALIGO 심사와 병렬 해결.
 4. Issue #32.

--- a/docs/plans/HANDOFF_mvp_round_direct_aligo_review_pause.md
+++ b/docs/plans/HANDOFF_mvp_round_direct_aligo_review_pause.md
@@ -27,6 +27,19 @@
 8. `PAYMENT-WEBHOOK-SIGNATURE-COVERAGE`
 9. Issue #32
 
+## Task 2D integration closeout
+
+현재 workspace에서 P0/security integration candidate의 문서 정합화까지 완료했다.
+
+- candidate: `codex/task-2c-r1-reg001` / `c9d60f6`
+- 상태: `TASK_2C_REGRESSION_VERIFIED`
+- candidate에서 종료: `F-001`, `P0-001`, `P0-002`, `REG-001`, `ENV-001`
+- evidence: [Task 2D integration closeout report](REPORT_task_2d_integration_closeout.md)
+- 현재 `origin/main`: `256abc7`; candidate는 아직 main/production에 반영되지 않았다.
+- main 이후 문서-only redelivery P0 변경은 read-only로 확인해 이 문서 기준에 반영했으며, candidate를 rebase/merge하지 않았다.
+
+다음 재개 지점은 candidate를 현재 main에 branch+PR로 통합하는 절차다. 이후 최신 main의 redelivery 상태머신, admin refund, legal, ALIGO, exact-SHA E2E와 production 승인 게이트를 순서대로 진행한다.
+
 ## 최우선 재개 — Driver 승인 + direct read 결합 위험
 
 운영 불변식은 **관리자 승인 전 driver 권한을 얻을 수 없고, driver가 필요한 최소 주문만 접근한다**는 것이다.

--- a/docs/plans/HANDOFF_mvp_round_direct_aligo_review_pause.md
+++ b/docs/plans/HANDOFF_mvp_round_direct_aligo_review_pause.md
@@ -27,42 +27,46 @@
 8. `PAYMENT-WEBHOOK-SIGNATURE-COVERAGE`
 9. Issue #32
 
-## Task 2D integration closeout
+## Task 2F-B publication reconciliation
 
 현재 workspace에서 P0/security integration candidate의 문서 정합화까지 완료했다.
 
-- candidate: `codex/task-2c-r1-reg001` / `c9d60f6`
-- 상태: `TASK_2C_REGRESSION_VERIFIED`
+- candidate: `codex/task-2c-r1-reg001` / Task 2F-A auth change `1da3dee`
+- 상태: `TASK_2F_B_PUBLICATION_CANDIDATE`
 - candidate에서 종료: `F-001`, `P0-001`, `P0-002`, `REG-001`, `ENV-001`
 - evidence: [Task 2D integration closeout report](REPORT_task_2d_integration_closeout.md)
-- 현재 `origin/main`: `256abc7`; candidate는 아직 main/production에 반영되지 않았다.
-- main 이후 문서-only redelivery P0 변경은 read-only로 확인해 이 문서 기준에 반영했으며, candidate를 rebase/merge하지 않았다.
+- candidate auth 추가 검증: public register/login approval gate, Kakao 자동승인 방지, JWT/current-user 경계.
+- 현재 `origin/main`: `d6185bd`; candidate는 아직 main/production에 반영되지 않았다.
+- `AUTH-SESSION-CLAIM-REVOCATION`은 OPEN이며 refresh/session lifecycle 완료를 주장하지 않는다.
 
-다음 재개 지점은 candidate를 현재 main에 branch+PR로 통합하는 절차다. 이후 최신 main의 redelivery 상태머신, admin refund, legal, ALIGO, exact-SHA E2E와 production 승인 게이트를 순서대로 진행한다.
+다음 재개 지점은 candidate를 현재 main에 branch+PR로 통합하고 PR CI를 확인하는 절차다. 이후 `AUTH-SESSION-CLAIM-REVOCATION`, 최신 main의 redelivery 상태머신, admin refund, legal, ALIGO, exact-SHA E2E와 production 승인 게이트를 순서대로 진행한다.
 
 ## 최우선 재개 — Driver 승인 + direct read 결합 위험
 
 운영 불변식은 **관리자 승인 전 driver 권한을 얻을 수 없고, driver가 필요한 최소 주문만 접근한다**는 것이다.
 
-2026-08-24 감사에서 Kakao 자동승인 외에 공개 email 경로를 추가 확인했다.
+2026-08-24 감사에서 확인된 public/Kakao approval bypass는 Task 2F-B candidate에서 다음과 같이 검증됐다.
 
-- `POST /auth/register`는 `role: driver`를 허용한다.
-- seller와 달리 driver registration에는 invite/approval gate가 없다.
-- `POST /auth/login`은 `driverApproved`를 확인하지 않고 저장된 `role=driver`로 JWT를 발급한다.
-- 신규 Kakao driver도 `driverApproved: true`로 생성되고 legacy 승인 필드 누락 driver도 로그인 중 자동 승인된다.
-- Firebase custom token은 현재 JWT role/storeId를 claims로 사용한다.
-- 동시에 current Firestore Rules에는 broad driver order read P0가 남아 있다.
+- `POST /auth/register` driver는 `driverApproved: false`로 저장되고 client approval 주입이 거부된다.
+- `POST /auth/login`은 false/missing approval driver를 JWT/refresh token 발급 전에 거부한다.
+- 신규 Kakao driver와 legacy approval 필드 누락 driver는 로그인 side effect로 자동 승인되지 않는다.
+- JWT strategy와 Firebase custom token은 current user의 role/approval/suspension 경계를 확인한다.
+- `AUTH-SESSION-CLAIM-REVOCATION`의 refresh/stale claims lifecycle과 broad driver order read P0는 남아 있다.
 
 따라서 frontend에서 일반 driver credentials UI를 숨기는 것만으로 해결되지 않는다. **API authorization boundary + Firebase claim + Rules read 경계를 함께 fail-closed**해야 한다.
 
-완료 시 반드시:
+Candidate에서 확인된 범위:
 
-- public registration이 승인 전 usable driver authorization을 만들지 않고,
-- 미승인 email/Kakao driver가 driver JWT/Firebase claim을 얻지 못하며,
-- login side-effect 자동 승인이 제거되고,
-- refresh/custom-token이 authoritative approval/role/store 상태로 수렴하며,
-- driver direct Firestore read가 필요한 최소 대상·필드로 제한되고,
-- 승인 전/후 API/Firebase/Rules 직접 회귀가 존재해야 한다.
+- public registration이 승인 전 usable driver authorization을 만들지 않음
+- 미승인 email/Kakao driver가 driver JWT/Firebase claim을 얻지 못함
+- login side-effect 자동승인 방지
+- JWT/Firebase/Rules current-user 경계 직접 회귀
+
+Remaining:
+
+- refresh/custom-token session lifecycle이 authoritative approval/role/store 상태로 수렴
+- driver direct Firestore read가 필요한 최소 대상·필드로 제한
+- candidate의 main 통합 및 PR CI/merge readiness
 
 정본: `docs/specs/api/auth.md`, `docs/specs/api/orders.md`, `docs/BACKLOG.md`.
 

--- a/docs/plans/PLAN_mvp_round_direct_launch_blockers.md
+++ b/docs/plans/PLAN_mvp_round_direct_launch_blockers.md
@@ -13,17 +13,27 @@
 - 재개: `docs/plans/HANDOFF_mvp_round_direct_aligo_review_pause.md`
 - 미완료: `docs/BACKLOG.md`
 
+## Task 2C candidate closeout
+
+- 검증 candidate: `codex/task-2c-r1-reg001` / `c9d60f6`
+- 상태: `TASK_2C_REGRESSION_VERIFIED`
+- 완료 범위: `F-001`, `P0-001`, `P0-002`, `REG-001`, `ENV-001`
+- 검증 증거: [Task 2D integration closeout report](REPORT_task_2d_integration_closeout.md)
+- 현재 `origin/main`: `256abc7`; candidate code는 아직 main에 통합되지 않았다.
+- 다음 Git 단계는 branch+PR 검토이며, Task 2D에서 rebase/merge/push하지 않았다.
+- 최신 main의 redelivery P0 상태머신(`ORDER-REDELIVERY-PAID-RESUME-GATE`)은 candidate 범위 밖의 미완료 작업이다.
+
 ## 출시 게이트
 
 | ID | 게이트 | 상태 |
 |---|---|---|
 | 0A | GitHub `main` protection/ruleset | 미완료 — Issue #32 |
-| 0B | payment finalization 비`PAID` 차단 | 미완료 — P0 FINDING |
-| 0C | order mutation authorization 직접 거부 회귀 | 미완료 — P0 GAP |
-| 0D | order direct Firestore read·최소화 | 미완료 — P0 FINDING |
-| 0E | driver 승인 + session/claims revocation | 미완료 — P0 FINDING/DECISION |
+| 0B | payment finalization 비`PAID` 차단 | candidate 검증 완료 — main 통합 대기 |
+| 0C | order mutation authorization 직접 거부 회귀 | candidate 관련 회귀 완료 — main 통합 대기 |
+| 0D | order direct Firestore read·최소화 | candidate Rules 경계 검증 완료 — field minimization/main 통합 대기 |
+| 0E | driver 승인 + session/claims revocation | candidate driver gate 검증 완료 — 일반 refresh policy/main 통합 대기 |
 | 0F | admin force-refund lifecycle | 미완료 — P0 FINDING |
-| 0G | 유료 재배송 payment-request/hold-resolution/resume 상태머신 | 미완료 — P0 FINDING |
+| 0G | 유료 재배송 payment-request/hold-resolution/resume 상태머신 | 미완료 — P0 FINDING, candidate 범위 밖 |
 | 0H | payment webhook real-signature coverage | 미완료 — P0 COVERAGE GAP |
 | 0I | admin privileged mutation authorization + settlement pay coverage | 미완료 — P0 COVERAGE GAP |
 | 1 | ALIGO 8종 최종 승인 | 검수중 |

--- a/docs/plans/PLAN_mvp_round_direct_launch_blockers.md
+++ b/docs/plans/PLAN_mvp_round_direct_launch_blockers.md
@@ -13,14 +13,16 @@
 - 재개: `docs/plans/HANDOFF_mvp_round_direct_aligo_review_pause.md`
 - 미완료: `docs/BACKLOG.md`
 
-## Task 2C candidate closeout
+## Task 2F-B candidate publication reconciliation
 
-- 검증 candidate: `codex/task-2c-r1-reg001` / `c9d60f6`
-- 상태: `TASK_2C_REGRESSION_VERIFIED`
+- 검증 candidate: `codex/task-2c-r1-reg001` / Task 2F-A auth change `1da3dee`
+- 상태: `TASK_2F_B_PUBLICATION_CANDIDATE`
 - 완료 범위: `F-001`, `P0-001`, `P0-002`, `REG-001`, `ENV-001`
 - 검증 증거: [Task 2D integration closeout report](REPORT_task_2d_integration_closeout.md)
-- 현재 `origin/main`: `256abc7`; candidate code는 아직 main에 통합되지 않았다.
-- 다음 Git 단계는 branch+PR 검토이며, Task 2D에서 rebase/merge/push하지 않았다.
+- candidate의 추가 auth 범위: public driver register/login approval gate, Kakao 자동승인 방지, JWT/current-user 경계.
+- 현재 `origin/main`: `d6185bd`; candidate code는 아직 main에 통합되지 않았다.
+- `AUTH-SESSION-CLAIM-REVOCATION`은 OPEN이며, refresh/session lifecycle 완료로 해석하지 않는다.
+- 다음 Git 단계는 branch+PR 검토다.
 - 최신 main의 redelivery P0 상태머신(`ORDER-REDELIVERY-PAID-RESUME-GATE`)은 candidate 범위 밖의 미완료 작업이다.
 
 ## 출시 게이트
@@ -31,7 +33,7 @@
 | 0B | payment finalization 비`PAID` 차단 | candidate 검증 완료 — main 통합 대기 |
 | 0C | order mutation authorization 직접 거부 회귀 | candidate 관련 회귀 완료 — main 통합 대기 |
 | 0D | order direct Firestore read·최소화 | candidate Rules 경계 검증 완료 — field minimization/main 통합 대기 |
-| 0E | driver 승인 + session/claims revocation | candidate driver gate 검증 완료 — 일반 refresh policy/main 통합 대기 |
+| 0E | driver 승인 + session/claims revocation | candidate public/Kakao/JWT gate 검증 완료 — `AUTH-SESSION-CLAIM-REVOCATION` OPEN, main 통합 대기 |
 | 0F | admin force-refund lifecycle | 미완료 — P0 FINDING |
 | 0G | 유료 재배송 payment-request/hold-resolution/resume 상태머신 | 미완료 — P0 FINDING, candidate 범위 밖 |
 | 0H | payment webhook real-signature coverage | 미완료 — P0 COVERAGE GAP |
@@ -91,17 +93,9 @@
 ### Task 0.7 — Driver approval·session revocation
 - Backlog: `AUTH-DRIVER-APPROVAL-AND-SESSION-REVOCATION`
 - Priority: highest security coupling with Task 0.6
-- Current bypasses:
-  - public email `register(role=driver) → login` can issue driver JWT without approval
-  - new Kakao driver auto-approved
-  - legacy missing approval flag auto-approved during login
-  - refresh/custom-token can preserve stale authorization claims
-- Required:
-  - public registration cannot create usable driver authorization pre-approval
-  - unapproved email/Kakao driver cannot receive driver JWT/Firebase claim
-  - login-side automatic approval removed
-  - authoritative refresh/claim revocation policy + direct pre/post approval tests
-- Status: todo_code_security
+- Candidate verified (not yet main): public register/login approval gate, Kakao new/legacy no-auto-approval, JWT strategy/current-user/Firebase approval boundary.
+- Remaining: `AUTH-SESSION-CLAIM-REVOCATION` — authoritative refresh state, stale claims, suspension/role/store/approval revocation SLA, access-token window, logout/rotation regression.
+- Status: candidate_gate_verified / todo_session_revocation
 
 ### Task 0.8 — Admin force-refund lifecycle
 - Backlog: `ADMIN-FORCE-REFUND-CONSISTENCY`

--- a/docs/plans/REPORT_task_2d_integration_closeout.md
+++ b/docs/plans/REPORT_task_2d_integration_closeout.md
@@ -1,0 +1,62 @@
+<!-- Language: ko -->
+
+# Task 2D — P0 Integration Candidate Document Closeout
+
+## 범위와 기준
+
+- Workspace: `C:/Develop/greenhub-task-2c-r1`
+- Branch: `codex/task-2c-r1-reg001`
+- Candidate HEAD: `c9d60f63af63a841f92ac56666fbafc6b49ec029`
+- Task 2C result: `TASK_2C_REGRESSION_VERIFIED`
+- Task 2C 당시 `origin/main`: `97674e97a4f2f763f83a51a79c65012425c4a50c`
+- Task 2D 시작 시 current `origin/main`: `256abc705c6895a0d43936207382238be15bd976`
+- Candidate/main merge-base: `97674e97a4f2f763f83a51a79c65012425c4a50c`
+
+`origin/main`은 merge-base 이후 문서-only redelivery P0 정합화 커밋 12개가 진행됐다. candidate code 영역과 overlap은 0개였고, Task 2D에서는 rebase/merge하지 않았다. 최신 main의 문서 상태를 read-only로 검토해 current backlog/plan/handoff/orders spec에 반영했다.
+
+## Candidate verified scope
+
+- `F-001`: driver approval, JWT/current-user validation, stale/suspended/role-mismatch/session and assignment/ownership boundaries
+- `P0-002`: cancelled order + late provider payment race, no order resurrection, safe refund/finalization convergence, idempotency
+- `P0-001`: provider non-`PAID` finalization denial, `PAID` success, amount mismatch guard
+- `REG-001`: candidate-added API spec lint remediation
+- `ENV-001`: safe session-local Firebase config; driver typecheck/build
+
+## Validation evidence
+
+| Area | Result |
+|---|---|
+| API | 41 suites / 319 tests PASS |
+| Focused candidate | 3 suites / 16 tests PASS |
+| Consumer | 106 tests PASS |
+| Seller | 7 files / 43 tests PASS |
+| Driver | 11 tests PASS |
+| Shared | 2 files / 9 tests PASS |
+| Firestore Rules | 23 / 23 PASS |
+| Candidate API ESLint | 0 errors / 0 warnings |
+| Driver typecheck | PASS |
+| API build | PASS |
+| Consumer build | PASS |
+| Seller build | PASS |
+| Driver build | PASS |
+| Deployment safety | PASS |
+| `git diff --check` | PASS |
+
+The root `pnpm build` orchestration hit the pre-existing parallel `copy-fonts.cjs` destination race. Sequential application builds all passed; this is not a candidate build regression.
+
+## Current versus historical
+
+- Current candidate is verified locally, but it is not yet in `origin/main`, has no PR, and is not a production release.
+- Latest main redelivery payment-request/hold-resolution/resume P0 remains unresolved and outside this candidate.
+- Production/Preview Playwright E2E, real PortOne side effects, ALIGO delivery, production Firebase mutation, and production Vercel deployment were not run.
+- Firestore Java 17 failure and the initial Firebase `auth/invalid-api-key` are historical environment findings; `ENV-001` is closed.
+
+## Known baseline debt
+
+- `apps/api/src/payments/payments.service.spec.ts:90` — TS2698 spread type error, reproduced before REG-001.
+- API global lint debt — 1,168 errors / 114 warnings, separate from candidate spec lint.
+- Root aggregate build — existing `copy-fonts.cjs` parallel destination race.
+
+## Next action
+
+Review and, if approved, integrate this candidate into the current `main` through the repository's branch+PR process. Do not push, merge, deploy, or treat this candidate as production approval automatically.

--- a/docs/specs/api/auth.md
+++ b/docs/specs/api/auth.md
@@ -9,6 +9,17 @@
 > **앱 인증 정본**: `apps/consumer/src/auth.ts`, `apps/seller/src/auth.ts`, `apps/driver/src/auth.ts`
 > **Preview OAuth 정책**: `docs/specs/ops/preview-auth-url-policy.md`
 
+## Task 2C candidate overlay
+
+현재 branch candidate `c9d60f6`에서는 `F-001` driver 보안 경계를 검증했다.
+
+- 신규/기존 driver의 승인 대기 상태를 로그인 side effect로 true로 만들지 않는 회귀가 PASS했다.
+- API `JwtStrategy`가 driver 요청마다 현재 Firestore user의 role, `driverApproved`, `suspended`를 확인한다.
+- Firebase custom token 발급도 현재 user 상태를 확인하며, Firestore Rules는 승인 claim과 현재 user 문서를 함께 검증한다.
+- stale/suspended/role-mismatch/missing-user/cross-driver 경계가 Rules runtime 23/23 PASS와 API focused/full regression으로 확인됐다.
+
+이 overlay는 현재 candidate에 한정된다. 아래 `origin/main` baseline finding과 일반 refresh-token revocation policy는 candidate가 main에 통합되기 전까지 main 출시 상태로 `VERIFIED` 처리하지 않는다.
+
 ## 1. 인증 계층
 
 Greenhub 인증은 두 계층으로 나뉜다.

--- a/docs/specs/api/auth.md
+++ b/docs/specs/api/auth.md
@@ -9,16 +9,17 @@
 > **앱 인증 정본**: `apps/consumer/src/auth.ts`, `apps/seller/src/auth.ts`, `apps/driver/src/auth.ts`
 > **Preview OAuth 정책**: `docs/specs/ops/preview-auth-url-policy.md`
 
-## Task 2C candidate overlay
+## Task 2F-B candidate overlay
 
-현재 branch candidate `c9d60f6`에서는 `F-001` driver 보안 경계를 검증했다.
+현재 `codex/task-2c-r1-reg001` candidate에는 Task 2F-A auth change `1da3dee`가 포함되어 있다. 아래 항목은 candidate에서 검증된 하위 범위이며, PR/main 통합 전에는 `main` 출시 상태로 해석하지 않는다.
 
-- 신규/기존 driver의 승인 대기 상태를 로그인 side effect로 true로 만들지 않는 회귀가 PASS했다.
-- API `JwtStrategy`가 driver 요청마다 현재 Firestore user의 role, `driverApproved`, `suspended`를 확인한다.
-- Firebase custom token 발급도 현재 user 상태를 확인하며, Firestore Rules는 승인 claim과 현재 user 문서를 함께 검증한다.
-- stale/suspended/role-mismatch/missing-user/cross-driver 경계가 Rules runtime 23/23 PASS와 API focused/full regression으로 확인됐다.
+- 공개 `POST /auth/register`의 driver user는 `driverApproved: false`로 생성되고, client가 `driverApproved: true`를 주입할 수 없다.
+- 공개 `POST /auth/register` → `POST /auth/login`에서 승인값이 `false`이거나 누락된 driver는 JWT/refresh side effect 전에 거부된다. 승인된 driver는 정상 로그인하고 consumer/seller/admin 경로는 유지된다.
+- Kakao 신규 driver는 자동 승인되지 않고, 기존 승인 필드 누락 driver도 로그인 side effect로 자동 승인되지 않는다.
+- API `JwtStrategy`와 Firebase custom-token 경계가 현재 Firestore user의 role, `driverApproved`, `suspended`를 확인하며, stale/suspended/role-mismatch/missing-user/cross-driver 경계가 기존 candidate Rules/API 회귀로 확인됐다.
+- 직접 근거: `apps/api/src/auth/auth.controller.spec.ts`, `apps/api/src/auth/auth.service.spec.ts`, `apps/api/src/auth/strategies/jwt.strategy.spec.ts`.
 
-이 overlay는 현재 candidate에 한정된다. 아래 `origin/main` baseline finding과 일반 refresh-token revocation policy는 candidate가 main에 통합되기 전까지 main 출시 상태로 `VERIFIED` 처리하지 않는다.
+`AUTH-SESSION-CLAIM-REVOCATION`은 여전히 OPEN이다. refresh 시 authoritative user 상태 재조회, suspended/role/store/approval 변경 수렴, access-token revocation window와 session rotation 정책은 이 candidate에서 완료로 주장하지 않는다.
 
 ## 1. 인증 계층
 
@@ -119,34 +120,35 @@ consumer | seller | driver
 
 따라서 **관리자 승인 전 driver 권한을 획득할 수 없다는 계약**을 current 안전 계약으로 사용한다. role 승격·driver 승인·스토어 소유권을 OAuth targetRole, 공개 가입 role, 또는 stale token payload만으로 자동 부여하지 않는다.
 
-### 현재 구현 불일치 — Driver approval P0 `IMPLEMENTATION FINDING`
+### Candidate reconciliation — Driver approval P0
 
-2026-08-24 직접 대조에서 위 계약과 충돌하는 세 경로가 확인됐다.
+2026-08-24 `origin/main` 감사에서 신규/legacy Kakao 자동승인과 공개 email register/login 우회가 확인됐다. candidate에서는 다음 approval-gate 하위 범위를 직접 고정했다.
 
-1. 기존 Kakao 사용자 role이 `driver`이고 `driverApproved` 필드가 `undefined`이면 로그인 중 `driverApproved: true`를 자동 기록한다.
-2. Kakao 사용자 매핑이 없는 신규 사용자가 `targetRole: driver`를 요청하면 신규 user를 `role: driver`, `driverApproved: true`로 즉시 생성한다.
-3. 공개 `POST /auth/register`는 `role: driver`를 허용하고 seller와 달리 invite/approval gate 없이 driver user를 만들 수 있다. 이어지는 공개 `POST /auth/login`은 `driverApproved`를 확인하지 않고 저장된 `role: driver`로 API JWT를 발급한다.
+1. 신규 Kakao `targetRole: driver`는 `driverApproved: false`로 생성된다.
+2. 기존 `driverApproved` 누락 driver는 Kakao 로그인 중 자동 승인되지 않는다.
+3. 공개 `POST /auth/register`는 driver를 false approval 상태로 만들고 client-supplied approval을 거부한다. 이어지는 공개 `POST /auth/login`은 승인되지 않은 driver의 API JWT/refresh token 발급을 거부한다.
 
-즉 driver 앱 callback이 승인 flag를 확인하더라도 **API authorization boundary 자체에서 관리자 승인 게이트의 독립성이 보장되지 않는다.** 특히 email register→login 경로는 frontend Credentials provider 노출 여부와 무관하게 API에 직접 호출 가능하다.
-
-`GET /auth/firebase-token`은 현재 JWT의 `role/storeId`로 Firebase custom claims를 생성하므로, 승인 없이 발급된 driver JWT가 Firebase role claim으로 이어질 수 있다. 이 문제는 broad driver order read가 남아 있는 `ORDER-DIRECT-READ-AUTHORIZATION-AND-MINIMIZATION`과 결합 위험이 있다.
-
-현재 `auth.service.spec.ts`는 Kakao identity·role mismatch·suspended login 일부는 검증하지만 `register(role=driver) → login` 승인 전 거부와 신규 driver 승인 게이트를 직접 고정하지 않는다.
+따라서 frontend Credentials UI 비노출에 의존하지 않는 API authorization boundary가 candidate에서 확인됐다. Firebase custom token도 현재 user의 승인·정지·역할 경계를 확인한다. broad driver order read와 refresh/session lifecycle은 별도 P0로 남는다.
 
 추적 umbrella: `docs/BACKLOG.md`의 `AUTH-DRIVER-APPROVAL-AND-SESSION-REVOCATION`. 기술 finding 이름으로 `DRIVER-APPROVAL-GATE-BYPASS`를 사용할 수 있으나 별도 완료 항목으로 중복 추적하지 않는다.
 
-최소 완료 조건:
+Candidate에서 확인된 조건:
 
-- 공개 registration이 관리자 승인 전 usable driver authorization을 만들지 못함
-- email login이 미승인 driver에게 driver JWT를 발급하지 않음
-- 미승인 driver JWT/세션에서 Firebase driver custom claim을 발급하지 않음
-- 신규 Kakao identity의 `targetRole: driver`가 관리자 승인 없이 `driverApproved: true` 권한을 만들지 못함
-- 기존 `driverApproved` 누락 계정을 로그인 시 자동 승인하지 않음
-- 과거 계정 migration이 필요하면 로그인 side effect가 아닌 명시적·감사 가능한 migration/관리 절차로 분리
-- admin 승인 전 driver 앱·driver API·Firestore 권한 획득 거부
-- admin 승인 후 email/Kakao의 허용된 정상 driver 로그인 유지
-- consumer/seller/admin role 진입 회귀 없음
-- register/login/Kakao + API/Firebase claim의 승인 전/후 직접 unit/integration/E2E 회귀
+- [x] 공개 registration이 관리자 승인 전 usable driver authorization을 만들지 않음
+- [x] email login이 미승인 driver에게 driver JWT/refresh token을 발급하지 않음
+- [x] 미승인 driver의 Firebase driver custom claim 발급을 거부함
+- [x] 신규 Kakao identity의 `targetRole: driver`가 관리자 승인 없이 `driverApproved: true`를 만들지 않음
+- [x] 기존 `driverApproved` 누락 계정을 로그인 시 자동 승인하지 않음
+- [x] admin 승인 전 driver API/Firebase/Rules 경계를 거부하는 candidate 회귀
+- [x] admin 승인 후 driver 정상 경로 및 consumer/seller/admin role 진입 회귀
+
+여전히 남은 조건:
+
+- [ ] 과거 계정 migration이 필요하면 로그인 side effect가 아닌 명시적·감사 가능한 절차로 분리
+- [ ] `AUTH-SESSION-CLAIM-REVOCATION`: refresh 시 authoritative 상태 재조회와 stale claim 재발급 차단
+- [ ] suspended/role/store/driver approval 변경의 session revocation SLA와 access-token window 결정
+- [ ] logout/refresh-token rotation을 포함한 session lifecycle 직접 회귀
+- [ ] candidate를 `main`에 통합
 
 ## 6. Access / Refresh token과 권한 변경 수렴
 
@@ -170,8 +172,10 @@ consumer | seller | driver
 판정:
 
 - 신규 로그인에서 `suspended === true`를 거부하는 동작은 구현·테스트됨.
-- **이미 발급된 세션의 정지/권한 변경 수렴은 `DECISION REQUIRED` + P0 authorization remediation 대상**이다.
+- **이미 발급된 세션의 정지/권한 변경 수렴은 `AUTH-SESSION-CLAIM-REVOCATION` OPEN, `DECISION REQUIRED` + P0 authorization remediation 대상**이다.
 - 특히 “정지된 계정이 refresh를 통해 계속 새 권한 토큰을 얻을 수 있음”을 정상 계약으로 간주하지 않는다.
+
+Task 2F-A/2F-B의 public approval-gate와 current-user 경계 검증은 이 refresh/session lifecycle finding을 닫지 않는다.
 
 `AUTH-SESSION-CLAIM-REVOCATION` 최소 완료 조건:
 
@@ -319,6 +323,7 @@ interface SavedAddress {
 
 | 날짜 | 내용 |
 |---|---|
+| 2026-08-24 | Task 2F-B candidate에서 public driver register/login approval gate, Kakao 자동승인 방지, JWT/current-user 경계를 검증하고 `AUTH-SESSION-CLAIM-REVOCATION`은 OPEN으로 유지 |
 | 2026-08-24 | 공개 email `register(role=driver) → login`이 승인 없이 driver JWT를 발급할 수 있는 추가 P0 우회를 반영하고 Kakao/refresh/Firebase claim과 하나의 driver authorization lifecycle로 정합화 |
 | 2026-08-24 | 신규/legacy driver 자동 승인 경로를 P0 IMPLEMENTATION FINDING으로 분리하고, 정지·role/store 변경의 refresh/custom-token stale claims를 P0 revocation 결정·remediation으로 명시 |
 | 2026-08-23 | Kakao 운영 OAuth, E2E 전용 Credentials, driver approval, refresh/custom-token 현행 계약에 맞춰 전면 정합화 |

--- a/docs/specs/api/orders.md
+++ b/docs/specs/api/orders.md
@@ -9,6 +9,17 @@
 > **회차 직배송 제품 계약**: `docs/specs/mvp-sales-round-direct-delivery.md`
 > **운영 계약**: `docs/specs/ops/mvp-sales-round-runbook.md`
 
+## Task 2C candidate overlay
+
+이 spec의 P0 finding은 현재 `origin/main` 기준이며, 아래 candidate 상태와 분리한다.
+
+- `F-001`: current candidate `c9d60f6`에서 driver approval/current-user/stale-session Rules 경계를 직접 검증했다. Firestore Rules 23/23 PASS.
+- `P0-002`: cancellation과 late provider payment의 부활 방지·refund convergence를 candidate에서 직접 검증했다. focused candidate 3 suites/16 tests 및 full API 319 tests PASS.
+- candidate는 아직 `origin/main` `256abc7`에 통합되지 않았다.
+ - 최신 main의 `ORDER-REDELIVERY-PAID-RESUME-GATE`는 이 candidate가 해결한 항목이 아니며 아래 P0 finding으로 유지한다.
+
+ 통합 증거: [Task 2D integration closeout report](../../plans/REPORT_task_2d_integration_closeout.md).
+
 ## 1. 소유권
 
 `orders`는 consumer·seller·driver가 공유하는 핵심 도메인이다.

--- a/docs/specs/api/payments.md
+++ b/docs/specs/api/payments.md
@@ -8,6 +8,16 @@
 > **서버 구현 정본**: `apps/api/src/payments/**`
 > **주문 연계 계약**: `docs/specs/api/orders.md`, `docs/specs/mvp-sales-round-direct-delivery.md`
 
+## Task 2C candidate overlay
+
+현재 branch candidate `c9d60f6`에서 다음을 검증했다.
+
+- `P0-001`: `finalizePaidOrder()`가 provider `status !== 'PAID'` 입력을 side effect 없이 차단하고, `PAID` 정상 경로와 amount mismatch guard를 유지한다.
+- `P0-002`: 취소 주문에 뒤늦게 도착한 provider payment가 주문을 부활시키지 않고 refund/finalization convergence와 idempotency를 유지한다.
+- focused candidate 3 suites/16 tests 및 full API 41 suites/319 tests PASS.
+
+이 overlay는 아직 `origin/main` `256abc7`에 통합되지 않은 candidate의 검증 상태다. 아래 main baseline finding은 main 통합 전 출시 상태로 유지한다.
+
 ## 1. 소유권과 범위
 
 - 결제 검증·최종화·환불·재배송비 결제 처리는 NestJS API가 소유한다.

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -253,6 +253,7 @@
       "fields": [
         { "fieldPath": "status", "order": "ASCENDING" },
         { "fieldPath": "deliveryMethod", "order": "ASCENDING" },
+        { "fieldPath": "driverId", "order": "ASCENDING" },
         { "fieldPath": "preparedAt", "order": "ASCENDING" }
       ]
     },

--- a/firestore.rules
+++ b/firestore.rules
@@ -12,10 +12,18 @@ service cloud.firestore {
         isPublicSaleRoundStatus(round.data.status);
     }
 
+    function currentUser() {
+      return get(/databases/$(database)/documents/users/$(request.auth.uid));
+    }
+
     function isApprovedDriver() {
       return request.auth != null &&
         request.auth.token.role == 'driver' &&
-        request.auth.token.get('driverApproved', false) == true;
+        request.auth.token.get('driverApproved', false) == true &&
+        exists(/databases/$(database)/documents/users/$(request.auth.uid)) &&
+        currentUser().data.get('role', null) == 'driver' &&
+        currentUser().data.get('driverApproved', false) == true &&
+        currentUser().data.get('suspended', false) != true;
     }
 
     function isAssignedDriver() {

--- a/firestore.rules
+++ b/firestore.rules
@@ -12,12 +12,32 @@ service cloud.firestore {
         isPublicSaleRoundStatus(round.data.status);
     }
 
-    // orders: Firebase Auth 필수 + 본인 storeId, admin, driver 허용
+    function isApprovedDriver() {
+      return request.auth != null &&
+        request.auth.token.role == 'driver' &&
+        request.auth.token.get('driverApproved', false) == true;
+    }
+
+    function isAssignedDriver() {
+      return isApprovedDriver() &&
+        resource.data.get('driverId', null) == request.auth.uid;
+    }
+
+    function isAvailablePickup() {
+      return isApprovedDriver() &&
+        resource.data.get('status', null) == 'PREPARING' &&
+        resource.data.get('driverId', null) == null &&
+        resource.data.get('deliveryMethod', null) in ['direct', 'hub'];
+    }
+
+    // orders: 매장 소유자·관리자·승인된 기사의 계약된 주문만 허용
     match /orders/{orderId} {
       allow read: if request.auth != null &&
-        (resource.data.storeId == request.auth.token.storeId ||
+        ((request.auth.token.role == 'seller' &&
+          resource.data.storeId == request.auth.token.storeId) ||
          request.auth.token.role == 'admin' ||
-         request.auth.token.role == 'driver');
+         isAssignedDriver() ||
+         isAvailablePickup());
       allow write: if false;
     }
 

--- a/tests/firestore/firestore-rules.test.mjs
+++ b/tests/firestore/firestore-rules.test.mjs
@@ -1,3 +1,4 @@
+import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 import { after, before, test } from 'node:test';
 import {
@@ -11,6 +12,7 @@ import {
   doc,
   getDoc,
   getDocs,
+  orderBy,
   query,
   setDoc,
   updateDoc,
@@ -85,6 +87,8 @@ async function seedFixtures() {
         status: 'PREPARING',
         driverId: null,
         deliveryMethod: 'direct',
+        preparedAt: '2026-08-23T08:00:00.000Z',
+        updatedAt: '2026-08-23T08:00:00.000Z',
       },
       'orders/order-store-2': {
         storeId: 'store-2',
@@ -92,6 +96,8 @@ async function seedFixtures() {
         status: 'DELIVERING',
         driverId: 'driver-1',
         deliveryMethod: 'direct',
+        preparedAt: '2026-08-23T07:00:00.000Z',
+        updatedAt: '2026-08-23T09:00:00.000Z',
       },
       'orders/order-driver-other': {
         storeId: 'store-1',
@@ -99,6 +105,8 @@ async function seedFixtures() {
         status: 'DELIVERING',
         driverId: 'driver-2',
         deliveryMethod: 'direct',
+        preparedAt: '2026-08-23T06:00:00.000Z',
+        updatedAt: '2026-08-23T10:00:00.000Z',
       },
       'orders/order-pickup-parcel': {
         storeId: 'store-1',
@@ -106,6 +114,14 @@ async function seedFixtures() {
         status: 'PREPARING',
         driverId: null,
         deliveryMethod: 'parcel',
+        preparedAt: '2026-08-23T11:00:00.000Z',
+        updatedAt: '2026-08-23T11:00:00.000Z',
+      },
+      'users/driver-lifecycle': {
+        id: 'driver-lifecycle',
+        role: 'driver',
+        driverApproved: false,
+        suspended: false,
       },
       'saleRounds/round-1': { storeId: 'store-1', status: 'OPEN' },
       'saleRounds/round-draft': { storeId: 'store-1', status: 'DRAFT' },
@@ -249,7 +265,9 @@ test('기존 주문의 판매자 매장과 기사 및 관리자 읽기 권한을
   const seller = testEnvironment
     .authenticatedContext('seller-1', { role: 'seller', storeId: 'store-1' })
     .firestore();
-  const driver = testEnvironment.authenticatedContext('driver-1', { role: 'driver' }).firestore();
+  const driver = testEnvironment
+    .authenticatedContext('driver-1', { role: 'driver', driverApproved: true })
+    .firestore();
   const admin = testEnvironment.authenticatedContext('admin-1', { role: 'admin' }).firestore();
   const user = testEnvironment.authenticatedContext('user-1').firestore();
 
@@ -292,4 +310,134 @@ test('승인된 기사는 배정 주문과 미배정 수거 주문만 읽고 다
   await assertSucceeds(getDocs(assignedQuery));
   await assertSucceeds(getDocs(pickupQuery));
   await assertFails(getDocs(unboundedDriverQuery));
+});
+
+test('주문은 미인증·consumer·seller·미승인 driver·승인 claim 누락 driver가 읽을 수 없다', async () => {
+  const unauthenticated = testEnvironment.unauthenticatedContext().firestore();
+  const consumer = testEnvironment
+    .authenticatedContext('consumer-1', { role: 'consumer' })
+    .firestore();
+  const seller = testEnvironment
+    .authenticatedContext('seller-1', { role: 'seller', storeId: 'store-1' })
+    .firestore();
+  const pendingDriver = testEnvironment
+    .authenticatedContext('pending-driver-2', { role: 'driver', driverApproved: false })
+    .firestore();
+  const missingClaimDriver = testEnvironment
+    .authenticatedContext('missing-claim-driver', { role: 'driver' })
+    .firestore();
+
+  await assertFails(getDoc(doc(unauthenticated, 'orders', 'order-store-1')));
+  await assertFails(getDoc(doc(consumer, 'orders', 'order-store-1')));
+  await assertFails(getDocs(collection(seller, 'orders')));
+  await assertFails(getDoc(doc(seller, 'orders', 'order-store-2')));
+  await assertFails(getDoc(doc(pendingDriver, 'orders', 'order-store-1')));
+  await assertFails(getDoc(doc(missingClaimDriver, 'orders', 'order-store-1')));
+});
+
+test('승인된 driver는 허용된 주문만 읽고 주문 write는 할 수 없다', async () => {
+  const approvedDriver = testEnvironment
+    .authenticatedContext('driver-1', { role: 'driver', driverApproved: true })
+    .firestore();
+  const otherApprovedDriver = testEnvironment
+    .authenticatedContext('driver-2', { role: 'driver', driverApproved: true })
+    .firestore();
+
+  await assertSucceeds(getDoc(doc(approvedDriver, 'orders', 'order-store-1')));
+  await assertSucceeds(getDoc(doc(approvedDriver, 'orders', 'order-store-2')));
+  await assertFails(getDoc(doc(approvedDriver, 'orders', 'order-driver-other')));
+  await assertFails(getDoc(doc(approvedDriver, 'orders', 'order-pickup-parcel')));
+  await assertFails(getDoc(doc(otherApprovedDriver, 'orders', 'order-store-2')));
+
+  await assertFails(
+    setDoc(doc(approvedDriver, 'orders', 'order-created-by-driver'), {
+      status: 'DELIVERING',
+      driverId: 'driver-1',
+    }),
+  );
+  await assertFails(
+    updateDoc(doc(approvedDriver, 'orders', 'order-store-1'), { driverId: 'driver-1' }),
+  );
+  await assertFails(deleteDoc(doc(approvedDriver, 'orders', 'order-store-1')));
+});
+
+test('driver 화면의 실제 pickup·assigned query는 허용 범위를 벗어나지 않는다', async () => {
+  const approvedDriver = testEnvironment
+    .authenticatedContext('driver-1', { role: 'driver', driverApproved: true })
+    .firestore();
+
+  const pickupQuery = query(
+    collection(approvedDriver, 'orders'),
+    where('status', '==', 'PREPARING'),
+    where('deliveryMethod', 'in', ['direct', 'hub']),
+    where('driverId', '==', null),
+    // driver 보드의 실제 정렬 조건
+    orderBy('preparedAt', 'asc'),
+  );
+  const boardAssignedQuery = query(
+    collection(approvedDriver, 'orders'),
+    where('status', 'in', ['DELIVERING', 'DELIVERY_HELD']),
+    where('driverId', '==', 'driver-1'),
+    // driver 보드의 실제 정렬 조건
+    orderBy('updatedAt', 'asc'),
+  );
+  const mapAssignedQuery = query(
+    collection(approvedDriver, 'orders'),
+    where('status', '==', 'DELIVERING'),
+    where('driverId', '==', 'driver-1'),
+  );
+  const unboundedQuery = query(
+    collection(approvedDriver, 'orders'),
+    where('status', 'in', ['PREPARING', 'DELIVERING']),
+  );
+
+  const pickupSnapshot = await assertSucceeds(getDocs(pickupQuery));
+  const boardAssignedSnapshot = await assertSucceeds(getDocs(boardAssignedQuery));
+  const mapAssignedSnapshot = await assertSucceeds(getDocs(mapAssignedQuery));
+
+  assert.deepEqual(
+    pickupSnapshot.docs.map((snapshot) => snapshot.id),
+    ['order-store-1'],
+  );
+  assert.deepEqual(
+    boardAssignedSnapshot.docs.map((snapshot) => snapshot.id),
+    ['order-store-2'],
+  );
+  assert.deepEqual(
+    mapAssignedSnapshot.docs.map((snapshot) => snapshot.id),
+    ['order-store-2'],
+  );
+  await assertFails(getDocs(unboundedQuery));
+});
+
+test('승인 상태 변경 뒤 기존 claim은 stale 상태로 남고 새 claim만 Rules 결과를 바꾼다', async () => {
+  const oldPendingToken = testEnvironment
+    .authenticatedContext('driver-lifecycle', { role: 'driver', driverApproved: false })
+    .firestore();
+
+  await assertFails(getDoc(doc(oldPendingToken, 'orders', 'order-store-1')));
+
+  await testEnvironment.withSecurityRulesDisabled(async (context) => {
+    await updateDoc(doc(context.firestore(), 'users', 'driver-lifecycle'), {
+      driverApproved: true,
+    });
+  });
+
+  // 기존 token은 users 문서의 변경을 재조회하지 않으므로 계속 거부된다.
+  await assertFails(getDoc(doc(oldPendingToken, 'orders', 'order-store-1')));
+
+  const newApprovedToken = testEnvironment
+    .authenticatedContext('driver-lifecycle', { role: 'driver', driverApproved: true })
+    .firestore();
+  await assertSucceeds(getDoc(doc(newApprovedToken, 'orders', 'order-store-1')));
+
+  await testEnvironment.withSecurityRulesDisabled(async (context) => {
+    await updateDoc(doc(context.firestore(), 'users', 'driver-lifecycle'), {
+      driverApproved: false,
+      suspended: true,
+    });
+  });
+
+  // 승인 철회·정지 뒤에도 이미 발급된 true claim은 Rules에서 계속 유효하다.
+  await assertSucceeds(getDoc(doc(newApprovedToken, 'orders', 'order-store-1')));
 });

--- a/tests/firestore/firestore-rules.test.mjs
+++ b/tests/firestore/firestore-rules.test.mjs
@@ -117,10 +117,73 @@ async function seedFixtures() {
         preparedAt: '2026-08-23T11:00:00.000Z',
         updatedAt: '2026-08-23T11:00:00.000Z',
       },
-      'users/driver-lifecycle': {
-        id: 'driver-lifecycle',
+      'orders/order-pickup-hub': {
+        storeId: 'store-1',
+        userId: 'user-5',
+        status: 'PREPARING',
+        driverId: null,
+        deliveryMethod: 'hub',
+        preparedAt: '2026-08-23T09:00:00.000Z',
+        updatedAt: '2026-08-23T09:00:00.000Z',
+      },
+      'users/driver-1': {
+        id: 'driver-1',
+        role: 'driver',
+        driverApproved: true,
+        suspended: false,
+      },
+      'users/driver-2': {
+        id: 'driver-2',
+        role: 'driver',
+        driverApproved: true,
+        suspended: false,
+      },
+      'users/pending-driver': {
+        id: 'pending-driver',
         role: 'driver',
         driverApproved: false,
+        suspended: false,
+      },
+      'users/pending-driver-2': {
+        id: 'pending-driver-2',
+        role: 'driver',
+        driverApproved: false,
+        suspended: false,
+      },
+      'users/missing-claim-driver': {
+        id: 'missing-claim-driver',
+        role: 'driver',
+        driverApproved: true,
+        suspended: false,
+      },
+      'users/driver-token-false-db-true': {
+        id: 'driver-token-false-db-true',
+        role: 'driver',
+        driverApproved: true,
+        suspended: false,
+      },
+      'users/driver-stale-approval': {
+        id: 'driver-stale-approval',
+        role: 'driver',
+        driverApproved: true,
+        suspended: false,
+      },
+      'users/driver-lifecycle-approval': {
+        id: 'driver-lifecycle-approval',
+        role: 'driver',
+        driverApproved: false,
+        suspended: false,
+      },
+      'users/driver-lifecycle-suspended': {
+        id: 'driver-lifecycle-suspended',
+        role: 'driver',
+        driverApproved: true,
+        suspended: false,
+      },
+      'users/driver-lifecycle-role': {
+        id: 'driver-lifecycle-role',
+        role: 'driver',
+        driverApproved: true,
         suspended: false,
       },
       'saleRounds/round-1': { storeId: 'store-1', status: 'OPEN' },
@@ -386,6 +449,18 @@ test('driver 화면의 실제 pickup·assigned query는 허용 범위를 벗어�
     where('status', '==', 'DELIVERING'),
     where('driverId', '==', 'driver-1'),
   );
+  const directPickupQuery = query(
+    collection(approvedDriver, 'orders'),
+    where('status', '==', 'PREPARING'),
+    where('deliveryMethod', '==', 'direct'),
+    where('driverId', '==', null),
+  );
+  const hubPickupQuery = query(
+    collection(approvedDriver, 'orders'),
+    where('status', '==', 'PREPARING'),
+    where('deliveryMethod', '==', 'hub'),
+    where('driverId', '==', null),
+  );
   const unboundedQuery = query(
     collection(approvedDriver, 'orders'),
     where('status', 'in', ['PREPARING', 'DELIVERING']),
@@ -394,10 +469,12 @@ test('driver 화면의 실제 pickup·assigned query는 허용 범위를 벗어�
   const pickupSnapshot = await assertSucceeds(getDocs(pickupQuery));
   const boardAssignedSnapshot = await assertSucceeds(getDocs(boardAssignedQuery));
   const mapAssignedSnapshot = await assertSucceeds(getDocs(mapAssignedQuery));
+  const directPickupSnapshot = await assertSucceeds(getDocs(directPickupQuery));
+  const hubPickupSnapshot = await assertSucceeds(getDocs(hubPickupQuery));
 
   assert.deepEqual(
     pickupSnapshot.docs.map((snapshot) => snapshot.id),
-    ['order-store-1'],
+    ['order-store-1', 'order-pickup-hub'],
   );
   assert.deepEqual(
     boardAssignedSnapshot.docs.map((snapshot) => snapshot.id),
@@ -407,37 +484,106 @@ test('driver 화면의 실제 pickup·assigned query는 허용 범위를 벗어�
     mapAssignedSnapshot.docs.map((snapshot) => snapshot.id),
     ['order-store-2'],
   );
+  assert.deepEqual(
+    directPickupSnapshot.docs.map((snapshot) => snapshot.id),
+    ['order-store-1'],
+  );
+  assert.deepEqual(
+    hubPickupSnapshot.docs.map((snapshot) => snapshot.id),
+    ['order-pickup-hub'],
+  );
   await assertFails(getDocs(unboundedQuery));
 });
 
-test('승인 상태 변경 뒤 기존 claim은 stale 상태로 남고 새 claim만 Rules 결과를 바꾼다', async () => {
-  const oldPendingToken = testEnvironment
-    .authenticatedContext('driver-lifecycle', { role: 'driver', driverApproved: false })
+test('이미 승인된 token도 users.driverApproved가 false가 되면 주문 read가 즉시 거부된다', async () => {
+  const driverToken = testEnvironment
+    .authenticatedContext('driver-stale-approval', { role: 'driver', driverApproved: true })
     .firestore();
 
-  await assertFails(getDoc(doc(oldPendingToken, 'orders', 'order-store-1')));
+  await assertSucceeds(getDoc(doc(driverToken, 'orders', 'order-store-1')));
 
   await testEnvironment.withSecurityRulesDisabled(async (context) => {
-    await updateDoc(doc(context.firestore(), 'users', 'driver-lifecycle'), {
-      driverApproved: true,
+    await updateDoc(doc(context.firestore(), 'users', 'driver-stale-approval'), {
+      driverApproved: false,
     });
   });
 
-  // 기존 token은 users 문서의 변경을 재조회하지 않으므로 계속 거부된다.
-  await assertFails(getDoc(doc(oldPendingToken, 'orders', 'order-store-1')));
+  await assertFails(getDoc(doc(driverToken, 'orders', 'order-store-1')));
 
-  const newApprovedToken = testEnvironment
-    .authenticatedContext('driver-lifecycle', { role: 'driver', driverApproved: true })
+  const staleQuery = query(
+    collection(driverToken, 'orders'),
+    where('status', '==', 'PREPARING'),
+    where('deliveryMethod', '==', 'direct'),
+    where('driverId', '==', null),
+  );
+  await assertFails(getDocs(staleQuery));
+});
+
+test('이미 승인된 token도 users.suspended가 true가 되면 주문 read가 즉시 거부된다', async () => {
+  const driverToken = testEnvironment
+    .authenticatedContext('driver-lifecycle-suspended', {
+      role: 'driver',
+      driverApproved: true,
+    })
     .firestore();
-  await assertSucceeds(getDoc(doc(newApprovedToken, 'orders', 'order-store-1')));
+
+  await assertSucceeds(getDoc(doc(driverToken, 'orders', 'order-store-1')));
 
   await testEnvironment.withSecurityRulesDisabled(async (context) => {
-    await updateDoc(doc(context.firestore(), 'users', 'driver-lifecycle'), {
-      driverApproved: false,
+    await updateDoc(doc(context.firestore(), 'users', 'driver-lifecycle-suspended'), {
       suspended: true,
     });
   });
 
-  // 승인 철회·정지 뒤에도 이미 발급된 true claim은 Rules에서 계속 유효하다.
-  await assertSucceeds(getDoc(doc(newApprovedToken, 'orders', 'order-store-1')));
+  await assertFails(getDoc(doc(driverToken, 'orders', 'order-store-1')));
+});
+
+test('이미 승인된 token도 users.role이 driver가 아니게 되면 주문 read가 즉시 거부된다', async () => {
+  const driverToken = testEnvironment
+    .authenticatedContext('driver-lifecycle-role', { role: 'driver', driverApproved: true })
+    .firestore();
+
+  await assertSucceeds(getDoc(doc(driverToken, 'orders', 'order-store-1')));
+
+  await testEnvironment.withSecurityRulesDisabled(async (context) => {
+    await updateDoc(doc(context.firestore(), 'users', 'driver-lifecycle-role'), {
+      role: 'consumer',
+    });
+  });
+
+  await assertFails(getDoc(doc(driverToken, 'orders', 'order-store-1')));
+});
+
+test('users 문서가 없거나 token claim이 false이면 현재 DB가 승인 상태여도 거부된다', async () => {
+  const missingUserToken = testEnvironment
+    .authenticatedContext('driver-no-user', { role: 'driver', driverApproved: true })
+    .firestore();
+  const falseClaimToken = testEnvironment
+    .authenticatedContext('driver-token-false-db-true', {
+      role: 'driver',
+      driverApproved: false,
+    })
+    .firestore();
+
+  await assertFails(getDoc(doc(missingUserToken, 'orders', 'order-store-1')));
+  await assertFails(getDoc(doc(falseClaimToken, 'orders', 'order-store-1')));
+});
+
+test('미승인 users가 승인된 뒤 새 승인 token만 주문 read를 허용한다', async () => {
+  const oldToken = testEnvironment
+    .authenticatedContext('driver-lifecycle-approval', { role: 'driver', driverApproved: false })
+    .firestore();
+
+  await testEnvironment.withSecurityRulesDisabled(async (context) => {
+    await updateDoc(doc(context.firestore(), 'users', 'driver-lifecycle-approval'), {
+      driverApproved: true,
+      suspended: false,
+    });
+  });
+
+  await assertFails(getDoc(doc(oldToken, 'orders', 'order-store-1')));
+  const newToken = testEnvironment
+    .authenticatedContext('driver-lifecycle-approval', { role: 'driver', driverApproved: true })
+    .firestore();
+  await assertSucceeds(getDoc(doc(newToken, 'orders', 'order-store-1')));
 });

--- a/tests/firestore/firestore-rules.test.mjs
+++ b/tests/firestore/firestore-rules.test.mjs
@@ -50,7 +50,18 @@ function clientContexts() {
         .authenticatedContext('seller-1', { role: 'seller', storeId: 'store-1' })
         .firestore(),
     ],
-    ['기사', testEnvironment.authenticatedContext('driver-1', { role: 'driver' }).firestore()],
+    [
+      '승인 기사',
+      testEnvironment
+        .authenticatedContext('driver-1', { role: 'driver', driverApproved: true })
+        .firestore(),
+    ],
+    [
+      '미승인 기사',
+      testEnvironment
+        .authenticatedContext('pending-driver', { role: 'driver', driverApproved: false })
+        .firestore(),
+    ],
     ['관리자', testEnvironment.authenticatedContext('admin-1', { role: 'admin' }).firestore()],
   ];
 }
@@ -68,8 +79,34 @@ async function seedFixtures() {
         category: 'orchid',
         bloomDuration: '60~90일',
       },
-      'orders/order-store-1': { storeId: 'store-1', userId: 'user-1' },
-      'orders/order-store-2': { storeId: 'store-2', userId: 'user-2' },
+      'orders/order-store-1': {
+        storeId: 'store-1',
+        userId: 'user-1',
+        status: 'PREPARING',
+        driverId: null,
+        deliveryMethod: 'direct',
+      },
+      'orders/order-store-2': {
+        storeId: 'store-2',
+        userId: 'user-2',
+        status: 'DELIVERING',
+        driverId: 'driver-1',
+        deliveryMethod: 'direct',
+      },
+      'orders/order-driver-other': {
+        storeId: 'store-1',
+        userId: 'user-3',
+        status: 'DELIVERING',
+        driverId: 'driver-2',
+        deliveryMethod: 'direct',
+      },
+      'orders/order-pickup-parcel': {
+        storeId: 'store-1',
+        userId: 'user-4',
+        status: 'PREPARING',
+        driverId: null,
+        deliveryMethod: 'parcel',
+      },
       'saleRounds/round-1': { storeId: 'store-1', status: 'OPEN' },
       'saleRounds/round-draft': { storeId: 'store-1', status: 'DRAFT' },
       'saleRoundItems/item-1': {
@@ -221,4 +258,38 @@ test('기존 주문의 판매자 매장과 기사 및 관리자 읽기 권한을
   await assertSucceeds(getDoc(doc(driver, 'orders', 'order-store-2')));
   await assertSucceeds(getDoc(doc(admin, 'orders', 'order-store-2')));
   await assertFails(getDoc(doc(user, 'orders', 'order-store-1')));
+});
+
+test('승인된 기사는 배정 주문과 미배정 수거 주문만 읽고 다른 기사 주문은 읽지 못한다', async () => {
+  const approvedDriver = testEnvironment
+    .authenticatedContext('driver-1', { role: 'driver', driverApproved: true })
+    .firestore();
+  const pendingDriver = testEnvironment
+    .authenticatedContext('pending-driver', { role: 'driver', driverApproved: false })
+    .firestore();
+
+  await assertSucceeds(getDoc(doc(approvedDriver, 'orders', 'order-store-2')));
+  await assertSucceeds(getDoc(doc(approvedDriver, 'orders', 'order-store-1')));
+  await assertFails(getDoc(doc(approvedDriver, 'orders', 'order-driver-other')));
+  await assertFails(getDoc(doc(approvedDriver, 'orders', 'order-pickup-parcel')));
+  await assertFails(getDoc(doc(pendingDriver, 'orders', 'order-store-2')));
+
+  const assignedQuery = query(
+    collection(approvedDriver, 'orders'),
+    where('driverId', '==', 'driver-1'),
+  );
+  const pickupQuery = query(
+    collection(approvedDriver, 'orders'),
+    where('status', '==', 'PREPARING'),
+    where('deliveryMethod', 'in', ['direct', 'hub']),
+    where('driverId', '==', null),
+  );
+  const unboundedDriverQuery = query(
+    collection(approvedDriver, 'orders'),
+    where('status', 'in', ['PREPARING', 'DELIVERING']),
+  );
+
+  await assertSucceeds(getDocs(assignedQuery));
+  await assertSucceeds(getDocs(pickupQuery));
+  await assertFails(getDocs(unboundedDriverQuery));
 });


### PR DESCRIPTION
## Included scope

- Task 2C/2D candidate scope preserved: F-001, P0-001, P0-002, REG-001, ENV-001, including Firestore Rules and deployment-safety evidence.
- Task 2F-A: public driver register/login approval gate. Public driver registration persists `driverApproved: false` and rejects client-supplied approval; false/missing approval is rejected before JWT/refresh side effects; approved drivers and consumer/seller/admin login paths remain valid.
- Kakao no-auto-approval and JWT/current-user approval, suspension, role, and Firebase custom-token boundaries remain verified in the candidate.
- Task 2F-B reconciles current auth SSOT docs without rewriting historical PR #50 audit reports.

## Auth status

- FIXED/VERIFIED in this candidate: public driver register -> login approval bypass; Kakao new/legacy auto-approval; current-user JWT/Firebase approval boundary.
- STILL OPEN: `AUTH-SESSION-CLAIM-REVOCATION` — authoritative user revalidation on refresh, suspended/role/store/approval change convergence, access-token revocation window, and logout/rotation lifecycle.

## Verification at publication candidate

- Auth focused: 3 suites / 36 tests PASS.
- Public register/login regression: PASS within the auth controller/service suites; rejected before JWT signing and refresh-token persistence.
- Payment/security focused: 3 suites / 16 tests PASS.
- Firestore Rules: 23 / 23 PASS on local emulator with portable JDK 21.
- Driver typecheck: `pnpm --filter driver exec tsc --noEmit` PASS.
- API build: PASS.
- Modified auth specs/strategy lint: 0 errors / 0 warnings.
- `auth.service.ts` lint delta: 0; current and `origin/main` baseline both report 20 errors / 1 warning.
- Deployment safety: PASS.
- `git diff --check origin/main...HEAD`: PASS; worktree clean.

## Known baseline debt

- Existing TS2698/type debt and global API lint debt remain outside this scope.
- Existing `auth.service.ts` lint debt is unchanged at 20 errors / 1 warning.
- Existing copy-fonts race/dependency issue remains outside this scope.

## Remaining P0 / release blockers

- `AUTH-SESSION-CLAIM-REVOCATION`.
- `ADMIN-PRIVILEGED-MUTATION-COVERAGE`.
- `PAYMENT-WEBHOOK-SIGNATURE-COVERAGE`.
- Direct Firestore authorization/minimization and order mutation authorization coverage.
- `ORDER-REDELIVERY-PAID-RESUME-GATE` and `ADMIN-FORCE-REFUND-CONSISTENCY`.
- `SETTLEMENT-LIFECYCLE-COVERAGE` — `IMPLEMENTED / UNVERIFIED`, P0 coverage gap; direct evidence remains missing for create, duplicate, confirm cutoff/race, cancel, and paid reversal prevention.
- `MARKETING-CONSENT-LIFECYCLE-CONSISTENCY` — P0 implementation finding; checkout consent, user preferences, withdrawal, user-level SSOT, sender gating, and retention evidence remain unresolved.
- Notification evidence boundary: Alimtalk retry/SMS fallback, fail-closed configuration/template handling, delivery idempotency, and final-failure operation issue are unit/service-tested; actual ALIGO provider verification is `NOT RUN`.
- `LEGACY-GROUP-CANCEL-NOTIFICATION`: `LATER`.

## Safety boundary

- `NOT_RUN_EXTERNAL_SAFETY`: no actual PortOne payment/refund, ALIGO send/configuration, production Firebase/Firestore mutation, production environment change, deployment, rollback, or production data mutation was run.
- This PR is not merged or auto-merged by this task.