### PR TITLE
docs: ALIGO 회차 템플릿 8종 승인 상태 반영

### DIFF
--- a/docs/memory.md
+++ b/docs/memory.md
@@ -8,7 +8,7 @@
 
 - Git·GitHub: `2026-08-24 KST`
 - Vercel 배포 안전 증거: `2026-08-23 KST`
-- ALIGO 마지막 provider 상태: `2026-08-23`
+- ALIGO 마지막 provider 상태: `2026-08-27 KST`
 - 운영 상태 변경은 별도 승인 없이 수행하지 않는다.
 
 ## Git·배포 기준선
@@ -42,6 +42,7 @@
 - 회차 직배송 MVP는 `main` 통합 완료.
 - consumer 구매, seller 회차·주문, driver 직배송, 결제·환불·재배송비·보류·사진·운영 예외 흐름 존재.
 - 카카오 비즈니스 채널 승인 완료.
+- ALIGO 회차 알림 템플릿 8종 provider 승인 완료 — 2026-08-27 15:06 KST 경 provider UI에서 모두 `승인완료` 확인.
 - 운영 Firebase rules/indexes는 출시 전 read-only 재조회 필요.
 - production 회차 배포·첫 운영 회차·`salesMode` 전환 미실행.
 - 판매 모드: `legacy`.
@@ -147,17 +148,31 @@ repo-side 배포 방어는 완료. GitHub 관리자 레벨 PR required/required 
 
 ## ALIGO 상태
 
-마지막 provider snapshot:
+마지막 provider snapshot — 2026-08-27 15:06 KST 경:
 
 - 발신 프로필·senderkey 준비 완료.
 - 회차 알림 템플릿 8종 등록·심사 요청 완료.
-- 8종 모두 `검수중`.
+- 8종 모두 `승인완료`.
+- provider 심사 외부 blocker 해소.
 - 실제 알림톡·SMS 발송 0건.
 - production ALIGO 자격 증명·매핑 미반영.
 
-코드 레벨 알림톡 3회 retry→SMS fallback, 설정 fail-closed, notification delivery idempotency는 직접 테스트가 있다. 이를 실제 provider 승인·발송 증거로 확장하지 않는다.
+승인 템플릿:
 
-현재성이 필요하면 provider에서 다시 조회한다.
+- `UK_5691` 주문 접수
+- `UK_5692` 상품 준비 시작
+- `UK_5693` 배송 시작
+- `UK_5694` 배송 보류
+- `UK_5695` 재배송비 결제 요청
+- `UK_5696` 재배송 예정
+- `UK_5697` 배송 완료
+- `UK_5698` 주문 취소
+
+코드 레벨 알림톡 3회 retry→SMS fallback, 설정 fail-closed, notification delivery idempotency는 직접 테스트가 있다. 이를 실제 provider 발송 증거로 확장하지 않는다.
+
+승인 증거: `docs/reports/REPORT_aligo_template_approval_20260827.md`.
+
+다음 ALIGO gate는 provider code 1:1 매핑 확인 → 승인된 템플릿 격리 알림톡 → SMS fallback 실제 검증이다. 실제 발송과 production 설정은 별도 승인 없이는 수행하지 않는다.
 
 ## 판매 활성화 legal 상태
 
@@ -197,9 +212,9 @@ repo-side 배포 방어는 완료. GitHub 관리자 레벨 PR required/required 
 
 1. Task 2F-B candidate PR CI/merge를 진행하고, 이후 `AUTH-SESSION-CLAIM-REVOCATION` + `ORDER-DIRECT-READ-AUTHORIZATION-AND-MINIMIZATION` 결합 위험을 해결·직접 회귀한다.
 2. `ORDER-REDELIVERY-PAID-RESUME-GATE` 상태머신 전체 구현·직접 회귀.
-3. `SETTLEMENT-LIFECYCLE-COVERAGE`, `MARKETING-CONSENT-LIFECYCLE-CONSISTENCY`, admin privileged, webhook, payment finalization, admin refund, order mutation 등 나머지 P0를 ALIGO 심사와 병렬 해결.
+3. `SETTLEMENT-LIFECYCLE-COVERAGE`, `MARKETING-CONSENT-LIFECYCLE-CONSISTENCY`, admin privileged, webhook, payment finalization, admin refund, order mutation 등 나머지 P0를 병렬 해결.
 4. Issue #32.
-5. ALIGO 상태 재조회 → 승인 뒤 실제 알림톡/SMS fallback.
+5. ALIGO provider code 1:1 매핑 확인 → 승인된 템플릿 격리 알림톡 → SMS fallback 실제 검증.
 6. 모든 P0 결과 기준 legal 재정합화.
 7. actual release SHA → E2E 52+cleanup → Firebase 재조회 → 승인된 production 설정/배포.
 8. 첫 회차 검수 → 최종 승인 → `salesMode: round_direct`.

--- a/docs/plans/HANDOFF_mvp_round_direct_aligo_review_pause.md
+++ b/docs/plans/HANDOFF_mvp_round_direct_aligo_review_pause.md
@@ -1,19 +1,21 @@
 <!-- Language: ko -->
 
-# 회차 직배송 MVP — ALIGO 심사 대기 인계
+# 회차 직배송 MVP — ALIGO 승인 후 재개 인계
 
 > 현재 재개 지점만 관리한다. 상세 상태는 `docs/memory.md`, Acceptance Criteria는 `docs/BACKLOG.md`, 의존성은 `docs/plans/PLAN_mvp_round_direct_launch_blockers.md`를 따른다.
 
-## 현재 상태 — 2026-08-24 KST
+## 현재 상태 — 2026-08-27 KST
 
 - 회차 직배송 MVP `main` 통합 완료.
-- 카카오 비즈니스 채널, ALIGO 발신 프로필·senderkey, 회차 알림 템플릿 8종 등록·심사 요청 완료.
-- 마지막 provider 확인: 8종 모두 `검수중`, 실제 발송 0건.
+- 카카오 비즈니스 채널, ALIGO 발신 프로필·senderkey 준비 완료.
+- 회차 알림 템플릿 8종 provider 승인 완료.
+- 2026-08-27 15:06 KST 경 ALIGO SmartSMS 템플릿 관리 화면에서 8종 모두 `승인완료` 확인.
+- 실제 알림톡·SMS 발송 0건.
 - production ALIGO 설정 미반영.
 - 첫 운영 회차 미생성, `salesMode=legacy`.
 - production은 exact release SHA + 별도 승인 절차를 사용한다.
 
-현재 외부 차단점은 ALIGO 8종 심사 완료다. 재개 시 provider 상태를 다시 확인한다. 단, 출시 P0는 심사와 병렬 진행 가능하다.
+ALIGO 8종 provider 심사 차단점은 해소됐다. 승인 증거는 `docs/reports/REPORT_aligo_template_approval_20260827.md`를 따른다. 다음 ALIGO 단계는 provider code 1:1 매핑 확인 → 승인된 템플릿 격리 알림톡 → SMS fallback 검증이며, 실제 발송과 production 설정은 별도 승인 경계를 유지한다.
 
 병렬 출시 P0:
 
@@ -41,7 +43,7 @@
 - 현재 `origin/main`: `d6185bd`; candidate는 아직 main/production에 반영되지 않았다.
 - `AUTH-SESSION-CLAIM-REVOCATION`은 OPEN이며 refresh/session lifecycle 완료를 주장하지 않는다.
 
-다음 재개 지점은 candidate를 현재 main에 branch+PR로 통합하고 PR CI를 확인하는 절차다. 이후 `AUTH-SESSION-CLAIM-REVOCATION`, 최신 main의 redelivery 상태머신, admin refund, legal, ALIGO, exact-SHA E2E와 production 승인 게이트를 순서대로 진행한다.
+다음 재개 지점은 candidate를 현재 main에 branch+PR로 통합하고 PR CI를 확인하는 절차다. 이후 `AUTH-SESSION-CLAIM-REVOCATION`, 최신 main의 redelivery 상태머신, admin refund, legal, ALIGO provider 실제 검증, exact-SHA E2E와 production 승인 게이트를 순서대로 진행한다.
 
 ## 최우선 재개 — Driver 승인 + direct read 결합 위험
 
@@ -135,9 +137,9 @@ checkout consent는 order+retention에 저장되지만 MY 설정은 별도 user 
 
 ## 지금 하지 말 것
 
-- 심사 중 ALIGO 템플릿 중복 등록·임의 수정
-- 승인 전 실제 알림톡/SMS
-- secret/실제 tpl_code/개인정보 Git 기록
+- 승인된 ALIGO 템플릿 임의 수정·중복 등록
+- 별도 승인 없는 실제 알림톡/SMS
+- secret/실제 senderkey 원문/개인정보 Git 기록
 - direct `main`
 - main merge를 production 승인으로 해석
 - 승인 없는 production/Firebase/운영 회차/`salesMode`
@@ -161,24 +163,23 @@ checkout consent는 order+retention에 저장되지만 MY 설정은 별도 user 
 10. webhook signature real-verifier 회귀
 11. Issue #32
 12. read-only 문서/코드 감사
-13. ALIGO 상태 조회
+13. ALIGO provider code 1:1 매핑 read-only 확인
 
-## ALIGO 승인 뒤
+## ALIGO 승인 완료 후
 
 1. P0 10개 + Issue #32 완료 확인
-2. ALIGO 8종 상태 재확인
-3. provider code 1:1 검사
-4. 승인 후 격리 알림톡
-5. 승인 후 SMS fallback
-6. 실제 재배송/환불/정산/read-minimization/auth/marketing 결과 기준 legal 재정합화
-7. actual release SHA
-8. exact SHA E2E 52+cleanup
-9. 운영 Firebase read-only
-10. 승인 후 production ALIGO 설정
-11. exact-SHA deployment 절차
-12. 별도 Task 3.1 승인 뒤 production
-13. metadata SHA + smoke
-14. 첫 회차 → 최종 판정 → `round_direct`
+2. provider code 1:1 검사
+3. 승인된 8종 기준 격리 알림톡
+4. SMS fallback
+5. 실제 재배송/환불/정산/read-minimization/auth/marketing 결과 기준 legal 재정합화
+6. actual release SHA
+7. exact SHA E2E 52+cleanup
+8. 운영 Firebase read-only
+9. 승인 후 production ALIGO 설정
+10. exact-SHA deployment 절차
+11. 별도 Task 3.1 승인 뒤 production
+12. metadata SHA + smoke
+13. 첫 회차 → 최종 판정 → `round_direct`
 
 ## 완료 체크
 
@@ -186,6 +187,7 @@ checkout consent는 order+retention에 저장되지만 MY 설정은 별도 user 
 - [x] 카카오 채널 승인
 - [x] ALIGO sender profile/senderkey
 - [x] 8종 등록·심사 요청
+- [x] ALIGO 8종 승인 — 2026-08-27 provider UI 확인
 - [x] repo-side main auto-production 차단
 - [ ] driver approval/session revocation + public register/login gate
 - [ ] order direct read 최소화
@@ -198,7 +200,7 @@ checkout consent는 order+retention에 저장되지만 MY 설정은 별도 user 
 - [ ] marketing consent lifecycle consistency
 - [ ] webhook signature real-verifier coverage
 - [ ] Issue #32
-- [ ] ALIGO 8종 승인
+- [ ] provider code 1:1 매핑 검증
 - [ ] 실제 알림톡/SMS fallback
 - [ ] legal
 - [ ] release SHA E2E 52+cleanup

--- a/docs/plans/PLAN_mvp_round_direct_launch_blockers.md
+++ b/docs/plans/PLAN_mvp_round_direct_launch_blockers.md
@@ -6,9 +6,11 @@
 
 ## 메타
 
-- 최종 정합화: 2026-08-24 KST
-- 상태: `active_p0_parallel / aligo_external_review_pending`
-- 외부 차단점: ALIGO 8종 provider 심사 완료
+- 최종 정합화: 2026-08-27 KST
+- 상태: `active_p0_parallel / aligo_provider_approved`
+- 외부 ALIGO 심사 차단점: 해소 — 회차 템플릿 8종 `승인완료`
+- 다음 ALIGO gate: provider code 1:1 확인 → 격리 알림톡 → SMS fallback
+- 승인 증거: `docs/reports/REPORT_aligo_template_approval_20260827.md`
 - 상태 SSOT: `docs/memory.md`
 - 재개: `docs/plans/HANDOFF_mvp_round_direct_aligo_review_pause.md`
 - 미완료: `docs/BACKLOG.md`
@@ -40,8 +42,8 @@
 | 0I | admin privileged mutation authorization + settlement pay coverage | 미완료 — P0 COVERAGE GAP |
 | 0J | settlement 생성·confirm·cancel core lifecycle coverage | 미완료 — P0 COVERAGE GAP |
 | 0K | marketing consent→preference→withdrawal→retention lifecycle | 미완료 — P0 FINDING |
-| 1 | ALIGO 8종 최종 승인 | 검수중 |
-| 2 | 실제 알림톡 | 미실행 |
+| 1 | ALIGO 8종 최종 승인 | 완료 — 2026-08-27 provider UI 8종 `승인완료` |
+| 2 | provider code 1:1 검사 + 실제 알림톡 | 미실행 |
 | 3 | SMS fallback | 미실행 |
 | 4 | 판매 활성화 legal | 미실행 |
 | 5 | actual release SHA | 미실행 |
@@ -55,7 +57,7 @@
 
 1. repository 변경은 최신 `main` 기반 branch+PR.
 2. direct `main` 금지.
-3. 0A~0K는 ALIGO 심사와 병렬 가능.
+3. 0A~0K는 ALIGO provider 실제 검증과 병렬 가능.
 4. P0를 문서/UI 변경만으로 완료 처리하지 않는다.
 5. 금전·권한 불변식은 server boundary + 직접 거부/정상/동시성 회귀가 필요하다.
 6. driver 관리자 승인 계약은 public register/login, Kakao, refresh, Firebase claims까지 하나의 authorization lifecycle로 검증한다.
@@ -69,6 +71,7 @@
 14. production은 exact SHA/artifact + 별도 승인.
 15. provider metadata SHA 불일치 시 traffic 전환 금지.
 16. 첫 회차 `SCHEDULED` 전 `salesMode` 전환 금지.
+17. ALIGO provider 템플릿 승인과 실제 발송 검증을 구분하며, 승인만으로 production 알림 경로를 `VERIFIED` 처리하지 않는다.
 
 ## Phase 0 — 코드·권한·금전 안전성
 
@@ -191,10 +194,12 @@
 
 ## Phase 1 — ALIGO
 
-1. 8종 승인 (`blocked_external_review`)
-2. provider code 1:1 검사
-3. 승인 후 격리 실제 알림톡
-4. 승인 후 SMS fallback
+1. [x] 8종 provider 승인 — 2026-08-27 15:06 KST 경 모두 `승인완료`
+2. [ ] provider code 1:1 검사
+3. [ ] 승인된 템플릿 격리 실제 알림톡
+4. [ ] SMS fallback
+
+증거: `docs/reports/REPORT_aligo_template_approval_20260827.md`.
 
 ## Phase 2 — legal·release SHA
 

--- a/docs/reports/REPORT_aligo_template_approval_20260827.md
+++ b/docs/reports/REPORT_aligo_template_approval_20260827.md
@@ -1,0 +1,47 @@
+<!-- Language: ko -->
+
+# ALIGO 회차 알림 템플릿 8종 승인 확인 — 2026-08-27
+
+## 상태
+
+`ALIGO_8_TEMPLATES_APPROVED`
+
+## 확인 시각
+
+- 2026-08-27 15:06 KST 경 ALIGO SmartSMS 카카오 템플릿 관리 화면에서 직접 확인.
+- 카카오채널ID: `@greenlove` — 정상.
+- 아래 8종 모두 승인 상태가 `승인완료`로 표시됨.
+
+## 승인 템플릿
+
+| 템플릿코드 | 템플릿명 | 승인 상태 |
+|---|---|---|
+| `UK_5691` | 주문 접수 | 승인완료 |
+| `UK_5692` | 상품 준비 시작 | 승인완료 |
+| `UK_5693` | 배송 시작 | 승인완료 |
+| `UK_5694` | 배송 보류 | 승인완료 |
+| `UK_5695` | 재배송비 결제 요청 | 승인완료 |
+| `UK_5696` | 재배송 예정 | 승인완료 |
+| `UK_5697` | 배송 완료 | 승인완료 |
+| `UK_5698` | 주문 취소 | 승인완료 |
+
+## 이번 확인으로 닫힌 항목
+
+- ALIGO 회차 알림 템플릿 8종 provider 심사 대기.
+- `ALI-01 — ALIGO Template Approval` 외부 대기 상태.
+
+## 아직 닫히지 않은 항목
+
+이번 승인은 provider 템플릿 심사 완료만 의미한다. 다음은 별도 검증/승인이 필요하다.
+
+- 내부 logical template code ↔ provider `tpl_code` 1:1 매핑 확인.
+- 승인된 템플릿 기준 격리 알림톡 실제 발송 검증.
+- SMS fallback 실제 검증.
+- production ALIGO credentials/template mapping 반영.
+- actual release SHA 기준 notification path 회귀 및 release gate.
+
+## 운영 안전 경계
+
+- 실제 알림톡/SMS 발송은 이번 문서 갱신에서 수행하지 않았다.
+- production ALIGO 설정 변경을 수행하지 않았다.
+- secret, senderkey 원문, 개인정보를 문서에 기록하지 않는다.


### PR DESCRIPTION
## 변경 내용
- 2026-08-27 ALIGO SmartSMS provider UI에서 회차 알림 템플릿 8종 모두 `승인완료` 확인 상태 반영
- 승인 템플릿 코드/이름 증거 report 추가
- `docs/memory.md`의 ALIGO provider snapshot 갱신
- ALIGO 재개 handoff를 심사 대기 → 승인 후 provider 검증 단계로 전환
- launch blocker plan의 ALIGO gate 1을 완료 처리

## 확인된 8종
- UK_5691 주문 접수
- UK_5692 상품 준비 시작
- UK_5693 배송 시작
- UK_5694 배송 보류
- UK_5695 재배송비 결제 요청
- UK_5696 재배송 예정
- UK_5697 배송 완료
- UK_5698 주문 취소

## 안전 경계
- 실제 알림톡/SMS 발송 없음
- production ALIGO 설정 변경 없음
- secret/개인정보 기록 없음
- docs-only 변경

다음 ALIGO gate는 provider code 1:1 매핑 확인 → 승인 템플릿 격리 알림톡 → SMS fallback 검증입니다.