### PR TITLE
fix: 제한된 브랜치 복구 변경사항 재통합

### DIFF
--- a/apps/api/src/ai/ai.service.spec.ts
+++ b/apps/api/src/ai/ai.service.spec.ts
@@ -1,0 +1,110 @@
+import { ConfigService } from '@nestjs/config';
+import { Test } from '@nestjs/testing';
+import { GoogleGenerativeAI } from '@google/generative-ai';
+import { AiService, type GenerateContentParams } from './ai.service';
+
+jest.mock('@google/generative-ai', () => ({
+  GoogleGenerativeAI: jest.fn(),
+}));
+
+const GoogleGenerativeAIMock = GoogleGenerativeAI as jest.MockedClass<typeof GoogleGenerativeAI>;
+const TEST_API_KEY = 'test-only-gemini-key';
+const params: GenerateContentParams = {
+  variety: null,
+  selection: {
+    colors: [],
+    fragrance: 'none',
+    bloomCondition: 'bud',
+    stemType: '외대',
+    bundleUnit: '1단',
+  },
+  sellerNote: '테스트 메모',
+};
+
+function createConfig(apiKey?: string) {
+  const get = jest.fn((key: string) => (key === 'GEMINI_API_KEY' ? apiKey : undefined));
+  return { config: { get } as unknown as ConfigService, get };
+}
+
+function mockModel(responseText = '{"headline":"테스트 헤드라인","description":"테스트 설명"}') {
+  const generateContent = jest.fn().mockResolvedValue({
+    response: { text: jest.fn().mockReturnValue(responseText) },
+  });
+  const getGenerativeModel = jest.fn().mockReturnValue({ generateContent });
+
+  GoogleGenerativeAIMock.mockImplementation(
+    () => ({ getGenerativeModel }) as unknown as GoogleGenerativeAI,
+  );
+
+  return { generateContent, getGenerativeModel };
+}
+
+describe('AiService', () => {
+  beforeEach(() => {
+    GoogleGenerativeAIMock.mockReset();
+  });
+
+  it('키가 없어도 Nest 서비스 구성이 성공하고 실제 호출 시 설정 오류를 반환한다', async () => {
+    const { config, get } = createConfig();
+    const moduleRef = await Test.createTestingModule({
+      providers: [AiService, { provide: ConfigService, useValue: config }],
+    }).compile();
+
+    try {
+      const service = moduleRef.get(AiService);
+
+      expect(service).toBeInstanceOf(AiService);
+      expect(GoogleGenerativeAIMock).not.toHaveBeenCalled();
+
+      await expect(service.generateProductContent(params)).rejects.toThrow(
+        'GEMINI_API_KEY가 설정되지 않았습니다.',
+      );
+      expect(get).toHaveBeenCalledWith('GEMINI_API_KEY');
+      expect(GoogleGenerativeAIMock).not.toHaveBeenCalled();
+    } finally {
+      await moduleRef.close();
+    }
+  });
+
+  it('생성자에서는 Gemini SDK와 모델을 초기화하지 않는다', () => {
+    const { config, get } = createConfig(TEST_API_KEY);
+    const { getGenerativeModel } = mockModel();
+
+    new AiService(config);
+
+    expect(get).not.toHaveBeenCalled();
+    expect(GoogleGenerativeAIMock).not.toHaveBeenCalled();
+    expect(getGenerativeModel).not.toHaveBeenCalled();
+  });
+
+  it('유효한 모의 키에서는 첫 AI 호출 때 모델을 만들고 기존 응답을 반환한다', async () => {
+    const { config } = createConfig(TEST_API_KEY);
+    const { generateContent, getGenerativeModel } = mockModel();
+    const service = new AiService(config);
+
+    await expect(service.generateProductContent(params)).resolves.toEqual({
+      headline: '테스트 헤드라인',
+      description: '테스트 설명',
+    });
+
+    expect(GoogleGenerativeAIMock).toHaveBeenCalledTimes(1);
+    expect(GoogleGenerativeAIMock).toHaveBeenCalledWith(TEST_API_KEY);
+    expect(getGenerativeModel).toHaveBeenCalledTimes(1);
+    expect(getGenerativeModel).toHaveBeenCalledWith({ model: 'gemini-3-flash-preview' });
+    expect(generateContent).toHaveBeenCalledTimes(1);
+    expect(generateContent).toHaveBeenCalledWith(expect.stringContaining('테스트 메모'));
+  });
+
+  it('같은 서비스 인스턴스의 반복 호출에서는 모델 초기화를 반복하지 않는다', async () => {
+    const { config } = createConfig(TEST_API_KEY);
+    const { generateContent, getGenerativeModel } = mockModel();
+    const service = new AiService(config);
+
+    await service.generateProductContent(params);
+    await service.generateProductContent({ ...params, sellerNote: '두 번째 테스트 메모' });
+
+    expect(GoogleGenerativeAIMock).toHaveBeenCalledTimes(1);
+    expect(getGenerativeModel).toHaveBeenCalledTimes(1);
+    expect(generateContent).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/api/src/ai/ai.service.ts
+++ b/apps/api/src/ai/ai.service.ts
@@ -18,21 +18,17 @@ export interface GenerateContentResult {
 
 @Injectable()
 export class AiService {
-  private readonly model: GenerativeModel;
+  private model?: GenerativeModel;
 
-  constructor(private readonly config: ConfigService) {
-    const apiKey = this.config.get<string>('GEMINI_API_KEY');
-    if (!apiKey) throw new InternalServerErrorException('GEMINI_API_KEY가 설정되지 않았습니다.');
-    const genAI = new GoogleGenerativeAI(apiKey);
-    this.model = genAI.getGenerativeModel({ model: 'gemini-3-flash-preview' });
-  }
+  constructor(private readonly config: ConfigService) {}
 
   async generateProductContent(params: GenerateContentParams): Promise<GenerateContentResult> {
     const prompt = buildProductContentPrompt(params);
+    const model = this.getModel();
 
     let text: string;
     try {
-      const result = await this.model.generateContent(prompt);
+      const result = await model.generateContent(prompt);
       text = result.response.text().trim();
     } catch (e: any) {
       throw new InternalServerErrorException(`Gemini 호출 실패: ${e?.message ?? e}`);
@@ -68,5 +64,16 @@ export class AiService {
       headline: typeof parsed.headline === 'string' ? parsed.headline : '',
       description: typeof parsed.description === 'string' ? parsed.description : '',
     };
+  }
+
+  private getModel(): GenerativeModel {
+    if (this.model) return this.model;
+
+    const apiKey = this.config.get<string>('GEMINI_API_KEY');
+    if (!apiKey) throw new InternalServerErrorException('GEMINI_API_KEY가 설정되지 않았습니다.');
+
+    const genAI = new GoogleGenerativeAI(apiKey);
+    this.model = genAI.getGenerativeModel({ model: 'gemini-3-flash-preview' });
+    return this.model;
   }
 }

--- a/apps/consumer/src/app/cart/page.test.mjs
+++ b/apps/consumer/src/app/cart/page.test.mjs
@@ -43,6 +43,12 @@ const requireForTest = (specifier) => {
       useCart: () => ({ items: [] }),
     };
   }
+  if (specifier === '@/lib/cartValidation') {
+    return {
+      getCartItemValidationIssues: () => [],
+      getCartValidationError: () => null,
+    };
+  }
   if (specifier === '@/lib/api-base-url') {
     return { getApiBaseUrl: () => 'http://localhost:3000' };
   }
@@ -243,4 +249,19 @@ test('화면은 기존 검증 API와 인증을 사용하고 제외 항목을 장
   assert.match(source, /결제 대상에서 제외/);
   assert.match(source, /JSON\.stringify\(checkoutItems\)/);
   assert.doesNotMatch(source, /clearCart\(\).*validate/s);
+});
+
+test('legacy 필수 정보가 없으면 현재 장바구니 화면에서 수정 후 결제로만 진행한다', () => {
+  assert.match(source, /getCartItemValidationIssues/);
+  assert.match(source, /getCartValidationError/);
+  assert.match(source, /hasLegacyValidationIssues/);
+  assert.match(source, /다시 선택하기/);
+  assert.match(
+    source,
+    /disabled=\{checkoutItems\.length === 0 \|\| isChecking \|\| hasLegacyValidationIssues\}/,
+  );
+  assert.match(
+    source,
+    /if \(checkoutItems\.length === 0 \|\| isChecking \|\| hasLegacyValidationIssues\) return;/,
+  );
 });

--- a/apps/consumer/src/app/cart/page.tsx
+++ b/apps/consumer/src/app/cart/page.tsx
@@ -1,11 +1,25 @@
 'use client';
-import { ActionIcon, Badge, Box, Button, Container, Divider, Group, Paper, Stack, Text, Title } from '@mantine/core';
+import {
+  ActionIcon,
+  Alert,
+  Badge,
+  Box,
+  Button,
+  Container,
+  Divider,
+  Group,
+  Paper,
+  Stack,
+  Text,
+  Title,
+} from '@mantine/core';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useSession } from 'next-auth/react';
 import { useEffect, useState } from 'react';
 import { type CartItem, isRoundCartItem, type RoundCartItem, useCart } from '@/hooks/useCart';
 import { getApiBaseUrl } from '@/lib/api-base-url';
+import { getCartItemValidationIssues, getCartValidationError } from '@/lib/cartValidation';
 
 const API_URL = getApiBaseUrl();
 type RoundCartValidation =
@@ -296,9 +310,12 @@ export default function CartPage() {
   const checkoutAmount = checkoutItems.reduce((sum, item) => sum + item.price * item.quantity, 0);
   const checkoutCount = checkoutItems.reduce((sum, item) => sum + item.quantity, 0);
   const excludedCount = isRoundCart ? items.length - checkoutItems.length : 0;
+  const legacyItems = items.filter((item) => !isRoundCartItem(item));
+  const legacyValidationError = getCartValidationError(legacyItems);
+  const hasLegacyValidationIssues = legacyValidationError !== null;
   const isChecking = isRoundCart && validation.status !== 'ready';
   function handleCheckout() {
-    if (checkoutItems.length === 0 || isChecking) return;
+    if (checkoutItems.length === 0 || isChecking || hasLegacyValidationIssues) return;
     sessionStorage.setItem('checkout_cart', JSON.stringify(checkoutItems));
     router.push('/checkout?from=cart');
   }
@@ -345,6 +362,7 @@ export default function CartPage() {
       <Stack gap="sm" mb="lg">
         {items.map((item) => {
           const roundItem = isRoundCartItem(item) ? item : null;
+          const itemIssues = roundItem ? [] : getCartItemValidationIssues(item);
           const productHref = roundItem
             ? `/products/${item.productId}?round=${encodeURIComponent(roundItem.roundId)}`
             : `/products/${item.productId}`;
@@ -411,6 +429,28 @@ export default function CartPage() {
                             weekday: 'short',
                           })}
                         </Text>
+                      )}
+                      {itemIssues.length > 0 && (
+                        <Alert color="orange" variant="light" mt="sm" p="xs">
+                          <Stack gap={4}>
+                            {itemIssues.map((issue) => (
+                              <Text key={issue.code} size="sm">
+                                {issue.itemMessage}
+                              </Text>
+                            ))}
+                            <Button
+                              component={Link}
+                              href={productHref}
+                              size="xs"
+                              variant="light"
+                              color="orange"
+                              radius="md"
+                              mt={4}
+                            >
+                              다시 선택하기
+                            </Button>
+                          </Stack>
+                        </Alert>
                       )}
                     </>
                   )}
@@ -482,12 +522,17 @@ export default function CartPage() {
           </Text>
         </Group>
       </Paper>
+      {hasLegacyValidationIssues && (
+        <Text mb="xs" ta="center" size="sm" c="var(--color-text-disabled)">
+          문제 있는 상품을 다시 선택하면 결제할 수 있어요.
+        </Text>
+      )}
       <Button
         fullWidth
         size="lg"
         color="brand"
         radius="md"
-        disabled={checkoutItems.length === 0 || isChecking}
+        disabled={checkoutItems.length === 0 || isChecking || hasLegacyValidationIssues}
         onClick={handleCheckout}
       >
         {isChecking

--- a/apps/consumer/src/app/checkout/page.test.mjs
+++ b/apps/consumer/src/app/checkout/page.test.mjs
@@ -56,6 +56,7 @@ const requireForTest = (specifier) => {
   if (specifier === '@/hooks/usePayment') return { usePayment: () => ({}) };
   if (specifier === '@/hooks/useSaleRounds') return { useSaleRounds: () => ({}) };
   if (specifier === '@/lib/acquisition') return { getAcquisitionSnapshot: () => null };
+  if (specifier === '@/lib/cartValidation') return { getCartValidationError: () => null };
   if (specifier === '@/lib/api-base-url') {
     return { getApiBaseUrl: () => 'http://localhost:3000' };
   }
@@ -271,4 +272,15 @@ test('legacy checkout은 기존 PortOne 공개 설정 검증 뒤에만 SDK를 �
   assert.ok(guard >= 0 && guard < sdkImport);
   assert.match(legacyCheckoutSource, /storeId: configuration\.portoneStoreId/);
   assert.match(legacyCheckoutSource, /channelKey: configuration\.channelKey/);
+});
+
+test('legacy checkout은 장바구니 필수 정보가 없으면 결제 호출 전에 차단한다', () => {
+  const start = source.indexOf('function LegacyCartCheckoutContent');
+  const end = source.indexOf('function RoundCartCheckoutContent', start);
+  const legacyCheckoutSource = source.slice(start, end);
+
+  assert.match(legacyCheckoutSource, /getCartValidationError\(cartItems\)/);
+  assert.match(legacyCheckoutSource, /!cartValidationError/);
+  assert.match(legacyCheckoutSource, /if \(cartValidationError\)/);
+  assert.match(legacyCheckoutSource, /setError\(cartValidationError\)/);
 });

--- a/apps/consumer/src/app/checkout/page.tsx
+++ b/apps/consumer/src/app/checkout/page.tsx
@@ -23,6 +23,7 @@ import { type PaymentMethod, usePayment } from '@/hooks/usePayment';
 import { type PublicSaleRound, useSaleRounds } from '@/hooks/useSaleRounds';
 import { getAcquisitionSnapshot } from '@/lib/acquisition';
 import { getApiBaseUrl } from '@/lib/api-base-url';
+import { getCartValidationError } from '@/lib/cartValidation';
 import { readPortonePaymentConfiguration } from '@/lib/portone-config';
 import CheckoutForm from './_components/CheckoutForm';
 
@@ -261,8 +262,10 @@ function LegacyCartCheckoutContent({ cartItems }: { cartItems: CartItem[] }) {
   const paymentAttemptIds = useRef(new Map<string, string>());
 
   const totalAmount = cartItems.reduce((sum, i) => sum + i.price * i.quantity, 0);
+  const cartValidationError = getCartValidationError(cartItems);
   const isLoading = state === 'creating' || state === 'paying';
   const canPay =
+    !cartValidationError &&
     !isLoading &&
     !!address.address &&
     !!address.zipCode &&
@@ -272,6 +275,11 @@ function LegacyCartCheckoutContent({ cartItems }: { cartItems: CartItem[] }) {
 
   async function handlePay() {
     if (state !== 'idle' && state !== 'error') return;
+    if (cartValidationError) {
+      setError(cartValidationError);
+      setState('error');
+      return;
+    }
     setError(null);
 
     const accessToken = session?.user?.accessToken ?? '';
@@ -362,7 +370,7 @@ function LegacyCartCheckoutContent({ cartItems }: { cartItems: CartItem[] }) {
       onPaymentMethodChange={setPaymentMethod}
       isLoading={isLoading}
       canPay={canPay}
-      error={error}
+      error={cartValidationError ?? error}
       onPay={handlePay}
     />
   );

--- a/apps/consumer/src/components/BottomNav.test.mjs
+++ b/apps/consumer/src/components/BottomNav.test.mjs
@@ -49,3 +49,17 @@ test('판매 모드 확인 전에는 기존 내비게이션을 노출하지 않�
     /storeMode\.salesMode === 'round_direct' \? ROUND_DIRECT_TABS : LEGACY_TABS/,
   );
 });
+
+test('인증되지 않았거나 세션을 확인하는 동안에는 장바구니 배지를 숨긴다', () => {
+  assert.match(source, /useSession/);
+  assert.match(source, /const \{ status: sessionStatus \} = useSession\(\);/);
+  assert.match(
+    source,
+    /const visibleItemCount = sessionStatus === 'authenticated' \? itemCount : 0;/,
+  );
+  assert.match(source, /tab\.showBadge && visibleItemCount > 0/);
+});
+
+test('인증된 사용자의 장바구니 수량은 배지에 표시한다', () => {
+  assert.match(source, /visibleItemCount > 99 \? '99\+' : visibleItemCount/);
+});

--- a/apps/consumer/src/components/BottomNav.tsx
+++ b/apps/consumer/src/components/BottomNav.tsx
@@ -7,6 +7,7 @@ import { doc, getDoc } from 'firebase/firestore';
 import { Home, LayoutGrid, ShoppingCart, User, Users } from 'lucide-react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
+import { useSession } from 'next-auth/react';
 import { useEffect, useMemo, useState } from 'react';
 import { useCart } from '@/hooks/useCart';
 import { useProducts } from '@/hooks/useProducts';
@@ -87,7 +88,9 @@ function useStoreMode(storeId: string | null, productsLoading: boolean): StoreMo
 
 export default function BottomNav() {
   const pathname = usePathname();
+  const { status: sessionStatus } = useSession();
   const { itemCount } = useCart();
+  const visibleItemCount = sessionStatus === 'authenticated' ? itemCount : 0;
   const { products, loading: productsLoading, error: productsError } = useProducts();
   const storeId = useMemo(() => findSingleStoreId(products), [products]);
   const storeMode = useStoreMode(storeId, productsLoading);
@@ -132,7 +135,7 @@ export default function BottomNav() {
                     strokeWidth={isActive ? 2.2 : 1.8}
                     color={isActive ? 'var(--color-primary)' : 'var(--color-text-disabled)'}
                   />
-                  {tab.showBadge && itemCount > 0 && (
+                  {tab.showBadge && visibleItemCount > 0 && (
                     <Box
                       style={{
                         position: 'absolute',
@@ -151,7 +154,7 @@ export default function BottomNav() {
                         padding: '0 4px',
                       }}
                     >
-                      {itemCount > 99 ? '99+' : itemCount}
+                      {visibleItemCount > 99 ? '99+' : visibleItemCount}
                     </Box>
                   )}
                 </Box>

--- a/apps/consumer/src/hooks/useCart.test.mjs
+++ b/apps/consumer/src/hooks/useCart.test.mjs
@@ -54,6 +54,13 @@ test('기존 CartItem과 기존 localStorage 배열을 계속 읽는다', () => 
   assert.deepEqual(parseCartSnapshot(JSON.stringify([legacyItem])), [legacyItem]);
 });
 
+test('스토어 참조가 없는 legacy 항목은 결제 전 가드를 위해 보존한다', () => {
+  const [restored] = parseCartSnapshot(JSON.stringify([{ ...legacyItem, storeId: undefined }]));
+
+  assert.equal(restored.storeId, '');
+  assert.equal(isRoundCartItem(restored), false);
+});
+
 test('완전한 회차 계약만 회차 장바구니 항목으로 복원한다', () => {
   const [restored] = parseCartSnapshot(JSON.stringify([roundItem]));
 

--- a/apps/consumer/src/hooks/useCart.ts
+++ b/apps/consumer/src/hooks/useCart.ts
@@ -76,7 +76,6 @@ function readBaseCartItem(value: unknown): CartItem | null {
     (value.deliveryMethod !== 'direct' &&
       value.deliveryMethod !== 'hub' &&
       value.deliveryMethod !== 'parcel') ||
-    !isNonEmptyString(value.storeId) ||
     (value.requestedDeliveryDate !== undefined && typeof value.requestedDeliveryDate !== 'string')
   ) {
     return null;
@@ -90,7 +89,8 @@ function readBaseCartItem(value: unknown): CartItem | null {
     quantity: value.quantity,
     saleType: value.saleType,
     deliveryMethod: value.deliveryMethod,
-    storeId: value.storeId,
+    // 과거 장바구니의 누락된 스토어 참조는 결제 전 가드가 수정 경로를 보여주도록 보존한다.
+    storeId: typeof value.storeId === 'string' ? value.storeId : '',
     ...(value.requestedDeliveryDate ? { requestedDeliveryDate: value.requestedDeliveryDate } : {}),
   };
 }
@@ -123,6 +123,7 @@ function normalizeStoredCartItem(value: unknown): CartItem | null {
 export function isRoundCartItem(item: CartItem | undefined): item is RoundCartItem {
   return (
     !!item &&
+    isNonEmptyString(item.storeId) &&
     isCartIdentifier(item.roundId) &&
     isCartIdentifier(item.roundItemId) &&
     isPrice(item.roundPrice) &&

--- a/apps/consumer/src/lib/cartValidation.test.mjs
+++ b/apps/consumer/src/lib/cartValidation.test.mjs
@@ -1,0 +1,107 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+import ts from 'typescript';
+
+const source = await readFile(new URL('./cartValidation.ts', import.meta.url), 'utf8');
+const testableSource = `${source}
+export { getCartItemValidationIssues, getCartValidationError, hasCartValidationIssues };`;
+const compiled = ts.transpileModule(testableSource, {
+  compilerOptions: {
+    module: ts.ModuleKind.CommonJS,
+    target: ts.ScriptTarget.ES2022,
+  },
+  fileName: 'cartValidation.ts',
+}).outputText;
+
+const validationModule = { exports: {} };
+const requireForTest = (specifier) => {
+  if (specifier === '@/hooks/useCart') {
+    return {
+      isRoundCartItem: (item) =>
+        typeof item?.storeId === 'string' &&
+        item.storeId.length > 0 &&
+        typeof item?.roundId === 'string' &&
+        typeof item?.roundItemId === 'string' &&
+        item.roundPrice === item.price,
+    };
+  }
+  throw new Error(`예상하지 못한 장바구니 검증 모듈 요청: ${specifier}`);
+};
+
+new Function('require', 'module', 'exports', compiled)(
+  requireForTest,
+  validationModule,
+  validationModule.exports,
+);
+
+const { getCartItemValidationIssues, getCartValidationError, hasCartValidationIssues } =
+  validationModule.exports;
+
+const legacyItem = {
+  productId: 'product-1',
+  name: '기존 호접란',
+  price: 25000,
+  image: '',
+  quantity: 1,
+  saleType: 'normal',
+  deliveryMethod: 'direct',
+  storeId: 'store-1',
+  requestedDeliveryDate: '2026-09-08',
+};
+
+test('스토어가 없는 legacy 항목은 결제 전에 차단한다', () => {
+  const issues = getCartItemValidationIssues({ ...legacyItem, storeId: '' });
+
+  assert.deepEqual(
+    issues.map((issue) => issue.code),
+    ['missing-store'],
+  );
+  assert.equal(hasCartValidationIssues([{ ...legacyItem, storeId: '' }]), true);
+  assert.match(getCartValidationError([{ ...legacyItem, storeId: '' }]), /상점 정보/);
+});
+
+test('배송 희망일이 없는 배송 대상 legacy 항목은 결제 전에 차단한다', () => {
+  const item = { ...legacyItem, requestedDeliveryDate: undefined };
+
+  assert.deepEqual(
+    getCartItemValidationIssues(item).map((issue) => issue.code),
+    ['missing-delivery-date'],
+  );
+  assert.match(getCartValidationError([item]), /배송 날짜/);
+});
+
+test('필수 정보가 있는 legacy 장바구니는 기존 결제를 허용한다', () => {
+  assert.deepEqual(getCartItemValidationIssues(legacyItem), []);
+  assert.equal(getCartValidationError([legacyItem]), null);
+  assert.equal(hasCartValidationIssues([legacyItem]), false);
+});
+
+test('택배·공동구매와 회차 직배송은 legacy 배송일 가드의 대상이 아니다', () => {
+  assert.deepEqual(
+    getCartItemValidationIssues({
+      ...legacyItem,
+      deliveryMethod: 'parcel',
+      requestedDeliveryDate: undefined,
+    }),
+    [],
+  );
+  assert.deepEqual(
+    getCartItemValidationIssues({
+      ...legacyItem,
+      saleType: 'group',
+      requestedDeliveryDate: undefined,
+    }),
+    [],
+  );
+  assert.deepEqual(
+    getCartItemValidationIssues({
+      ...legacyItem,
+      requestedDeliveryDate: undefined,
+      roundId: 'round-1',
+      roundItemId: 'round-item-1',
+      roundPrice: legacyItem.price,
+    }),
+    [],
+  );
+});

--- a/apps/consumer/src/lib/cartValidation.ts
+++ b/apps/consumer/src/lib/cartValidation.ts
@@ -1,0 +1,54 @@
+import { type CartItem, isRoundCartItem } from '@/hooks/useCart';
+
+export type CartValidationIssueCode = 'missing-store' | 'missing-delivery-date';
+
+export interface CartValidationIssue {
+  code: CartValidationIssueCode;
+  itemMessage: string;
+  checkoutMessage: string;
+}
+
+const MISSING_STORE_ISSUE: CartValidationIssue = {
+  code: 'missing-store',
+  itemMessage: '상점 정보가 없어 다시 선택해야 결제할 수 있어요.',
+  checkoutMessage: '상점 정보가 없는 상품이 있어 결제할 수 없습니다. 장바구니를 다시 담아 주세요.',
+};
+
+const MISSING_DELIVERY_DATE_ISSUE: CartValidationIssue = {
+  code: 'missing-delivery-date',
+  itemMessage: '배송일을 다시 선택해야 결제할 수 있어요.',
+  checkoutMessage: '배송 날짜가 없는 상품이 있어 결제할 수 없습니다. 장바구니를 다시 담아 주세요.',
+};
+
+export function getCartItemValidationIssues(item: CartItem): CartValidationIssue[] {
+  if (isRoundCartItem(item)) return [];
+
+  const issues: CartValidationIssue[] = [];
+
+  if (!item.storeId) {
+    issues.push(MISSING_STORE_ISSUE);
+  }
+
+  if (
+    item.saleType !== 'group' &&
+    item.deliveryMethod !== 'parcel' &&
+    !item.requestedDeliveryDate
+  ) {
+    issues.push(MISSING_DELIVERY_DATE_ISSUE);
+  }
+
+  return issues;
+}
+
+export function getCartValidationError(items: CartItem[]): string | null {
+  for (const item of items) {
+    const issue = getCartItemValidationIssues(item)[0];
+    if (issue) return issue.checkoutMessage;
+  }
+
+  return null;
+}
+
+export function hasCartValidationIssues(items: CartItem[]): boolean {
+  return getCartValidationError(items) !== null;
+}

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -316,6 +316,94 @@ repo-side production auto-deploy 차단은 완료. GitHub 관리자 레벨 보�
 - [ ] force push·branch delete 차단
 - [ ] 재조회에서 enforcement 확인
 
+### P0_CANDIDATE_PENDING_CONTROL_TOWER — SALE-ROUND-STATE-ATOMICITY-AND-RECOVERY
+
+현재 source 재검증 결과 `CURRENT_UNRESOLVED`다. 회차 수정·수동 개방·주문 예약·취소 복구가 하나의
+신선한 상태·시간·소유권 경계로 수렴하지 않아 조기 주문, 상품 snapshot 혼합, `CANCELLING`
+고착 가능성이 남아 있다. runtime 증거는 확보했지만 최종 P0 및 release gate 승격은 product/release
+authority가 결정하므로 `P0_CANDIDATE_PENDING_CONTROL_TOWER`로 표시한다.
+
+현재 직접 근거:
+
+- [x] `SaleRoundsService.updateRound()`는 transaction 밖에서 `DRAFT|SCHEDULED`를 확인한 뒤,
+  `writeTransaction()` 안에서 fresh round status를 다시 확인하지 않는다.
+- [x] item 교체 시 `getRoundItems()`가 transaction snapshot이 아닌 별도 query로 실행된 뒤 기존
+  item 삭제와 새 item 생성을 같은 write callback에서 수행한다.
+- [x] `SaleRoundStateService.updateStatus()`의 수동 `SCHEDULED → OPEN` 경로는
+  `orderOpenAt`·`orderCloseAt` window를 확인하지 않는다.
+- [x] `OrderCapacityService.assertRoundReservable()`는 `OPEN`, 취소 없음, `orderCloseAt`만 확인하고
+  `orderOpenAt`을 방어적으로 확인하지 않는다.
+- [x] 회차 취소는 `CANCELLING`을 먼저 기록하지만 `owner|lease|expiry` 없이 주문 정리를 수행하고,
+  두 번째 `CANCELLING` 요청은 이미 진행 중이라는 이유로 거부한다.
+- [x] 현재 직접 테스트는 stale `updateStatus`, 자동 상태 전이, caught `LOCAL_FAILED` 재시도를
+  고정하지만 `updateRound` race, 조기 수동 `OPEN`, pre-open reservation, process-crash recovery,
+  cancellation stale-worker fencing은 직접 고정하지 않는다.
+
+Sale-round subfinding matrix:
+
+| Subfinding | Current state | Evidence | Canonical action |
+|---|---|---|---|
+| updateRound race | `OPEN` | precheck와 write 사이 fresh status 재검증 없음 | round read와 edit eligibility를 같은 transaction에서 재검증하고 충돌 시 side effect 0 |
+| item replacement | `OPEN` | 현재 item query가 transaction 밖이며 삭제·재생성이 live reservation과 원자적으로 묶이지 않음 | active/reserved/ordered item을 보호하고 한 coherent snapshot만 교체 |
+| manual OPEN gate | `OPEN` | 수동 상태 전이가 `orderOpenAt <= now < orderCloseAt`를 확인하지 않음 | authoritative schedule window를 만족할 때만 `SCHEDULED → OPEN` 허용 |
+| reservation/openAt | `OPEN` | reservation path가 `OPEN`과 close만 확인하고 openAt을 확인하지 않음 | reservation에서도 동일한 open/close window를 defense-in-depth로 확인 |
+| CANCELLING crash recovery | `OPEN` | `CANCELLING` 저장 뒤 별도 주문 정리 중단 시 deterministic resume/reaper 없음 | owner·lease·expiry 기반 인수 또는 명시적 deterministic recovery 추가 |
+| claim ownership | `OPEN` | cancellation record에 owner·lease·expiry가 없고 claim 상태만 저장 | claim 획득·갱신·만료·재인수를 원자적으로 정의 |
+| stale worker overwrite | `PARTIAL` | 현재 API는 두 번째 `CANCELLING` claimant을 거부해 takeover가 일어나지 않지만, failure/finalize write에 owner token fence가 없음 | recovery worker 도입 시 old worker의 상태·counter·환불 결과 덮어쓰기를 fresh claim 검증으로 차단 |
+
+영향:
+
+- 판매 시작 전 주문·예약과 잘못된 가격·상품·한도 snapshot이 발생할 수 있다.
+- live edit와 reservation이 경합하면 현재 상품 삭제 또는 item 수량·주문 집계의 혼합 상태가 될 수 있다.
+- process crash 뒤 회차가 `CANCELLING`에 고착되어 주문·환불·capacity 정리가 끝났는지 판정할 수 없다.
+
+완료 acceptance:
+
+- [ ] edit eligibility와 round/item snapshot을 실제 write transaction에서 fresh-read하고
+  `OPEN|CLOSED|COMPLETED|CANCELLED` 또는 사용 중 item의 edit side effect를 거부
+- [ ] 동시 edit/open/reservation에서 한 요청만 정책에 맞게 성공하고 가격·상품·한도 snapshot이
+  혼합되지 않음
+- [ ] `SCHEDULED → OPEN`과 reservation 모두 `orderOpenAt <= now < orderCloseAt`을 확인
+- [ ] orphaned `CANCELLING`을 owner·lease·expiry로 안전하게 인수하거나 deterministic recovery
+  절차로 재개
+- [ ] recovery 재실행에서 이미 환불·취소된 주문과 round/item/held counter를 중복 변경하지 않음
+- [ ] A~G 각 race·crash·stale-worker 시나리오의 직접 회귀와 기존 자동 OPEN/CLOSE·capacity reopen·
+  정상 취소 재시도 회귀 유지
+
+owner 제안: `apps/api/src/sale-rounds/**`를 주 owner로 하고 `apps/api/src/orders/order-capacity.service.ts`
+및 `apps/api/src/orders/round-order-lifecycle.service.ts`와 함께 구현한다. 최종 release 영향은
+product/release control tower가 판정한다.
+
+정본 routing: active summary와 acceptance는 이 항목, 기술 계약은
+`docs/specs/mvp-sales-round-direct-delivery.md`, 운영 중단·재개 규칙은
+`docs/specs/ops/mvp-sales-round-runbook.md`에 둔다.
+
+### BR-R3 — 증거 분류와 역사 승격 경계
+
+이번 정본화는 선택지 B를 적용한다. 역사 보고서 전체를 current branch에 복구하지 않고, 역사
+commit과 경로만 추적 가능한 `HISTORICAL_EVIDENCE`로 남긴다. 현재 판정과 acceptance의 정본은
+아래 `CURRENT_IMPLEMENTATION_EVIDENCE`와 이 Backlog의 세 finding이다.
+
+- `HISTORICAL_EVIDENCE`: `54af6edf44008848e586b1707d0f1fd13470a5f6`의
+  `docs/reports/REPORT_retention_operations_sale_round_audit_20260824.md`는 2026-08-24 당시의
+  감사 보고서다. 현재 branch에는 보고서 파일을 복구하지 않으며, 과거 결론을 현재 `VERIFIED`로
+  승격하지 않는다.
+- `CURRENT_IMPLEMENTATION_EVIDENCE`: 현재 source·직접 테스트·current spec·runbook을 다시
+  대조한 결과다. 일반 retention purge, operation issue 기본 동작·정상 claim, sale-round 자동
+  상태 전이·capacity reopen·정상 취소 재시도는 기존 계약 범위에서 유지되며, 세 finding의
+  현재 공백은 별도 항목과 subfinding matrix로 분리했다.
+- 위에서 유지된 직접 검증 항목은 `RESOLVED_NOT_PROMOTED`다. 이는 해당 base contract가 현재
+  증거로 유지된다는 뜻일 뿐, 이번 세 finding이 해결되었거나 release gate·production 승인이
+  되었다는 뜻이 아니다.
+- `CURRENT_UNRESOLVED_FINDING`: `SALE-ROUND-STATE-ATOMICITY-AND-RECOVERY`,
+  `RETENTION-DELETE-ISSUE-ROUTING`, `OPERATION-ACTION-CLAIM-FENCING`만 이번 BR-R3의
+  current unresolved finding으로 canonicalize한다. 발견 사실만으로 구현·release gate·production
+  승인을 의미하지 않는다.
+- `FUTURE_REENABLE_REQUIREMENT`: 역사 보고서의 marketing consent lifecycle 논점은 현재
+  `MARKETING_NOT_USED_IN_PILOT` controlled-pilot 정책을 변경하거나 새 finding으로 승격하지 않는다. 향후 marketing을 다시
+  활성화할 때에만 당시의 동의·철회·보관·법무·provider·release 증거를 현재 권위로 재검증하고,
+  별도 승인된 Task에서 범위를 확정한다.
+
 ---
 
 ## BLOCKED_EXTERNAL
@@ -378,6 +466,81 @@ repo-side production auto-deploy 차단은 완료. GitHub 관리자 레벨 보�
 ---
 
 ## LATER
+
+### RETENTION-DELETE-ISSUE-ROUTING
+
+현재 source 재검증 결과 `CURRENT_UNRESOLVED`다. 배송 사진 Storage 삭제가 3회 모두 실패하면
+`RETENTION_DELETE_FAILED`는 생성되지만, 배송 사진 보관 record에 `storeId`가 없어 현재 store-scoped
+운영 예외 목록으로 안정적으로 route되지 않는다.
+
+현재 직접 근거:
+
+- [x] `DeliveryPhotosService.attachPhoto()`가 배송 사진 retention metadata로 `{ orderId, photoId }`만
+  저장하고 `storeId`를 저장하지 않는다.
+- [x] `RetentionService.deleteStorageObject()`는 누락된 `storeId`를 `String(... ?? '')`로 바꾸어
+  issue를 생성한다.
+- [x] `OperationsController`와 `OperationsService.listIssuesForStore()`는 `/stores/:storeId`와
+  issue `storeId` 일치를 요구한다.
+- [x] seller parser도 비어 있거나 손상된 `storeId`를 읽지 않는다.
+- [x] retention purge의 3회 retry, record 보존, 멱등 issue 생성 자체는 직접 테스트되지만, 누락·알 수
+  없는 store의 운영자 visibility와 global queue는 직접 테스트·구현 근거가 없다.
+
+영향: 삭제 실패한 비공개 배송 사진과 보관 record가 남을 수 있고, 담당 셀러의 store-scoped
+운영 화면에서 확인·재처리 대상이 유실될 수 있다. 일반 배송 사진 만료가 완료 후 90일이므로
+현재 출시 직전 gate로 확정하지 않고 `P2_CANDIDATE` / `LATER`로 routing한다.
+
+완료 acceptance:
+
+- [ ] non-PII `storeId` 보존으로 store issue route를 보장하거나 admin/technical global retention
+  queue 중 하나를 current contract로 확정
+- [ ] missing/unknown store가 false success가 되지 않고 지정된 운영 queue에 항상 보인다.
+- [ ] retry·resolve·record 보존 관계와 동일 실패 멱등성을 직접 회귀하고 원본 삭제·record 선삭제를 금지
+- [ ] issue와 보관 metadata에 주소·전화번호·Storage 서명 URL·비밀값을 기록하지 않음
+
+owner 제안: `apps/api/src/orders/delivery-photos.service.ts`, `apps/api/src/retention/**`,
+`apps/api/src/operations/**`; seller 표시가 필요하면 최소 parser/UI 변경은 별도 구현 Task로 분리한다.
+
+정본 routing: LATER summary는 이 항목, 보관 계약은
+`docs/specs/mvp-sales-round-direct-delivery.md`, 현재 운영 중단·전달 규칙은
+`docs/specs/ops/mvp-sales-round-runbook.md`에 둔다.
+
+### OPERATION-ACTION-CLAIM-FENCING
+
+현재 source 재검증 결과 `CURRENT_UNRESOLVED`다. `claimAction()`은 5분 `actionClaim` token을
+발급하지만 action 실행 후 성공·실패 write가 현재 claim의 fresh token을 확인하지 않아, 만료된
+worker가 새 claimant의 최신 상태를 지우거나 덮을 수 있다.
+
+현재 직접 근거:
+
+- [x] `claimAction()`은 transaction에서 lease token과 expiry를 저장한다.
+- [x] `runAction()`은 최초에 읽은 issue snapshot을 spread해 성공·실패를 일반 update하고,
+  `claimToken`을 새 문서의 token과 비교하지 않는다.
+- [x] `RESEND_SMS`는 outer operation claim과 별도로 직접 외부 문자 발송을 호출한다.
+- [x] 정상 lease 안의 동시 요청은 한 번만 외부 호출하는 테스트가 있지만, lease 만료 후 takeover와
+  stale completion/failure race를 검증하는 직접 테스트는 없다.
+
+영향: worker A가 지연된 사이 worker B가 takeover하면 A의 늦은 completion/failure가 B의 claim·action
+감사·issue status를 덮을 수 있다. 특히 문자 재발송은 operation-level 외부 중복 방어가 직접 입증되지
+않았고, 환불 내부 claim이 있더라도 operation claim fencing의 대체 증거가 아니다.
+
+우선순위 후보: `P1_CANDIDATE` / 현재 Backlog routing은 수동 운영 경로인 `LATER`로 둔다.
+
+완료 acceptance:
+
+- [ ] 외부 action 직전과 completion/failure write에서 owner token 또는 generation을 fresh-read해
+  현재 claim이 아니면 side effect·상태 write·claim clear를 수행하지 않음
+- [ ] lease가 외부 호출 중 만료될 수 있는 action은 provider idempotency 또는 authoritative
+  reconciliation 없이는 자동 재시도하지 않음
+- [ ] A 지연 → B takeover → A 늦은 성공/실패 race에서 B의 최신 claim·status·audit가 보존되고
+  문자·환불 외부 side effect가 중복되지 않음
+- [ ] 기존 action mapping, 최신 주문·결제 재조회, 민감정보 없는 감사 기록, 정상 동시 claim 회귀 유지
+
+owner 제안: `apps/api/src/operations/**`; refund·SMS provider 경계의 idempotency/reconciliation은
+각 `payments`·`notifications` owner와 함께 별도 구현 Task로 정의한다.
+
+정본 routing: LATER summary는 이 항목, operation issue 기술 계약은
+`docs/specs/mvp-sales-round-direct-delivery.md`, 수동 조치 중단 규칙은
+`docs/specs/ops/mvp-sales-round-runbook.md`에 둔다.
 
 ### LEGACY-GROUP-CANCEL-NOTIFICATION
 

--- a/docs/specs/mvp-sales-round-direct-delivery.md
+++ b/docs/specs/mvp-sales-round-direct-delivery.md
@@ -22,12 +22,22 @@
 - 필수 필드는 `storeId`, `status`, `name`, 주문 시작·마감 시각, 경매일, 배송 시작·종료 시각, 활성 배송 지역, 배송지 한도, 상품 수량 한도, 주문·예약 집계다.
 - 주문 마감 시각 또는 배송지·상품 한도 중 먼저 도달한 조건에 따라 `CLOSED`로 전환한다.
 - 상태 전환은 `DRAFT → SCHEDULED → OPEN → CLOSED → COMPLETED` 순서만 허용하며 역전이나 단계 건너뛰기를 거부한다.
+- 수동 `SCHEDULED → OPEN`과 주문 예약은 `orderOpenAt <= now < orderCloseAt`인 authoritative
+  schedule window를 함께 확인한다. 저장된 `OPEN` 상태만으로 시작 전 주문을 허용하지 않는다.
+- `DRAFT|SCHEDULED` 회차 편집은 실제 write transaction에서 fresh status를 재확인하고, live
+  reservation·ordered item을 삭제하거나 가격·상품·한도 snapshot을 혼합하지 않는다.
 - `DELIVERY_HELD` 또는 그 밖의 미완료 주문이 남아 있으면 `COMPLETED` 전환을 거부한다.
 - 판매자는 자신이 소유한 스토어 회차만 변경할 수 있고 관리자는 이 소유권 검사에서 예외다.
 - 판매자 회차 목록·상세 조회도 스토어 `ownerId`를 서버에서 확인하며, 역할만으로 다른 스토어 회차를 읽을 수 없다.
 - 결제 주문이 있는 회차 취소는 결제별 환불을 성공시킨 뒤 `CANCELLED`로 확정하며 중복 취소는 환불을 다시 적용하지 않는다.
+- 회차 취소의 `CANCELLING` 작업은 owner·lease·expiry와 stale worker fencing을 가져야 하며,
+  process interruption 뒤 안전하게 인수·재개하거나 deterministic recovery로 닫혀야 한다.
 - 용량 때문에 자동 마감된 회차는 주문 마감 전 한도가 반환되면 `OPEN`으로 복귀한다. 일정 종료·수동 마감 회차는 자동 재개하지 않는다.
 - Firestore `Timestamp`는 API에서 ISO8601 문자열로 반환하고 회차 목록은 정규화된 시각 기준 최신순으로 정렬한다.
+
+위 회차 atomicity·recovery 항목은 current intended contract다. 현재 구현에서 fresh edit gate,
+pre-open reservation gate, cancellation recovery/fencing이 직접 충족되는지는
+`docs/BACKLOG.md`의 `SALE-ROUND-STATE-ATOMICITY-AND-RECOVERY`에서 별도로 판정한다.
 
 ### `saleRoundItems`
 
@@ -70,6 +80,11 @@
 - 해결된 같은 원인이 재발하면 최신 안전 스냅샷을 병합하고 항목을 다시 연다.
 - 예외 유형별 허용 action만 실행하며, 동시 조치는 claim을 획득한 한 요청만 외부 동작을 수행한다.
 - 조치 실행 전 최신 결제·주문 상태를 다시 검증하고, 담당자·시각·결과·실패 사유를 감사 기록으로 남긴다.
+- lease 만료 뒤 새 claimant가 생길 수 있는 action은 성공·실패 기록에서 fresh owner token 또는
+  generation을 확인해 stale worker가 최신 claim·status·audit를 덮지 못하게 한다.
+
+현재 `claimAction()`의 만료 takeover fencing은 직접 검증되지 않았고
+`OPERATION-ACTION-CLAIM-FENCING`에서 별도 implementation finding으로 추적한다.
 
 ## API 계약
 
@@ -134,6 +149,9 @@
 - 법정 보관 컬렉션과 배송 사진 원본은 소비자앱·드라이버앱·일반 셀러 권한에서 직접 접근할 수 없다.
 - 각 보관 기록은 파기 예정 시각을 가지며 정기 작업이 만료 기록과 연결 Storage 파일을 영구 삭제한다.
 - 정기 파기는 Firestore 쓰기 한도보다 작은 450건 배치로 500건 초과 대상도 반복 처리하며, Storage 삭제가 최종 실패하면 안전한 운영 예외만 남기고 보관 문서는 유지한다.
+- `RETENTION_DELETE_FAILED`는 store-scoped route 또는 admin/technical global queue에서 확인할 수
+  있어야 한다. 현재 배송 사진 failure route의 store identity·global visibility 공백은
+  `RETENTION-DELETE-ISSUE-ROUTING`에서 별도 추적한다.
 
 ## 검증 기준
 

--- a/docs/specs/ops/mvp-sales-round-runbook.md
+++ b/docs/specs/ops/mvp-sales-round-runbook.md
@@ -120,11 +120,17 @@ node scripts/enable-dear-orchid-round-direct.mjs --apply --target-mode=round_dir
 | --- | --- | --- | --- |
 | 생성 `DRAFT` | 대표자·셀러 운영자. 이전 회차와 이번 주 상품 정본 준비 | 새 `roundId`, 상품 중복 없음, 회차 가격·상품별 한도, 이천시 활성 지역, 일정 순서 | 상품·가격·시간대 불명확 시 저장·예약 중단 후 대표자 확인 |
 | 예약 `SCHEDULED` | 대표자. 주문 시작 < 주문 마감 <= 경매 < 배송 시작 < 배송 종료 | `schedule.timezone=Asia/Seoul`, 일요일 24:00 마감, 월요일 경매, 화요일 00:00~09:00 배송 | 과거 시각, 일정 역전, 잘못된 지역·한도, 링크 오노출 시 예약 중단 후 기술 담당자 확인 |
-| 판매 `OPEN` | 셀러 운영자. 공개 링크와 결제 준비 확인 | 공개 회차·상품 조회, 가격, `closeReason=null`, 예약·주문 집계, 당근 링크 | 가격·상품·지역 불일치, 결제 오류 증가, 비회차 판매 방식 노출 시 신규 유입 중단과 롤백 판단 |
+| 판매 `OPEN` | 셀러 운영자. 공개 링크와 결제 준비 확인. 서버가 `orderOpenAt <= now < orderCloseAt`을 확인 | 공개 회차·상품 조회, 가격, `closeReason=null`, 예약·주문 집계, 당근 링크, authoritative 시작 window | 시작 전 수동 `OPEN`, 가격·상품·지역 불일치, 결제 오류 증가, 비회차 판매 방식 노출 시 신규 유입 중단과 롤백 판단 |
 | 마감 `CLOSED` | 대표자. 일요일 24:00 또는 수동·한도 마감 | `closeReason=SCHEDULE_ENDED|CAPACITY|MANUAL`, 신규 주문 차단, `PENDING`·결제 조회 예외 목록 | 마감 뒤 신규 예약, 결제 상태 불명확, 카운터 불일치 시 매입 확정 중단 후 기술·결제 담당자 확인 |
 | 완료 `COMPLETED` | 대표자. 모든 주문 종결과 확인 필요 점검 완료 | 모든 회차 주문이 `DELIVERED|REVIEWED|CANCELLED`, `heldOrderCount=0`, 관련 `OPEN` 예외 검토 | 미완료·보류 주문은 서버가 거부. 관련 `OPEN` 예외나 사진·환불·연락 증거 누락 시 운영 정책상 완료 시도 중단 |
 
-`CAPACITY`로 닫힌 회차는 주문 마감 전 확보량이 반환되면 자동으로 `OPEN` 복귀할 수 있다. `SCHEDULE_ENDED` 또는 `MANUAL` 마감은 자동 재개되지 않는다. 상태 변경 직전에는 항상 재조회한다.
+`CAPACITY`로 닫힌 회차는 주문 마감 전 확보량이 반환되면 자동으로 `OPEN` 복귀할 수 있다. `SCHEDULE_ENDED` 또는 `MANUAL` 마감은 자동 재개되지 않는다. 수동 `SCHEDULED → OPEN`은 서버가 authoritative `orderOpenAt <= now < orderCloseAt`을 확인한 경우에만 허용한다. 상태 변경 직전에는 항상 재조회한다.
+
+회차 편집은 `DRAFT|SCHEDULED`의 fresh 상태와 item snapshot을 같은 write transaction에서 재확인해야
+한다. `OPEN` 전환·예약·배송 주문과 경합해 어느 상태인지 확정할 수 없거나 item 사용량이 이미
+존재하면 저장을 중단하고 기술 담당자에게 전달한다. `CANCELLING` 저장 뒤 process interruption은
+현재 owner·lease·expiry 기반 deterministic recovery가 직접 검증된 상태가 아니므로,
+Firestore를 직접 `CANCELLED`로 고치거나 주문을 임의 정리하지 않는다.
 
 ### 5.2 일요일 주문 마감
 
@@ -248,7 +254,10 @@ node scripts/enable-dear-orchid-round-direct.mjs --apply --target-mode=round_dir
 - `disputeStatus=OPEN` 또는 `legalHold=true`는 파기하지 않는다.
 - Storage 삭제는 최대 3회 시도하며 최종 실패 시 보관 문서를 유지하고 `RETENTION_DELETE_FAILED`를 연다.
 - 실패한 원본을 수동 삭제하거나 보관 문서만 먼저 삭제하지 않는다.
-- 현재 `RETENTION_DELETE_FAILED`에는 자동 운영 조치가 없고, 일부 사진 보관 기록은 스토어 범위 목록에 나타나지 않을 수 있다. 관리자·기술 담당자가 서비스 로그와 관리자 범위에서 확인한다.
+- 현재 `RETENTION_DELETE_FAILED`에는 자동 운영 조치가 없고, 배송 사진 failure는 store identity가
+  없어 일부 기록이 스토어 범위 목록에 나타나지 않을 수 있으며 current API에서 global retention
+  queue도 확인되지 않았다. 이를 확인 완료로 간주하거나 원본·보관 문서를 임의 삭제하지 말고,
+  `RETENTION-DELETE-ISSUE-ROUTING`에 따라 기술 담당자에게 전달한다.
 - 같은 원인의 재시도는 다음 승인된 정기 작업 또는 기술 담당자의 복구 절차로만 수행한다.
 
 ## 7. 소비자 장애 시 `legacy` 롤백
@@ -313,7 +322,7 @@ node scripts/enable-dear-orchid-round-direct.mjs --dry-run --target-mode=legacy
 1. 운영 예외 `refresh`로 주문·로컬 결제 상태를 재확인한다.
 2. 허용 조치가 `RETRY_REFUND`인지 확인한다.
 3. 별도 승인 뒤 한 번만 실행한다.
-4. 서버는 5분 claim으로 동시 실행을 막고, 로컬 결제가 이미 `REFUNDED|CANCELLED`면 외부 환불을 반복하지 않는다.
+4. 서버는 5분 claim으로 정상 동시 실행을 막고, 로컬 결제가 이미 `REFUNDED|CANCELLED`면 외부 환불을 반복하지 않는다. lease 만료 뒤 takeover와 stale worker fencing은 현재 직접 검증되지 않았으므로, 호출 결과나 소유권이 불명확하면 자동 재시도하지 않고 기술 담당자에게 전달한다.
 5. `SUCCEEDED` 감사 기록, 예외 `RESOLVED`, PortOne 취소 상태, 로컬 `CANCELLED`를 모두 확인한다.
 
 실패하면 같은 버튼을 연속 클릭하지 않는다. `FAILED` 감사 기록과 실패 시각을 남기고 결제 운영자·기술 담당자에게 전달한다.
@@ -380,4 +389,5 @@ node scripts/enable-dear-orchid-round-direct.mjs --dry-run --target-mode=legacy
 
 | 날짜 | 내용 |
 |---|---|
+| 2026-09-02 | 회차 edit/open/reservation race와 취소 recovery, 보관 failure routing의 현재 미해결 범위를 `docs/BACKLOG.md`와 정합화 |
 | 2026-08-23 | 과거 `Task 6.7` 출시 전제 표현을 현재 `memory`/HANDOFF/launch PLAN 게이트와 실제 출시 SHA 원격 E2E 기준으로 정합화 |


### PR DESCRIPTION
## 복구 범위

### Consumer

- 게스트 장바구니 badge 보호
- `legacy` 장바구니의 `store`·배송일 누락 precheckout guard

### API

- Gemini 지연 초기화
- Gemini credential과 API bootstrap 격리

### Documentation

- 보관 파기 issue routing finding
- operation action claim fencing finding
- sale-round atomicity/recovery finding

## 판정 경계

- 역사 브랜치를 전체 병합하지 않았습니다.
- 브랜치 복구는 의미와 범위를 제한해 수행했습니다.
- production activation을 수행하지 않았습니다.
- deployment를 수행하지 않았습니다.
- 외부 provider mutation을 수행하지 않았습니다.
- recovery branch의 검증된 head는 `ea22c40070fe78a94f1386fdaf3df8f3db7b8c43`입니다.
- 대상 기준 브랜치는 `main`이며 기준 SHA는 `656eb3da236134da93b73fddb153fc161356c60b`입니다.

## 검증

- Consumer `node --test` 전체: 121개 통과
- Consumer TypeScript 검사: 통과
- Consumer lint: 종료 코드 0, 기존 경고 16개와 정보 5개
- API 지정 Jest 집중 검증: 6개 통과
- API 지정 Jest 통합 대상 검증: 19개 통과
- API TypeScript 검사: 통과
- API build: 통과
- 문서 finding ID 고유성·모순 문구 탐색·`git diff --check`: 통과

이번 PR은 검토만을 위한 것이며 자동 병합·`main` 변경·배포를 수행하지 않습니다.