### PR TITLE
fix: complete post-integration selective reintegration

### DIFF
--- a/apps/api/src/admin/admin.module.ts
+++ b/apps/api/src/admin/admin.module.ts
@@ -1,10 +1,12 @@
 import { Module } from '@nestjs/common';
 import { AdminController } from './admin.controller';
 import { AdminService } from './admin.service';
+import { OrdersModule } from '../orders/orders.module';
 import { PaymentsModule } from '../payments/payments.module';
+import { SettlementsModule } from '../settlements/settlements.module';
 
 @Module({
-  imports: [PaymentsModule],
+  imports: [PaymentsModule, OrdersModule, SettlementsModule],
   controllers: [AdminController],
   providers: [AdminService],
 })

--- a/apps/api/src/admin/admin.service.spec.ts
+++ b/apps/api/src/admin/admin.service.spec.ts
@@ -18,9 +18,16 @@ describe('AdminService driver session 보강', () => {
       doc: jest.fn().mockReturnValue(userRef),
       Timestamp: { now: jest.fn(() => 'now') },
     };
+    const settlements = { cancelSettlement: jest.fn().mockResolvedValue(undefined) };
+    const roundLifecycle = { cancelForRound: jest.fn() };
     return {
       firestore,
-      service: new AdminService(firestore as unknown as FirestoreService, {} as never),
+      service: new AdminService(
+        firestore as unknown as FirestoreService,
+        {} as never,
+        settlements as never,
+        roundLifecycle as never,
+      ),
       userRef,
     };
   }
@@ -48,5 +55,262 @@ describe('AdminService driver session 보강', () => {
     await service.suspendDriver('driver-1', { suspended: false });
 
     expect(firebaseAuth.revokeRefreshTokens).not.toHaveBeenCalled();
+  });
+});
+
+type Data = Record<string, any>;
+
+function makeSnapshot(data: Data | null, ref: Data) {
+  return { exists: data !== null, data: () => data, ref };
+}
+
+function makeLegacyForceRefundFixture(orderOverrides: Data = {}) {
+  const records = new Map<string, Data>([
+    [
+      'orders/order-1',
+      {
+        id: 'order-1',
+        storeId: 'store-1',
+        status: 'ACCEPTED',
+        schemaVersion: 1,
+        saleType: 'normal',
+        deliveryMethod: 'direct',
+        quantity: 1,
+        requestedDeliveryDate: '2026-08-25',
+        ...orderOverrides,
+      },
+    ],
+    [
+      'dailyCaps/store-1_2026-08-25',
+      { totalCap: 10, usedSlots: 1 },
+    ],
+  ]);
+  const refs = new Map<string, Data>();
+  const doc = jest.fn((path: string) => {
+    if (!refs.has(path)) {
+      const ref = {
+        path,
+        get: jest.fn(async () => makeSnapshot(records.get(path) ?? null, ref)),
+        update: jest.fn(async (data: Data) => {
+          records.set(path, { ...(records.get(path) ?? {}), ...data });
+        }),
+      };
+      refs.set(path, ref);
+    }
+    return refs.get(path);
+  });
+  const firestore = {
+    doc,
+    runTransaction: jest.fn(async (callback: (tx: Data) => Promise<unknown>) => {
+      const pending = new Map<string, Data>();
+      const tx = {
+        get: jest.fn(async (ref: Data) =>
+          makeSnapshot(pending.get(ref.path) ?? records.get(ref.path) ?? null, ref),
+        ),
+        update: jest.fn((ref: Data, data: Data) => {
+          pending.set(ref.path, { ...(pending.get(ref.path) ?? records.get(ref.path) ?? {}), ...data });
+        }),
+      };
+      const result = await callback(tx);
+      for (const [path, data] of pending) records.set(path, data);
+      return result;
+    }),
+    Timestamp: {
+      now: jest.fn(() => new Date('2026-08-25T00:00:00.000Z')),
+      fromDate: jest.fn((date: Date) => date),
+    },
+  };
+  const payments = { processRefundByOrderId: jest.fn().mockResolvedValue(undefined) };
+  const settlements = { cancelSettlement: jest.fn().mockResolvedValue(undefined) };
+  const roundLifecycle = { cancelForRound: jest.fn() };
+  const service = new AdminService(
+    firestore as never,
+    payments as never,
+    settlements as never,
+    roundLifecycle as never,
+  );
+  return { records, firestore, payments, settlements, roundLifecycle, service };
+}
+
+describe('AdminService 강제 환불 수렴', () => {
+  it.each([
+    ['direct', { deliveryMethod: 'direct' }],
+    ['hub', { deliveryMethod: 'hub' }],
+  ])('legacy normal %s는 daily capacity를 한 번 반환한다', async (_name, overrides) => {
+    const fixture = makeLegacyForceRefundFixture(overrides);
+
+    await fixture.service.forceRefund('order-1', {});
+    await fixture.service.forceRefund('order-1', {});
+
+    expect(fixture.records.get('dailyCaps/store-1_2026-08-25')?.usedSlots).toBe(0);
+    expect(fixture.records.get('orders/order-1')?.legacyDailyCapacity).toMatchObject({
+      status: 'RELEASED',
+      quantity: 1,
+    });
+    expect(fixture.settlements.cancelSettlement).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
+    ['legacy normal parcel', { saleType: 'normal', deliveryMethod: 'parcel' }],
+    ['legacy group direct', { saleType: 'group', deliveryMethod: 'direct' }],
+    ['legacy group hub', { saleType: 'group', deliveryMethod: 'hub' }],
+    ['schemaVersion 2', { schemaVersion: 2, deliveryMethod: 'direct' }],
+  ])('%s는 legacy daily capacity를 변경하지 않는다', async (_name, overrides) => {
+    const fixture = makeLegacyForceRefundFixture(overrides);
+
+    await fixture.service.forceRefund('order-1', {});
+
+    expect(fixture.records.get('dailyCaps/store-1_2026-08-25')?.usedSlots).toBe(1);
+    expect(fixture.records.get('orders/order-1')?.legacyDailyCapacity).toBeUndefined();
+  });
+
+  it('이미 반환된 legacy capacity를 다시 감소시키지 않는다', async () => {
+    const fixture = makeLegacyForceRefundFixture({
+      status: 'CANCELLED',
+      legacyDailyCapacity: {
+        status: 'RELEASED',
+        date: '2026-08-25',
+        quantity: 1,
+      },
+    });
+    fixture.records.set('dailyCaps/store-1_2026-08-25', { totalCap: 10, usedSlots: 0 });
+
+    await fixture.service.forceRefund('order-1', {});
+
+    expect(fixture.records.get('dailyCaps/store-1_2026-08-25')?.usedSlots).toBe(0);
+  });
+
+  it('환불 실패 시 주문·capacity·정산을 변경하지 않는다', async () => {
+    const fixture = makeLegacyForceRefundFixture();
+    fixture.payments.processRefundByOrderId.mockRejectedValueOnce(new Error('환불 실패'));
+
+    await expect(fixture.service.forceRefund('order-1', {})).rejects.toThrow('환불 실패');
+
+    expect(fixture.records.get('orders/order-1')?.status).toBe('ACCEPTED');
+    expect(fixture.records.get('dailyCaps/store-1_2026-08-25')?.usedSlots).toBe(1);
+    expect(fixture.settlements.cancelSettlement).not.toHaveBeenCalled();
+  });
+
+  it('schemaVersion 2 회차는 기존 round cancellation lifecycle에 위임한다', async () => {
+    const fixture = makeLegacyForceRefundFixture({
+      schemaVersion: 2,
+      roundId: 'round-1',
+      reservationId: 'reservation-1',
+    });
+    fixture.roundLifecycle.cancelForRound.mockResolvedValue({
+      orderId: 'order-1',
+      status: 'CANCELLED',
+    });
+
+    await expect(fixture.service.forceRefund('order-1', { reason: '관리자 사유' })).resolves.toEqual({
+      orderId: 'order-1',
+      status: 'CANCELLED',
+    });
+
+    expect(fixture.roundLifecycle.cancelForRound).toHaveBeenCalledWith({
+      storeId: 'store-1',
+      orderId: 'order-1',
+      expectedStatus: 'ACCEPTED',
+      reason: '관리자 사유',
+    });
+    expect(fixture.payments.processRefundByOrderId).not.toHaveBeenCalled();
+    expect(fixture.records.get('dailyCaps/store-1_2026-08-25')?.usedSlots).toBe(1);
+  });
+});
+
+describe('AdminService 정산 KST 날짜 범위', () => {
+  function makeSettlementService(records: Data[] = []) {
+    const calls: unknown[][] = [];
+    const query = {
+      where: jest.fn((...args: unknown[]) => {
+        calls.push(args);
+        return query;
+      }),
+      orderBy: jest.fn((...args: unknown[]) => {
+        calls.push(args);
+        return query;
+      }),
+      limit: jest.fn((...args: unknown[]) => {
+        calls.push(args);
+        return query;
+      }),
+      get: jest.fn().mockImplementation(async () => ({
+        docs: records
+          .filter((record) =>
+            calls.every(([field, operator, expected]) => {
+              if (field !== 'settledAt' || !(expected instanceof Date)) return true;
+              const actual = record['settledAt'];
+              if (!(actual instanceof Date)) return false;
+              if (operator === '>=') return actual.getTime() >= expected.getTime();
+              if (operator === '<') return actual.getTime() < expected.getTime();
+              return true;
+            }),
+          )
+          .map((record) => ({ data: () => record })),
+      })),
+    };
+    const firestore = {
+      collection: jest.fn().mockReturnValue(query),
+      Timestamp: { fromDate: jest.fn((date: Date) => date) },
+    };
+    const service = new AdminService(
+      firestore as never,
+      {} as never,
+      {} as never,
+      {} as never,
+    );
+    return { calls, service };
+  }
+
+  it('동일 날짜를 KST start inclusive와 next-day start exclusive로 조회한다', async () => {
+    const fixture = makeSettlementService();
+
+    await fixture.service.getSettlements({ from: '2026-08-24', to: '2026-08-24' });
+
+    expect(fixture.calls).toContainEqual([
+      'settledAt',
+      '>=',
+      new Date('2026-08-23T15:00:00.000Z'),
+    ]);
+    expect(fixture.calls).toContainEqual([
+      'settledAt',
+      '<',
+      new Date('2026-08-24T15:00:00.000Z'),
+    ]);
+  });
+
+  it('여러 날짜는 from 시작부터 to 다음 날 시작 전까지 조회한다', async () => {
+    const fixture = makeSettlementService();
+
+    await fixture.service.getSettlements({ from: '2026-08-24', to: '2026-08-26' });
+
+    expect(fixture.calls).toContainEqual([
+      'settledAt',
+      '>=',
+      new Date('2026-08-23T15:00:00.000Z'),
+    ]);
+    expect(fixture.calls).toContainEqual([
+      'settledAt',
+      '<',
+      new Date('2026-08-26T15:00:00.000Z'),
+    ]);
+  });
+
+  it('시작 시각은 포함하고 끝 시각은 제외하며 끝 직전은 포함한다', async () => {
+    const fixture = makeSettlementService([
+      { id: 'at-start', settledAt: new Date('2026-08-23T15:00:00.000Z') },
+      { id: 'before-end', settledAt: new Date('2026-08-24T14:59:59.999Z') },
+      { id: 'at-end', settledAt: new Date('2026-08-24T15:00:00.000Z') },
+    ]);
+
+    const result = await fixture.service.getSettlements({
+      from: '2026-08-24',
+      to: '2026-08-24',
+    });
+
+    expect(result.settlements.map((settlement: Data) => settlement['id'])).toEqual([
+      'at-start',
+      'before-end',
+    ]);
   });
 });

--- a/apps/api/src/admin/admin.service.spec.ts
+++ b/apps/api/src/admin/admin.service.spec.ts
@@ -133,6 +133,22 @@ function makeLegacyForceRefundFixture(orderOverrides: Data = {}) {
 }
 
 describe('AdminService 강제 환불 수렴', () => {
+  it.each(['PENDING', 'DELIVERING', 'HUB_ARRIVED', 'PICKED_UP', 'DELIVERED', 'REVIEWED'])(
+    '%s 상태는 legacy 관리자 환불을 거부하고 모든 부수효과를 차단한다',
+    async (status) => {
+      const fixture = makeLegacyForceRefundFixture({ status });
+
+      await expect(fixture.service.forceRefund('order-1', {})).rejects.toThrow(
+        '현재 주문 상태에서는 관리자 환불을 처리할 수 없습니다.',
+      );
+
+      expect(fixture.payments.processRefundByOrderId).not.toHaveBeenCalled();
+      expect(fixture.settlements.cancelSettlement).not.toHaveBeenCalled();
+      expect(fixture.records.get('orders/order-1')?.status).toBe(status);
+      expect(fixture.records.get('dailyCaps/store-1_2026-08-25')?.usedSlots).toBe(1);
+    },
+  );
+
   it.each([
     ['direct', { deliveryMethod: 'direct' }],
     ['hub', { deliveryMethod: 'hub' }],
@@ -187,8 +203,80 @@ describe('AdminService 강제 환불 수렴', () => {
     await expect(fixture.service.forceRefund('order-1', {})).rejects.toThrow('환불 실패');
 
     expect(fixture.records.get('orders/order-1')?.status).toBe('ACCEPTED');
+    expect(fixture.records.get('orders/order-1')?.cancellation).toMatchObject({
+      status: 'REFUND_FAILED',
+    });
     expect(fixture.records.get('dailyCaps/store-1_2026-08-25')?.usedSlots).toBe(1);
     expect(fixture.settlements.cancelSettlement).not.toHaveBeenCalled();
+  });
+
+  it('활성 refund claim을 만난 두 번째 요청은 local 취소를 선행하지 않는다', async () => {
+    const fixture = makeLegacyForceRefundFixture();
+    let releaseProvider!: () => void;
+    let providerStarted!: () => void;
+    const providerStartedPromise = new Promise<void>((resolve) => {
+      providerStarted = resolve;
+    });
+    const providerReleasePromise = new Promise<void>((resolve) => {
+      releaseProvider = resolve;
+    });
+    fixture.payments.processRefundByOrderId.mockImplementationOnce(async () => {
+      providerStarted();
+      await providerReleasePromise;
+    });
+
+    const first = fixture.service.forceRefund('order-1', {});
+    await providerStartedPromise;
+
+    await expect(fixture.service.forceRefund('order-1', {})).rejects.toThrow(
+      '주문 환불이 이미 처리 중입니다.',
+    );
+    expect(fixture.payments.processRefundByOrderId).toHaveBeenCalledTimes(1);
+    expect(fixture.settlements.cancelSettlement).not.toHaveBeenCalled();
+    expect(fixture.records.get('orders/order-1')?.status).toBe('ACCEPTED');
+    expect(fixture.records.get('dailyCaps/store-1_2026-08-25')?.usedSlots).toBe(1);
+
+    releaseProvider();
+    await expect(first).resolves.toEqual({ ok: true, orderId: 'order-1' });
+    expect(fixture.records.get('dailyCaps/store-1_2026-08-25')?.usedSlots).toBe(0);
+    expect(fixture.settlements.cancelSettlement).toHaveBeenCalledTimes(1);
+  });
+
+  it('provider 성공 뒤 local 실패는 LOCAL_FAILED로 남고 재시도에서 provider를 반복하지 않는다', async () => {
+    const fixture = makeLegacyForceRefundFixture();
+    const providerRefund = jest.fn();
+    let providerAlreadyRefunded = false;
+    fixture.payments.processRefundByOrderId.mockImplementation(async () => {
+      if (providerAlreadyRefunded) return;
+      providerAlreadyRefunded = true;
+      providerRefund();
+    });
+    fixture.records.delete('dailyCaps/store-1_2026-08-25');
+
+    await expect(fixture.service.forceRefund('order-1', {})).rejects.toThrow(
+      'legacy daily capacity 문서가 없습니다',
+    );
+    expect(providerRefund).toHaveBeenCalledTimes(1);
+    expect(fixture.records.get('orders/order-1')).toMatchObject({
+      status: 'ACCEPTED',
+      cancellation: { status: 'LOCAL_FAILED' },
+    });
+    expect(fixture.settlements.cancelSettlement).not.toHaveBeenCalled();
+
+    fixture.records.set('dailyCaps/store-1_2026-08-25', { totalCap: 10, usedSlots: 1 });
+    await expect(fixture.service.forceRefund('order-1', {})).resolves.toEqual({
+      ok: true,
+      orderId: 'order-1',
+    });
+
+    expect(providerRefund).toHaveBeenCalledTimes(1);
+    expect(fixture.payments.processRefundByOrderId).toHaveBeenCalledTimes(2);
+    expect(fixture.records.get('orders/order-1')).toMatchObject({
+      status: 'CANCELLED',
+      cancellation: { status: 'COMPLETED' },
+    });
+    expect(fixture.records.get('dailyCaps/store-1_2026-08-25')?.usedSlots).toBe(0);
+    expect(fixture.settlements.cancelSettlement).toHaveBeenCalledTimes(1);
   });
 
   it('schemaVersion 2 회차는 기존 round cancellation lifecycle에 위임한다', async () => {

--- a/apps/api/src/admin/admin.service.ts
+++ b/apps/api/src/admin/admin.service.ts
@@ -1,8 +1,12 @@
 import { Injectable, NotFoundException, BadRequestException } from '@nestjs/common';
+import { dateRangeKST } from '@greenhub/shared';
 import * as admin from 'firebase-admin';
 import { v4 as uuidv4 } from 'uuid';
 import { FirestoreService } from '../firestore/firestore.service';
+import { RoundOrderLifecycleService } from '../orders/round-order-lifecycle.service';
 import { PaymentsService } from '../payments/payments.service';
+import { releaseLegacyDailyCapacityInTransaction } from '../payments/_lib/legacy-daily-capacity';
+import { SettlementsService } from '../settlements/settlements.service';
 import {
   QueryAdminSettlementsDto,
   QueryAdminOrdersDto,
@@ -18,6 +22,8 @@ export class AdminService {
   constructor(
     private readonly firestore: FirestoreService,
     private readonly payments: PaymentsService,
+    private readonly settlements: SettlementsService,
+    private readonly roundLifecycle: RoundOrderLifecycleService,
   ) {}
 
   // ── Stores ──────────────────────────────────────────────────────
@@ -135,22 +141,38 @@ export class AdminService {
   }
 
   async forceRefund(orderId: string, dto: ForceRefundDto) {
-    const orderSnap = await this.firestore.doc(`orders/${orderId}`).get();
+    const orderRef = this.firestore.doc(`orders/${orderId}`);
+    const orderSnap = await orderRef.get();
     if (!orderSnap.exists) throw new NotFoundException('주문을 찾을 수 없습니다.');
 
     const order = orderSnap.data()!;
-    if (order['status'] === 'CANCELLED') {
-      throw new BadRequestException('이미 취소된 주문입니다.');
+    const reason = dto.reason ?? '관리자 강제 환불';
+
+    if (order['schemaVersion'] === 2 && order['roundId']) {
+      const result = await this.roundLifecycle.cancelForRound({
+        storeId: order['storeId'],
+        orderId,
+        expectedStatus: order['status'],
+        reason,
+      });
+      await this.settlements.cancelSettlement(orderId);
+      return result;
     }
 
-    const reason = dto.reason ?? '관리자 강제 환불';
     await this.payments.processRefundByOrderId(orderId, reason);
 
-    await this.firestore.doc(`orders/${orderId}`).update({
-      status: 'CANCELLED',
-      cancelReason: reason,
-      updatedAt: this.firestore.Timestamp.now(),
+    await this.firestore.runTransaction(async (tx) => {
+      const freshSnap = await tx.get(orderRef);
+      if (!freshSnap.exists) throw new NotFoundException('주문을 찾을 수 없습니다.');
+
+      await releaseLegacyDailyCapacityInTransaction(this.firestore, tx, orderId, reason);
+      tx.update(orderRef, {
+        status: 'CANCELLED',
+        cancelReason: reason,
+        updatedAt: this.firestore.Timestamp.now(),
+      });
     });
+    await this.settlements.cancelSettlement(orderId);
 
     return { ok: true, orderId };
   }
@@ -164,12 +186,12 @@ export class AdminService {
       query = query.where('storeId', '==', dto.storeId);
     }
     if (dto.from) {
-      query = query.where('settledAt', '>=', this.firestore.Timestamp.fromDate(new Date(dto.from)));
+      const { start } = dateRangeKST(dto.from);
+      query = query.where('settledAt', '>=', this.firestore.Timestamp.fromDate(start));
     }
     if (dto.to) {
-      const toDate = new Date(dto.to);
-      toDate.setHours(23, 59, 59, 999);
-      query = query.where('settledAt', '<=', this.firestore.Timestamp.fromDate(toDate));
+      const { endExclusive } = dateRangeKST(dto.to);
+      query = query.where('settledAt', '<', this.firestore.Timestamp.fromDate(endExclusive));
     }
 
     query = query.orderBy('settledAt', 'desc').limit(500);

--- a/apps/api/src/admin/admin.service.ts
+++ b/apps/api/src/admin/admin.service.ts
@@ -1,9 +1,17 @@
-import { Injectable, NotFoundException, BadRequestException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { randomUUID } from 'node:crypto';
 import { dateRangeKST } from '@greenhub/shared';
 import * as admin from 'firebase-admin';
 import { v4 as uuidv4 } from 'uuid';
 import { FirestoreService } from '../firestore/firestore.service';
 import { RoundOrderLifecycleService } from '../orders/round-order-lifecycle.service';
+import type { OrderStatus } from '../orders/dto/update-status.dto';
+import { getAllowedTransitions } from '../orders/orders.helpers';
 import { PaymentsService } from '../payments/payments.service';
 import { releaseLegacyDailyCapacityInTransaction } from '../payments/_lib/legacy-daily-capacity';
 import { SettlementsService } from '../settlements/settlements.service';
@@ -16,6 +24,13 @@ import {
   ForceRefundDto,
   UpsertBannerDto,
 } from './dto/admin.dto';
+
+const LEGACY_REFUND_CLAIM_MS = 5 * 60 * 1000;
+
+type LegacyRefundClaimResult =
+  | { kind: 'done' }
+  | { kind: 'in_progress' }
+  | { kind: 'claimed'; token: string };
 
 @Injectable()
 export class AdminService {
@@ -159,22 +174,184 @@ export class AdminService {
       return result;
     }
 
-    await this.payments.processRefundByOrderId(orderId, reason);
+    return this.forceLegacyRefund(orderId, reason);
+  }
+
+  private async forceLegacyRefund(orderId: string, reason: string) {
+    const claim = await this.claimLegacyRefund(orderId, reason);
+    if (claim.kind === 'done') {
+      await this.settlements.cancelSettlement(orderId);
+      return { ok: true, orderId };
+    }
+    if (claim.kind === 'in_progress') {
+      throw new ConflictException('주문 환불이 이미 처리 중입니다.');
+    }
+
+    try {
+      // 주문 claim을 획득한 뒤에만 provider를 호출한다.
+      await this.payments.processRefundByOrderId(orderId, reason);
+    } catch (error) {
+      await this.recordLegacyRefundState(orderId, claim.token, 'REFUND_FAILED', reason);
+      throw error;
+    }
+
+    try {
+      await this.applyLegacyLocalCancellation(orderId, claim.token, reason);
+      await this.settlements.cancelSettlement(orderId);
+    } catch (error) {
+      await this.recordLegacyRefundState(orderId, claim.token, 'LOCAL_FAILED', reason);
+      throw error;
+    }
+
+    return { ok: true, orderId };
+  }
+
+  private async claimLegacyRefund(
+    orderId: string,
+    reason: string,
+  ): Promise<LegacyRefundClaimResult> {
+    const token = randomUUID();
+    let result: LegacyRefundClaimResult = { kind: 'claimed', token };
 
     await this.firestore.runTransaction(async (tx) => {
-      const freshSnap = await tx.get(orderRef);
-      if (!freshSnap.exists) throw new NotFoundException('주문을 찾을 수 없습니다.');
+      const orderRef = this.firestore.doc(`orders/${orderId}`);
+      const orderSnap = await tx.get(orderRef);
+      if (!orderSnap.exists) throw new NotFoundException('주문을 찾을 수 없습니다.');
+
+      const order = orderSnap.data() as Record<string, any>;
+      const cancellation = (order['cancellation'] ?? null) as Record<string, any> | null;
+      const cancellationStatus = cancellation?.['status'] as string | undefined;
+
+      // 이미 cancellation까지 완료된 취소는 외부 provider와 capacity를 다시 건드리지 않는다.
+      if (order['status'] === 'CANCELLED' && cancellationStatus === 'COMPLETED') {
+        result = { kind: 'done' };
+        return;
+      }
+
+      let expiredClaim = false;
+      if (cancellationStatus === 'REFUNDING') {
+        const refundClaim = cancellation?.['refundClaim'] as
+          | { token?: string; expiresAt?: number }
+          | undefined;
+        if (
+          !refundClaim ||
+          typeof refundClaim.token !== 'string' ||
+          refundClaim.token.length === 0 ||
+          typeof refundClaim.expiresAt !== 'number'
+        ) {
+          result = { kind: 'in_progress' };
+          return;
+        }
+        if (refundClaim.expiresAt > Date.now()) {
+          result = { kind: 'in_progress' };
+          return;
+        }
+        expiredClaim = true;
+      }
+
+      const retryable = ['LOCAL_PENDING', 'LOCAL_FAILED', 'REFUND_FAILED'].includes(
+        cancellationStatus ?? '',
+      );
+      const statusAllowsRefund = this.isLegacyRefundableStatus(order['status']);
+      const cancelledRetryAllowsRefund =
+        order['status'] === 'CANCELLED' && (retryable || expiredClaim);
+      const cancelledWithoutState = order['status'] === 'CANCELLED' && !cancellation;
+      if (!statusAllowsRefund && !cancelledRetryAllowsRefund && !cancelledWithoutState) {
+        throw new BadRequestException('현재 주문 상태에서는 관리자 환불을 처리할 수 없습니다.');
+      }
+
+      const now = this.firestore.Timestamp.now();
+      tx.update(orderRef, {
+        cancellation: {
+          status: 'REFUNDING',
+          reason,
+          refundClaim: {
+            token,
+            expiresAt: Date.now() + LEGACY_REFUND_CLAIM_MS,
+          },
+          updatedAt: this.toIso(now),
+        },
+        updatedAt: now,
+      });
+    });
+
+    return result;
+  }
+
+  private async applyLegacyLocalCancellation(orderId: string, token: string, reason: string) {
+    await this.firestore.runTransaction(async (tx) => {
+      const orderRef = this.firestore.doc(`orders/${orderId}`);
+      const orderSnap = await tx.get(orderRef);
+      if (!orderSnap.exists) throw new NotFoundException('주문을 찾을 수 없습니다.');
+
+      const order = orderSnap.data() as Record<string, any>;
+      const cancellation = (order['cancellation'] ?? null) as Record<string, any> | null;
+      if (
+        cancellation?.['status'] !== 'REFUNDING' ||
+        cancellation?.['refundClaim']?.['token'] !== token
+      ) {
+        throw new ConflictException('주문 환불 claim이 더 이상 유효하지 않습니다.');
+      }
 
       await releaseLegacyDailyCapacityInTransaction(this.firestore, tx, orderId, reason);
+      const now = this.firestore.Timestamp.now();
       tx.update(orderRef, {
         status: 'CANCELLED',
         cancelReason: reason,
-        updatedAt: this.firestore.Timestamp.now(),
+        cancellation: {
+          status: 'COMPLETED',
+          reason,
+          completedAt: this.toIso(now),
+          updatedAt: this.toIso(now),
+        },
+        updatedAt: now,
       });
     });
-    await this.settlements.cancelSettlement(orderId);
+  }
 
-    return { ok: true, orderId };
+  private async recordLegacyRefundState(
+    orderId: string,
+    token: string,
+    status: 'REFUND_FAILED' | 'LOCAL_FAILED',
+    reason: string,
+  ) {
+    await this.firestore.runTransaction(async (tx) => {
+      const orderRef = this.firestore.doc(`orders/${orderId}`);
+      const orderSnap = await tx.get(orderRef);
+      if (!orderSnap.exists) return;
+
+      const cancellation = (orderSnap.data()?.['cancellation'] ?? null) as Record<
+        string,
+        any
+      > | null;
+      const ownsClaim = cancellation?.['refundClaim']?.['token'] === token;
+      const localCompletionFailed =
+        status === 'LOCAL_FAILED' && cancellation?.['status'] === 'COMPLETED';
+      if (!ownsClaim && !localCompletionFailed) return;
+
+      const now = this.firestore.Timestamp.now();
+      tx.update(orderRef, {
+        cancellation: {
+          status,
+          reason,
+          updatedAt: this.toIso(now),
+        },
+        updatedAt: now,
+      });
+    });
+  }
+
+  private isLegacyRefundableStatus(status: unknown): status is OrderStatus {
+    return (
+      typeof status === 'string' &&
+      getAllowedTransitions('admin', status as OrderStatus).includes('CANCELLED')
+    );
+  }
+
+  private toIso(value: any) {
+    if (value instanceof Date) return value.toISOString();
+    if (typeof value?.toDate === 'function') return value.toDate().toISOString();
+    return new Date(value).toISOString();
   }
 
   // ── Settlements ──────────────────────────────────────────────────

--- a/apps/api/src/ai/dto/generate-content.dto.spec.ts
+++ b/apps/api/src/ai/dto/generate-content.dto.spec.ts
@@ -1,0 +1,31 @@
+import 'reflect-metadata';
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { COLOR_OPTIONS } from '@greenhub/shared';
+import { GenerateContentDto } from './generate-content.dto';
+
+const selection = {
+  colors: [...COLOR_OPTIONS],
+  stemType: '외대',
+  fragrance: 'none',
+  bloomCondition: 'half',
+  bundleUnit: '1단',
+};
+
+describe('AI 상품 선택 색상 계약', () => {
+  it('현재 19개 색상을 허용한다', async () => {
+    const errors = await validate(plainToInstance(GenerateContentDto, { selection }));
+
+    expect(errors).toHaveLength(0);
+  });
+
+  it('오타 색상을 거부한다', async () => {
+    const errors = await validate(
+      plainToInstance(GenerateContentDto, {
+        selection: { ...selection, colors: ['레드', '오류'] },
+      }),
+    );
+
+    expect(errors).not.toHaveLength(0);
+  });
+});

--- a/apps/api/src/ai/dto/generate-content.dto.ts
+++ b/apps/api/src/ai/dto/generate-content.dto.ts
@@ -1,10 +1,11 @@
 import { IsString, IsEnum, IsArray, IsOptional, ValidateNested } from 'class-validator';
 import { Type } from 'class-transformer';
+import { COLOR_OPTIONS, type ColorOption } from '@greenhub/shared';
 
 export class SelectionDto {
   @IsArray()
-  @IsString({ each: true })
-  colors: string[];
+  @IsEnum(COLOR_OPTIONS, { each: true })
+  colors: ColorOption[];
 
   @IsEnum(['외대', '쌍대', '가지', '3대'])
   stemType: string;

--- a/apps/api/src/firestore/firestore-indexes.spec.ts
+++ b/apps/api/src/firestore/firestore-indexes.spec.ts
@@ -203,7 +203,7 @@ const QUERY_CONTRACTS: QueryContract[] = [
       'async getSummary(',
       ".where('storeId', '==', storeId)",
       ".where('settledAt', '>=',",
-      ".where('settledAt', '<=',",
+      ".where('settledAt', '<',",
     ],
     collectionGroup: 'settlements',
     queryScope: 'COLLECTION',

--- a/apps/api/src/orders/orders-lifecycle.service.ts
+++ b/apps/api/src/orders/orders-lifecycle.service.ts
@@ -14,6 +14,7 @@ import type { OrderStatus, UpdateStatusDto } from './dto/update-status.dto';
 import { OrderCapacityService } from './order-capacity.service';
 import { getAllowedTransitions, NOTIFICATION_MAP } from './orders.helpers';
 import { RoundOrderLifecycleService } from './round-order-lifecycle.service';
+import { releaseLegacyDailyCapacityInTransaction } from '../payments/_lib/legacy-daily-capacity';
 
 const DELIVERY_HOLD_CUSTOMER_REASONS: Record<string, string> = {
   WEATHER: '기상 상황으로 배송이 지연되었습니다.',
@@ -174,6 +175,14 @@ export class OrdersLifecycleService {
       nextStatus === 'DELIVERY_HELD' ? 1 : currentStatus === 'DELIVERY_HELD' ? -1 : 0;
     if (heldOrderDelta !== 0 && order['roundId']) {
       await this.firestore.runTransaction(async (t) => {
+        const orderRef = this.firestore.doc(`orders/${orderId}`);
+        const latestOrderSnap = await t.get(orderRef);
+        if (!latestOrderSnap.exists || latestOrderSnap.data()?.['storeId'] !== storeId) {
+          throw new NotFoundException();
+        }
+        if (latestOrderSnap.data()?.['status'] !== currentStatus) {
+          throw new ConflictException('주문 상태가 변경되었습니다.');
+        }
         const roundRef = this.firestore.doc(`saleRounds/${order['roundId']}`);
         const roundSnap = await t.get(roundRef);
         if (!roundSnap.exists || roundSnap.data()?.['storeId'] !== storeId) {
@@ -184,7 +193,15 @@ export class OrdersLifecycleService {
           heldOrderCount: heldOrderDelta,
         });
         t.update(roundRef, { counters, updatedAt: update['updatedAt'] });
-        t.update(this.firestore.doc(`orders/${orderId}`), update);
+        if (nextStatus === 'CANCELLED') {
+          await releaseLegacyDailyCapacityInTransaction(
+            this.firestore,
+            t,
+            orderId,
+            confirmedCancelReason ?? '판매자 취소',
+          );
+        }
+        t.update(orderRef, update);
       });
     } else {
       const isDriverAssignment =
@@ -206,7 +223,27 @@ export class OrdersLifecycleService {
           transaction.update(orderRef, update);
         });
       } else {
-        await this.firestore.doc(`orders/${orderId}`).update(update);
+        if (nextStatus === 'CANCELLED') {
+          await this.firestore.runTransaction(async (transaction) => {
+            const orderRef = this.firestore.doc(`orders/${orderId}`);
+            const latestSnap = await transaction.get(orderRef);
+            if (!latestSnap.exists || latestSnap.data()?.['storeId'] !== storeId) {
+              throw new NotFoundException();
+            }
+            if (latestSnap.data()?.['status'] !== currentStatus) {
+              throw new ConflictException('주문 상태가 변경되었습니다.');
+            }
+            await releaseLegacyDailyCapacityInTransaction(
+              this.firestore,
+              transaction,
+              orderId,
+              confirmedCancelReason ?? '판매자 취소',
+            );
+            transaction.update(orderRef, update);
+          });
+        } else {
+          await this.firestore.doc(`orders/${orderId}`).update(update);
+        }
       }
     }
 

--- a/apps/api/src/payments/_lib/legacy-daily-capacity.ts
+++ b/apps/api/src/payments/_lib/legacy-daily-capacity.ts
@@ -1,0 +1,197 @@
+type LegacyOrder = Record<string, any>;
+
+type Snapshot = {
+  exists: boolean;
+  data(): LegacyOrder | undefined;
+};
+
+type Transaction = {
+  get(ref: unknown): Promise<Snapshot>;
+  update(ref: unknown, data: Record<string, unknown>): void;
+};
+
+type FirestoreLike = {
+  doc(path: string): unknown;
+  Timestamp: { now(): unknown };
+};
+
+type CapacityState = {
+  status: 'HELD' | 'RELEASED';
+  date: string;
+  quantity: number;
+  updatedAt?: unknown;
+  reason?: string;
+};
+
+export class LegacyDailyCapacityError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'LegacyDailyCapacityError';
+  }
+}
+
+export function isLegacyDailyCapacityEligible(order: LegacyOrder): boolean {
+  return (
+    order['schemaVersion'] !== 2 &&
+    order['saleType'] === 'normal' &&
+    (order['deliveryMethod'] === 'direct' || order['deliveryMethod'] === 'hub')
+  );
+}
+
+export function legacyDailyCapacityDateKey(order: LegacyOrder): string {
+  const requestedDate = order['requestedDeliveryDate'];
+  if (requestedDate !== undefined && requestedDate !== null && requestedDate !== '') {
+    if (typeof requestedDate !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(requestedDate)) {
+      throw new LegacyDailyCapacityError('legacy requestedDeliveryDate 형식이 올바르지 않습니다.');
+    }
+    return requestedDate;
+  }
+
+  const createdAt = toDate(order['createdAt']);
+  if (!createdAt) {
+    throw new LegacyDailyCapacityError('legacy daily capacity 날짜를 확인할 수 없습니다.');
+  }
+
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'Asia/Seoul',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).formatToParts(createdAt);
+  const values = Object.fromEntries(parts.map((part) => [part.type, part.value]));
+  return `${values['year']}-${values['month']}-${values['day']}`;
+}
+
+export async function releaseLegacyDailyCapacityInTransaction(
+  firestore: FirestoreLike,
+  tx: Transaction,
+  orderId: string,
+  reason: string,
+): Promise<'RELEASED' | 'ALREADY_RELEASED' | 'NOT_ELIGIBLE'> {
+  const orderRef = firestore.doc(`orders/${orderId}`);
+  const orderSnap = await tx.get(orderRef);
+  if (!orderSnap.exists) return 'NOT_ELIGIBLE';
+
+  const order = orderSnap.data() ?? {};
+  if (!isLegacyDailyCapacityEligible(order)) return 'NOT_ELIGIBLE';
+
+  const state = readCapacityState(order);
+  if (state?.status === 'RELEASED') return 'ALREADY_RELEASED';
+
+  const date = state?.date ?? legacyDailyCapacityDateKey(order);
+  const quantity = state?.quantity ?? legacyQuantity(order);
+  const capRef = firestore.doc(`dailyCaps/${order['storeId']}_${date}`);
+  const capSnap = await tx.get(capRef);
+  if (!capSnap.exists) {
+    throw new LegacyDailyCapacityError(`legacy daily capacity 문서가 없습니다: ${date}`);
+  }
+
+  const cap = capSnap.data() ?? {};
+  const usedSlots = finiteNumber(cap['usedSlots']);
+  if (usedSlots < quantity) {
+    throw new LegacyDailyCapacityError('legacy daily capacity 점유 상태가 이미 반환되었거나 손상되었습니다.');
+  }
+
+  const now = firestore.Timestamp.now();
+  tx.update(capRef, { usedSlots: usedSlots - quantity });
+  tx.update(orderRef, {
+    legacyDailyCapacity: {
+      status: 'RELEASED',
+      date,
+      quantity,
+      updatedAt: now,
+      reason,
+    },
+  });
+  return 'RELEASED';
+}
+
+export async function reacquireLegacyDailyCapacityInTransaction(
+  firestore: FirestoreLike,
+  tx: Transaction,
+  orderId: string,
+  order: LegacyOrder,
+): Promise<'REACQUIRED' | 'ALREADY_HELD' | 'NOT_ELIGIBLE'> {
+  if (!isLegacyDailyCapacityEligible(order)) return 'NOT_ELIGIBLE';
+
+  const orderRef = firestore.doc(`orders/${orderId}`);
+  const freshSnap = await tx.get(orderRef);
+  if (!freshSnap.exists) throw new LegacyDailyCapacityError('주문이 없어 legacy capacity를 재확보할 수 없습니다.');
+  const freshOrder = freshSnap.data() ?? order;
+  if (!isLegacyDailyCapacityEligible(freshOrder)) return 'NOT_ELIGIBLE';
+
+  const state = readCapacityState(freshOrder);
+  if (state?.status === 'HELD') return 'ALREADY_HELD';
+
+  const date = state?.date ?? legacyDailyCapacityDateKey(freshOrder);
+  const quantity = state?.quantity ?? legacyQuantity(freshOrder);
+  const capRef = firestore.doc(`dailyCaps/${freshOrder['storeId']}_${date}`);
+  const capSnap = await tx.get(capRef);
+  if (!capSnap.exists) {
+    throw new LegacyDailyCapacityError(`legacy daily capacity 문서가 없습니다: ${date}`);
+  }
+
+  const cap = capSnap.data() ?? {};
+  const usedSlots = finiteNumber(cap['usedSlots']);
+  const totalCap = finiteNumber(cap['totalCap']);
+  if (usedSlots + quantity > totalCap) {
+    throw new LegacyDailyCapacityError('legacy daily capacity를 재확보할 수 없습니다.');
+  }
+
+  const now = firestore.Timestamp.now();
+  tx.update(capRef, { usedSlots: usedSlots + quantity });
+  tx.update(orderRef, {
+    legacyDailyCapacity: {
+      status: 'HELD',
+      date,
+      quantity,
+      updatedAt: now,
+      reason: 'late_paid_reacquire',
+    },
+  });
+  return 'REACQUIRED';
+}
+
+function readCapacityState(order: LegacyOrder): CapacityState | null {
+  const value = order['legacyDailyCapacity'];
+  if (!value || typeof value !== 'object') return null;
+  if (value['status'] !== 'HELD' && value['status'] !== 'RELEASED') {
+    throw new LegacyDailyCapacityError('legacy daily capacity 상태가 올바르지 않습니다.');
+  }
+  return {
+    status: value['status'],
+    date: value['date'],
+    quantity: value['quantity'],
+    updatedAt: value['updatedAt'],
+    reason: value['reason'],
+  };
+}
+
+function legacyQuantity(order: LegacyOrder): number {
+  const quantity = finiteNumber(order['quantity']);
+  if (quantity <= 0) {
+    throw new LegacyDailyCapacityError('legacy daily capacity 수량이 올바르지 않습니다.');
+  }
+  return quantity;
+}
+
+function finiteNumber(value: unknown): number {
+  const number = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(number) || number < 0) {
+    throw new LegacyDailyCapacityError('legacy daily capacity 숫자 상태가 올바르지 않습니다.');
+  }
+  return number;
+}
+
+function toDate(value: unknown): Date | null {
+  if (value instanceof Date) return Number.isNaN(value.getTime()) ? null : value;
+  if (value && typeof (value as { toDate?: unknown }).toDate === 'function') {
+    const date = (value as { toDate(): Date }).toDate();
+    return date instanceof Date && !Number.isNaN(date.getTime()) ? date : null;
+  }
+  if (typeof value === 'string' || typeof value === 'number') {
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? null : date;
+  }
+  return null;
+}

--- a/apps/api/src/payments/legacy-daily-capacity-recovery.spec.ts
+++ b/apps/api/src/payments/legacy-daily-capacity-recovery.spec.ts
@@ -1,0 +1,322 @@
+import { OrdersLifecycleService } from '../orders/orders-lifecycle.service';
+import {
+  isLegacyDailyCapacityEligible,
+  legacyDailyCapacityDateKey,
+} from './_lib/legacy-daily-capacity';
+import { PaymentFinalizationService } from './payment-finalization.service';
+import { PaymentsService } from './payments.service';
+
+type Data = Record<string, any>;
+
+function makeSnap(data: Data | null, ref?: Data) {
+  return { exists: data !== null, data: () => data, ref };
+}
+
+function makeFirestore(initial: Record<string, Data>) {
+  const records = new Map(Object.entries(initial));
+  const refs = new Map<string, Data>();
+  const doc = jest.fn((path: string) => {
+    if (!refs.has(path)) {
+      refs.set(path, {
+        path,
+        get: jest.fn(async () => makeSnap(records.get(path) ?? null, refs.get(path))),
+        set: jest.fn(async (data: Data) => records.set(path, data)),
+        update: jest.fn(async (data: Data) =>
+          records.set(path, { ...(records.get(path) ?? {}), ...data }),
+        ),
+      });
+    }
+    return refs.get(path);
+  });
+
+  let transactionQueue = Promise.resolve();
+  const firestore = {
+    doc,
+    collection: jest.fn(),
+    runTransaction: jest.fn((callback: (tx: Data) => Promise<unknown>) => {
+      const result = transactionQueue.then(async () => {
+        const pending = new Map<string, Data>();
+        const tx = {
+          get: jest.fn(async (ref: Data) =>
+            makeSnap(pending.get(ref.path) ?? records.get(ref.path) ?? null, ref),
+          ),
+          set: jest.fn((ref: Data, data: Data) => pending.set(ref.path, data)),
+          update: jest.fn((ref: Data, data: Data) => {
+            const current = pending.get(ref.path) ?? records.get(ref.path) ?? {};
+            pending.set(ref.path, { ...current, ...data });
+          }),
+        };
+        const value = await callback(tx);
+        for (const [path, data] of pending) records.set(path, data);
+        return value;
+      });
+      transactionQueue = result.then(
+        () => undefined,
+        () => undefined,
+      );
+      return result;
+    }),
+    Timestamp: {
+      now: jest.fn(() => new Date('2026-08-25T00:00:00.000Z')),
+      fromDate: jest.fn((date: Date) => date),
+    },
+    FieldValue: {
+      increment: jest.fn((value: number) => ({ __increment: value })),
+    },
+  };
+  return { firestore, records };
+}
+
+function makeLegacyOrder(overrides: Data = {}) {
+  return {
+    id: 'order-1',
+    storeId: 'store-1',
+    userId: 'user-1',
+    status: 'PENDING',
+    schemaVersion: 1,
+    saleType: 'normal',
+    deliveryMethod: 'direct',
+    quantity: 2,
+    requestedDeliveryDate: '2026-08-25',
+    createdAt: new Date('2026-08-24T23:00:00.000Z'),
+    totalAmount: 100000,
+    ...overrides,
+  };
+}
+
+function makeFinalization(orderOverrides: Data = {}, capOverrides: Data = {}) {
+  const order = makeLegacyOrder(orderOverrides);
+  const { firestore, records } = makeFirestore({
+    'orders/order-1': order,
+    'dailyCaps/store-1_2026-08-25': {
+      storeId: 'store-1',
+      date: '2026-08-25',
+      totalCap: 10,
+      usedSlots: 2,
+      ...capOverrides,
+    },
+  });
+  const portone = { refund: jest.fn().mockResolvedValue(undefined) };
+  const capacity = {
+    consumeReservationInTransaction: jest.fn(),
+    releaseReservationInTransaction: jest.fn(),
+    reserveCheckout: jest.fn(),
+  };
+  const service = new PaymentFinalizationService(
+    firestore as never,
+    portone as never,
+    { sendToUser: jest.fn() } as never,
+    { log: jest.fn() } as never,
+    capacity as never,
+    { createOrMergeIssue: jest.fn() } as never,
+    { saveRecord: jest.fn().mockResolvedValue(undefined) } as never,
+    { refundByOrderId: jest.fn().mockResolvedValue(undefined) } as never,
+  );
+  return { firestore, records, portone, capacity, service };
+}
+
+const paidPayment = {
+  amount: { total: 100000 },
+  status: 'PAID',
+  method: { type: 'CARD' },
+  transactionId: 'tx-1',
+} as never;
+
+describe('legacy daily capacity 정책', () => {
+  it.each([
+    ['normal direct', { saleType: 'normal', deliveryMethod: 'direct' }, true],
+    ['normal hub', { saleType: 'normal', deliveryMethod: 'hub' }, true],
+    ['normal parcel', { saleType: 'normal', deliveryMethod: 'parcel' }, false],
+    ['group direct', { saleType: 'group', deliveryMethod: 'direct' }, false],
+    ['group hub', { saleType: 'group', deliveryMethod: 'hub' }, false],
+    ['group parcel', { saleType: 'group', deliveryMethod: 'parcel' }, false],
+    ['round v2 direct', { schemaVersion: 2, deliveryMethod: 'direct' }, false],
+  ])('%s eligibility를 명시적으로 판정한다', (_name, overrides, expected) => {
+    expect(isLegacyDailyCapacityEligible(makeLegacyOrder(overrides))).toBe(expected);
+  });
+
+  it('requestedDeliveryDate를 우선 사용하고 없으면 createdAt을 KST로 변환한다', () => {
+    expect(
+      legacyDailyCapacityDateKey(
+        makeLegacyOrder({
+          requestedDeliveryDate: '2026-08-26',
+          createdAt: new Date('2026-08-25T15:00:00.000Z'),
+        }),
+      ),
+    ).toBe('2026-08-26');
+    expect(
+      legacyDailyCapacityDateKey(
+        makeLegacyOrder({ requestedDeliveryDate: null, createdAt: new Date('2026-08-25T15:00:00.000Z') }),
+      ),
+    ).toBe('2026-08-26');
+  });
+
+  it.each(['payment_failed', 'timeout'])(
+    '%s cancellation은 eligible legacy capacity를 한 번만 반환한다',
+    async (reason) => {
+      const fixture = makeFinalization();
+
+      await fixture.service.cancelPendingOrder('order-1', reason);
+      await fixture.service.cancelPendingOrder('order-1', reason);
+
+      expect(fixture.records.get('dailyCaps/store-1_2026-08-25')?.['usedSlots']).toBe(0);
+      expect(fixture.records.get('orders/order-1')).toMatchObject({
+        status: 'CANCELLED',
+        legacyDailyCapacity: { status: 'RELEASED', quantity: 2 },
+      });
+    },
+  );
+
+  it('payment failure webhook은 실제 finalization recovery를 호출한다', async () => {
+    const fixture = makeFinalization();
+    const service = new PaymentsService(
+      fixture.firestore as never,
+      {} as never,
+      fixture.service,
+      {} as never,
+      { isOrderChargePaymentId: jest.fn().mockReturnValue(false) } as never,
+    );
+
+    await service.handleWebhook({
+      type: 'Transaction.Failed',
+      data: { paymentId: 'order-1' },
+    } as never);
+
+    expect(fixture.records.get('dailyCaps/store-1_2026-08-25')?.['usedSlots']).toBe(0);
+    expect(fixture.records.get('orders/order-1')?.['status']).toBe('CANCELLED');
+  });
+
+  it.each([
+    ['normal parcel', { saleType: 'normal', deliveryMethod: 'parcel' }],
+    ['group direct', { saleType: 'group', deliveryMethod: 'direct' }],
+    ['group hub', { saleType: 'group', deliveryMethod: 'hub' }],
+    ['round v2 direct', { schemaVersion: 2, deliveryMethod: 'direct', reservationId: 'reservation-1' }],
+  ])('%s cancellation은 legacy daily cap을 변경하지 않는다', async (_name, overrides) => {
+    const fixture = makeFinalization(overrides);
+
+    await fixture.service.cancelPendingOrder('order-1', 'timeout');
+
+    expect(fixture.records.get('dailyCaps/store-1_2026-08-25')?.['usedSlots']).toBe(2);
+    expect(fixture.records.get('orders/order-1')?.['legacyDailyCapacity']).toBeUndefined();
+  });
+
+  it('점유량보다 큰 반환은 clamp하지 않고 transaction을 실패시켜 음수화를 막는다', async () => {
+    const fixture = makeFinalization({}, { usedSlots: 1 });
+
+    await expect(fixture.service.cancelPendingOrder('order-1', 'timeout')).rejects.toThrow(
+      '점유 상태가 이미 반환되었거나 손상되었습니다',
+    );
+
+    expect(fixture.records.get('dailyCaps/store-1_2026-08-25')?.['usedSlots']).toBe(1);
+    expect(fixture.records.get('orders/order-1')?.['status']).toBe('PENDING');
+  });
+
+  it('timeout 뒤 late PAID는 capacity를 transaction 안에서 재확보한 뒤 ACCEPTED로 확정한다', async () => {
+    const fixture = makeFinalization(
+      {
+        status: 'CANCELLED',
+        cancelReason: 'timeout',
+        legacyDailyCapacity: {
+          status: 'RELEASED',
+          date: '2026-08-25',
+          quantity: 2,
+        },
+      },
+      { usedSlots: 0 },
+    );
+
+    await expect(fixture.service.finalizePaidOrder('order-1', paidPayment)).resolves.toEqual({
+      ok: true,
+      status: 'ACCEPTED',
+    });
+
+    expect(fixture.records.get('dailyCaps/store-1_2026-08-25')?.['usedSlots']).toBe(2);
+    expect(fixture.records.get('orders/order-1')).toMatchObject({
+      status: 'ACCEPTED',
+      legacyDailyCapacity: { status: 'HELD', quantity: 2 },
+    });
+  });
+
+  it('late PAID capacity 재확보 실패는 ACCEPTED 확정 없이 환불 상태로 수렴한다', async () => {
+    const fixture = makeFinalization(
+      {
+        status: 'CANCELLED',
+        cancelReason: 'timeout',
+        legacyDailyCapacity: {
+          status: 'RELEASED',
+          date: '2026-08-25',
+          quantity: 2,
+        },
+      },
+      { usedSlots: 10 },
+    );
+
+    await expect(fixture.service.finalizePaidOrder('order-1', paidPayment)).resolves.toEqual({
+      ok: false,
+      reason: 'late_payment_refunded',
+    });
+
+    expect(fixture.portone.refund).toHaveBeenCalledTimes(1);
+    expect(fixture.records.get('orders/order-1')).toMatchObject({
+      status: 'CANCELLED',
+      latePaymentRefundedAt: expect.anything(),
+    });
+    expect(fixture.records.get('payments/order-1')).toMatchObject({ status: 'CANCELLED' });
+    expect(fixture.records.get('dailyCaps/store-1_2026-08-25')?.['usedSlots']).toBe(10);
+  });
+});
+
+describe('legacy seller cancellation recovery', () => {
+  it.each(['direct', 'hub'])(
+    'seller cancellation은 normal %s capacity를 한 번만 반환한다',
+    async (deliveryMethod) => {
+      const order = makeLegacyOrder({ status: 'ACCEPTED', deliveryMethod });
+      const { firestore, records } = makeFirestore({
+        'orders/order-1': order,
+        'stores/store-1': { ownerId: 'seller-1' },
+        'dailyCaps/store-1_2026-08-25': {
+          storeId: 'store-1',
+          date: '2026-08-25',
+          totalCap: 10,
+          usedSlots: 2,
+        },
+      });
+      const payments = { processRefundByOrderId: jest.fn().mockResolvedValue(undefined) };
+      const settlements = { cancelSettlement: jest.fn().mockResolvedValue(undefined) };
+      const service = new OrdersLifecycleService(
+        firestore as never,
+        { sendToUser: jest.fn(), sendToGroupParticipants: jest.fn() } as never,
+        payments as never,
+        settlements as never,
+        {} as never,
+        {} as never,
+      );
+
+      await service.updateStatus(
+        'store-1',
+        'order-1',
+        'seller-1',
+        { status: 'CANCELLED', reason: '재고 부족' } as never,
+        'seller',
+      );
+
+      expect(records.get('dailyCaps/store-1_2026-08-25')?.['usedSlots']).toBe(0);
+      expect(records.get('orders/order-1')).toMatchObject({
+        status: 'CANCELLED',
+        legacyDailyCapacity: { status: 'RELEASED', quantity: 2 },
+      });
+
+      await expect(
+        service.updateStatus(
+          'store-1',
+          'order-1',
+          'seller-1',
+          { status: 'CANCELLED', reason: '재고 부족' } as never,
+          'seller',
+        ),
+      ).rejects.toThrow();
+      expect(payments.processRefundByOrderId).toHaveBeenCalledTimes(1);
+      expect(records.get('dailyCaps/store-1_2026-08-25')?.['usedSlots']).toBe(0);
+    },
+  );
+});

--- a/apps/api/src/payments/payment-finalization.service.ts
+++ b/apps/api/src/payments/payment-finalization.service.ts
@@ -7,9 +7,16 @@ import { OrderCapacityService } from '../orders/order-capacity.service';
 import { RetentionService } from '../retention/retention.service';
 import { PortoneClient } from './portone.client';
 import { PaymentRefundService } from './payment-refund.service';
+import {
+  isLegacyDailyCapacityEligible,
+  LegacyDailyCapacityError,
+  reacquireLegacyDailyCapacityInTransaction,
+  releaseLegacyDailyCapacityInTransaction,
+} from './_lib/legacy-daily-capacity';
 
 type PaymentData = Awaited<ReturnType<PortoneClient['getPayment']>>;
 const LATE_PAYMENT_REFUND_REASON = '결제 만료 후 회차 한도 마감';
+const LEGACY_LATE_PAYMENT_REFUND_REASON = '결제 만료 후 일일 배송 용량 재확보 실패';
 
 @Injectable()
 export class PaymentFinalizationService {
@@ -99,56 +106,77 @@ export class PaymentFinalizationService {
     const now = this.firestore.Timestamp.now();
     let applied = false;
     let cancellationOutcome: 'REFUND' | null = null;
-    await this.firestore.runTransaction(async (tx) => {
-      const orderRef = this.firestore.doc(`orders/${orderId}`);
-      const paymentRef = this.firestore.doc(`payments/${orderId}`);
-      const freshSnap = await tx.get(orderRef);
-      if (!freshSnap.exists) return;
-      const freshOrder = freshSnap.data() as Record<string, any>;
-      if (this.isCancellationSettlementCandidate(freshOrder)) {
-        const paymentSnap = await tx.get(paymentRef);
-        const payment = paymentSnap.exists ? (paymentSnap.data() as Record<string, any>) : null;
-        if (payment?.['status'] !== 'CANCELLED' && !payment?.['refundedAt']) {
-          if (payment?.['status'] !== 'PAID') {
-            await this.writePaidPaymentInTransaction(
-              tx,
-              orderId,
-              freshOrder,
-              paymentData,
-              now,
-              freshOrder['status'],
-            );
+    try {
+      await this.firestore.runTransaction(async (tx) => {
+        const orderRef = this.firestore.doc(`orders/${orderId}`);
+        const paymentRef = this.firestore.doc(`payments/${orderId}`);
+        const freshSnap = await tx.get(orderRef);
+        if (!freshSnap.exists) return;
+        const freshOrder = freshSnap.data() as Record<string, any>;
+        if (this.isCancellationSettlementCandidate(freshOrder)) {
+          const paymentSnap = await tx.get(paymentRef);
+          const payment = paymentSnap.exists ? (paymentSnap.data() as Record<string, any>) : null;
+          if (payment?.['status'] !== 'CANCELLED' && !payment?.['refundedAt']) {
+            if (payment?.['status'] !== 'PAID') {
+              await this.writePaidPaymentInTransaction(
+                tx,
+                orderId,
+                freshOrder,
+                paymentData,
+                now,
+                freshOrder['status'],
+              );
+            }
+            cancellationOutcome = 'REFUND';
           }
-          cancellationOutcome = 'REFUND';
+          return;
         }
-        return;
-      }
-      if (!this.canFinalize(freshOrder)) return;
+        if (!this.canFinalize(freshOrder)) return;
 
-      if (freshOrder['schemaVersion'] === 2) {
-        if (!reservationId) throw new Error('결제 예약 식별자가 없습니다.');
-        await this.capacity.consumeReservationInTransaction(tx, {
-          reservationId,
-          orderId,
-          paymentId: orderId,
+        if (this.isLegacyTimeoutPaymentCandidate(freshOrder)) {
+          await reacquireLegacyDailyCapacityInTransaction(this.firestore, tx, orderId, freshOrder);
+        }
+        if (freshOrder['schemaVersion'] === 2) {
+          if (!reservationId) throw new Error('결제 예약 식별자가 없습니다.');
+          await this.capacity.consumeReservationInTransaction(tx, {
+            reservationId,
+            orderId,
+            paymentId: orderId,
+          });
+        }
+        tx.update(orderRef, {
+          status: freshOrder['saleType'] === 'group' ? 'RECRUITING' : 'ACCEPTED',
+          ...(reservationId ? { reservationId } : {}),
+          updatedAt: now,
         });
-      }
-      tx.update(orderRef, {
-        status: freshOrder['saleType'] === 'group' ? 'RECRUITING' : 'ACCEPTED',
-        ...(reservationId ? { reservationId } : {}),
-        updatedAt: now,
+        const finalStatus = freshOrder['saleType'] === 'group' ? 'RECRUITING' : 'ACCEPTED';
+        await this.writePaidPaymentInTransaction(
+          tx,
+          orderId,
+          freshOrder,
+          paymentData,
+          now,
+          finalStatus,
+        );
+        applied = true;
       });
-      const finalStatus = freshOrder['saleType'] === 'group' ? 'RECRUITING' : 'ACCEPTED';
-      await this.writePaidPaymentInTransaction(
-        tx,
-        orderId,
-        freshOrder,
-        paymentData,
-        now,
-        finalStatus,
-      );
-      applied = true;
-    });
+    } catch (error) {
+      if (error instanceof LegacyDailyCapacityError) {
+        await this.portone.refund(
+          orderId,
+          paymentData.amount.total,
+          LEGACY_LATE_PAYMENT_REFUND_REASON,
+        );
+        await this.recordLateRefund(
+          orderId,
+          order,
+          paymentData,
+          LEGACY_LATE_PAYMENT_REFUND_REASON,
+        );
+        return { ok: false, reason: 'late_payment_refunded' };
+      }
+      throw error;
+    }
     if (cancellationOutcome === 'REFUND') {
       try {
         await this.refunds.refundByOrderId(
@@ -189,22 +217,16 @@ export class PaymentFinalizationService {
       const orderSnap = await tx.get(orderRef);
       if (!orderSnap.exists || orderSnap.data()?.['status'] !== 'PENDING') return;
       const order = orderSnap.data() as Record<string, any>;
-      if (order['schemaVersion'] === 2 && order['reservationId']) {
-        await this.capacity.releaseReservationInTransaction(
-          tx,
-          order['reservationId'],
-          reason === 'timeout' ? 'EXPIRED' : 'RELEASED',
-        );
-      } else if (order['deliveryMethod'] !== 'parcel') {
-        const createdAt = order['createdAt'];
-        const date =
-          order['requestedDeliveryDate'] ??
-          (typeof createdAt?.toDate === 'function'
-            ? createdAt.toDate().toISOString().split('T')[0]
-            : new Date(createdAt).toISOString().split('T')[0]);
-        tx.update(this.firestore.doc(`dailyCaps/${order['storeId']}_${date}`), {
-          usedSlots: this.firestore.FieldValue.increment(-(order['quantity'] ?? 0)),
-        });
+      if (order['schemaVersion'] === 2) {
+        if (order['reservationId']) {
+          await this.capacity.releaseReservationInTransaction(
+            tx,
+            order['reservationId'],
+            reason === 'timeout' ? 'EXPIRED' : 'RELEASED',
+          );
+        }
+      } else {
+        await releaseLegacyDailyCapacityInTransaction(this.firestore, tx, orderId, reason);
       }
       tx.update(orderRef, { status: 'CANCELLED', cancelReason: reason, updatedAt: now });
       applied = true;
@@ -225,6 +247,14 @@ export class PaymentFinalizationService {
     return (
       (order['status'] === 'CANCELLED' && order['cancelReason'] !== 'timeout') ||
       ['LOCAL_PENDING', 'LOCAL_FAILED', 'REFUNDING'].includes(order['cancellation']?.['status'])
+    );
+  }
+
+  private isLegacyTimeoutPaymentCandidate(order: Record<string, any>) {
+    return (
+      order['status'] === 'CANCELLED' &&
+      order['cancelReason'] === 'timeout' &&
+      isLegacyDailyCapacityEligible(order)
     );
   }
 
@@ -283,6 +313,7 @@ export class PaymentFinalizationService {
     orderId: string,
     order: Record<string, any>,
     paymentData: PaymentData,
+    refundReason = LATE_PAYMENT_REFUND_REASON,
   ) {
     const now = this.firestore.Timestamp.now();
     await this.firestore.runTransaction(async (tx) => {
@@ -302,7 +333,7 @@ export class PaymentFinalizationService {
         portoneTransactionId: paymentData.transactionId,
         refundAmount: paymentData.amount.total,
         refundedAt: now,
-        refundReason: LATE_PAYMENT_REFUND_REASON,
+        refundReason,
         refundClaim: null,
         createdAt: now,
         updatedAt: now,

--- a/apps/api/src/products/dto/create-product.dto.ts
+++ b/apps/api/src/products/dto/create-product.dto.ts
@@ -9,6 +9,7 @@ import {
   Min,
   ValidateNested,
 } from 'class-validator';
+import { COLOR_OPTIONS, type ColorOption } from '@greenhub/shared';
 
 import { Type } from 'class-transformer';
 
@@ -41,8 +42,8 @@ export class GroupConfigDto {
 
 export class SelectionDto {
   @IsArray()
-  @IsString({ each: true })
-  colors: string[];
+  @IsEnum(COLOR_OPTIONS, { each: true })
+  colors: ColorOption[];
 
   @IsEnum(['외대', '쌍대', '가지', '3대'])
   stemType: string;

--- a/apps/api/src/products/dto/product-contract.spec.ts
+++ b/apps/api/src/products/dto/product-contract.spec.ts
@@ -1,0 +1,71 @@
+import 'reflect-metadata';
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { COLOR_OPTIONS } from '@greenhub/shared';
+import { CreateProductDto } from './create-product.dto';
+import { ProductQueryDto } from './product-query.dto';
+
+const validProduct = {
+  name: '테스트 상품',
+  images: ['https://example.com/product.jpg'],
+  price: 10000,
+  category: 'cut_flower',
+  saleType: 'normal',
+  deliverySize: 'small',
+  selection: {
+    colors: [...COLOR_OPTIONS],
+    stemType: '외대',
+    fragrance: 'none',
+    bloomCondition: 'half',
+    bundleUnit: '1단',
+  },
+};
+
+describe('상품 ColorOption 계약', () => {
+  it('현재 19개 색상을 상품 입력에서 허용한다', async () => {
+    const errors = await validate(plainToInstance(CreateProductDto, validProduct));
+
+    expect(errors).toHaveLength(0);
+  });
+
+  it.each([
+    ['단일 잘못된 색상', ['알 수 없는 색상']],
+    ['유효·잘못된 색상 혼합', ['레드', '알 수 없는 색상']],
+  ])('%s을 거부한다', async (_label, colors) => {
+    const errors = await validate(
+      plainToInstance(CreateProductDto, {
+        ...validProduct,
+        selection: { ...validProduct.selection, colors },
+      }),
+    );
+
+    expect(errors).not.toHaveLength(0);
+  });
+
+  it('배열이 아닌 단일 색상 값도 거부한다', async () => {
+    const errors = await validate(
+      plainToInstance(CreateProductDto, {
+        ...validProduct,
+        selection: { ...validProduct.selection, colors: '레드' },
+      }),
+    );
+
+    expect(errors).not.toHaveLength(0);
+  });
+});
+
+describe('상품 색상 조회 필터 계약', () => {
+  it('반복·쉼표 구분 색상을 정규화하고 허용한다', async () => {
+    const query = plainToInstance(ProductQueryDto, { colors: ['레드', '핑크,화이트'] });
+    const errors = await validate(query);
+
+    expect(errors).toHaveLength(0);
+    expect(query.colors).toEqual(['레드', '핑크', '화이트']);
+  });
+
+  it('잘못된 색상 필터를 거부한다', async () => {
+    const errors = await validate(plainToInstance(ProductQueryDto, { colors: '레드,오류' }));
+
+    expect(errors).not.toHaveLength(0);
+  });
+});

--- a/apps/api/src/products/dto/product-query.dto.ts
+++ b/apps/api/src/products/dto/product-query.dto.ts
@@ -1,5 +1,6 @@
 import { IsOptional, IsEnum, IsBoolean } from 'class-validator';
 import { Transform } from 'class-transformer';
+import { COLOR_OPTIONS, type ColorOption } from '@greenhub/shared';
 
 export class ProductQueryDto {
   @IsOptional()
@@ -7,7 +8,16 @@ export class ProductQueryDto {
   category?: string;
 
   @IsOptional()
-  colors?: string | string[];
+  @Transform(({ value }) => {
+    if (value === undefined || value === null || value === '') return undefined;
+    const values = Array.isArray(value) ? value : [value];
+    return values
+      .flatMap((item) => String(item).split(','))
+      .map((item) => item.trim())
+      .filter(Boolean);
+  })
+  @IsEnum(COLOR_OPTIONS, { each: true })
+  colors?: ColorOption[];
 
   @IsOptional()
   @IsEnum(['normal', 'group'])

--- a/apps/api/src/products/products.service.spec.ts
+++ b/apps/api/src/products/products.service.spec.ts
@@ -58,3 +58,36 @@ describe('공개 상품 API', () => {
     await expect(service.getPublicProduct(product.id)).resolves.toEqual(product);
   });
 });
+
+describe('legacy daily cap 날짜 기본값', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('KST 자정 직후에도 오늘 날짜를 KST 기준으로 조회한다', async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-08-24T15:30:00.000Z'));
+
+    const calls: unknown[][] = [];
+    const query = {} as {
+      where: jest.Mock;
+      get: jest.Mock;
+    };
+    query.where = jest.fn((...args: unknown[]) => {
+      calls.push(args);
+      return query;
+    });
+    query.get = jest.fn().mockResolvedValue({ docs: [] });
+
+    const firestore = {
+      doc: jest.fn(),
+      collection: jest.fn().mockReturnValue(query),
+    };
+    const service = new ProductsService(firestore as never);
+
+    await service.getDailyCaps('store-1', 'seller-1', undefined, undefined, 'admin');
+
+    expect(calls).toContainEqual(['date', '>=', '2026-08-25']);
+    expect(calls).toContainEqual(['date', '<=', '2026-08-25']);
+  });
+});

--- a/apps/api/src/products/products.service.ts
+++ b/apps/api/src/products/products.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, NotFoundException, ForbiddenException } from '@nestjs/common';
 import { v4 as uuidv4 } from 'uuid';
+import { todayKST } from '@greenhub/shared';
 import { FirestoreService } from '../firestore/firestore.service';
 import { CreateProductDto } from './dto/create-product.dto';
 import { ProductQueryDto } from './dto/product-query.dto';
@@ -205,7 +206,7 @@ export class ProductsService {
   async getDailyCaps(storeId: string, sellerId: string, from?: string, to?: string, role?: string) {
     await this.assertSellerOwnsStore(storeId, sellerId, role);
 
-    const today = new Date().toISOString().split('T')[0];
+    const today = todayKST();
     const fromDate = from ?? today;
     const toDate = to ?? today;
 

--- a/apps/api/src/settlements/settlements.service.spec.ts
+++ b/apps/api/src/settlements/settlements.service.spec.ts
@@ -1,0 +1,125 @@
+import { SettlementsService } from './settlements.service';
+
+function makeService(records: Array<Record<string, unknown>> = []) {
+  const calls: unknown[][] = [];
+  const query = {} as {
+    where: jest.Mock;
+    orderBy: jest.Mock;
+    get: jest.Mock;
+  };
+  query.where = jest.fn((...args: unknown[]) => {
+    calls.push(args);
+    return query;
+  });
+  query.orderBy = jest.fn((...args: unknown[]) => {
+    calls.push(args);
+    return query;
+  });
+  query.get = jest.fn().mockImplementation(async () => ({
+    docs: records
+      .filter((record) =>
+        calls.every(([field, operator, expected]) => {
+          if (field !== 'settledAt' || (operator !== '>=' && operator !== '<')) return true;
+          const actual = record['settledAt'];
+          if (!(actual instanceof Date) || !(expected instanceof Date)) return false;
+          if (operator === '>=') return actual.getTime() >= expected.getTime();
+          if (operator === '<') return actual.getTime() < expected.getTime();
+          return true;
+        }),
+      )
+      .map((record) => ({ data: () => record })),
+  }));
+
+  const firestore = {
+    collection: jest.fn().mockReturnValue(query),
+    doc: jest.fn(),
+    Timestamp: {
+      fromDate: jest.fn((date: Date) => date),
+      now: jest.fn(() => new Date('2026-08-25T00:00:00.000Z')),
+    },
+  };
+  const config = { get: jest.fn().mockReturnValue(undefined) };
+  return { calls, service: new SettlementsService(firestore as never, config as never) };
+}
+
+describe('SettlementsService KST 날짜 범위', () => {
+  it('동일한 from/to는 KST 하루의 start inclusive와 endExclusive를 사용한다', async () => {
+    const { calls, service } = makeService();
+
+    await service.getSettlements('store-1', 'admin-1', 'admin', {
+      from: '2026-08-24',
+      to: '2026-08-24',
+    });
+
+    expect(calls).toContainEqual([
+      'settledAt',
+      '>=',
+      new Date('2026-08-23T15:00:00.000Z'),
+    ]);
+    expect(calls).toContainEqual([
+      'settledAt',
+      '<',
+      new Date('2026-08-24T15:00:00.000Z'),
+    ]);
+  });
+
+  it('여러 날 범위는 from 날짜 시작부터 to 다음 날 시작 직전까지 포함한다', async () => {
+    const { calls, service } = makeService();
+
+    await service.getSettlements('store-1', 'admin-1', 'admin', {
+      from: '2026-08-24',
+      to: '2026-08-26',
+    });
+
+    expect(calls).toContainEqual([
+      'settledAt',
+      '>=',
+      new Date('2026-08-23T15:00:00.000Z'),
+    ]);
+    expect(calls).toContainEqual([
+      'settledAt',
+      '<',
+      new Date('2026-08-26T15:00:00.000Z'),
+    ]);
+  });
+
+  it('endExclusive 직전 레코드는 포함하고 정확히 위치한 레코드는 제외한다', async () => {
+    const { service } = makeService([
+      { id: 'before-end', settledAt: new Date('2026-08-24T14:59:59.999Z') },
+      { id: 'at-end', settledAt: new Date('2026-08-24T15:00:00.000Z') },
+    ]);
+
+    const result = await service.getSettlements('store-1', 'admin-1', 'admin', {
+      from: '2026-08-24',
+      to: '2026-08-24',
+    });
+
+    expect(result.settlements.map((settlement: Record<string, unknown>) => settlement['id'])).toEqual([
+      'before-end',
+    ]);
+  });
+
+  it('summary 기본 날짜도 KST business date를 사용한다', async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-08-24T15:30:00.000Z'));
+
+    try {
+      const { calls, service } = makeService();
+      const result = await service.getSummary('store-1', 'admin-1', 'admin', {});
+
+      expect(result.date).toBe('2026-08-25');
+      expect(calls).toContainEqual([
+        'settledAt',
+        '>=',
+        new Date('2026-08-24T15:00:00.000Z'),
+      ]);
+      expect(calls).toContainEqual([
+        'settledAt',
+        '<',
+        new Date('2026-08-25T15:00:00.000Z'),
+      ]);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});

--- a/apps/api/src/settlements/settlements.service.ts
+++ b/apps/api/src/settlements/settlements.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, ForbiddenException, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Cron } from '@nestjs/schedule';
+import { dateRangeKST, todayKST } from '@greenhub/shared';
 import { FirestoreService } from '../firestore/firestore.service';
 import { QuerySettlementsDto, QuerySummaryDto } from './dto/query-settlements.dto';
 import { calcFee } from './_lib/fee-calculator';
@@ -77,13 +78,12 @@ export class SettlementsService {
       ref = ref.where('status', '==', dto.status);
     }
     if (dto.from) {
-      ref = ref.where('settledAt', '>=', this.firestore.Timestamp.fromDate(new Date(dto.from)));
+      const { start } = dateRangeKST(dto.from);
+      ref = ref.where('settledAt', '>=', this.firestore.Timestamp.fromDate(start));
     }
     if (dto.to) {
-      // to 날짜 23:59:59까지 포함
-      const toDate = new Date(dto.to);
-      toDate.setHours(23, 59, 59, 999);
-      ref = ref.where('settledAt', '<=', this.firestore.Timestamp.fromDate(toDate));
+      const { endExclusive } = dateRangeKST(dto.to);
+      ref = ref.where('settledAt', '<', this.firestore.Timestamp.fromDate(endExclusive));
     }
 
     // N10(F-2): 어드민(desc)과 정렬 방향 통일 — 양 화면 settledAt 최신순.
@@ -98,17 +98,15 @@ export class SettlementsService {
   async getSummary(storeId: string, requesterId: string, role: string, dto: QuerySummaryDto) {
     await this.verifyOwnership(storeId, requesterId, role);
 
-    const targetDate = dto.date ?? new Date().toISOString().split('T')[0];
-    const start = new Date(targetDate);
-    const end = new Date(targetDate);
-    end.setHours(23, 59, 59, 999);
+    const targetDate = dto.date ?? todayKST();
+    const { start, endExclusive } = dateRangeKST(targetDate);
 
     const snap = await (
       this.firestore
         .collection('settlements')
         .where('storeId', '==', storeId)
         .where('settledAt', '>=', this.firestore.Timestamp.fromDate(start))
-        .where('settledAt', '<=', this.firestore.Timestamp.fromDate(end)) as any
+        .where('settledAt', '<', this.firestore.Timestamp.fromDate(endExclusive)) as any
     ).get();
 
     const settlements: Record<string, unknown>[] = snap.docs.map((d: any) => d.data());

--- a/apps/api/src/varieties/dto/create-variety.dto.ts
+++ b/apps/api/src/varieties/dto/create-variety.dto.ts
@@ -1,4 +1,5 @@
 import { IsString, IsEnum, IsBoolean, IsArray, IsOptional } from 'class-validator';
+import { COLOR_OPTIONS, type ColorOption, type StemType } from '@greenhub/shared';
 
 export class CreateVarietyDto {
   @IsString()
@@ -18,7 +19,7 @@ export class CreateVarietyDto {
 
   @IsArray()
   @IsEnum(['외대', '쌍대', '가지', '3대'], { each: true })
-  availableStemTypes: string[];
+  availableStemTypes: StemType[];
 
   @IsBoolean()
   hasFragrance: boolean;
@@ -33,8 +34,8 @@ export class CreateVarietyDto {
   careLevel: string;
 
   @IsArray()
-  @IsString({ each: true })
-  typicalColors: string[];
+  @IsEnum(COLOR_OPTIONS, { each: true })
+  typicalColors: ColorOption[];
 
   @IsOptional()
   @IsString()

--- a/apps/api/src/varieties/dto/update-variety.dto.ts
+++ b/apps/api/src/varieties/dto/update-variety.dto.ts
@@ -1,4 +1,5 @@
 import { IsString, IsEnum, IsBoolean, IsArray, IsOptional } from 'class-validator';
+import { COLOR_OPTIONS, type ColorOption, type FlowerSize, type PlantSize, type StemType } from '@greenhub/shared';
 
 export class UpdateVarietyDto {
   @IsOptional()
@@ -12,6 +13,19 @@ export class UpdateVarietyDto {
   @IsOptional()
   @IsString()
   subCategory?: string;
+
+  @IsOptional()
+  @IsEnum(['small', 'medium', 'large'])
+  flowerSize?: FlowerSize;
+
+  @IsOptional()
+  @IsEnum(['small', 'medium', 'large'])
+  plantSize?: PlantSize;
+
+  @IsOptional()
+  @IsArray()
+  @IsEnum(['외대', '쌍대', '가지', '3대'], { each: true })
+  availableStemTypes?: StemType[];
 
   @IsOptional()
   @IsBoolean()
@@ -31,8 +45,8 @@ export class UpdateVarietyDto {
 
   @IsOptional()
   @IsArray()
-  @IsString({ each: true })
-  typicalColors?: string[];
+  @IsEnum(COLOR_OPTIONS, { each: true })
+  typicalColors?: ColorOption[];
 
   @IsOptional()
   @IsString()

--- a/apps/api/src/varieties/dto/variety-contract.spec.ts
+++ b/apps/api/src/varieties/dto/variety-contract.spec.ts
@@ -1,0 +1,62 @@
+import 'reflect-metadata';
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { COLOR_OPTIONS } from '@greenhub/shared';
+import { CreateVarietyDto } from './create-variety.dto';
+import { UpdateVarietyDto } from './update-variety.dto';
+
+const validCreate = {
+  name: '테스트 품종',
+  category: 'orchid',
+  subCategory: 'phalaenopsis',
+  flowerSize: 'small',
+  plantSize: 'medium',
+  availableStemTypes: ['외대'],
+  hasFragrance: false,
+  fragranceLevel: 'none',
+  bloomDuration: '60~90일',
+  careLevel: 'normal',
+  typicalColors: [...COLOR_OPTIONS],
+};
+
+describe('품종 ColorOption 계약', () => {
+  it('생성 시 현재 19개 색상을 허용한다', async () => {
+    const errors = await validate(plainToInstance(CreateVarietyDto, validCreate));
+
+    expect(errors).toHaveLength(0);
+  });
+
+  it('생성 시 잘못된 색상을 거부한다', async () => {
+    const errors = await validate(
+      plainToInstance(CreateVarietyDto, { ...validCreate, typicalColors: ['레드', '오류'] }),
+    );
+
+    expect(errors).not.toHaveLength(0);
+  });
+});
+
+describe('품종 PATCH 계약', () => {
+  it('mutable 품종 속성을 부분 수정할 수 있다', async () => {
+    const dto = plainToInstance(UpdateVarietyDto, {
+      flowerSize: 'large',
+      plantSize: 'small',
+      availableStemTypes: ['쌍대', '3대'],
+      typicalColors: ['핑크', '화이트'],
+      notes: '수정된 메모',
+    });
+    const errors = await validate(dto);
+
+    expect(errors).toHaveLength(0);
+  });
+
+  it('기존 enum validation을 유지한다', async () => {
+    const errors = await validate(
+      plainToInstance(UpdateVarietyDto, {
+        flowerSize: 'huge',
+        availableStemTypes: ['알 수 없는 줄기'],
+      }),
+    );
+
+    expect(errors).not.toHaveLength(0);
+  });
+});

--- a/apps/api/src/varieties/varieties.service.spec.ts
+++ b/apps/api/src/varieties/varieties.service.spec.ts
@@ -1,0 +1,76 @@
+import 'reflect-metadata';
+import { plainToInstance } from 'class-transformer';
+import { VarietiesService } from './varieties.service';
+import { UpdateVarietyDto } from './dto/update-variety.dto';
+
+describe('VarietiesService.update', () => {
+  it('mutable 품종 속성을 PATCH하고 기존 필드도 함께 갱신한다', async () => {
+    const update = jest.fn().mockResolvedValue(undefined);
+    const existing = {
+      name: '기존 품종',
+      flowerSize: 'small',
+      plantSize: 'medium',
+      availableStemTypes: ['외대'],
+      notes: '기존 메모',
+    };
+    const document = {
+      get: jest.fn().mockResolvedValue({ exists: true, data: () => existing }),
+      update,
+    };
+    const collection = { doc: jest.fn().mockReturnValue(document) };
+    const firestore = { collection: jest.fn().mockReturnValue(collection) };
+    const service = new VarietiesService(firestore as never);
+    const dto = plainToInstance(UpdateVarietyDto, {
+      flowerSize: 'large',
+      plantSize: 'small',
+      availableStemTypes: ['쌍대', '3대'],
+      notes: '새 메모',
+    });
+
+    const result = await service.update('variety-1', dto);
+
+    expect(update).toHaveBeenCalledWith({
+      flowerSize: 'large',
+      plantSize: 'small',
+      availableStemTypes: ['쌍대', '3대'],
+      notes: '새 메모',
+    });
+    expect(result).toMatchObject({
+      flowerSize: 'large',
+      plantSize: 'small',
+      availableStemTypes: ['쌍대', '3대'],
+      notes: '새 메모',
+    });
+  });
+
+  it('생략한 필드는 기존 값을 유지한다', async () => {
+    const update = jest.fn().mockResolvedValue(undefined);
+    const existing = {
+      name: '기존 품종',
+      flowerSize: 'small',
+      plantSize: 'medium',
+      availableStemTypes: ['외대'],
+      notes: '기존 메모',
+    };
+    const document = {
+      get: jest.fn().mockResolvedValue({ exists: true, data: () => existing }),
+      update,
+    };
+    const collection = { doc: jest.fn().mockReturnValue(document) };
+    const firestore = { collection: jest.fn().mockReturnValue(collection) };
+    const service = new VarietiesService(firestore as never);
+
+    const result = await service.update(
+      'variety-1',
+      plainToInstance(UpdateVarietyDto, { notes: '새 메모' }),
+    );
+
+    expect(update).toHaveBeenCalledWith({ notes: '새 메모' });
+    expect(result).toMatchObject({
+      flowerSize: 'small',
+      plantSize: 'medium',
+      availableStemTypes: ['외대'],
+      notes: '새 메모',
+    });
+  });
+});

--- a/apps/api/src/varieties/varieties.service.ts
+++ b/apps/api/src/varieties/varieties.service.ts
@@ -38,10 +38,13 @@ export class VarietiesService {
   async update(id: string, dto: UpdateVarietyDto) {
     const doc = await this.firestore.collection('varieties').doc(id).get();
     if (!doc.exists) throw new NotFoundException(`품종을 찾을 수 없습니다: ${id}`);
+    const changes = Object.fromEntries(
+      Object.entries(dto).filter(([, value]) => value !== undefined),
+    );
     await this.firestore
       .collection('varieties')
       .doc(id)
-      .update({ ...dto });
-    return { id, ...doc.data(), ...dto };
+      .update(changes);
+    return { id, ...doc.data(), ...changes };
   }
 }

--- a/apps/consumer/src/app/category/page.tsx
+++ b/apps/consumer/src/app/category/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { Category, ColorOption, Product, SaleRoundItem, SalesMode } from '@greenhub/shared';
+import type { Category, ColorOption, Product, SaleRoundItem, SaleType, SalesMode } from '@greenhub/shared';
 import { normalizeSalesMode } from '@greenhub/shared';
 import {
   Box,
@@ -24,7 +24,7 @@ import { useProducts } from '@/hooks/useProducts';
 import { type PublicSaleRound, useSaleRounds } from '@/hooks/useSaleRounds';
 import { db } from '@/lib/firebase';
 
-const TABS: { label: string; value: Category | undefined; saleType?: 'group' | 'direct' }[] = [
+const TABS: { label: string; value: Category | undefined; saleType?: SaleType }[] = [
   { label: '전체', value: undefined },
   { label: '공동구매', value: undefined, saleType: 'group' },
   { label: '절화', value: 'cut_flower' },

--- a/apps/consumer/src/app/products/[id]/_components/DeliveryDatePicker.test.mjs
+++ b/apps/consumer/src/app/products/[id]/_components/DeliveryDatePicker.test.mjs
@@ -1,0 +1,18 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+const source = await readFile(new URL('./DeliveryDatePicker.tsx', import.meta.url), 'utf8');
+
+test('배송일 picker는 KST today와 UTC 독립 달력 계산을 사용한다', () => {
+  assert.match(source, /import \{ todayKST \} from '@greenhub\/shared'/);
+  assert.match(source, /const todayStr = todayKST\(\)/);
+  assert.match(source, /Date\.UTC\(year, month, 1\)/);
+  assert.match(source, /getUTCDay\(\)/);
+  assert.doesNotMatch(source, /toISOString\(\)\.split\('T'\)/);
+});
+
+test('배송일 picker의 선택일 표시는 Asia/Seoul 기준이다', () => {
+  assert.match(source, /T00:00:00\+09:00/);
+  assert.match(source, /timeZone: 'Asia\/Seoul'/);
+});

--- a/apps/consumer/src/app/products/[id]/_components/DeliveryDatePicker.tsx
+++ b/apps/consumer/src/app/products/[id]/_components/DeliveryDatePicker.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
+import { todayKST } from '@greenhub/shared';
 import { ActionIcon, Box, Group, Paper, SimpleGrid, Text } from '@mantine/core';
 import { useDeliverySlots } from '@/hooks/useDailyCap';
 
@@ -20,8 +21,8 @@ function toDateStr(year: number, month: number, day: number): string {
 
 /** 해당 월의 주 단위 날짜 그리드 (앞쪽 빈칸은 null) */
 function buildCalendar(year: number, month: number): (string | null)[][] {
-  const firstDay = new Date(year, month, 1).getDay();
-  const daysInMonth = new Date(year, month + 1, 0).getDate();
+  const firstDay = new Date(Date.UTC(year, month, 1)).getUTCDay();
+  const daysInMonth = new Date(Date.UTC(year, month + 1, 0)).getUTCDate();
   const weeks: (string | null)[][] = [];
   let week: (string | null)[] = Array(firstDay).fill(null);
 
@@ -46,23 +47,28 @@ function buildCalendar(year: number, month: number): (string | null)[][] {
  * 월 이동은 당월 + 익월 2개월로 제한.
  */
 export default function DeliveryDatePicker({ storeId, value, onChange }: Props) {
-  const now = useMemo(() => new Date(), []);
+  const todayStr = todayKST();
+  const [todayYear, todayMonth] = todayStr.split('-').map(Number);
   // 0 = 당월, 1 = 익월
   const [monthOffset, setMonthOffset] = useState(0);
 
-  const viewYear = now.getFullYear() + Math.floor((now.getMonth() + monthOffset) / 12);
-  const viewMonth = (now.getMonth() + monthOffset) % 12;
+  const viewYear = todayYear + Math.floor((todayMonth - 1 + monthOffset) / 12);
+  const viewMonth = (todayMonth - 1 + monthOffset) % 12;
 
   // 당월 1일 ~ 익월 말일 범위를 한 번에 구독 (월 이동 시 재쿼리 불필요)
-  const from = toDateStr(now.getFullYear(), now.getMonth(), 1);
-  const toMonthDate = new Date(now.getFullYear(), now.getMonth() + 2, 0);
-  const to = toDateStr(toMonthDate.getFullYear(), toMonthDate.getMonth(), toMonthDate.getDate());
+  const from = toDateStr(todayYear, todayMonth - 1, 1);
+  const toMonthDate = new Date(Date.UTC(todayYear, todayMonth + 1, 0));
+  const to = toDateStr(
+    toMonthDate.getUTCFullYear(),
+    toMonthDate.getUTCMonth(),
+    toMonthDate.getUTCDate(),
+  );
 
   const { slots, loading } = useDeliverySlots(storeId, from, to);
 
   const calendar = buildCalendar(viewYear, viewMonth);
-  const todayStr = now.toISOString().split('T')[0];
-  const monthLabel = new Date(viewYear, viewMonth).toLocaleDateString('ko-KR', {
+  const monthLabel = new Date(Date.UTC(viewYear, viewMonth, 1)).toLocaleDateString('ko-KR', {
+    timeZone: 'Asia/Seoul',
     year: 'numeric',
     month: 'long',
   });
@@ -212,7 +218,8 @@ export default function DeliveryDatePicker({ storeId, value, onChange }: Props) 
         mt="xs"
       >
         {value
-          ? `선택: ${new Date(value).toLocaleDateString('ko-KR', {
+          ? `선택: ${new Date(`${value}T00:00:00+09:00`).toLocaleDateString('ko-KR', {
+              timeZone: 'Asia/Seoul',
               month: 'long',
               day: 'numeric',
               weekday: 'short',

--- a/apps/consumer/src/hooks/useDailyCap.test.mjs
+++ b/apps/consumer/src/hooks/useDailyCap.test.mjs
@@ -1,0 +1,11 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+const source = await readFile(new URL('./useDailyCap.ts', import.meta.url), 'utf8');
+
+test('useDailyCap의 기본 daily cap key는 KST business date를 사용한다', () => {
+  assert.match(source, /import \{ todayKST \} from '@greenhub\/shared'/);
+  assert.match(source, /date \?\? todayKST\(\)/);
+  assert.doesNotMatch(source, /toISOString\(\)\.split\('T'\)/);
+});

--- a/apps/consumer/src/hooks/useDailyCap.ts
+++ b/apps/consumer/src/hooks/useDailyCap.ts
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { collection, doc, onSnapshot, query, where } from 'firebase/firestore';
+import { todayKST } from '@greenhub/shared';
 import { db } from '@/lib/firebase';
 import type { DailyCap } from '@greenhub/shared';
 
@@ -21,7 +22,7 @@ export function useDailyCap(storeId: string | null, date?: string): UseDailyCapR
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const resolvedDate = date ?? new Date().toISOString().split('T')[0];
+  const resolvedDate = date ?? todayKST();
   const docId = storeId ? `${storeId}_${resolvedDate}` : null;
 
   useEffect(() => {

--- a/apps/consumer/src/hooks/useProducts.test.mjs
+++ b/apps/consumer/src/hooks/useProducts.test.mjs
@@ -1,0 +1,12 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const source = readFileSync(fileURLToPath(new URL('./useProducts.ts', import.meta.url)), 'utf8');
+
+test('소비자 상품 조회 훅은 shared SaleType을 사용한다', () => {
+  assert.match(source, /SaleType/);
+  assert.match(source, /saleType\?: SaleType/);
+  assert.doesNotMatch(source, /saleType\?: ['"]group['"] \| ['"]direct['"]/);
+});

--- a/apps/consumer/src/hooks/useProducts.ts
+++ b/apps/consumer/src/hooks/useProducts.ts
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react';
 import { doc, getDoc } from 'firebase/firestore';
 import { db } from '@/lib/firebase';
-import type { Product, Category, ColorOption, Variety } from '@greenhub/shared';
+import type { Product, Category, ColorOption, SaleType, Variety } from '@greenhub/shared';
 
 export interface StoreInfo {
   id: string;
@@ -23,7 +23,7 @@ const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3000';
 export function useProducts(
   category?: Category,
   colors?: ColorOption[],
-  saleType?: 'group' | 'direct',
+  saleType?: SaleType,
 ) {
   const [products, setProducts] = useState<Product[]>([]);
   const [loading, setLoading] = useState(true);

--- a/apps/seller/src/app/products/_components/TouchSelector.tsx
+++ b/apps/seller/src/app/products/_components/TouchSelector.tsx
@@ -1,28 +1,7 @@
 'use client';
 
 import { Badge, Button, Group, Paper, Stack, Text, TextInput } from '@mantine/core';
-
-const COLOR_OPTIONS = [
-  '레드',
-  '핑크',
-  '연핑크',
-  '로즈',
-  '화이트',
-  '크림',
-  '옐로우',
-  '골드',
-  '오렌지',
-  '퍼플',
-  '바이올렛',
-  '연보라',
-  '블루',
-  '그린',
-  '무늬',
-  '브라운',
-  '베이지',
-  '블랙',
-  '그레이',
-] as const;
+import { COLOR_OPTIONS } from '@greenhub/shared';
 
 const STEM_OPTIONS = [
   { value: '외대', label: '외대', desc: '1줄기' },

--- a/packages/shared/src/date.test.ts
+++ b/packages/shared/src/date.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { todayKST, toDateStrKST } from './date.js';
+import { dateRangeKST, todayKST, toDateStrKST } from './date.js';
 
 describe('todayKST', () => {
   afterEach(() => {
@@ -38,5 +38,39 @@ describe('toDateStrKST', () => {
     const base = new Date('2026-05-24T03:00:00Z'); // KST 5/24 정오
     const next = new Date(base.getTime() + 86400000); // KST 5/25 정오
     expect(toDateStrKST(next)).toBe('2026-05-25');
+  });
+
+  it.each([
+    ['KST 자정', '2026-08-23T15:00:00.000Z'],
+    ['KST 08:59:59.999', '2026-08-23T23:59:59.999Z'],
+    ['KST 09:00:00.000', '2026-08-24T00:00:00.000Z'],
+    ['KST 23:59:59.999', '2026-08-24T14:59:59.999Z'],
+  ])('%s 경계에서 KST business date를 유지한다', (_label, instant) => {
+    expect(toDateStrKST(new Date(instant))).toBe('2026-08-24');
+  });
+
+  it('다음 날 KST 자정에서 business date가 전환된다', () => {
+    expect(toDateStrKST(new Date('2026-08-24T15:00:00.000Z'))).toBe('2026-08-25');
+  });
+});
+
+describe('dateRangeKST', () => {
+  it('하루 범위는 KST 시작 inclusive와 다음 날 시작 exclusive를 반환한다', () => {
+    const range = dateRangeKST('2026-08-24');
+
+    expect(range.start.toISOString()).toBe('2026-08-23T15:00:00.000Z');
+    expect(range.endExclusive.toISOString()).toBe('2026-08-24T15:00:00.000Z');
+  });
+
+  it('입력 날짜가 여러 날이어도 하루 단위 범위 의미를 유지한다', () => {
+    const range = dateRangeKST('2026-08-26');
+
+    expect(range.start.toISOString()).toBe('2026-08-25T15:00:00.000Z');
+    expect(range.endExclusive.toISOString()).toBe('2026-08-26T15:00:00.000Z');
+  });
+
+  it('날짜 전용 형식이 아니거나 존재하지 않는 날짜를 거부한다', () => {
+    expect(() => dateRangeKST('2026-8-24')).toThrow(RangeError);
+    expect(() => dateRangeKST('2026-02-30')).toThrow(RangeError);
   });
 });

--- a/packages/shared/src/date.ts
+++ b/packages/shared/src/date.ts
@@ -10,6 +10,12 @@
  */
 
 const KST_OFFSET_MS = 9 * 60 * 60 * 1000;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export interface KSTDateRange {
+  start: Date;
+  endExclusive: Date;
+}
 
 /** KST 기준 오늘 날짜를 YYYY-MM-DD로 반환 (UTC 자정~오전9시 하루 밀림 방지) */
 export function todayKST(): string {
@@ -19,4 +25,30 @@ export function todayKST(): string {
 /** 주어진 시각의 KST 기준 날짜를 YYYY-MM-DD로 반환 */
 export function toDateStrKST(date: Date): string {
   return new Date(date.getTime() + KST_OFFSET_MS).toISOString().slice(0, 10);
+}
+
+/** KST 달력 날짜의 시작 시각과 다음 날 시작 시각을 UTC instant로 반환 */
+export function dateRangeKST(date: string): KSTDateRange {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(date);
+  if (!match) {
+    throw new RangeError(`KST 달력 날짜는 YYYY-MM-DD 형식이어야 합니다: ${date}`);
+  }
+
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const utcMidnight = new Date(0);
+  utcMidnight.setUTCFullYear(year, month - 1, day);
+  utcMidnight.setUTCHours(0, 0, 0, 0);
+
+  if (
+    utcMidnight.getUTCFullYear() !== year ||
+    utcMidnight.getUTCMonth() !== month - 1 ||
+    utcMidnight.getUTCDate() !== day
+  ) {
+    throw new RangeError(`유효하지 않은 KST 달력 날짜입니다: ${date}`);
+  }
+
+  const start = new Date(utcMidnight.getTime() - KST_OFFSET_MS);
+  return { start, endExclusive: new Date(start.getTime() + DAY_MS) };
 }

--- a/packages/shared/src/product.types.test.ts
+++ b/packages/shared/src/product.types.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest';
+import { COLOR_OPTIONS } from './product.types.js';
+
+describe('ColorOption 공통 계약', () => {
+  it('현재 색상 19개를 런타임 목록으로 제공한다', () => {
+    expect(COLOR_OPTIONS).toHaveLength(19);
+    expect(new Set(COLOR_OPTIONS).size).toBe(19);
+  });
+});

--- a/packages/shared/src/product.types.ts
+++ b/packages/shared/src/product.types.ts
@@ -1,25 +1,28 @@
 export type Category = 'cut_flower' | 'orchid' | 'foliage'
 
-export type ColorOption =
-  | '레드'
-  | '핑크'
-  | '연핑크'
-  | '로즈'
-  | '화이트'
-  | '크림'
-  | '옐로우'
-  | '골드'
-  | '오렌지'
-  | '퍼플'
-  | '바이올렛'
-  | '연보라'
-  | '블루'
-  | '그린'
-  | '무늬'
-  | '브라운'
-  | '베이지'
-  | '블랙'
-  | '그레이'
+export const COLOR_OPTIONS = [
+  '레드',
+  '핑크',
+  '연핑크',
+  '로즈',
+  '화이트',
+  '크림',
+  '옐로우',
+  '골드',
+  '오렌지',
+  '퍼플',
+  '바이올렛',
+  '연보라',
+  '블루',
+  '그린',
+  '무늬',
+  '브라운',
+  '베이지',
+  '블랙',
+  '그레이',
+] as const
+
+export type ColorOption = (typeof COLOR_OPTIONS)[number]
 
 export type DeliverySize = 'small' | 'medium' | 'large'
 


### PR DESCRIPTION
## Summary

Completes the bounded post-integration selective reintegration identified after the PR #51 main integration.

### Task A — Legacy Daily Capacity Recovery

- restore legacy normal direct/hub capacity lifecycle
- exclude group, parcel, and schemaVersion:2 round capacity
- recover capacity for payment failure/timeout and seller cancellation
- handle late PAID capacity reacquisition safely

### Task B — KST Date Boundary

- centralize KST date/range handling
- use start-inclusive / next-day-exclusive settlement ranges
- align product today, consumer daily capacity, and delivery date UI

### Task C — Contract Alignment

- enforce shared ColorOption runtime contract
- align SaleType to normal | group
- align Variety update DTO/service behavior

### Task D — Admin Convergence

- converge legacy Admin force-refund lifecycle
- fail closed on invalid order states
- add durable concurrent refund claim
- make provider-success/local-failure retry safe
- preserve Admin KST settlement range behavior

## Exact Candidate

46d4c900507ef2bc234f40fdf50d3bc03bf1a8a4

Base at verification:

80798e265a364f19fa051210c761b715d2fb4d18

## Verification

- API focused: 9 suites / 88 tests PASS
- API full unit: 48 suites / 393 tests PASS
- shared: 18 tests PASS
- consumer: 108 tests PASS
- full build/type verification PASS
- final regression gate: PASS
- worktree clean

## Safety Boundary

- no production deployment
- no actual PortOne payment/refund
- no ALIGO send
- no production Firebase/Firestore mutation
- no Railway mutation

This PR contains only the already verified 3-commit selective-reintegration candidate.