### PR TITLE
docs: settlement·notification·legal 정합성 P0 보강

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -165,7 +165,7 @@ admin refund가 정상 cancellation의 추가 charge·capacity·held counter·se
 
 ### P0 — SETTLEMENT-LIFECYCLE-COVERAGE
 
-settlement 생성·자동 확정·취소 transaction 구현은 존재하지만 core financial lifecycle의 직접 상태·race 회귀가 부족하다.
+settlement 생성·자동 확정·취소 transaction 구현은 존재하지만 core financial lifecycle의 직접 상태·race 회귀가 없다.
 
 현재 직접 근거:
 
@@ -180,7 +180,8 @@ settlement 생성·자동 확정·취소 transaction 구현은 존재하지만 c
 판정:
 
 - core implementation = `IMPLEMENTED`.
-- 간접 통합 실행 가능성은 있으나 핵심 금전 불변식 직접 증거가 부족해 `PARTIALLY VERIFIED`.
+- 실제 service의 간접 통합 실행은 core 상태의 직접 검증으로 세지 않는다.
+- 핵심 금전 불변식 직접 증거가 없으므로 `UNVERIFIED`.
 - P0 `COVERAGE GAP`으로 추적한다.
 
 남음:

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -163,6 +163,86 @@ admin refund가 정상 cancellation의 추가 charge·capacity·held counter·se
 
 정본: `docs/specs/api/admin.md`, `docs/specs/api/settlements.md`; 증거: `docs/reports/REPORT_auth_orders_admin_verification_audit_20260824.md`.
 
+### P0 — SETTLEMENT-LIFECYCLE-COVERAGE
+
+settlement 생성·자동 확정·취소 transaction 구현은 존재하지만 core financial lifecycle의 직접 상태·race 회귀가 부족하다.
+
+현재 직접 근거:
+
+- [x] `createSettlement()`는 transaction에서 기존 문서를 재확인하고 pending settlement를 생성
+- [x] fee/net/completedStatus snapshot 구현
+- [x] `confirmDueSettlements()`는 due pending을 transaction fresh-read 후 confirmed로 전환
+- [x] `cancelSettlement()`는 pending/confirmed를 cancelled로 전환하고 cancelled 멱등·paid 역전 방지를 구현
+- [x] 회차 E2E fixture는 실제 `SettlementsService`를 주입
+- [x] 현재 `apps/api/src/settlements`에 core lifecycle 전용 `*.spec.ts` 없음
+- [x] 회차 전체 흐름 E2E는 settlement 생성·중복·confirm·cancel·paid 보존을 직접 assertion하지 않음
+
+판정:
+
+- core implementation = `IMPLEMENTED`.
+- 간접 통합 실행 가능성은 있으나 핵심 금전 불변식 직접 증거가 부족해 `PARTIALLY VERIFIED`.
+- P0 `COVERAGE GAP`으로 추적한다.
+
+남음:
+
+- [ ] `createSettlement()` 1건 생성 + fee/net/status/completedStatus snapshot
+- [ ] `DELIVERED → REVIEWED`/동시 완료 호출에서 중복 생성·settledAt 덮어쓰기 없음
+- [ ] confirm cutoff 이전 pending 유지, due pending만 confirmed
+- [ ] confirm/cancel race에서 cancelled 미덮어쓰기
+- [ ] cancel missing no-op
+- [ ] pending/confirmed → cancelled
+- [ ] cancelled 멱등
+- [ ] paid → cancelled 역전 금지
+- [ ] 실제 회차 E2E에서 DELIVERED settlement 1건 + REVIEWED 중복 없음
+- [ ] 정상 cancellation에서 pending/confirmed settlement 수렴
+- [ ] 회귀 SHA `main` 통합
+
+admin `confirmed → paid` authorization/status 전이는 별도 `ADMIN-PRIVILEGED-MUTATION-COVERAGE`가 소유한다.
+
+정본: `docs/specs/api/settlements.md`; 증거: `docs/reports/REPORT_settlements_notifications_legal_ops_audit_20260824.md`.
+
+### P0 — MARKETING-CONSENT-LIFECYCLE-CONSISTENCY
+
+round checkout 선택 마케팅 consent, user preference, 철회, retention evidence가 하나의 authoritative lifecycle로 수렴하지 않는다.
+
+현재 직접 근거:
+
+- [x] round checkout은 기본 해제 선택 마케팅 checkbox 제공
+- [x] 동의 시 order request에 `marketingConsent` 포함
+- [x] round order 생성은 order snapshot + `marketingConsentLogs` `CONSENT` record 저장
+- [x] MY 마케팅 설정은 `users.notificationPreferences`만 읽음
+- [x] checkout consent는 user preference를 동기화하지 않음
+- [x] Auth 신규 user는 `notificationPreferences` pair를 기본 초기화하지 않음
+- [x] MY “즉시 철회”는 user preference만 false로 갱신
+- [x] 철회 시 `MARKETING_CONSENT` withdrawal retention record 생성 경로 없음
+- [x] 정보성 ORDER_* 연락은 마케팅 동의와 별개라는 UI/notification 계약 존재
+- [x] 현재 실제 선택 마케팅 sender는 이번 감사에서 확인되지 않음
+
+판정:
+
+- consent 수집/설정 UI와 저장 구성은 존재한다.
+- 동의→현재 상태→철회→retention evidence가 불일치하므로 P0 `IMPLEMENTATION FINDING`.
+- 실제 마케팅 발송이 미운영이라는 이유로 consent lifecycle의 모순을 정상 계약으로 두지 않는다.
+
+완료 정책 — 둘 중 하나를 명시적으로 선택:
+
+- [ ] **미사용 정책**: MVP에서 실제 마케팅을 하지 않으면 consent 수집/설정 노출을 비활성화·제거하고 불필요한 저장을 중단
+- [ ] **유지 정책**: user-level authoritative SSOT + checkout 동기화 + 철회 evidence + sender gating을 구현
+
+공통 완료 조건:
+
+- [ ] 신규 user의 marketing 상태가 정의되고 MY 설정이 오류 없이 해석
+- [ ] checkout consent와 authoritative user 상태가 정책대로 일치
+- [ ] 채널별 철회가 다른 채널 상태를 보존
+- [ ] 철회 timestamp/policy/channel retention evidence 생성
+- [ ] 중복 철회 멱등
+- [ ] 실제 marketing sender가 존재한다면 opt-out 채널 발송 차단
+- [ ] ORDER_* 주문·결제·배송 정보성 연락은 marketing opt-out 때문에 차단되지 않음
+- [ ] legal current fact와 공개 출시 문구를 최종 정책에 맞춰 정합화
+- [ ] 회귀 SHA `main` 통합
+
+정본: `docs/specs/api/notifications.md`, `docs/specs/legal/README.md`, `docs/specs/mvp-sales-round-direct-delivery.md`; 증거: `docs/reports/REPORT_settlements_notifications_legal_ops_audit_20260824.md`.
+
 ### P0 — ORDER-DIRECT-READ-AUTHORIZATION-AND-MINIMIZATION
 
 API authorization보다 seller/driver raw Firestore read 경계가 넓다.
@@ -254,8 +334,10 @@ repo-side production auto-deploy 차단은 완료. GitHub 관리자 레벨 보�
 
 - [ ] 주문 성립·취소·환불·배송·재배송비·보류 실제 정책
 - [ ] 재배송 payment-required 상태머신과 결제 전 재개 금지 계약 반영
+- [ ] settlement 생성·확정·취소·지급 실제 정책/검증 결과 반영
 - [ ] PortOne/PG 개인정보 처리
 - [ ] ALIGO 전화번호·메시지 처리
+- [ ] marketing consent 유지/미사용 최종 정책 + 동의·철회·보관 실제 lifecycle 반영
 - [ ] order direct-read 최소화 뒤 seller/driver 접근 설명
 - [ ] 시행일·이전 버전
 - [ ] legal tests
@@ -268,6 +350,8 @@ repo-side production auto-deploy 차단은 완료. GitHub 관리자 레벨 보�
 - [ ] `ORDER-REDELIVERY-PAID-RESUME-GATE`
 - [ ] `ADMIN-FORCE-REFUND-CONSISTENCY`
 - [ ] `ADMIN-PRIVILEGED-MUTATION-COVERAGE`
+- [ ] `SETTLEMENT-LIFECYCLE-COVERAGE`
+- [ ] `MARKETING-CONSENT-LIFECYCLE-CONSISTENCY`
 - [ ] `ORDER-DIRECT-READ-AUTHORIZATION-AND-MINIMIZATION`
 - [ ] `AUTH-DRIVER-APPROVAL-AND-SESSION-REVOCATION`
 - [ ] `ORDER-MUTATION-AUTHORIZATION-COVERAGE`
@@ -288,6 +372,19 @@ repo-side production auto-deploy 차단은 완료. GitHub 관리자 레벨 보�
 ---
 
 ## LATER
+
+### LEGACY-GROUP-CANCEL-NOTIFICATION
+
+legacy 목표 미달 공동구매에서 consumer `GROUP_CANCELLED_LACK` 알림이 누락될 수 있다.
+
+현재 `cancelGroupBuyLack()`가 주문을 먼저 `CANCELLED`로 바꾼 뒤 `sendToGroupParticipants()`를 호출하고, sender는 `CANCELLED`를 대상에서 제외한다.
+
+- [ ] 취소 대상 participant snapshot 또는 동등 명시적 recipient 집합 사용
+- [ ] consumer 목표미달 취소 알림 1회 직접 회귀
+- [ ] 판매자 취소 알림 정상 유지
+- [ ] 다른 template의 terminal filtering 의미 유지
+
+정본: `docs/specs/api/notifications.md`.
 
 ### NOTIFICATION-RETRY-POLICY
 - [ ] backoff·오류 분류·rate limit·중복 SMS·관측 지표

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -85,13 +85,37 @@ admin refund는 본 결제 환불 뒤 주문을 직접 `CANCELLED` write하며 �
 
 정본: `docs/specs/api/admin.md`, `docs/specs/api/settlements.md`; 증거: `docs/reports/REPORT_auth_orders_admin_verification_audit_20260824.md`.
 
-### 6. 결제 finalization provider 상태 방어
+### 6. Settlement core lifecycle coverage
+
+`SettlementsService`는 transaction 기반 생성·`pending → confirmed`·취소·paid 역전 방지를 구현한다. 회차 E2E fixture도 실제 service를 주입한다.
+
+그러나 전용 settlement lifecycle test가 없고 회차 통합 E2E도 settlement 생성 1건, 중복 방지, confirm cutoff/race, cancel/paid 보존을 직접 assertion하지 않는다.
+
+**`SETTLEMENT-LIFECYCLE-COVERAGE` = IMPLEMENTED / PARTIALLY VERIFIED + P0 COVERAGE GAP**.
+
+Admin `confirmed → paid`는 기존 `ADMIN-PRIVILEGED-MUTATION-COVERAGE`가 별도로 소유한다.
+
+정본: `docs/specs/api/settlements.md`; 증거: `docs/reports/REPORT_settlements_notifications_legal_ops_audit_20260824.md`.
+
+### 7. Marketing consent lifecycle
+
+round checkout에는 선택 마케팅 consent가 있고 consent retention record도 생성한다. 반면 MY 설정은 별도 `users.notificationPreferences`만 사용하고, checkout consent는 이를 동기화하지 않으며 신규 user 기본 preference도 없다. “즉시 철회”는 preference만 false로 바꾸고 withdrawal retention evidence를 남기지 않는다.
+
+현재 실제 선택 마케팅 sender는 확인되지 않았고, 주문·결제·배송 정보성 연락은 선택 마케팅과 별개의 계약이다.
+
+**`MARKETING-CONSENT-LIFECYCLE-CONSISTENCY` = P0 IMPLEMENTATION FINDING**.
+
+MVP에서 마케팅을 사용하지 않으면 consent 수집/설정 노출을 비활성화·제거하는 선택도 가능하고, 유지한다면 user-level SSOT + checkout sync + withdrawal evidence + sender gating을 구현한다.
+
+정본: `docs/specs/api/notifications.md`, `docs/specs/legal/README.md`; 증거: `docs/reports/REPORT_settlements_notifications_legal_ops_audit_20260824.md`.
+
+### 8. 결제 finalization provider 상태 방어
 
 `finalizePaidOrder()` boundary가 비`PAID` provider 입력을 자체 차단하지 않는다.
 
 **`PAYMENT-FINALIZATION-PAID-GUARD` = P0 IMPLEMENTATION FINDING**.
 
-### 7. PortOne webhook signature 검증 coverage
+### 9. PortOne webhook signature 검증 coverage
 
 webhook signature 구현은 raw body + id/timestamp/signature, timestamp ±5분, HMAC SHA-256 timing-safe 검증을 사용한다. 그러나 현재 회차 E2E의 signature verifier는 mock이며 real verifier의 valid HMAC 성공·non-empty invalid HMAC 거부·body/id/timestamp 변조 거부를 직접 고정한 증거가 부족하다.
 
@@ -99,13 +123,13 @@ webhook signature 구현은 raw body + id/timestamp/signature, timestamp ±5분,
 
 정본: `docs/specs/api/payments.md`; 증거: `docs/reports/REPORT_payment_webhook_signature_coverage_20260824.md`.
 
-### 8. 주문 mutation authorization 회귀
+### 10. 주문 mutation authorization 회귀
 
 ownership guard는 구현돼 있으나 타-store seller·비담당 driver·first-claim 외 action과 거부 side-effect 0 직접 회귀가 부족하다.
 
 **`ORDER-MUTATION-AUTHORIZATION-COVERAGE` = IMPLEMENTED / UNVERIFIED + P0 COVERAGE GAP**.
 
-### 9. GitHub main protection
+### 11. GitHub main protection
 
 repo-side 배포 방어는 완료. GitHub 관리자 레벨 PR required/required check/force-push·delete 차단은 Issue #32가 남아 있다.
 
@@ -119,14 +143,19 @@ repo-side 배포 방어는 완료. GitHub 관리자 레벨 PR required/required 
 - 실제 알림톡·SMS 발송 0건.
 - production ALIGO 자격 증명·매핑 미반영.
 
+코드 레벨 알림톡 3회 retry→SMS fallback, 설정 fail-closed, notification delivery idempotency는 직접 테스트가 있다. 이를 실제 provider 승인·발송 증거로 확장하지 않는다.
+
 현재성이 필요하면 provider에서 다시 조회한다.
 
 ## 판매 활성화 legal 상태
 
 - production `/privacy`, `/terms`는 2026-08-19 비판매 상태 기준.
 - 실제 판매 전 주문·취소·환불·재배송비·보류, PortOne/PG, ALIGO, seller/driver 개인정보 접근을 재정합화해야 한다.
+- 2026-08-19 consumer legal baseline의 “마케팅 수신 동의 기능 없음” 사실은 현재 코드와 달라 `docs/specs/legal/README.md`의 2026-08-24 errata가 해당 구현 사실을 우선한다.
+- 현재는 선택 marketing consent UI/storage가 존재하지만 실제 marketing sender는 확인되지 않았으며 `MARKETING-CONSENT-LIFECYCLE-CONSISTENCY`가 남아 있다.
 - broad read를 legal 문구로 정당화하지 않는다.
 - 재배송 payment-required 상태머신과 admin refund 실제 정책을 legal의 재배송비·환불 설명에 반영한다.
+- settlement 생성·확정·취소·지급 검증 결과와 marketing consent 유지/미사용 최종 정책을 legal 확정 전에 반영한다.
 
 ## 검증 상태
 
@@ -156,9 +185,9 @@ repo-side 배포 방어는 완료. GitHub 관리자 레벨 PR required/required 
 
 1. `AUTH-DRIVER-APPROVAL-AND-SESSION-REVOCATION` + `ORDER-DIRECT-READ-AUTHORIZATION-AND-MINIMIZATION` 결합 위험을 최우선으로 해결·직접 회귀·`main` 통합.
 2. `ORDER-REDELIVERY-PAID-RESUME-GATE` 상태머신 전체 구현·직접 회귀.
-3. `ADMIN-PRIVILEGED-MUTATION-COVERAGE`, webhook coverage, payment finalization, admin refund, order mutation 등 나머지 P0를 ALIGO 심사와 병렬 해결.
+3. `SETTLEMENT-LIFECYCLE-COVERAGE`, `MARKETING-CONSENT-LIFECYCLE-CONSISTENCY`, admin privileged, webhook, payment finalization, admin refund, order mutation 등 나머지 P0를 ALIGO 심사와 병렬 해결.
 4. Issue #32.
 5. ALIGO 상태 재조회 → 승인 뒤 실제 알림톡/SMS fallback.
-6. P0 결과 기준 legal 재정합화.
+6. 모든 P0 결과 기준 legal 재정합화.
 7. actual release SHA → E2E 52+cleanup → Firebase 재조회 → 승인된 production 설정/배포.
 8. 첫 회차 검수 → 최종 승인 → `salesMode: round_direct`.

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -89,9 +89,9 @@ admin refund는 본 결제 환불 뒤 주문을 직접 `CANCELLED` write하며 �
 
 `SettlementsService`는 transaction 기반 생성·`pending → confirmed`·취소·paid 역전 방지를 구현한다. 회차 E2E fixture도 실제 service를 주입한다.
 
-그러나 전용 settlement lifecycle test가 없고 회차 통합 E2E도 settlement 생성 1건, 중복 방지, confirm cutoff/race, cancel/paid 보존을 직접 assertion하지 않는다.
+그러나 전용 settlement lifecycle test가 없고 회차 통합 E2E도 settlement 생성 1건, 중복 방지, confirm cutoff/race, cancel/paid 보존을 직접 assertion하지 않는다. 실제 service의 간접 실행은 core 금전 상태의 직접 증거로 세지 않는다.
 
-**`SETTLEMENT-LIFECYCLE-COVERAGE` = IMPLEMENTED / PARTIALLY VERIFIED + P0 COVERAGE GAP**.
+**`SETTLEMENT-LIFECYCLE-COVERAGE` = IMPLEMENTED / UNVERIFIED + P0 COVERAGE GAP**.
 
 Admin `confirmed → paid`는 기존 `ADMIN-PRIVILEGED-MUTATION-COVERAGE`가 별도로 소유한다.
 

--- a/docs/plans/HANDOFF_mvp_round_direct_aligo_review_pause.md
+++ b/docs/plans/HANDOFF_mvp_round_direct_aligo_review_pause.md
@@ -24,8 +24,10 @@
 5. `ORDER-MUTATION-AUTHORIZATION-COVERAGE`
 6. `ADMIN-FORCE-REFUND-CONSISTENCY`
 7. `ADMIN-PRIVILEGED-MUTATION-COVERAGE`
-8. `PAYMENT-WEBHOOK-SIGNATURE-COVERAGE`
-9. Issue #32
+8. `SETTLEMENT-LIFECYCLE-COVERAGE`
+9. `MARKETING-CONSENT-LIFECYCLE-CONSISTENCY`
+10. `PAYMENT-WEBHOOK-SIGNATURE-COVERAGE`
+11. Issue #32
 
 ## 최우선 재개 — Driver 승인 + direct read 결합 위험
 
@@ -84,6 +86,27 @@
 
 정본: `docs/specs/api/orders.md`, `docs/BACKLOG.md`.
 
+## 새 감사 P0 포인터
+
+### Settlement core lifecycle
+
+transaction 구현은 있으나 생성 1건·중복 방지·confirm cutoff/race·cancel·paid 보존 직접 assertion이 부족하다.
+
+- Backlog: `SETTLEMENT-LIFECYCLE-COVERAGE`
+- Contract: `docs/specs/api/settlements.md`
+- Evidence: `docs/reports/REPORT_settlements_notifications_legal_ops_audit_20260824.md`
+- Admin `confirmed → paid`는 `ADMIN-PRIVILEGED-MUTATION-COVERAGE`와 분리한다.
+
+### Marketing consent lifecycle
+
+checkout consent는 order+retention에 저장되지만 MY 설정은 별도 user preference를 읽고, checkout이 이를 동기화하지 않으며 철회 retention evidence가 없다.
+
+- Backlog: `MARKETING-CONSENT-LIFECYCLE-CONSISTENCY`
+- Contract: `docs/specs/api/notifications.md`, `docs/specs/legal/README.md`
+- Evidence: `docs/reports/REPORT_settlements_notifications_legal_ops_audit_20260824.md`
+- 제품 선택: MVP marketing 미사용이면 consent 수집/설정 노출 제거; 유지면 user-level SSOT + withdrawal evidence + sender gating.
+- ORDER_* 정보성 연락은 marketing opt-out과 분리한다.
+
 ## 나머지 P0 포인터
 
 - Payment finalization: `docs/specs/api/payments.md`
@@ -102,6 +125,9 @@
 - main merge를 production 승인으로 해석
 - 승인 없는 production/Firebase/운영 회차/`salesMode`
 - P0를 frontend 버튼 숨김·UI redirect·legal 문구만으로 정상화
+- settlement transaction 코드만 보고 financial lifecycle을 `VERIFIED` 처리
+- marketing checkbox/UI만 보고 consent lifecycle 완료 처리
+- 현재 정보성 ORDER_* 알림을 marketing opt-out으로 막아 consent 문제를 해결
 - P0 전 actual release SHA 확정
 
 ## 병렬 가능 작업
@@ -113,19 +139,21 @@
 5. order mutation 거부 회귀
 6. admin force-refund lifecycle
 7. admin privileged mutation + settlement pay 직접 회귀
-8. webhook signature real-verifier 회귀
-9. Issue #32
-10. read-only 문서/코드 감사
-11. ALIGO 상태 조회
+8. settlement create/confirm/cancel core lifecycle 회귀
+9. marketing consent lifecycle 정책 결정·구현·회귀
+10. webhook signature real-verifier 회귀
+11. Issue #32
+12. read-only 문서/코드 감사
+13. ALIGO 상태 조회
 
 ## ALIGO 승인 뒤
 
-1. P0 8개 + Issue #32 완료 확인
+1. P0 10개 + Issue #32 완료 확인
 2. ALIGO 8종 상태 재확인
 3. provider code 1:1 검사
 4. 승인 후 격리 알림톡
 5. 승인 후 SMS fallback
-6. 실제 재배송/환불/read-minimization/auth 결과 기준 legal 재정합화
+6. 실제 재배송/환불/정산/read-minimization/auth/marketing 결과 기준 legal 재정합화
 7. actual release SHA
 8. exact SHA E2E 52+cleanup
 9. 운영 Firebase read-only
@@ -149,6 +177,8 @@
 - [ ] order mutation coverage
 - [ ] admin force-refund
 - [ ] admin privileged mutation + settlement pay coverage
+- [ ] settlement core lifecycle coverage
+- [ ] marketing consent lifecycle consistency
 - [ ] webhook signature real-verifier coverage
 - [ ] Issue #32
 - [ ] ALIGO 8종 승인

--- a/docs/plans/PLAN_mvp_round_direct_launch_blockers.md
+++ b/docs/plans/PLAN_mvp_round_direct_launch_blockers.md
@@ -26,6 +26,8 @@
 | 0G | 유료 재배송 payment-request/hold-resolution/resume 상태머신 | 미완료 — P0 FINDING |
 | 0H | payment webhook real-signature coverage | 미완료 — P0 COVERAGE GAP |
 | 0I | admin privileged mutation authorization + settlement pay coverage | 미완료 — P0 COVERAGE GAP |
+| 0J | settlement 생성·confirm·cancel core lifecycle coverage | 미완료 — P0 COVERAGE GAP |
+| 0K | marketing consent→preference→withdrawal→retention lifecycle | 미완료 — P0 FINDING |
 | 1 | ALIGO 8종 최종 승인 | 검수중 |
 | 2 | 실제 알림톡 | 미실행 |
 | 3 | SMS fallback | 미실행 |
@@ -41,17 +43,20 @@
 
 1. repository 변경은 최신 `main` 기반 branch+PR.
 2. direct `main` 금지.
-3. 0A~0I는 ALIGO 심사와 병렬 가능.
+3. 0A~0K는 ALIGO 심사와 병렬 가능.
 4. P0를 문서/UI 변경만으로 완료 처리하지 않는다.
 5. 금전·권한 불변식은 server boundary + 직접 거부/정상/동시성 회귀가 필요하다.
 6. driver 관리자 승인 계약은 public register/login, Kakao, refresh, Firebase claims까지 하나의 authorization lifecycle로 검증한다.
 7. admin role boundary는 UI redirect만으로 `VERIFIED` 처리하지 않는다.
-8. webhook auth는 mock E2E만으로 `VERIFIED` 처리하지 않고 real verifier의 valid/invalid 양방향 증거가 필요하다.
-9. actual release SHA는 0A~0I + legal 해결 뒤 고정한다.
-10. exact SHA E2E 52+cleanup 전 production 금지.
-11. production은 exact SHA/artifact + 별도 승인.
-12. provider metadata SHA 불일치 시 traffic 전환 금지.
-13. 첫 회차 `SCHEDULED` 전 `salesMode` 전환 금지.
+8. settlement core는 transaction 구현만으로 `VERIFIED` 처리하지 않고 생성·중복·confirm·cancel·paid 역전 방지를 직접 고정한다.
+9. 선택 marketing consent는 checkout checkbox 성공만으로 완료하지 않고 authoritative state → withdrawal → retention evidence → sender gating까지 검증한다.
+10. 주문·결제·배송 정보성 연락은 선택 marketing opt-out과 별개의 계약으로 유지한다.
+11. webhook auth는 mock E2E만으로 `VERIFIED` 처리하지 않고 real verifier의 valid/invalid 양방향 증거가 필요하다.
+12. actual release SHA는 0A~0K + legal 해결 뒤 고정한다.
+13. exact SHA E2E 52+cleanup 전 production 금지.
+14. production은 exact SHA/artifact + 별도 승인.
+15. provider metadata SHA 불일치 시 traffic 전환 금지.
+16. 첫 회차 `SCHEDULED` 전 `salesMode` 전환 금지.
 
 ## Phase 0 — 코드·권한·금전 안전성
 
@@ -149,6 +154,37 @@
   - 실제 guard를 mock으로 우회하지 않는 integration 증거
 - Status: todo_test_security_financial
 
+### Task 0.12 — Settlement core lifecycle coverage
+- Backlog: `SETTLEMENT-LIFECYCLE-COVERAGE`
+- Contract: `docs/specs/api/settlements.md`
+- Evidence: `docs/reports/REPORT_settlements_notifications_legal_ops_audit_20260824.md`
+- Goal: settlement 생성·중복·자동 confirm·cancel의 core financial lifecycle을 직접 고정
+- Required:
+  - create 1건 + fee/net/status/completedStatus snapshot
+  - DELIVERED→REVIEWED/동시 완료 중복 생성·snapshot overwrite 없음
+  - cutoff 전 pending 유지 / due pending confirmed
+  - confirm/cancel race에서 cancelled 미덮어쓰기
+  - missing no-op, pending/confirmed cancelled, cancelled 멱등, paid 역전 금지
+  - 실제 회차 integration에서 DELIVERED settlement 1건 + REVIEWED 중복 없음
+- Status: todo_test_financial
+
+### Task 0.13 — Marketing consent lifecycle consistency
+- Backlog: `MARKETING-CONSENT-LIFECYCLE-CONSISTENCY`
+- Contract: `docs/specs/api/notifications.md`, `docs/specs/legal/README.md`
+- Evidence: `docs/reports/REPORT_settlements_notifications_legal_ops_audit_20260824.md`
+- Goal: checkout consent, user preference, withdrawal, retention evidence를 한 정책으로 수렴
+- Decision:
+  - MVP에서 marketing 미사용 → consent 수집/설정 노출 비활성화·제거
+  - 유지 → user-level SSOT + checkout sync + withdrawal evidence + sender gating
+- Required regardless of decision:
+  - 신규 user marketing state 정의
+  - 설정 화면이 authoritative state만 표시
+  - 철회 channel/state/evidence 멱등성
+  - 실제 marketing sender가 있다면 opt-out 준수
+  - ORDER_* 정보성 연락은 marketing opt-out과 분리
+  - final legal wording과 실제 구현 일치
+- Status: todo_code_legal
+
 ## Phase 1 — ALIGO
 
 1. 8종 승인 (`blocked_external_review`)
@@ -159,11 +195,11 @@
 ## Phase 2 — legal·release SHA
 
 ### Task 2.1 — 판매 활성화 legal
-- Dependency: ALIGO 실제 검증 + Task 0.6 + 0.7 + 0.8 + 0.9
-- Required: 주문/환불/재배송비/보류 실제 상태머신, 개인정보 처리, ALIGO, seller/driver 최소 접근, legal tests
+- Dependency: ALIGO 실제 검증 + Task 0.6 + 0.7 + 0.8 + 0.9 + 0.12 + 0.13
+- Required: 주문/환불/정산/재배송비/보류 실제 상태머신, marketing consent 실제 정책, 개인정보 처리, ALIGO, seller/driver 최소 접근, legal tests
 
 ### Task 2.2 — actual release SHA
-- Dependency: Task 0.3~0.11 + 2.1
+- Dependency: Task 0.3~0.13 + 2.1
 
 ### Task 2.3 — exact SHA E2E
 - Goal: chromium 26 + mobile 26 = 52, cleanup success
@@ -193,12 +229,14 @@
 
 ## 최종 완료 기준
 
-- Task 0A~0I 직접 증거와 함께 `main` 포함.
+- Task 0A~0K 직접 증거와 함께 `main` 포함.
 - 승인 전 public email/Kakao driver authorization과 stale Firebase claims 우회 해결.
 - driver 권한과 order direct-read 최소화가 결합 위험 없이 fail-closed.
 - 유료 재배송 payment request가 실제 결제 가능한 상태를 유지하고, 결제 전 모든 배송 시작 경로가 fail-closed.
-- webhook signature valid/invalid real-verifier evidence 포함.
+- settlement 생성·confirm·cancel core lifecycle 직접 상태/race 증거 포함.
 - admin privileged mutation role boundary + settlement pay 직접 증거 포함.
+- marketing consent 유지/미사용 정책이 checkout·preference·withdrawal·retention·legal에 일관되게 반영.
+- webhook signature valid/invalid real-verifier evidence 포함.
 - admin refund·payment finalization·권한/개인정보 P0 해결.
 - Issue #32 완료.
 - ALIGO 승인+실발송/fallback.

--- a/docs/reports/REPORT_settlements_notifications_legal_ops_audit_20260824.md
+++ b/docs/reports/REPORT_settlements_notifications_legal_ops_audit_20260824.md
@@ -1,0 +1,155 @@
+<!-- Language: ko -->
+
+# REPORT — Settlements / Notifications / Legal / Ops 정합성 감사
+
+> 날짜: 2026-08-24 KST
+> 기준 `main`: `d6185bd676d79214ccd4949209162900e4a69bc0`
+> 범위: settlements → notifications → legal/ops Spec·Code·Test 삼각 검증
+> 판정 기준: `docs/DOCUMENT_CONSISTENCY.md`
+
+## 요약 판정
+
+| 영역 | 판정 | 결과 |
+|---|---|---|
+| Settlement core lifecycle | `IMPLEMENTED / PARTIALLY VERIFIED` + P0 `COVERAGE GAP` | transaction 구현은 있으나 핵심 상태·동시성 직접 assertion 부족 |
+| Admin settlement pay | 기존 P0 유지 | `ADMIN-PRIVILEGED-MUTATION-COVERAGE`가 소유 |
+| ALIGO retry/fallback | direct unit/service evidence 존재 | 3회 알림톡 + 1회 SMS, fail-closed, idempotency를 직접 검증 |
+| ALIGO actual provider | 외부/운영 미검증 | 8종 심사와 실제 격리 발송은 별도 출시 게이트 |
+| Marketing consent lifecycle | P0 `IMPLEMENTATION FINDING` | checkout consent, user preference, withdrawal, retention evidence가 단일 lifecycle로 수렴하지 않음 |
+| Legacy group cancellation notice | LATER `IMPLEMENTATION FINDING` | `CANCELLED` 전환 뒤 participant sender가 CANCELLED를 제외해 알림 누락 가능 |
+| Legal current facts | L1 문서 불일치 | 마케팅 발송은 미운영이지만 consent UI/storage는 이미 존재 |
+| Ops redelivery contract | intended contract 유지 | 기존 `ORDER-REDELIVERY-PAID-RESUME-GATE` 구현 finding이 소유 |
+
+## 1. Settlement core lifecycle
+
+`SettlementsService`는 다음을 구현한다.
+
+- 완료 주문에서 `settlements/{orderId}` 1건 생성
+- transaction 안에서 중복 존재 재확인
+- `pending` 초기 상태와 fee/net snapshot
+- 04:00 KST cron의 due `pending → confirmed`
+- confirm transaction fresh-read로 cancelled race 보호
+- `cancelSettlement()`의 pending/confirmed → cancelled
+- cancelled 멱등 no-op
+- paid settlement 역전 방지
+
+그러나 현재 `apps/api/src/settlements`에는 전용 `*.spec.ts`가 없다. 회차 API E2E fixture는 실제 `SettlementsService`를 주입하지만 현재 전체 흐름 테스트에서 settlement 생성·중복·confirm·cancel·paid 보존을 직접 assertion하지 않는다.
+
+따라서 코드 존재를 전체 financial lifecycle의 `VERIFIED`로 확장하지 않는다.
+
+### 판정
+
+새 P0 `SETTLEMENT-LIFECYCLE-COVERAGE`:
+
+- 구현: `IMPLEMENTED`
+- 일부 간접 통합 경로: 존재
+- 핵심 금전 상태·race 직접 증거: 부족
+- 최종: `PARTIALLY VERIFIED + P0 COVERAGE GAP`
+
+`ADMIN-PRIVILEGED-MUTATION-COVERAGE`는 admin `confirmed → paid` authorization/status 경계를 계속 소유하고, 이 P0는 settlement 생성·confirm·cancel의 core lifecycle을 소유한다.
+
+## 2. Notifications delivery
+
+현재 `notifications-delivery.spec.ts`는 다음을 직접 고정한다.
+
+- 알림톡 1회 성공 시 추가 시도 없음
+- 실패 시 최대 3회 시도
+- 3회 실패 후 동일 본문 SMS 1회 fallback
+- credential/template mapping/required variable 오류는 외부 요청 전 fail-closed
+- 실제 성공 channel·attempt count 기록
+- 주문 배송 연락처 우선 및 허용 fallback
+- 최종 실패 `CUSTOMER_NOTICE_FAILED`
+- 동일 운영 예외 중복 방지
+- 명시적 SMS resend 기록
+- notification delivery idempotency key의 단일 발송
+
+따라서 위 isolated delivery contract는 직접 테스트 근거가 있다. 다만 ALIGO provider 승인 상태와 실제 provider 발송 성공은 이 증거로 대체하지 않는다.
+
+## 3. Marketing consent lifecycle
+
+의도된 계약은 선택 마케팅과 주문·결제·배송 정보성 연락을 분리하고, 선택 동의·철회를 감사 가능한 증거로 남기는 것이다.
+
+현재 구현은 다음처럼 분리돼 있다.
+
+### checkout consent
+
+- round checkout은 선택 마케팅 checkbox를 제공한다.
+- 동의 시 order request에 `marketingConsent`를 넣는다.
+- `RoundOrderCreateService`는 order snapshot에 consent를 저장한다.
+- 동시에 `marketingConsentLogs`에 `recordType: CONSENT` retention record를 저장한다.
+
+### user preference
+
+- MY 마케팅 설정은 `users/{userId}.notificationPreferences`의 `alimtalk/sms` pair를 읽는다.
+- 철회는 `/notifications/me/preferences`로 해당 bool을 false로 바꾼다.
+- Auth 신규 사용자 생성은 이 preference pair를 기본 초기화하지 않는다.
+- checkout consent는 user preference를 동기화하지 않는다.
+
+### withdrawal evidence
+
+- 현재 preference 철회는 `users.notificationPreferences`만 갱신한다.
+- `MARKETING_CONSENT` retention의 withdrawal record를 생성하지 않는다.
+- current round-direct spec은 동의·철회 증거를 `marketingConsentLogs`에 보관한다고 규정한다.
+
+따라서 사용자가 checkout에서 동의한 뒤 MY 설정이 같은 상태를 반드시 보여준다는 보장이 없고, “즉시 철회”가 retention evidence로 남는다는 계약도 충족되지 않는다.
+
+### 판정
+
+새 P0 `MARKETING-CONSENT-LIFECYCLE-CONSISTENCY` = `IMPLEMENTATION FINDING`.
+
+완료 방식은 제품 결정을 허용한다.
+
+1. MVP에서 실제 마케팅 발송을 하지 않을 계획이면 consent 수집/설정 노출을 출시 전 비활성화하거나 제거하고 불필요한 consent 처리를 중단한다.
+2. consent 기능을 유지한다면 user-level SSOT, checkout 동기화, 철회 기록, idempotency, 실제 marketing sender gating을 하나의 lifecycle로 구현한다.
+
+어느 선택이든 주문·결제·배송 정보성 연락은 마케팅 opt-out과 별개로 유지한다. 거래 알림을 marketing preference로 차단하는 방식으로 해결하지 않는다.
+
+## 4. Legacy group cancellation notification
+
+`cancelGroupBuyLack()`는 RECRUITING 주문을 환불한 뒤 먼저 `CANCELLED`로 batch update하고, 이후 `sendToGroupParticipants(..., 'GROUP_CANCELLED_LACK')`를 호출한다.
+
+그러나 `sendToGroupParticipants()`는 `PENDING`, `CANCELLED`, `REVIEWED`를 terminal status로 제외한다.
+
+따라서 목표 미달로 방금 취소된 참여자는 consumer `GROUP_CANCELLED_LACK` 대상에서 빠질 수 있다.
+
+이 경로는 `round_direct` 출시의 active notification 8종 경로가 아니라 legacy 공동구매 경로이므로 새 출시 P0로 올리지 않고 `LEGACY-GROUP-CANCEL-NOTIFICATION` LATER implementation finding으로 추적한다.
+
+## 5. Legal current-fact drift
+
+`docs/specs/legal/consumer-legal-documents.md`의 2026-08-19 snapshot은 consumer에 마케팅 수신 동의 기능이 없다고 기록한다.
+
+2026-08-24 현재 코드는:
+
+- round checkout 선택 마케팅 consent UI
+- order `marketingConsent`
+- `marketingConsentLogs` consent retention
+- MY 마케팅 알림 설정 화면
+- `users.notificationPreferences`
+- 철회 PATCH endpoint
+
+를 가지고 있다.
+
+반면 실제 marketing message sender는 이번 감사에서 확인되지 않았고, 현재 정보성 주문 알림은 marketing consent와 별개다.
+
+따라서 정확한 현재 표현은 **“마케팅 발송은 미운영이지만 선택 동의·설정/저장 기능은 존재하며 lifecycle consistency P0가 남아 있다”**이다.
+
+공개 `/privacy`, `/terms`를 이번 docs-only 감사에서 판매 활성화 문구로 선반영하지 않는다. 최종 public legal 개정은 P0 결과와 ALIGO 실제 검증 후 별도 release gate에서 수행한다.
+
+## 6. Ops runbook
+
+runbook은 고객 책임 유료 재배송에서 `결제 전 재배송 금지`를 명시한다. 이는 intended operational contract로 유지한다.
+
+현재 code가 이 계약을 완전히 강제하지 않는 문제는 기존 `ORDER-REDELIVERY-PAID-RESUME-GATE` P0 implementation finding이 소유한다. runbook을 현재 code에 맞춰 완화하지 않는다.
+
+## 문서 전파
+
+- Settlement contract: `docs/specs/api/settlements.md`
+- Notifications contract: `docs/specs/api/notifications.md`
+- Legal launch gate/current-fact errata: `docs/specs/legal/README.md`
+- Backlog: `docs/BACKLOG.md`
+- Current state: `docs/memory.md`
+- Execution/resume: active PLAN/HANDOFF
+
+## 범위 경계
+
+이번 감사에서 코드, 테스트, provider, production, Firebase Rules, 운영 데이터, 실제 알림·결제·환불은 변경하지 않았다.

--- a/docs/reports/REPORT_settlements_notifications_legal_ops_audit_20260824.md
+++ b/docs/reports/REPORT_settlements_notifications_legal_ops_audit_20260824.md
@@ -11,7 +11,7 @@
 
 | 영역 | 판정 | 결과 |
 |---|---|---|
-| Settlement core lifecycle | `IMPLEMENTED / PARTIALLY VERIFIED` + P0 `COVERAGE GAP` | transaction 구현은 있으나 핵심 상태·동시성 직접 assertion 부족 |
+| Settlement core lifecycle | `IMPLEMENTED / UNVERIFIED` + P0 `COVERAGE GAP` | transaction 구현·간접 실행은 있으나 핵심 상태·동시성 직접 assertion 없음 |
 | Admin settlement pay | 기존 P0 유지 | `ADMIN-PRIVILEGED-MUTATION-COVERAGE`가 소유 |
 | ALIGO retry/fallback | direct unit/service evidence 존재 | 3회 알림톡 + 1회 SMS, fail-closed, idempotency를 직접 검증 |
 | ALIGO actual provider | 외부/운영 미검증 | 8종 심사와 실제 격리 발송은 별도 출시 게이트 |
@@ -35,16 +35,16 @@
 
 그러나 현재 `apps/api/src/settlements`에는 전용 `*.spec.ts`가 없다. 회차 API E2E fixture는 실제 `SettlementsService`를 주입하지만 현재 전체 흐름 테스트에서 settlement 생성·중복·confirm·cancel·paid 보존을 직접 assertion하지 않는다.
 
-따라서 코드 존재를 전체 financial lifecycle의 `VERIFIED`로 확장하지 않는다.
+따라서 실제 service가 통합 경로에서 실행된다는 사실을 core financial invariant의 검증으로 세지 않는다.
 
 ### 판정
 
 새 P0 `SETTLEMENT-LIFECYCLE-COVERAGE`:
 
 - 구현: `IMPLEMENTED`
-- 일부 간접 통합 경로: 존재
-- 핵심 금전 상태·race 직접 증거: 부족
-- 최종: `PARTIALLY VERIFIED + P0 COVERAGE GAP`
+- 실제 service의 간접 통합 실행: 존재
+- 핵심 금전 상태·race 직접 증거: 없음
+- 최종: `UNVERIFIED + P0 COVERAGE GAP`
 
 `ADMIN-PRIVILEGED-MUTATION-COVERAGE`는 admin `confirmed → paid` authorization/status 경계를 계속 소유하고, 이 P0는 settlement 생성·confirm·cancel의 core lifecycle을 소유한다.
 

--- a/docs/specs/api/notifications.md
+++ b/docs/specs/api/notifications.md
@@ -2,7 +2,7 @@
 
 # Notifications API / Domain Spec
 
-> **최종 정합화**: 2026-08-23
+> **최종 정합화**: 2026-08-24
 > **상태**: Current
 > **코드 정본**: `packages/shared/src/notification.types.ts`, `apps/api/src/notifications/**`
 > **운영 승인 상태**: 이 문서에 복제하지 않고 `docs/memory.md`와 활성 HANDOFF를 따른다.
@@ -168,6 +168,20 @@ API 내부 registry는 판매자용 legacy 코드도 추가로 지원한다.
 - 허용되지 않은 논리 코드
 - 현재 템플릿의 provider 매핑 누락
 
+### 직접 검증 상태
+
+2026-08-24 기준 `notifications-delivery.spec.ts`, template/mapping 관련 spec은 다음을 직접 검증한다.
+
+- 알림톡 성공 시 추가 재시도·SMS 없음
+- 실패 시 최대 3회 알림톡 재시도
+- 3회 실패 뒤 동일 본문 SMS 1회 fallback
+- 설정·mapping·필수 변수 오류의 외부 요청 0 fail-closed
+- 성공 channel과 attempt count 기록
+- 최종 실패 운영 예외
+- 동일 delivery idempotency key의 단일 발송
+
+따라서 위 **격리된 client/service 전달 계약은 직접 테스트 근거가 있다.** 다만 이 증거를 ALIGO provider 실제 승인 상태나 실제 외부 발송 성공으로 확장하지 않는다. 실제 provider 검증은 활성 출시 PLAN의 별도 승인 게이트다.
+
 ## 8. 수신자와 최종 실패 처리
 
 `NotificationsService.sendToUser()`는 주문 snapshot과 사용자 정보를 기준으로 수신 전화번호를 해석한다.
@@ -180,7 +194,7 @@ API 내부 registry는 판매자용 legacy 코드도 추가로 지원한다.
 
 운영 이슈에서 명시적으로 SMS 재발송하는 경로는 기존 실패 알림 기록의 전화번호·template code·variables를 사용해 `AligoClient.sendSms()`를 호출한다.
 
-## 9. 사용자 API
+## 9. 사용자 API와 선택 마케팅 동의
 
 모든 endpoint는 `JwtAuthGuard`를 사용한다.
 
@@ -218,7 +232,48 @@ API 내부 registry는 판매자용 legacy 코드도 추가로 지원한다.
 - 한 채널만 전달하면 기존 다른 채널 값을 보존
 - 저장 위치: `users/{userId}.notificationPreferences`
 
-주의: 현재 preference endpoint와 저장 계약이 존재한다는 것과 모든 시스템성 주문 알림 발송 경로가 이 설정을 실제 차단 조건으로 사용한다는 것은 별개다. 발송 정책을 바꾸려면 실제 `sendToUser()` 호출 계약과 법적·운영 요구를 별도 검토한다.
+### 마케팅과 정보성 연락의 경계
+
+consumer UI는 이 값을 **선택 마케팅 수신 상태**로 표시하고, 주문·결제·배송 정보성 연락은 마케팅 동의와 별개라고 안내한다.
+
+따라서 주문 상태 알림을 단순히 `notificationPreferences`가 false라는 이유로 막는 것은 현재 안전 계약이 아니다. 거래 수행에 필요한 정보성 연락과 선택 마케팅 sender를 구분한다.
+
+### 현재 구현 불일치 — `MARKETING-CONSENT-LIFECYCLE-CONSISTENCY` P0
+
+2026-08-24 checkout·orders·notifications·retention을 함께 대조한 결과 선택 마케팅 consent lifecycle이 하나의 authoritative 상태로 수렴하지 않는다.
+
+현재 경로:
+
+1. round checkout의 선택 checkbox가 동의되면 order request에 `marketingConsent`를 넣는다.
+2. `RoundOrderCreateService`는 order snapshot에 consent를 저장하고 `marketingConsentLogs`에 `recordType: CONSENT` retention record를 만든다.
+3. MY 마케팅 설정은 order consent가 아니라 `users.notificationPreferences`의 `alimtalk/sms` pair만 읽는다.
+4. checkout consent는 user preference를 갱신하지 않는다.
+5. Auth 신규 사용자 생성은 이 preference pair를 기본 초기화하지 않는다.
+6. MY의 “즉시 철회”는 `users.notificationPreferences`만 false로 바꾸고 `MARKETING_CONSENT` withdrawal retention record를 만들지 않는다.
+7. current round-direct spec은 마케팅 동의·철회 증거를 `marketingConsentLogs`에 보관한다고 규정한다.
+
+따라서 **checkout 동의 상태, MY 표시 상태, 철회 상태, 장기 retention evidence가 서로 다른 source로 분리돼 있다.** 현재 실제 marketing sender는 이번 감사에서 확인되지 않았으므로 마케팅 발송이 활성화됐다고 문서화하지 않는다.
+
+이 항목은 출시 전 P0 `IMPLEMENTATION FINDING`으로 추적한다.
+
+완료 정책은 둘 중 하나를 명시적으로 선택할 수 있다.
+
+- 실제 마케팅 발송을 MVP에서 하지 않을 경우: 불필요한 consent 수집/설정 노출을 출시 전 비활성화·제거하고 저장 계약을 단순화한다.
+- consent 기능을 유지할 경우: user-level SSOT, checkout 동기화, 철회 evidence, idempotency, 실제 marketing sender gating을 하나의 lifecycle로 구현한다.
+
+어느 경우에도 주문·결제·배송 정보성 연락은 marketing opt-out과 분리한다.
+
+최소 회귀:
+
+- 신규 사용자 preference 상태가 정의돼 있고 설정 화면이 오류 없이 해석
+- checkout 동의 후 authoritative user marketing 상태가 의도대로 반영
+- 한 채널 철회가 다른 채널 상태를 보존
+- 철회 시 timestamp/policy/channel을 포함한 감사 가능한 retention evidence 생성
+- 중복 철회가 중복 evidence·상태 손상을 만들지 않음
+- 실제 marketing sender가 존재한다면 철회 채널에 발송하지 않음
+- ORDER_* 정보성 알림은 마케팅 opt-out 때문에 사라지지 않음
+
+정본: `docs/BACKLOG.md`; 증거: `docs/reports/REPORT_settlements_notifications_legal_ops_audit_20260824.md`.
 
 ## 10. Legacy 공동구매 알림
 
@@ -226,10 +281,18 @@ API 내부 registry는 판매자용 legacy 코드도 추가로 지원한다.
 
 - 마감 임박 스케줄러
 - 목표 달성 시 참여 주문 `CONFIRMED` 전환 및 참여자 알림
-- 목표 미달 시 환불 후 `CANCELLED` 전환 및 참여자 알림
+- 목표 미달 시 환불 후 `CANCELLED` 전환 및 참여자 알림 의도
 - 판매자 그룹 확정/취소 알림
 
-이 계약은 회차 직배송 출시 템플릿 8종과 별개의 legacy 경로다. 회차 출시를 위해 legacy 코드를 임의 삭제하거나 provider 매핑 전체를 8종으로 축소하지 않는다.
+### 현재 legacy 구현 finding — 목표 미달 consumer 취소 알림
+
+`cancelGroupBuyLack()`는 RECRUITING 주문을 환불한 뒤 먼저 `CANCELLED`로 batch update하고 이후 `sendToGroupParticipants(..., 'GROUP_CANCELLED_LACK')`를 호출한다.
+
+그러나 `sendToGroupParticipants()`는 `PENDING`, `CANCELLED`, `REVIEWED`를 terminal status로 제외한다. 따라서 방금 `CANCELLED`된 참여자는 consumer 취소 알림 대상에서 빠질 수 있다.
+
+이 경로는 회차 직배송 출시 8종과 별개의 legacy 경로이므로 `LEGACY-GROUP-CANCEL-NOTIFICATION` LATER `IMPLEMENTATION FINDING`으로 추적한다. 현재 코드를 정당화하기 위해 “목표 미달 consumer 알림은 보내지 않는다”로 계약을 바꾸지 않는다.
+
+회귀 시에는 취소 대상 snapshot 또는 명시적 recipient 집합을 기준으로 consumer 취소 알림이 한 번만 전달되고, 다른 template의 terminal filtering 의미는 유지되는지 직접 확인한다.
 
 ## 11. FCM 상태
 
@@ -249,6 +312,8 @@ FCM을 다시 도입할 경우 별도 Task에서 다음을 함께 정의한다.
 - 테스트에서 실제 고객에게 알림톡·SMS를 발송하지 않는다.
 - provider 실제 발송은 승인된 격리 수신자와 명시적 승인 게이트에서만 수행한다.
 - provider 등록·승인 상태는 빠르게 바뀌므로 이 spec에 복제하지 않는다.
+- 마케팅 consent의 존재를 실제 마케팅 발송 활성화 증거로 사용하지 않는다.
+- 거래 정보성 연락과 선택 마케팅 수신 거부를 혼동하지 않는다.
 
 ## 13. 검증 진입점
 
@@ -259,16 +324,26 @@ FCM을 다시 도입할 경우 별도 Task에서 다음을 함께 정의한다.
 - `apps/api/src/notifications/aligo.client.ts`
 - `apps/api/src/notifications/notifications.service.ts`
 - `apps/api/src/notifications/notifications.controller.ts`
-- 관련 `*.spec.ts`
+- `apps/api/src/notifications/notifications-delivery.spec.ts`
+- `apps/api/src/notifications/notifications-preferences.spec.ts`
+- `apps/consumer/src/app/mypage/notifications/settings/**`
+- `apps/consumer/src/app/checkout/**`
+- `apps/api/src/orders/round-order-create.service.ts`
+- `apps/api/src/retention/retention.service.ts`
 - `packages/shared/src/notification.types.ts`
 - 회차 알림이면 `docs/specs/mvp-sales-round-direct-delivery.md`와 활성 출시 HANDOFF/PLAN
+- consent/ALIGO 공개 고지 변경이면 `docs/specs/legal/README.md`
 
 외부 실제 발송은 단위·통합 테스트의 대체물이 아니며 별도 승인된 운영 readiness 검증이다.
+
+선택 마케팅 변경은 단일 화면의 checkbox 동작만 확인하지 않고 consent → authoritative state → withdrawal → retention evidence → sender gating의 lifecycle을 직접 검증한다.
 
 ## 변경 이력
 
 | 날짜 | 내용 |
 |---|---|
+| 2026-08-24 | checkout consent·user preference·철회·retention evidence 분리를 `MARKETING-CONSENT-LIFECYCLE-CONSISTENCY` P0로 분리하고 legacy 목표미달 consumer 취소 알림 누락 가능성을 LATER finding으로 기록 |
+| 2026-08-24 | ALIGO 3회 retry+SMS fallback·fail-closed·delivery idempotency의 직접 테스트 근거와 실제 provider 검증을 분리 |
 | 2026-08-23 | 현행 ALIGO/SMS 구현, 3회 retry+1회 fallback, 실제 API 응답, FCM 미구현 상태, 회차 8종 매핑 계약에 맞춰 전면 정합화 |
 | 2026-08-22 | 내부 논리 코드와 ALIGO `tpl_code` 매핑 분리, 필수 본문 변수와 회차 알림 변수 계약 반영 |
 | 2026-03-26 | 초기 알림 도메인 초안 작성 |

--- a/docs/specs/api/settlements.md
+++ b/docs/specs/api/settlements.md
@@ -131,6 +131,34 @@ SETTLEMENT_CONFIRM_DELAY_DAYS env
 
 지급 완료 후 주문 취소·환불의 회계 처리는 단순 status 역전으로 해결하지 않는다. 현재 service는 warning을 남기고 paid settlement를 보존한다. 후속 회계 조정이 필요하면 별도 설계가 필요하다.
 
+### Core lifecycle 검증 상태 — `IMPLEMENTED / PARTIALLY VERIFIED` + P0 `COVERAGE GAP`
+
+2026-08-24 감사에서 위 생성·자동 확정·취소 구현은 직접 확인했다. 또한 회차 API E2E fixture는 실제 `SettlementsService`를 주입한다.
+
+그러나 현재 `apps/api/src/settlements`에는 core lifecycle 전용 `*.spec.ts`가 없고, 회차 전체 흐름 E2E도 다음 금전 불변식을 직접 assertion하지 않는다.
+
+- 완료 주문에서 settlement가 정확히 1건 생성됨
+- `DELIVERED → REVIEWED` 또는 동시 완료 호출이 기존 settlement를 덮어쓰거나 `settledAt`을 갱신하지 않음
+- fee/net/status/completedStatus snapshot이 의도대로 고정됨
+- cutoff 이전 pending은 유지되고 due pending만 confirmed로 전환됨
+- confirm과 cancel race에서 cancelled가 다시 confirmed로 덮이지 않음
+- pending/confirmed 취소는 cancelled로 수렴하고 cancelled는 멱등
+- paid settlement가 cancellation으로 역전되지 않음
+
+따라서 transaction 코드의 존재를 settlement core financial lifecycle 전체의 `VERIFIED`로 확장하지 않는다.
+
+이 공백은 `SETTLEMENT-LIFECYCLE-COVERAGE` P0가 소유한다. 최소 완료 조건:
+
+- `createSettlement()` 정상·중복·동시 호출 직접 회귀
+- fee/net/completedStatus/초기 timestamp snapshot 검증
+- `confirmDueSettlements()` cutoff 전/후와 fresh-status race 회귀
+- cancelled/paid를 confirm batch가 덮지 않는 회귀
+- `cancelSettlement()` missing/pending/confirmed/cancelled/paid 직접 회귀
+- 실제 회차 주문 `DELIVERED`가 settlement 1건을 만들고 `REVIEWED`가 중복 생성하지 않는 integration assertion
+- 정상 취소 lifecycle이 pending/confirmed settlement를 cancelled로 수렴시키는 integration assertion
+
+증거: `docs/reports/REPORT_settlements_notifications_legal_ops_audit_20260824.md`.
+
 ### Admin 강제 환불과의 현재 불일치 — P0
 
 `cancelSettlement()` 자체의 위 규칙과 별개로, 현재 `AdminService.forceRefund()`는 이 메서드를 호출하지 않는다.
@@ -243,6 +271,8 @@ PATCH /admin/settlements/:settlementId/pay
 
 증거: `docs/reports/REPORT_auth_orders_admin_verification_audit_20260824.md`.
 
+`SETTLEMENT-LIFECYCLE-COVERAGE`와 역할을 구분한다. core P0는 생성·confirm·cancel lifecycle을 소유하고, admin P0는 admin role boundary와 `confirmed → paid` 지급 mutation을 소유한다.
+
 ## 10. 인덱스
 
 현재 주요 query shape:
@@ -263,11 +293,11 @@ seller/admin UI는 공통 `SettlementStatus`, `STATUS_LABEL`, `STATUS_COLOR`를 
 
 ## 12. 회차 직배송과 정산
 
-회차 주문도 orders lifecycle에서 완료 상태에 도달하면 기존 settlement 생성 경로와 연결될 수 있다. 다만 첫 운영 회차 출시 전에 실제 회차 주문의 다음 흐름을 E2E로 다시 확인한다.
+회차 주문도 orders lifecycle에서 완료 상태에 도달하면 기존 settlement 생성 경로와 연결될 수 있다. 첫 운영 회차 출시 전에 `SETTLEMENT-LIFECYCLE-COVERAGE`의 직접 증거로 다음을 고정한다.
 
 - 배송사진 완료 → `DELIVERED`
 - settlement 1건만 생성
-- 후속 `REVIEWED`가 동일 settlement를 중복 생성하지 않음
+- 후속 `REVIEWED`가 동일 settlement를 중복 생성하거나 최초 snapshot을 덮지 않음
 - 정상 취소/환불 경합에서 pending/confirmed settlement가 `cancelled`로 수렴
 - `paid` settlement 이후 환불은 별도 회계 정책을 따름
 - admin 강제 환불도 `ADMIN-FORCE-REFUND-CONSISTENCY` 해결 후 같은 회계 불변식에 수렴
@@ -295,12 +325,15 @@ seller/admin UI는 공통 `SettlementStatus`, `STATUS_LABEL`, `STATUS_COLOR`를 
 
 금전 환불과 정산이 연결되는 변경은 payment provider 성공뿐 아니라 주문 상태, reservation/capacity, 재배송비, settlement 상태, 실패 재시도와 race를 함께 검증한다.
 
+core lifecycle은 transaction 구현만으로 `VERIFIED` 처리하지 않고 생성·중복·confirm·cancel·paid 역전 방지를 직접 정상/거부/동시성 회귀로 고정한다.
+
 admin 지급 상태 전이는 코드의 transaction 존재만으로 `VERIFIED` 처리하지 않고 정상·거부·동시성·authorization 경계를 직접 검증한다.
 
 ## 변경 이력
 
 | 날짜 | 내용 |
 |---|---|
+| 2026-08-24 | settlement 생성·confirm·cancel core lifecycle의 직접 상태/race assertion 부족을 `SETTLEMENT-LIFECYCLE-COVERAGE` P0로 분리 |
 | 2026-08-24 | admin `confirmed → paid` 구현과 직접 검증 증거를 분리해 `ADMIN-PRIVILEGED-MUTATION-COVERAGE` P0 COVERAGE GAP에 연결 |
 | 2026-08-24 | admin force refund가 `cancelSettlement()` 및 정상 취소 lifecycle을 우회하는 P0 정산 불일치를 명시 |
 | 2026-08-23 | 자동 confirm, transaction 멱등성, paid 역전 방지, admin 지급 API, 현재 조회/권한 계약으로 정합화 |

--- a/docs/specs/api/settlements.md
+++ b/docs/specs/api/settlements.md
@@ -131,7 +131,7 @@ SETTLEMENT_CONFIRM_DELAY_DAYS env
 
 지급 완료 후 주문 취소·환불의 회계 처리는 단순 status 역전으로 해결하지 않는다. 현재 service는 warning을 남기고 paid settlement를 보존한다. 후속 회계 조정이 필요하면 별도 설계가 필요하다.
 
-### Core lifecycle 검증 상태 — `IMPLEMENTED / PARTIALLY VERIFIED` + P0 `COVERAGE GAP`
+### Core lifecycle 검증 상태 — `IMPLEMENTED / UNVERIFIED` + P0 `COVERAGE GAP`
 
 2026-08-24 감사에서 위 생성·자동 확정·취소 구현은 직접 확인했다. 또한 회차 API E2E fixture는 실제 `SettlementsService`를 주입한다.
 
@@ -145,7 +145,7 @@ SETTLEMENT_CONFIRM_DELAY_DAYS env
 - pending/confirmed 취소는 cancelled로 수렴하고 cancelled는 멱등
 - paid settlement가 cancellation으로 역전되지 않음
 
-따라서 transaction 코드의 존재를 settlement core financial lifecycle 전체의 `VERIFIED`로 확장하지 않는다.
+실제 service가 E2E에 주입돼 호출될 수 있다는 사실은 위 상태를 직접 검사한 증거가 아니므로 core lifecycle을 `PARTIALLY VERIFIED`로도 승격하지 않는다.
 
 이 공백은 `SETTLEMENT-LIFECYCLE-COVERAGE` P0가 소유한다. 최소 완료 조건:
 
@@ -333,7 +333,7 @@ admin 지급 상태 전이는 코드의 transaction 존재만으로 `VERIFIED` �
 
 | 날짜 | 내용 |
 |---|---|
-| 2026-08-24 | settlement 생성·confirm·cancel core lifecycle의 직접 상태/race assertion 부족을 `SETTLEMENT-LIFECYCLE-COVERAGE` P0로 분리 |
+| 2026-08-24 | settlement 생성·confirm·cancel core lifecycle의 직접 상태/race assertion 부재를 `SETTLEMENT-LIFECYCLE-COVERAGE` P0 `IMPLEMENTED / UNVERIFIED`로 분리 |
 | 2026-08-24 | admin `confirmed → paid` 구현과 직접 검증 증거를 분리해 `ADMIN-PRIVILEGED-MUTATION-COVERAGE` P0 COVERAGE GAP에 연결 |
 | 2026-08-24 | admin force refund가 `cancelSettlement()` 및 정상 취소 lifecycle을 우회하는 P0 정산 불일치를 명시 |
 | 2026-08-23 | 자동 confirm, transaction 멱등성, paid 역전 방지, admin 지급 API, 현재 조회/권한 계약으로 정합화 |

--- a/docs/specs/legal/README.md
+++ b/docs/specs/legal/README.md
@@ -7,11 +7,30 @@
 
 ## 현재 정본
 
-- consumer 개인정보처리방침·이용약관 계약: `docs/specs/legal/consumer-legal-documents.md`
+- consumer 개인정보처리방침·이용약관 공개 baseline: `docs/specs/legal/consumer-legal-documents.md`
 - 실제 공개 구현:
   - `apps/consumer/src/app/privacy/page.tsx`
   - `apps/consumer/src/app/terms/page.tsx`
 - 공개 사업자 정보 정본: `apps/consumer/src/lib/publicBusinessInfo.ts`
+
+### 2026-08-24 current-fact errata — 선택 마케팅 동의
+
+`docs/specs/legal/consumer-legal-documents.md`는 2026-08-19 공개 페이지 baseline이며, 그 문서의 **“consumer에 마케팅 수신 동의 기능이 없다”는 구현 사실은 더 이상 현재가 아니다.** 마케팅 동의 존재 여부에 한해서는 이 errata가 해당 2026-08-19 snapshot보다 우선한다.
+
+현재 코드에는 다음이 존재한다.
+
+- round checkout의 선택 카카오톡/문자 마케팅 동의 checkbox
+- order `marketingConsent` snapshot
+- `marketingConsentLogs`의 consent retention record
+- MY `마케팅 알림 설정` 화면
+- `users/{userId}.notificationPreferences`
+- `PATCH /notifications/me/preferences` 철회 경로
+
+반면 **실제 선택 마케팅 메시지를 발송하는 sender는 이번 감사에서 확인되지 않았고**, 주문·결제·배송 정보성 연락은 마케팅 동의와 별개의 현재 계약이다. 따라서 공개 문서에서 “마케팅 발송이 운영 중”이라고 확대해석하지 않는다.
+
+또한 checkout consent, user preference, 철회, retention evidence가 현재 하나의 lifecycle로 수렴하지 않는 `MARKETING-CONSENT-LIFECYCLE-CONSISTENCY` P0가 남아 있다. 최종 공개 legal 문구는 이 P0의 제품·구현 결정을 반영해 다시 확정한다.
+
+증거: `docs/reports/REPORT_settlements_notifications_legal_ops_audit_20260824.md`.
 
 ## 현재 공개 상태
 
@@ -22,6 +41,7 @@
 - 개인정보처리방침도 현재 상용 주문·결제·배송은 운영하지 않는다고 명시한다.
 - PortOne·결제사업자는 현재 상용 처리 수탁자로 운영하지 않는다고 고지한다.
 - ALIGO를 통한 실제 고객 알림 발송은 현재 공개 처리위탁 목록에 별도 공급자로 명시돼 있지 않다.
+- 선택 마케팅 consent UI/storage는 코드에 존재하지만 실제 마케팅 발송 활성화와 동의 lifecycle 정합화는 완료되지 않았다.
 
 따라서 이 문서들이 production에 반영돼 있다는 사실만으로 **회차 직배송 판매 활성화 법적 준비가 완료됐다고 판단하면 안 된다.**
 
@@ -33,10 +53,11 @@
 2. 주문 성립 시점, 취소·환불, 배송, 재배송비, 배송 보류 등 실제 MVP 정책과 공개 문구가 일치하는지 확인한다.
 3. PortOne 및 실제 결제사업자의 개인정보 처리 역할·데이터 흐름을 확인해 개인정보처리방침에 필요한 내용을 반영한다.
 4. 실제 고객 알림에 ALIGO를 사용한다면 전화번호·메시지 처리 흐름과 처리위탁/외부 서비스 고지 필요 범위를 확인한다.
-5. seller·driver에게 고객 배송정보가 노출되는 실제 처리 구조와 제3자 제공/내부 업무처리 설명이 일치하는지 확인한다. 특히 `docs/specs/api/orders.md`의 direct Firestore read P0가 해결되어 **업무 수행에 필요한 범위로 실제 접근 경계가 먼저 축소·검증**된 뒤 공개 문구를 확정한다.
-6. 시행일을 갱신하고 필요하면 이전 버전을 보존한다.
-7. `apps/consumer/src/app/legal-documents.test.mjs`의 **비판매 상태 고정 assertion**을 새 공개 계약에 맞게 수정한다.
-8. 변경된 법적 페이지가 release SHA에 포함된 뒤 production 배포 전에 비로그인 `/privacy`, `/terms`를 재검증한다.
+5. 선택 마케팅 consent를 유지한다면 `MARKETING-CONSENT-LIFECYCLE-CONSISTENCY`를 먼저 해결하고 수집 목적·항목·동의/철회·보관기간·실제 marketing sender 여부를 공개 문구와 일치시킨다. 실제 마케팅을 MVP에서 하지 않을 경우 불필요한 consent 수집/설정 노출을 중단하는 선택도 포함한다.
+6. seller·driver에게 고객 배송정보가 노출되는 실제 처리 구조와 제3자 제공/내부 업무처리 설명이 일치하는지 확인한다. 특히 `docs/specs/api/orders.md`의 direct Firestore read P0가 해결되어 **업무 수행에 필요한 범위로 실제 접근 경계가 먼저 축소·검증**된 뒤 공개 문구를 확정한다.
+7. 시행일을 갱신하고 필요하면 이전 버전을 보존한다.
+8. `apps/consumer/src/app/legal-documents.test.mjs`의 **비판매 상태 고정 assertion**을 새 공개 계약에 맞게 수정한다.
+9. 변경된 법적 페이지가 release SHA에 포함된 뒤 production 배포 전에 비로그인 `/privacy`, `/terms`를 재검증한다.
 
 이 게이트는 법률 자문을 대체하려는 것이 아니라, **현재 공개 문서와 실제 출시 동작이 서로 모순되는 것을 방지하기 위한 저장소 정합성 게이트**다. 법적 판단이 필요한 항목은 별도 확인을 거친다.
 
@@ -64,11 +85,25 @@
 
 정본과 remediation Acceptance Criteria는 `docs/specs/api/orders.md`, `docs/BACKLOG.md`를 따른다.
 
+### 현재 확인된 선행 P0 — 선택 마케팅 동의 lifecycle
+
+현재 checkout consent, user-level preference, withdrawal, retention evidence가 서로 다른 저장/갱신 경계를 사용한다.
+
+판매 활성화 legal을 확정하기 전 다음 중 하나로 수렴한다.
+
+- 마케팅을 MVP에서 사용하지 않음: consent 수집/설정 노출을 비활성화·제거하고 공개 문서에도 실제 미운영 상태를 반영.
+- consent 기능 유지: authoritative user-level 상태, checkout 동기화, 철회 evidence, 실제 marketing sender gating을 구현·직접 검증하고 공개 문구를 일치시킴.
+
+정보성 주문·결제·배송 연락은 선택 마케팅 동의와 별개로 유지한다.
+
+정본: `docs/specs/api/notifications.md`, `docs/specs/mvp-sales-round-direct-delivery.md`, `docs/BACKLOG.md`.
+
 ## 실행 순서 관계
 
 - ALIGO provider 심사 대기 중에는 현재 공개 문구를 미리 `판매 중` 상태로 바꾸지 않는다.
 - ALIGO 실제 격리 발송 검증과 같은 테스트는 별도 승인·격리 데이터로 수행할 수 있다.
 - seller/driver 주문 read authorization·데이터 최소화 P0가 해결되기 전에는 판매 활성화 개인정보 문구를 최종 확정하지 않는다.
+- `MARKETING-CONSENT-LIFECYCLE-CONSISTENCY` 결과가 확정되기 전에는 마케팅 consent/철회 공개 문구를 최종 확정하지 않는다.
 - 실제 출시 대상 SHA를 고정하기 **전에** 법적 문서와 공개 페이지 변경을 완료해야 한다. 법적 페이지 코드 변경도 release SHA의 일부이기 때문이다.
 - 최종 `salesMode: round_direct` 전환 전에 production에서 새 법적 문서가 노출되는지 확인한다.
 


### PR DESCRIPTION
## 감사 범위
`settlements → notifications → legal/ops`를 `docs/DOCUMENT_CONSISTENCY.md` 기준으로 Spec·Code·Test 삼각 검증했습니다.

## 핵심 finding

### 1. Settlement core lifecycle coverage P0
`SettlementsService`에는 transaction 기반 create/confirm/cancel 구현이 있지만:

- `apps/api/src/settlements`에 core lifecycle 전용 spec 없음
- 회차 E2E fixture는 실제 service를 주입하지만 settlement 상태를 직접 assert하지 않음
- create 1건/중복, confirm cutoff/race, cancel, paid 역전 방지의 직접 증거 없음

따라서 `SETTLEMENT-LIFECYCLE-COVERAGE`를 `IMPLEMENTED / UNVERIFIED + P0 COVERAGE GAP`으로 추가합니다.

Admin `confirmed → paid`는 기존 `ADMIN-PRIVILEGED-MUTATION-COVERAGE`가 계속 소유합니다.

### 2. Marketing consent lifecycle P0
현재 선택 마케팅 동의가 여러 source로 분리돼 있습니다.

- checkout consent → order snapshot + `marketingConsentLogs` CONSENT
- MY 설정 → `users.notificationPreferences`
- checkout consent는 user preference와 동기화하지 않음
- 신규 user는 preference pair 기본 초기화 없음
- MY 즉시 철회는 preference만 false로 변경
- withdrawal retention evidence 없음

따라서 `MARKETING-CONSENT-LIFECYCLE-CONSISTENCY`를 P0 `IMPLEMENTATION FINDING`으로 추가합니다.

MVP에서 marketing 미사용이면 consent 수집/설정 노출을 제거하는 선택도 허용하고, 유지한다면 user-level SSOT + withdrawal evidence + sender gating을 구현하도록 계약을 열어둡니다. ORDER_* 정보성 연락은 marketing opt-out과 별개로 유지합니다.

### 3. Notifications 검증 상태 정밀화
현재 unit/service tests가 직접 고정하는 범위:

- 알림톡 최대 3회 retry
- 3회 실패 후 SMS 1회 fallback
- config/template/required variable fail-closed
- delivery idempotency
- 최종 실패 operation issue

이 증거는 실제 ALIGO provider 승인/실발송으로 확장하지 않습니다.

### 4. Legacy 공동구매 취소 알림
`cancelGroupBuyLack()`가 주문을 먼저 CANCELLED로 만든 뒤 participant sender를 호출하고 sender는 CANCELLED를 제외해 consumer 목표미달 취소 알림이 누락될 수 있습니다.

회차 직배송 출시 8종과 별개의 legacy 경로라 `LEGACY-GROUP-CANCEL-NOTIFICATION` LATER finding으로 분리했습니다.

### 5. Legal current-fact errata
2026-08-19 legal baseline의 “마케팅 수신 동의 기능 없음”은 현재 코드와 달라졌습니다.

현재 정확한 표현은:
- consent UI/storage는 존재
- 실제 선택 marketing sender는 확인되지 않음
- consent lifecycle P0가 남음

공개 `/privacy`, `/terms` 자체는 이번 docs-only 감사에서 판매 상태 문구로 선반영하지 않습니다.

## 문서 변경
- `docs/specs/api/settlements.md`
- `docs/specs/api/notifications.md`
- `docs/specs/legal/README.md`
- `docs/BACKLOG.md`
- `docs/memory.md`
- 활성 PLAN/HANDOFF
- evidence report 추가

## 범위 경계
- docs-only
- 코드/테스트/Firebase Rules/provider/production/운영 데이터 변경 없음
- ALIGO 실제 발송 없음
- 실제 결제/환불 없음
