### PR TITLE
FE-DEV-LOCAL-M1: 로컬 런타임 런처·포트·준비성·수명주기

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,6 +1,9 @@
 set shell := ["bash", "-c"]
 
 # ── 개발 ──────────────────────────────────────────────────────
+dev:
+    pnpm dev:local
+
 dev-consumer:
     pnpm --filter consumer dev
 

--- a/dev.bat
+++ b/dev.bat
@@ -1,15 +1,5 @@
 @echo off
-echo Starting Green Love Dev Servers...
-echo.
-echo   consumer  → http://localhost:3000
-echo   seller    → http://localhost:3001
-echo   driver    → http://localhost:3003
-echo.
-
-start "GreenLove Consumer :3000" cmd /k "cd /d %~dp0apps\consumer && pnpm dev"
-timeout /t 2 /nobreak >nul
-start "GreenLove Seller   :3001" cmd /k "cd /d %~dp0apps\seller && pnpm dev --port 3001"
-timeout /t 2 /nobreak >nul
-start "GreenLove Driver   :3003" cmd /k "cd /d %~dp0apps\driver && pnpm dev"
-
-echo All servers started. Close each terminal window to stop.
+setlocal
+cd /d "%~dp0"
+node scripts\dev\local\launcher.mjs %*
+exit /b %ERRORLEVEL%

--- a/package.json
+++ b/package.json
@@ -4,8 +4,11 @@
   "version": "0.0.1",
   "scripts": {
     "postinstall": "node scripts/copy-fonts.cjs",
+    "dev": "node scripts/dev/local/launcher.mjs",
+    "dev:local": "node scripts/dev/local/launcher.mjs",
     "dev:consumer": "pnpm --filter consumer dev",
     "dev:api": "pnpm --filter api start:dev",
+    "test:local-launcher": "node --test scripts/dev/local/launcher.spec.mjs",
     "build": "pnpm --filter @greenhub/shared build && pnpm --filter api --filter consumer --filter seller --filter driver build",
     "lint": "pnpm -r lint",
     "typecheck": "pnpm -r typecheck",

--- a/scripts/dev/local/launcher.mjs
+++ b/scripts/dev/local/launcher.mjs
@@ -1,6 +1,10 @@
-import { execFile as nativeExecFile, spawn as nativeSpawn } from 'node:child_process';
+import {
+  execFile as nativeExecFile,
+  spawn as nativeSpawn,
+  spawnSync as nativeSpawnSync,
+} from 'node:child_process';
 import { createConnection, createServer } from 'node:net';
-import { dirname, resolve } from 'node:path';
+import { dirname, posix as posixPath, resolve, win32 as windowsPath } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const MODULE_DIRECTORY = dirname(fileURLToPath(import.meta.url));
@@ -25,6 +29,12 @@ export const LOCAL_RUNTIME_CONTRACT = Object.freeze({
     NODE_ENV: 'development',
     GREENHUB_SCHEDULES_ENABLED: 'false',
   }),
+});
+
+export const JAVA_RUNTIME_CONTRACT = Object.freeze({
+  minimumMajorVersion: 21,
+  explicitOverrideKey: 'GREENHUB_JAVA_HOME',
+  currentJavaHomeKey: 'JAVA_HOME',
 });
 
 export const FIXED_PORTS = Object.freeze([
@@ -99,6 +109,7 @@ const LOCAL_ENVIRONMENT_KEYS_TO_REMOVE = new Set([
   'GOOGLE_APPLICATION_CREDENTIALS_JSON',
   'GOOGLE_API_KEY',
   'GOOGLE_CLOUD_PROJECT',
+  'GREENHUB_JAVA_HOME',
   'JWT_REFRESH_SECRET',
   'JWT_SECRET',
   'NEXTAUTH_SECRET',
@@ -181,6 +192,13 @@ export class LocalRuntimeConfigurationError extends LocalRuntimeError {
   }
 }
 
+export class JavaRuntimeConfigurationError extends LocalRuntimeConfigurationError {
+  constructor(message) {
+    super(message);
+    this.name = 'JavaRuntimeConfigurationError';
+  }
+}
+
 export class PortCollisionError extends LocalRuntimeError {
   constructor(ports) {
     super(`로컬 runtime 포트가 이미 사용 중입니다: ${ports.join(', ')}`);
@@ -222,6 +240,239 @@ export class ShutdownRequestedError extends LocalRuntimeError {
 function readEnvironmentValue(environment, key) {
   const value = environment?.[key];
   return typeof value === 'string' ? value.trim() : '';
+}
+
+function hasEnvironmentKey(environment, key) {
+  return Object.keys(environment ?? {}).some(
+    (candidate) => candidate.toLowerCase() === key.toLowerCase(),
+  );
+}
+
+function pathApiForPlatform(platform) {
+  return platform === 'win32' ? windowsPath : posixPath;
+}
+
+function javaExecutableName(platform) {
+  return platform === 'win32' ? 'java.exe' : 'java';
+}
+
+function javaHomeFromEnvironment(environment, key) {
+  return readEnvironmentValue(environment, key).replace(/^"|"$/g, '');
+}
+
+function javaExecutableFromHome(javaHome, platform) {
+  return pathApiForPlatform(platform).join(javaHome, 'bin', javaExecutableName(platform));
+}
+
+function parseJavaMajorVersion(output) {
+  const text = String(output ?? '');
+  const propertyMatch = text.match(/(?:^|\r?\n)\s*java\.version\s*=\s*([0-9]+)(?:\.([0-9]+))?/m);
+  const versionMatch = text.match(/\bversion\s+"([0-9]+)(?:\.([0-9]+))?/i);
+  const openJdkMatch = text.match(/\b(?:openjdk|java)\s+([0-9]+)(?:\.([0-9]+))?/i);
+  const match = propertyMatch ?? versionMatch ?? openJdkMatch;
+  if (!match) return undefined;
+
+  const first = Number(match[1]);
+  const second = match[2] === undefined ? undefined : Number(match[2]);
+  if (!Number.isInteger(first)) return undefined;
+  return first === 1 && Number.isInteger(second) ? second : first;
+}
+
+function parseJavaHome(output) {
+  const match = String(output ?? '').match(/^\s*java\.home\s*=\s*(.+?)\s*$/m);
+  return match?.[1]?.trim() || undefined;
+}
+
+function javaRuntimeErrorMessage() {
+  return `Firebase Emulator를 실행하려면 Java ${JAVA_RUNTIME_CONTRACT.minimumMajorVersion}+가 필요합니다. ${JAVA_RUNTIME_CONTRACT.explicitOverrideKey}, ${JAVA_RUNTIME_CONTRACT.currentJavaHomeKey} 또는 PATH에 Java ${JAVA_RUNTIME_CONTRACT.minimumMajorVersion}+를 설정하세요.`;
+}
+
+function explicitJavaRuntimeError(javaHome, reason) {
+  return `${javaRuntimeErrorMessage()} ${JAVA_RUNTIME_CONTRACT.explicitOverrideKey}=${javaHome} ${reason}`;
+}
+
+export function discoverWindowsJavaFallbackHomes(environment = process.env) {
+  const pathApi = pathApiForPlatform('win32');
+  const roots = [
+    readEnvironmentValue(environment, 'ProgramW6432'),
+    readEnvironmentValue(environment, 'ProgramFiles'),
+    readEnvironmentValue(environment, 'ProgramFiles(x86)'),
+  ].filter(Boolean);
+  const candidates = roots.flatMap((root) => [
+    pathApi.join(root, 'Android', 'Android Studio', 'jbr'),
+    pathApi.join(root, 'Android Studio', 'jbr'),
+  ]);
+  const localAppData = readEnvironmentValue(environment, 'LOCALAPPDATA');
+  if (localAppData) {
+    candidates.push(pathApi.join(localAppData, 'Programs', 'Android Studio', 'jbr'));
+  }
+  return [...new Set(candidates)];
+}
+
+export function probeJavaExecutable({
+  executable,
+  environment,
+  javaHome,
+  source,
+  platform = process.platform,
+  spawnSyncImpl = nativeSpawnSync,
+} = {}) {
+  let result;
+  try {
+    result = spawnSyncImpl(executable, ['-XshowSettings:properties', '-version'], {
+      env: environment,
+      encoding: 'utf8',
+      shell: false,
+      windowsHide: platform === 'win32',
+    });
+  } catch {
+    return undefined;
+  }
+
+  if (result?.error || result?.status !== 0) return undefined;
+  const output = [result.stdout, result.stderr].filter(Boolean).join('\n');
+  const majorVersion = parseJavaMajorVersion(output);
+  if (!Number.isInteger(majorVersion)) return undefined;
+
+  return {
+    executable,
+    javaHome: javaHome || parseJavaHome(output),
+    majorVersion,
+    source,
+  };
+}
+
+function probeJavaCandidate(candidate, options) {
+  try {
+    return options.probeJavaRuntime({
+      ...candidate,
+      environment: options.baseEnvironment,
+      platform: options.platform,
+    });
+  } catch {
+    return undefined;
+  }
+}
+
+export function resolveJavaRuntime({
+  baseEnvironment = process.env,
+  platform = process.platform,
+  probeJavaRuntime = probeJavaExecutable,
+  windowsFallbackHomes,
+} = {}) {
+  const explicitJavaHome = javaHomeFromEnvironment(
+    baseEnvironment,
+    JAVA_RUNTIME_CONTRACT.explicitOverrideKey,
+  );
+  const hasExplicitOverride = hasEnvironmentKey(
+    baseEnvironment,
+    JAVA_RUNTIME_CONTRACT.explicitOverrideKey,
+  );
+  if (hasExplicitOverride) {
+    if (!explicitJavaHome) {
+      throw new JavaRuntimeConfigurationError(
+        `${javaRuntimeErrorMessage()} ${JAVA_RUNTIME_CONTRACT.explicitOverrideKey}가 비어 있습니다.`,
+      );
+    }
+    const candidate = {
+      executable: javaExecutableFromHome(explicitJavaHome, platform),
+      javaHome: explicitJavaHome,
+      source: 'explicit-override',
+    };
+    const result = probeJavaCandidate(candidate, {
+      baseEnvironment,
+      platform,
+      probeJavaRuntime,
+    });
+    if (!result) {
+      throw new JavaRuntimeConfigurationError(
+        explicitJavaRuntimeError(explicitJavaHome, '경로가 없거나 실행할 수 없습니다.'),
+      );
+    }
+    if (
+      !Number.isInteger(result.majorVersion) ||
+      result.majorVersion < JAVA_RUNTIME_CONTRACT.minimumMajorVersion
+    ) {
+      throw new JavaRuntimeConfigurationError(
+        explicitJavaRuntimeError(
+          explicitJavaHome,
+          `Java ${JAVA_RUNTIME_CONTRACT.minimumMajorVersion}+가 아닌 ${result.majorVersion}입니다.`,
+        ),
+      );
+    }
+    return { ...candidate, ...result, source: candidate.source };
+  }
+
+  const candidates = [];
+  const currentJavaHome = javaHomeFromEnvironment(
+    baseEnvironment,
+    JAVA_RUNTIME_CONTRACT.currentJavaHomeKey,
+  );
+  if (currentJavaHome) {
+    candidates.push({
+      executable: javaExecutableFromHome(currentJavaHome, platform),
+      javaHome: currentJavaHome,
+      source: 'java-home',
+    });
+  }
+  candidates.push({
+    executable: javaExecutableName(platform),
+    source: 'path',
+  });
+
+  if (platform === 'win32') {
+    const fallbackHomes = windowsFallbackHomes ?? discoverWindowsJavaFallbackHomes(baseEnvironment);
+    candidates.push(
+      ...fallbackHomes.map((javaHome) => ({
+        executable: javaExecutableFromHome(javaHome, platform),
+        javaHome,
+        source: 'windows-jbr-fallback',
+      })),
+    );
+  }
+
+  for (const candidate of candidates) {
+    const result = probeJavaCandidate(candidate, {
+      baseEnvironment,
+      platform,
+      probeJavaRuntime,
+    });
+    if (result?.majorVersion >= JAVA_RUNTIME_CONTRACT.minimumMajorVersion) {
+      return { ...candidate, ...result, source: candidate.source };
+    }
+  }
+
+  throw new JavaRuntimeConfigurationError(javaRuntimeErrorMessage());
+}
+
+export function projectJavaRuntime(environment, javaRuntime, platform = process.platform) {
+  if (
+    !javaRuntime ||
+    !Number.isInteger(javaRuntime.majorVersion) ||
+    javaRuntime.majorVersion < JAVA_RUNTIME_CONTRACT.minimumMajorVersion
+  ) {
+    throw new JavaRuntimeConfigurationError(javaRuntimeErrorMessage());
+  }
+
+  const projected = {
+    ...environment,
+    JAVA_HOME: javaRuntime.javaHome || '',
+  };
+  const javaBin = javaRuntime.javaHome
+    ? pathApiForPlatform(platform).join(javaRuntime.javaHome, 'bin')
+    : '';
+  if (javaBin) {
+    const pathKey = Object.hasOwn(projected, 'PATH')
+      ? 'PATH'
+      : Object.hasOwn(projected, 'Path')
+        ? 'Path'
+        : 'PATH';
+    const inheritedPath = readEnvironmentValue(projected, pathKey);
+    projected[pathKey] = [javaBin, inheritedPath]
+      .filter(Boolean)
+      .join(platform === 'win32' ? ';' : ':');
+  }
+  return projected;
 }
 
 function isProductionMarker(key, environment) {
@@ -307,6 +558,8 @@ export function buildChildSpecs({
   repositoryRoot = REPOSITORY_ROOT,
   pnpmCommand,
   firebaseCommand,
+  javaRuntime,
+  javaRuntimeResolver = resolveJavaRuntime,
 } = {}) {
   const resolvedPnpmCommand = pnpmCommand ?? executableName('pnpm', platform);
   const configuredFirebaseCommand = readEnvironmentValue(
@@ -315,6 +568,7 @@ export function buildChildSpecs({
   );
   const resolvedFirebaseCommand =
     firebaseCommand ?? (configuredFirebaseCommand || executableName('firebase', platform));
+  const selectedJavaRuntime = javaRuntime ?? javaRuntimeResolver({ baseEnvironment, platform });
 
   const appEnvironment = (port, nextAuthUrl) =>
     buildRuntimeEnvironment(baseEnvironment, {
@@ -330,9 +584,13 @@ export function buildChildSpecs({
     HOSTNAME: '127.0.0.1',
   });
 
-  const firebaseEnvironment = buildRuntimeEnvironment(baseEnvironment, {
-    HOSTNAME: '127.0.0.1',
-  });
+  const firebaseEnvironment = projectJavaRuntime(
+    buildRuntimeEnvironment(baseEnvironment, {
+      HOSTNAME: '127.0.0.1',
+    }),
+    selectedJavaRuntime,
+    platform,
+  );
 
   return [
     {
@@ -692,6 +950,8 @@ export function createLocalRuntime({
   logger = console,
   pnpmCommand,
   firebaseCommand,
+  javaRuntime,
+  javaRuntimeResolver = resolveJavaRuntime,
 } = {}) {
   const children = new Map();
   let cleanupPromise;
@@ -731,6 +991,8 @@ export function createLocalRuntime({
       repositoryRoot,
       pnpmCommand,
       firebaseCommand,
+      javaRuntime,
+      javaRuntimeResolver,
     });
 
     for (const spec of specs) {

--- a/scripts/dev/local/launcher.mjs
+++ b/scripts/dev/local/launcher.mjs
@@ -1,0 +1,901 @@
+import { execFile as nativeExecFile, spawn as nativeSpawn } from 'node:child_process';
+import { createConnection, createServer } from 'node:net';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const MODULE_DIRECTORY = dirname(fileURLToPath(import.meta.url));
+
+export const REPOSITORY_ROOT = resolve(MODULE_DIRECTORY, '../../..');
+
+export const LOCAL_RUNTIME_CONTRACT = Object.freeze({
+  projectId: 'greenhub-local',
+  storageBucket: 'greenhub-local.appspot.com',
+  ports: Object.freeze({
+    api: 3000,
+    consumer: 3001,
+    sellerAdmin: 3002,
+    driver: 3003,
+    auth: 9099,
+    firestore: 8080,
+    storage: 9199,
+  }),
+  requiredMarkers: Object.freeze({
+    GREENHUB_LOCAL_RUNTIME: 'true',
+    NEXT_PUBLIC_GREENHUB_LOCAL_RUNTIME: 'true',
+    NODE_ENV: 'development',
+    GREENHUB_SCHEDULES_ENABLED: 'false',
+  }),
+});
+
+export const FIXED_PORTS = Object.freeze([
+  LOCAL_RUNTIME_CONTRACT.ports.api,
+  LOCAL_RUNTIME_CONTRACT.ports.consumer,
+  LOCAL_RUNTIME_CONTRACT.ports.sellerAdmin,
+  LOCAL_RUNTIME_CONTRACT.ports.driver,
+  LOCAL_RUNTIME_CONTRACT.ports.firestore,
+  LOCAL_RUNTIME_CONTRACT.ports.auth,
+  LOCAL_RUNTIME_CONTRACT.ports.storage,
+]);
+
+export const READINESS_HTTP_TARGETS = Object.freeze([
+  Object.freeze({
+    name: 'api-health',
+    url: `http://localhost:${LOCAL_RUNTIME_CONTRACT.ports.api}/health`,
+    requiresOkStatus: true,
+  }),
+  Object.freeze({
+    name: 'consumer-login',
+    url: `http://localhost:${LOCAL_RUNTIME_CONTRACT.ports.consumer}/login`,
+    requiresOkStatus: false,
+  }),
+  Object.freeze({
+    name: 'seller-login',
+    url: `http://localhost:${LOCAL_RUNTIME_CONTRACT.ports.sellerAdmin}/login`,
+    requiresOkStatus: false,
+  }),
+  Object.freeze({
+    name: 'driver-login',
+    url: `http://localhost:${LOCAL_RUNTIME_CONTRACT.ports.driver}/login`,
+    requiresOkStatus: false,
+  }),
+]);
+
+export const READINESS_LISTENER_PORTS = Object.freeze([
+  LOCAL_RUNTIME_CONTRACT.ports.auth,
+  LOCAL_RUNTIME_CONTRACT.ports.firestore,
+  LOCAL_RUNTIME_CONTRACT.ports.storage,
+]);
+
+export const LOCAL_BROWSER_URLS = Object.freeze([
+  `http://localhost:${LOCAL_RUNTIME_CONTRACT.ports.consumer}/login`,
+  `http://localhost:${LOCAL_RUNTIME_CONTRACT.ports.sellerAdmin}/login`,
+  `http://localhost:${LOCAL_RUNTIME_CONTRACT.ports.driver}/login`,
+]);
+
+const LOCAL_CORS_ORIGINS = [
+  `http://localhost:${LOCAL_RUNTIME_CONTRACT.ports.consumer}`,
+  `http://localhost:${LOCAL_RUNTIME_CONTRACT.ports.sellerAdmin}`,
+  `http://localhost:${LOCAL_RUNTIME_CONTRACT.ports.driver}`,
+].join(',');
+
+const PRODUCTION_MARKERS = Object.freeze({
+  NODE_ENV: 'production',
+  VERCEL_ENV: 'production',
+  RAILWAY_ENVIRONMENT_NAME: 'production',
+});
+
+const LOCAL_ENVIRONMENT_KEYS_TO_REMOVE = new Set([
+  'AUTH_SECRET',
+  'AUTH_URL',
+  'CORS_ORIGIN',
+  'CLOUDSDK_CORE_PROJECT',
+  'E2E_TEST_SECRET',
+  'E2E_TEST',
+  'FIREBASE_CONFIG',
+  'FIREBASE_SERVICE_ACCOUNT',
+  'FIREBASE_SERVICE_ACCOUNT_JSON',
+  'FIREBASE_SERVICE_ACCOUNT_PATH',
+  'GOOGLE_APPLICATION_CREDENTIALS',
+  'GOOGLE_APPLICATION_CREDENTIALS_JSON',
+  'GOOGLE_API_KEY',
+  'GOOGLE_CLOUD_PROJECT',
+  'JWT_REFRESH_SECRET',
+  'JWT_SECRET',
+  'NEXTAUTH_SECRET',
+  'NEXTAUTH_URL',
+  'NEXTAUTH_URL_INTERNAL',
+  'RAILWAY_ENVIRONMENT_NAME',
+  'ROUND_DIRECT_E2E_DRIVER_EMAILS',
+  'ROUND_DIRECT_E2E_ENABLED',
+  'ROUND_DIRECT_E2E_PORTONE_FIXTURES_JSON',
+  'ROUND_DIRECT_E2E_SHARED_SECRET',
+  'VERCEL_ENV',
+  'VERCEL_GIT_COMMIT_SHA',
+  'VERCEL_PROJECT_PRODUCTION_URL',
+  'VERCEL_URL',
+]);
+
+const LOCAL_RUNTIME_SAFE_OVERRIDE_KEYS = new Set([
+  'AUTH_URL',
+  'CORS_ORIGIN',
+  'HOSTNAME',
+  'NEXTAUTH_URL',
+  'NEXT_PUBLIC_API_URL',
+  'PORT',
+]);
+
+const LOCAL_ENVIRONMENT_KEY_PREFIXES_TO_REMOVE = [
+  'ALIGO_',
+  'FIREBASE_SERVICE_ACCOUNT_',
+  'GEMINI_',
+  'KAKAO_',
+  'NEXT_PUBLIC_GEMINI_',
+  'NEXT_PUBLIC_KAKAO_',
+  'NEXT_PUBLIC_PORTONE_',
+  'PORTONE_',
+];
+
+const LOCAL_RUNTIME_DENY_VALUE_KEYS = Object.freeze([
+  'ALIGO_API_KEY',
+  'ALIGO_SENDER_KEY',
+  'ALIGO_SENDER_PHONE',
+  'ALIGO_TEMPLATE_CODES_JSON',
+  'ALIGO_USER_ID',
+  'E2E_TEST',
+  'E2E_TEST_SECRET',
+  'FIREBASE_CONFIG',
+  'FIREBASE_SERVICE_ACCOUNT',
+  'FIREBASE_SERVICE_ACCOUNT_JSON',
+  'FIREBASE_SERVICE_ACCOUNT_PATH',
+  'GEMINI_API_KEY',
+  'GOOGLE_APPLICATION_CREDENTIALS',
+  'GOOGLE_APPLICATION_CREDENTIALS_JSON',
+  'GOOGLE_API_KEY',
+  'KAKAO_CLIENT_ID',
+  'KAKAO_CLIENT_SECRET',
+  'NEXT_PUBLIC_PORTONE_KAKAOPAY_CHANNEL_KEY',
+  'NEXT_PUBLIC_PORTONE_NAVERPAY_CHANNEL_KEY',
+  'NEXT_PUBLIC_PORTONE_STORE_ID',
+  'NEXT_PUBLIC_KAKAO_MAP_KEY',
+  'NEXTAUTH_SECRET',
+  'NEXTAUTH_URL_INTERNAL',
+  'PORTONE_V2_SECRET',
+  'PORTONE_WEBHOOK_SECRET',
+  'ROUND_DIRECT_E2E_DRIVER_EMAILS',
+  'ROUND_DIRECT_E2E_ENABLED',
+  'ROUND_DIRECT_E2E_PORTONE_FIXTURES_JSON',
+  'ROUND_DIRECT_E2E_SHARED_SECRET',
+]);
+
+export class LocalRuntimeError extends Error {
+  constructor(message, options = {}) {
+    super(message, options);
+    this.name = 'LocalRuntimeError';
+  }
+}
+
+export class LocalRuntimeConfigurationError extends LocalRuntimeError {
+  constructor(message) {
+    super(message);
+    this.name = 'LocalRuntimeConfigurationError';
+  }
+}
+
+export class PortCollisionError extends LocalRuntimeError {
+  constructor(ports) {
+    super(`로컬 runtime 포트가 이미 사용 중입니다: ${ports.join(', ')}`);
+    this.name = 'PortCollisionError';
+    this.ports = [...ports];
+  }
+}
+
+export class ChildProcessExitError extends LocalRuntimeError {
+  constructor(name, code, signal) {
+    const exitDescription = signal ? `signal=${signal}` : `code=${code ?? 'unknown'}`;
+    super(`소유 child process가 예기치 않게 종료되었습니다: ${name} (${exitDescription})`);
+    this.name = 'ChildProcessExitError';
+    this.childName = name;
+    this.code = code;
+    this.signal = signal;
+  }
+}
+
+export class ReadinessTimeoutError extends LocalRuntimeError {
+  constructor(result, timeoutMs) {
+    const failed = result?.failures?.join(', ') || '미확인';
+    super(`local runtime readiness timeout (${timeoutMs}ms): ${failed}`);
+    this.name = 'ReadinessTimeoutError';
+    this.result = result;
+    this.timeoutMs = timeoutMs;
+  }
+}
+
+export class ShutdownRequestedError extends LocalRuntimeError {
+  constructor(exitCode, signal) {
+    super(`local runtime 종료 요청: ${signal}`);
+    this.name = 'ShutdownRequestedError';
+    this.exitCode = exitCode;
+    this.signal = signal;
+  }
+}
+
+function readEnvironmentValue(environment, key) {
+  const value = environment?.[key];
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function isProductionMarker(key, environment) {
+  return readEnvironmentValue(environment, key).toLowerCase() === PRODUCTION_MARKERS[key];
+}
+
+export function assertSafeLocalParentEnvironment(environment = process.env) {
+  const productionKeys = Object.keys(PRODUCTION_MARKERS).filter((key) =>
+    isProductionMarker(key, environment),
+  );
+
+  if (productionKeys.length > 0) {
+    throw new LocalRuntimeConfigurationError(
+      `production marker가 있는 환경에서는 local runtime을 시작할 수 없습니다: ${productionKeys.join(', ')}`,
+    );
+  }
+}
+
+export function isBlockedLocalEnvironmentKey(key) {
+  if (LOCAL_ENVIRONMENT_KEYS_TO_REMOVE.has(key)) return true;
+  return LOCAL_ENVIRONMENT_KEY_PREFIXES_TO_REMOVE.some((prefix) => key.startsWith(prefix));
+}
+
+function fixedLocalEnvironment(overrides = {}) {
+  const safeOverrides = Object.fromEntries(
+    Object.entries(overrides).filter(([key]) => LOCAL_RUNTIME_SAFE_OVERRIDE_KEYS.has(key)),
+  );
+
+  return {
+    ...safeOverrides,
+    ...LOCAL_RUNTIME_CONTRACT.requiredMarkers,
+    AUTH_SECRET: 'greenhub-local-auth-secret',
+    CORS_ORIGIN: LOCAL_CORS_ORIGINS,
+    FIREBASE_PROJECT_ID: LOCAL_RUNTIME_CONTRACT.projectId,
+    FIREBASE_STORAGE_BUCKET: LOCAL_RUNTIME_CONTRACT.storageBucket,
+    FIREBASE_AUTH_EMULATOR_HOST: `127.0.0.1:${LOCAL_RUNTIME_CONTRACT.ports.auth}`,
+    FIRESTORE_EMULATOR_HOST: `127.0.0.1:${LOCAL_RUNTIME_CONTRACT.ports.firestore}`,
+    STORAGE_EMULATOR_HOST: `127.0.0.1:${LOCAL_RUNTIME_CONTRACT.ports.storage}`,
+    FIREBASE_STORAGE_EMULATOR_HOST: `127.0.0.1:${LOCAL_RUNTIME_CONTRACT.ports.storage}`,
+    NEXT_PUBLIC_GREENHUB_LOCAL_RUNTIME: 'true',
+    NEXT_PUBLIC_FIREBASE_API_KEY: 'greenhub-local-emulator-key',
+    NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN: 'greenhub-local.firebaseapp.com',
+    NEXT_PUBLIC_FIREBASE_PROJECT_ID: LOCAL_RUNTIME_CONTRACT.projectId,
+    NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET: LOCAL_RUNTIME_CONTRACT.storageBucket,
+    NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID: 'greenhub-local-sender',
+    NEXT_PUBLIC_FIREBASE_APP_ID: 'greenhub-local-app',
+    NEXT_PUBLIC_FIREBASE_AUTH_EMULATOR_HOST: `127.0.0.1:${LOCAL_RUNTIME_CONTRACT.ports.auth}`,
+    NEXT_PUBLIC_FIRESTORE_EMULATOR_HOST: `127.0.0.1:${LOCAL_RUNTIME_CONTRACT.ports.firestore}`,
+    NEXT_PUBLIC_FIREBASE_STORAGE_EMULATOR_HOST: `127.0.0.1:${LOCAL_RUNTIME_CONTRACT.ports.storage}`,
+    GREENHUB_LOCAL_PROVIDER_OUTBOUND_POLICY: 'DENY_ALL_EXTERNAL_PROVIDER_DISPATCH',
+    JWT_SECRET: 'greenhub-local-jwt-secret',
+    JWT_REFRESH_SECRET: 'greenhub-local-jwt-refresh-secret',
+  };
+}
+
+export function buildRuntimeEnvironment(baseEnvironment = process.env, overrides = {}) {
+  assertSafeLocalParentEnvironment(baseEnvironment);
+
+  const sanitized = {};
+  for (const [key, value] of Object.entries(baseEnvironment ?? {})) {
+    if (!isBlockedLocalEnvironmentKey(key)) sanitized[key] = value;
+  }
+
+  const environment = {
+    ...sanitized,
+    ...fixedLocalEnvironment(overrides),
+  };
+
+  for (const key of LOCAL_RUNTIME_DENY_VALUE_KEYS) environment[key] = '';
+
+  return environment;
+}
+
+function executableName(binary, platform) {
+  if (platform !== 'win32') return binary;
+  if (/\.(?:cmd|exe|com)$/i.test(binary)) return binary;
+  return `${binary}.cmd`;
+}
+
+export function buildChildSpecs({
+  baseEnvironment = process.env,
+  platform = process.platform,
+  repositoryRoot = REPOSITORY_ROOT,
+  pnpmCommand,
+  firebaseCommand,
+} = {}) {
+  const resolvedPnpmCommand = pnpmCommand ?? executableName('pnpm', platform);
+  const configuredFirebaseCommand = readEnvironmentValue(
+    baseEnvironment,
+    'GREENHUB_FIREBASE_COMMAND',
+  );
+  const resolvedFirebaseCommand =
+    firebaseCommand ?? (configuredFirebaseCommand || executableName('firebase', platform));
+
+  const appEnvironment = (port, nextAuthUrl) =>
+    buildRuntimeEnvironment(baseEnvironment, {
+      PORT: String(port),
+      NEXT_PUBLIC_API_URL: `http://localhost:${LOCAL_RUNTIME_CONTRACT.ports.api}`,
+      NEXTAUTH_URL: nextAuthUrl,
+      AUTH_URL: nextAuthUrl,
+      HOSTNAME: '127.0.0.1',
+    });
+
+  const apiEnvironment = buildRuntimeEnvironment(baseEnvironment, {
+    PORT: String(LOCAL_RUNTIME_CONTRACT.ports.api),
+    HOSTNAME: '127.0.0.1',
+  });
+
+  const firebaseEnvironment = buildRuntimeEnvironment(baseEnvironment, {
+    HOSTNAME: '127.0.0.1',
+  });
+
+  return [
+    {
+      name: 'firebase-emulator-suite',
+      command: resolvedFirebaseCommand,
+      args: [
+        'emulators:start',
+        '--only',
+        'auth,firestore,storage',
+        '--project',
+        LOCAL_RUNTIME_CONTRACT.projectId,
+      ],
+      cwd: repositoryRoot,
+      env: firebaseEnvironment,
+    },
+    {
+      name: 'api',
+      command: resolvedPnpmCommand,
+      args: ['--filter', 'api', 'start:dev'],
+      cwd: repositoryRoot,
+      env: apiEnvironment,
+    },
+    {
+      name: 'consumer',
+      command: resolvedPnpmCommand,
+      args: [
+        '--filter',
+        'consumer',
+        'dev',
+        '--port',
+        String(LOCAL_RUNTIME_CONTRACT.ports.consumer),
+      ],
+      cwd: repositoryRoot,
+      env: appEnvironment(
+        LOCAL_RUNTIME_CONTRACT.ports.consumer,
+        `http://localhost:${LOCAL_RUNTIME_CONTRACT.ports.consumer}`,
+      ),
+    },
+    {
+      name: 'seller-admin',
+      command: resolvedPnpmCommand,
+      args: [
+        '--filter',
+        'seller',
+        'dev',
+        '--port',
+        String(LOCAL_RUNTIME_CONTRACT.ports.sellerAdmin),
+      ],
+      cwd: repositoryRoot,
+      env: appEnvironment(
+        LOCAL_RUNTIME_CONTRACT.ports.sellerAdmin,
+        `http://localhost:${LOCAL_RUNTIME_CONTRACT.ports.sellerAdmin}`,
+      ),
+    },
+    {
+      name: 'driver',
+      command: resolvedPnpmCommand,
+      args: ['--filter', 'driver', 'dev'],
+      cwd: repositoryRoot,
+      env: appEnvironment(
+        LOCAL_RUNTIME_CONTRACT.ports.driver,
+        `http://localhost:${LOCAL_RUNTIME_CONTRACT.ports.driver}`,
+      ),
+    },
+  ];
+}
+
+export function isPortAvailable(
+  port,
+  { host = '127.0.0.1', createServerImpl = createServer } = {},
+) {
+  return new Promise((resolveResult, rejectResult) => {
+    const server = createServerImpl();
+    let settled = false;
+
+    const settle = (callback, value) => {
+      if (settled) return;
+      settled = true;
+      callback(value);
+    };
+
+    server.once('error', (error) => {
+      if (error?.code === 'EADDRINUSE') settle(resolveResult, false);
+      else settle(rejectResult, error);
+    });
+
+    server.listen({ port, host, exclusive: true }, () => {
+      server.close((error) => {
+        if (error) settle(rejectResult, error);
+        else settle(resolveResult, true);
+      });
+    });
+  });
+}
+
+export function probePortListening(port, { host = '127.0.0.1', timeoutMs = 1000 } = {}) {
+  return new Promise((resolveResult) => {
+    const socket = createConnection({ port, host });
+    let settled = false;
+
+    const settle = (value) => {
+      if (settled) return;
+      settled = true;
+      socket.destroy();
+      resolveResult(value);
+    };
+
+    socket.setTimeout(timeoutMs, () => settle(false));
+    socket.once('connect', () => settle(true));
+    socket.once('error', () => settle(false));
+  });
+}
+
+export async function preflightPorts(ports = FIXED_PORTS, { probe = isPortAvailable } = {}) {
+  const results = await Promise.all(
+    ports.map(async (port) => ({ port, available: await probe(port) })),
+  );
+  const collisions = results.filter((result) => !result.available).map((result) => result.port);
+  if (collisions.length > 0) throw new PortCollisionError(collisions);
+  return results;
+}
+
+async function fetchWithTimeout(fetchImpl, url, timeoutMs, externalSignal) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  const abortFromOutside = () => controller.abort();
+  externalSignal?.addEventListener('abort', abortFromOutside, { once: true });
+  try {
+    return await fetchImpl(url, {
+      method: 'GET',
+      redirect: 'follow',
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timer);
+    externalSignal?.removeEventListener('abort', abortFromOutside);
+  }
+}
+
+async function readJsonResponse(response) {
+  if (typeof response?.json === 'function') return response.json();
+  if (typeof response?.text === 'function') return JSON.parse(await response.text());
+  return undefined;
+}
+
+async function checkHttpReadiness(
+  target,
+  { fetchImpl = fetch, requestTimeoutMs = 2000, signal } = {},
+) {
+  try {
+    const response = await fetchWithTimeout(fetchImpl, target.url, requestTimeoutMs, signal);
+    if (response.status !== 200) {
+      return { name: target.name, ok: false, reason: `HTTP ${response.status}` };
+    }
+
+    if (target.requiresOkStatus) {
+      const body = await readJsonResponse(response);
+      if (body?.status !== 'ok') {
+        return { name: target.name, ok: false, reason: 'status=ok 아님' };
+      }
+    }
+
+    return { name: target.name, ok: true };
+  } catch (error) {
+    return {
+      name: target.name,
+      ok: false,
+      reason: error?.name === 'AbortError' ? 'timeout' : error?.message || '연결 실패',
+    };
+  }
+}
+
+export async function checkReadinessOnce({
+  listenerPorts = READINESS_LISTENER_PORTS,
+  httpTargets = READINESS_HTTP_TARGETS,
+  portProbe = probePortListening,
+  fetchImpl = fetch,
+  requestTimeoutMs = 2000,
+  signal,
+} = {}) {
+  const listenerResults = await Promise.all(
+    listenerPorts.map(async (port) => {
+      try {
+        return { port, ok: await portProbe(port) };
+      } catch (error) {
+        return { port, ok: false, reason: error?.message || '연결 실패' };
+      }
+    }),
+  );
+  const httpResults = await Promise.all(
+    httpTargets.map((target) =>
+      checkHttpReadiness(target, { fetchImpl, requestTimeoutMs, signal }),
+    ),
+  );
+  const failures = [
+    ...listenerResults.filter((result) => !result.ok).map((result) => `port:${result.port}`),
+    ...httpResults
+      .filter((result) => !result.ok)
+      .map((result) => `${result.name}:${result.reason}`),
+  ];
+
+  return {
+    ready: failures.length === 0,
+    listeners: listenerResults,
+    http: httpResults,
+    failures,
+  };
+}
+
+export async function waitForReadiness({
+  timeoutMs = 120_000,
+  pollIntervalMs = 250,
+  signal,
+  ...options
+} = {}) {
+  const deadline = Date.now() + timeoutMs;
+  let lastResult;
+
+  while (Date.now() <= deadline) {
+    if (signal?.aborted) throw new LocalRuntimeError('readiness probe가 중단되었습니다.');
+    lastResult = await checkReadinessOnce({ ...options, signal });
+    if (lastResult.ready) return lastResult;
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) break;
+    await new Promise((resolveResult) => {
+      const timer = setTimeout(resolveResult, Math.min(pollIntervalMs, remainingMs));
+      signal?.addEventListener(
+        'abort',
+        () => {
+          clearTimeout(timer);
+          resolveResult();
+        },
+        { once: true },
+      );
+    });
+  }
+
+  throw new ReadinessTimeoutError(lastResult, timeoutMs);
+}
+
+function executeFile(execFileImpl, command, args) {
+  return new Promise((resolveResult, rejectResult) => {
+    execFileImpl(command, args, { windowsHide: true }, (error) => {
+      if (error) rejectResult(error);
+      else resolveResult();
+    });
+  });
+}
+
+function childHasExited(child) {
+  return child?.exitCode !== null && child?.exitCode !== undefined;
+}
+
+function waitForChildExit(child, timeoutMs) {
+  if (childHasExited(child)) return Promise.resolve(true);
+  if (typeof child?.once !== 'function') return Promise.resolve(false);
+
+  return new Promise((resolveResult) => {
+    let settled = false;
+    const settle = (value) => {
+      if (settled) return;
+      settled = true;
+      resolveResult(value);
+    };
+    child.once('exit', () => settle(true));
+    setTimeout(() => settle(childHasExited(child)), timeoutMs);
+  });
+}
+
+export async function terminateOwnedProcessTree(
+  child,
+  {
+    platform = process.platform,
+    execFileImpl = nativeExecFile,
+    signalProcess = process.kill,
+    gracePeriodMs = 3000,
+  } = {},
+) {
+  if (!child?.pid) return;
+
+  if (platform === 'win32') {
+    try {
+      await executeFile(execFileImpl, 'taskkill.exe', ['/PID', String(child.pid), '/T', '/F']);
+    } catch {
+      // 이미 종료된 owned process에 대한 idempotent cleanup은 성공으로 취급한다.
+    }
+    return;
+  }
+
+  try {
+    signalProcess(-child.pid, 'SIGTERM');
+  } catch (error) {
+    if (error?.code !== 'ESRCH') {
+      try {
+        child.kill?.('SIGTERM');
+      } catch {
+        // 아래의 강제 종료 단계에서 최종 정리를 시도한다.
+      }
+    }
+  }
+
+  if (await waitForChildExit(child, gracePeriodMs)) return;
+
+  try {
+    signalProcess(-child.pid, 'SIGKILL');
+  } catch (error) {
+    if (error?.code !== 'ESRCH') {
+      try {
+        child.kill?.('SIGKILL');
+      } catch {
+        // cleanup은 호출자 finally에서 계속된다.
+      }
+    }
+  }
+}
+
+export function openLocalBrowserUrls(
+  urls = LOCAL_BROWSER_URLS,
+  { platform = process.platform, spawnImpl = nativeSpawn } = {},
+) {
+  for (const url of urls) {
+    let command;
+    let args;
+    if (platform === 'win32') {
+      command = 'cmd.exe';
+      args = ['/c', 'start', '', url];
+    } else if (platform === 'darwin') {
+      command = 'open';
+      args = [url];
+    } else {
+      command = 'xdg-open';
+      args = [url];
+    }
+
+    try {
+      const browserProcess = spawnImpl(command, args, {
+        detached: true,
+        stdio: 'ignore',
+        windowsHide: true,
+      });
+      browserProcess?.once?.('error', () => {});
+      browserProcess?.unref?.();
+    } catch {
+      // 브라우저 열기는 선택 기능이며 runtime readiness를 거짓으로 만들지 않는다.
+    }
+  }
+}
+
+export function createLocalRuntime({
+  baseEnvironment = process.env,
+  platform = process.platform,
+  repositoryRoot = REPOSITORY_ROOT,
+  spawnImpl = nativeSpawn,
+  terminateProcessTree = terminateOwnedProcessTree,
+  childSpecsFactory = buildChildSpecs,
+  readinessOptions = {},
+  logger = console,
+  pnpmCommand,
+  firebaseCommand,
+} = {}) {
+  const children = new Map();
+  let cleanupPromise;
+  let lifecycleResult;
+  let resolveLifecycle;
+  let ready = false;
+  let stopping = false;
+  const abortController = new AbortController();
+
+  const lifecyclePromise = new Promise((resolveResult) => {
+    resolveLifecycle = resolveResult;
+  });
+
+  const fail = (error) => {
+    if (lifecycleResult || stopping) return;
+    lifecycleResult = { kind: 'failure', error };
+    resolveLifecycle(lifecycleResult);
+    abortController.abort();
+  };
+
+  const requestStop = (exitCode, signal) => {
+    if (lifecycleResult) return;
+    stopping = true;
+    lifecycleResult = { kind: 'stop', exitCode, signal };
+    resolveLifecycle(lifecycleResult);
+    abortController.abort();
+  };
+
+  const start = () => {
+    if (children.size > 0)
+      throw new LocalRuntimeError('local runtime은 한 번만 시작할 수 있습니다.');
+    if (stopping) throw new ShutdownRequestedError(130, '시작 전 종료 요청');
+
+    const specs = childSpecsFactory({
+      baseEnvironment,
+      platform,
+      repositoryRoot,
+      pnpmCommand,
+      firebaseCommand,
+    });
+
+    for (const spec of specs) {
+      let child;
+      try {
+        child = spawnImpl(spec.command, spec.args, {
+          cwd: spec.cwd,
+          env: spec.env,
+          stdio: 'inherit',
+          windowsHide: true,
+          detached: platform !== 'win32',
+          shell: platform === 'win32' && /\.cmd$/i.test(spec.command),
+        });
+      } catch (error) {
+        throw new LocalRuntimeError(`owned child process 시작 실패: ${spec.name}`, {
+          cause: error,
+        });
+      }
+      children.set(spec.name, { spec, child });
+      child?.once?.('error', (error) => {
+        fail(
+          new LocalRuntimeError(`owned child process 시작 실패: ${spec.name}`, { cause: error }),
+        );
+      });
+      child?.once?.('exit', (code, signal) => {
+        if (!stopping) fail(new ChildProcessExitError(spec.name, code, signal));
+      });
+    }
+
+    return children;
+  };
+
+  const waitUntilReady = async () => {
+    const readinessPromise = waitForReadiness({
+      ...readinessOptions,
+      signal: abortController.signal,
+    });
+    readinessPromise.catch(() => {});
+    const lifecycleFailurePromise = lifecyclePromise.then((result) => {
+      if (result.kind === 'failure') throw result.error;
+      throw new ShutdownRequestedError(result.exitCode, result.signal);
+    });
+    return Promise.race([readinessPromise, lifecycleFailurePromise]).then(
+      (result) => {
+        ready = true;
+        return result;
+      },
+      (error) => {
+        if (lifecycleResult?.kind === 'failure') throw lifecycleResult.error;
+        throw error;
+      },
+    );
+  };
+
+  const waitForTermination = () => lifecyclePromise;
+
+  const cleanup = () => {
+    if (cleanupPromise) return cleanupPromise;
+    stopping = true;
+    abortController.abort();
+    cleanupPromise = Promise.allSettled(
+      [...children.values()].map(({ child }) =>
+        Promise.resolve().then(() => terminateProcessTree(child, { platform })),
+      ),
+    ).then((results) => {
+      const failures = results.filter((result) => result.status === 'rejected');
+      if (failures.length > 0) {
+        logger.error?.(`owned process cleanup 중 ${failures.length}건의 오류가 발생했습니다.`);
+      }
+      return results;
+    });
+    return cleanupPromise;
+  };
+
+  return {
+    start,
+    waitUntilReady,
+    waitForTermination,
+    requestStop,
+    cleanup,
+    isReady: () => ready,
+    isStopping: () => stopping,
+    children,
+  };
+}
+
+export function parseLauncherOptions(argv = [], environment = process.env) {
+  const explicitlyOpen = argv.includes('--open-browser');
+  const explicitlyClosed = argv.includes('--no-browser');
+  return {
+    openBrowser: explicitlyClosed
+      ? false
+      : explicitlyOpen || readEnvironmentValue(environment, 'GREENHUB_OPEN_BROWSER') === 'true',
+  };
+}
+
+export async function runLocalRuntime({
+  baseEnvironment = process.env,
+  openBrowser = false,
+  openBrowserImpl = openLocalBrowserUrls,
+  signalSource = process,
+  logger = console,
+  portAvailabilityProbe = isPortAvailable,
+  ...runtimeOptions
+} = {}) {
+  const runtime = createLocalRuntime({ ...runtimeOptions, baseEnvironment, logger });
+  const signalHandlers = {
+    SIGINT: () => runtime.requestStop(130, 'SIGINT'),
+    SIGTERM: () => runtime.requestStop(143, 'SIGTERM'),
+  };
+
+  for (const [signal, handler] of Object.entries(signalHandlers)) {
+    signalSource.on(signal, handler);
+  }
+
+  try {
+    assertSafeLocalParentEnvironment(baseEnvironment);
+    await preflightPorts(runtimeOptions.ports ?? FIXED_PORTS, {
+      probe: portAvailabilityProbe,
+    });
+
+    if (runtime.isStopping()) throw new ShutdownRequestedError(130, 'preflight 중 종료 요청');
+
+    runtime.start();
+    await runtime.waitUntilReady();
+    logger.log?.('[local-runtime] READY: emulator, API, Consumer, Seller/Admin, Driver');
+
+    if (openBrowser) {
+      await openBrowserImpl(LOCAL_BROWSER_URLS);
+    }
+
+    const termination = await runtime.waitForTermination();
+    if (termination.kind === 'failure') throw termination.error;
+    return termination.exitCode ?? 0;
+  } catch (error) {
+    await runtime.cleanup();
+    if (error instanceof ShutdownRequestedError) {
+      logger.log?.(`[local-runtime] ${error.signal}에 따라 종료했습니다.`);
+      return error.exitCode;
+    }
+    throw error;
+  } finally {
+    for (const [signal, handler] of Object.entries(signalHandlers)) {
+      signalSource.removeListener(signal, handler);
+    }
+    await runtime.cleanup();
+  }
+}
+
+export async function main(argv = process.argv.slice(2), environment = process.env) {
+  const launcherOptions = parseLauncherOptions(argv, environment);
+  try {
+    return await runLocalRuntime({
+      baseEnvironment: environment,
+      openBrowser: launcherOptions.openBrowser,
+    });
+  } catch (error) {
+    console.error(`[local-runtime] 실행 실패: ${error?.message || error}`);
+    return 1;
+  }
+}
+
+const invokedFile = process.argv[1] ? resolve(process.argv[1]) : '';
+const moduleFile = resolve(fileURLToPath(import.meta.url));
+if (invokedFile === moduleFile) {
+  const exitCode = await main();
+  process.exitCode = exitCode;
+}

--- a/scripts/dev/local/launcher.spec.mjs
+++ b/scripts/dev/local/launcher.spec.mjs
@@ -11,16 +11,26 @@ import {
   checkReadinessOnce,
   createLocalRuntime,
   FIXED_PORTS,
+  JAVA_RUNTIME_CONTRACT,
+  JavaRuntimeConfigurationError,
   LOCAL_BROWSER_URLS,
   LocalRuntimeConfigurationError,
   LocalRuntimeError,
   PortCollisionError,
   parseLauncherOptions,
   ReadinessTimeoutError,
+  resolveJavaRuntime,
   runLocalRuntime,
   terminateOwnedProcessTree,
   waitForReadiness,
 } from './launcher.mjs';
+
+const TEST_JAVA_RUNTIME = Object.freeze({
+  executable: 'C:\\Java\\21\\bin\\java.exe',
+  javaHome: 'C:\\Java\\21',
+  majorVersion: JAVA_RUNTIME_CONTRACT.minimumMajorVersion,
+  source: 'test',
+});
 
 function fakeChild(pid) {
   const child = new EventEmitter();
@@ -29,6 +39,10 @@ function fakeChild(pid) {
   child.signalCode = null;
   child.kill = () => true;
   return child;
+}
+
+function runTestRuntime(options = {}) {
+  return runLocalRuntime({ javaRuntime: TEST_JAVA_RUNTIME, ...options });
 }
 
 function waitForServerListening(server, port) {
@@ -78,6 +92,8 @@ test('동결된 포트·marker·Firebase identity를 모든 child spec에 투영
   const specs = buildChildSpecs({
     baseEnvironment: {
       PATH: 'test-path',
+      JAVA_HOME: 'C:\\Java\\17',
+      GREENHUB_JAVA_HOME: 'C:\\Local\\Java\\21',
       NODE_ENV: 'development',
       PORTONE_V2_SECRET: '외부 비밀값',
       ALIGO_API_KEY: '외부 비밀값',
@@ -99,6 +115,7 @@ test('동결된 포트·marker·Firebase identity를 모든 child spec에 투영
     pnpmCommand: 'pnpm.cmd',
     firebaseCommand: 'firebase.cmd',
     repositoryRoot: 'C:\\repo',
+    javaRuntime: TEST_JAVA_RUNTIME,
   });
 
   assert.equal(specs.length, 5);
@@ -126,6 +143,7 @@ test('동결된 포트·marker·Firebase identity를 모든 child spec에 투영
   ]);
 
   for (const spec of specs) {
+    assert.equal('GREENHUB_JAVA_HOME' in spec.env, false);
     assert.equal(spec.env.GREENHUB_LOCAL_RUNTIME, 'true');
     assert.equal(spec.env.NEXT_PUBLIC_GREENHUB_LOCAL_RUNTIME, 'true');
     assert.equal(spec.env.NODE_ENV, 'development');
@@ -167,7 +185,112 @@ test('동결된 포트·marker·Firebase identity를 모든 child spec에 투영
   for (const spec of specs.filter((candidate) => appUrls.has(candidate.name))) {
     assert.equal(spec.env.NEXTAUTH_URL, appUrls.get(spec.name));
     assert.equal(spec.env.AUTH_URL, appUrls.get(spec.name));
+    assert.equal(spec.env.JAVA_HOME, 'C:\\Java\\17');
+    assert.equal(spec.env.PATH, 'test-path');
   }
+
+  const firebaseSpec = specs.find((spec) => spec.name === 'firebase-emulator-suite');
+  assert.equal(firebaseSpec.env.JAVA_HOME, 'C:\\Java\\21');
+  assert.equal(firebaseSpec.env.PATH, 'C:\\Java\\21\\bin;test-path');
+});
+
+test('Java 21 선택 순서는 JAVA_HOME, PATH, Windows JBR fallback을 구분한다', () => {
+  const javaHomeResult = resolveJavaRuntime({
+    baseEnvironment: { JAVA_HOME: 'C:\\Java\\21' },
+    platform: 'win32',
+    windowsFallbackHomes: [],
+    probeJavaRuntime: ({ source }) =>
+      source === 'java-home' ? { majorVersion: 21 } : { majorVersion: 17 },
+  });
+  assert.equal(javaHomeResult.source, 'java-home');
+  assert.equal(javaHomeResult.javaHome, 'C:\\Java\\21');
+
+  const fallbackResult = resolveJavaRuntime({
+    baseEnvironment: {
+      JAVA_HOME: 'C:\\Java\\17',
+      ProgramFiles: 'C:\\Program Files',
+    },
+    platform: 'win32',
+    windowsFallbackHomes: ['C:\\Program Files\\Android\\Android Studio\\jbr'],
+    probeJavaRuntime: ({ source }) =>
+      source === 'windows-jbr-fallback' ? { majorVersion: 21 } : { majorVersion: 17 },
+  });
+  assert.equal(fallbackResult.source, 'windows-jbr-fallback');
+  assert.equal(fallbackResult.javaHome, 'C:\\Program Files\\Android\\Android Studio\\jbr');
+});
+
+test('Java 17만 있으면 Java 21 미충족으로 fail-closed한다', () => {
+  assert.throws(
+    () =>
+      resolveJavaRuntime({
+        baseEnvironment: { JAVA_HOME: 'C:\\Java\\17' },
+        platform: 'win32',
+        windowsFallbackHomes: [],
+        probeJavaRuntime: () => ({ majorVersion: 17 }),
+      }),
+    (error) => error instanceof JavaRuntimeConfigurationError && /Java 21\+/.test(error.message),
+  );
+});
+
+test('잘못된 GREENHUB_JAVA_HOME은 fallback보다 먼저 fail-closed한다', () => {
+  const sources = [];
+  assert.throws(
+    () =>
+      resolveJavaRuntime({
+        baseEnvironment: {
+          GREENHUB_JAVA_HOME: 'C:\\missing-java',
+          JAVA_HOME: 'C:\\Java\\17',
+        },
+        platform: 'win32',
+        windowsFallbackHomes: ['C:\\Program Files\\Android\\Android Studio\\jbr'],
+        probeJavaRuntime: ({ source }) => {
+          sources.push(source);
+          return source === 'explicit-override' ? undefined : { majorVersion: 21 };
+        },
+      }),
+    (error) => error instanceof JavaRuntimeConfigurationError,
+  );
+  assert.deepEqual(sources, ['explicit-override']);
+});
+
+test('빈 GREENHUB_JAVA_HOME도 명시 override 오류로 fail-closed한다', () => {
+  assert.throws(
+    () =>
+      resolveJavaRuntime({
+        baseEnvironment: { GREENHUB_JAVA_HOME: '  ' },
+        platform: 'win32',
+        windowsFallbackHomes: ['C:\\Program Files\\Android\\Android Studio\\jbr'],
+        probeJavaRuntime: () => ({ majorVersion: 21 }),
+      }),
+    (error) => error instanceof JavaRuntimeConfigurationError,
+  );
+});
+
+test('Java 런타임을 결정하지 못하면 child spawn을 0회로 유지한다', async () => {
+  let spawnCount = 0;
+  await assert.rejects(
+    runLocalRuntime({
+      baseEnvironment: {
+        NODE_ENV: 'development',
+        GREENHUB_JAVA_HOME: 'C:\\missing-java',
+      },
+      javaRuntimeResolver: ({ baseEnvironment, platform }) =>
+        resolveJavaRuntime({
+          baseEnvironment,
+          platform,
+          windowsFallbackHomes: [],
+          probeJavaRuntime: () => undefined,
+        }),
+      portAvailabilityProbe: async () => true,
+      spawnImpl: () => {
+        spawnCount += 1;
+        return fakeChild(2750 + spawnCount);
+      },
+      signalSource: new EventEmitter(),
+    }),
+    (error) => error instanceof JavaRuntimeConfigurationError,
+  );
+  assert.equal(spawnCount, 0);
 });
 
 test('production marker가 있으면 local child 환경을 만들지 않고 fail-closed한다', () => {
@@ -190,7 +313,7 @@ test('production marker가 있으면 local child 환경을 만들지 않고 fail
 test('production marker가 있으면 launcher도 child spawn 전에 fail-closed한다', async () => {
   let spawnCount = 0;
   await assert.rejects(
-    runLocalRuntime({
+    runTestRuntime({
       baseEnvironment: { NODE_ENV: 'production' },
       spawnImpl: () => {
         spawnCount += 1;
@@ -206,7 +329,7 @@ test('production marker가 있으면 launcher도 child spawn 전에 fail-closed�
 test('포트 충돌은 child spawn보다 먼저 실패하고 spawn을 0회로 유지한다', async () => {
   let spawnCount = 0;
   await assert.rejects(
-    runLocalRuntime({
+    runTestRuntime({
       baseEnvironment: { NODE_ENV: 'development' },
       portAvailabilityProbe: async (port) => port !== 3000,
       spawnImpl: () => {
@@ -228,7 +351,7 @@ test('실제 점유 listener가 있으면 launcher는 child를 하나도 시작�
 
   try {
     await assert.rejects(
-      runLocalRuntime({
+      runTestRuntime({
         ports: [port],
         baseEnvironment: { NODE_ENV: 'development' },
         spawnImpl: () => {
@@ -294,7 +417,7 @@ test('readiness failure 뒤 owned child cleanup이 실행되고 브라우저는 
   let browserOpenCount = 0;
 
   await assert.rejects(
-    runLocalRuntime({
+    runTestRuntime({
       baseEnvironment: { NODE_ENV: 'development' },
       portAvailabilityProbe: async () => true,
       spawnImpl: () => fakeChild(nextPid++),
@@ -329,7 +452,7 @@ test('브라우저 열기는 READY 로그 뒤에만 실행되고 API URL은 포�
   const signalSource = new EventEmitter();
   let nextPid = 4700;
 
-  const exitCode = await runLocalRuntime({
+  const exitCode = await runTestRuntime({
     baseEnvironment: { NODE_ENV: 'development' },
     portAvailabilityProbe: async () => true,
     spawnImpl: () => fakeChild(nextPid++),
@@ -423,7 +546,7 @@ test('startup failure 뒤 launcher가 시작한 child 전부를 정리하고 unr
   let spawnCount = 0;
 
   await assert.rejects(
-    runLocalRuntime({
+    runTestRuntime({
       baseEnvironment: { NODE_ENV: 'development' },
       portAvailabilityProbe: async () => true,
       spawnImpl: () => {
@@ -458,7 +581,7 @@ test('owned child의 정상 코드 조기 종료도 premature termination failur
   let firstChild;
 
   await assert.rejects(
-    runLocalRuntime({
+    runTestRuntime({
       baseEnvironment: { NODE_ENV: 'development' },
       portAvailabilityProbe: async () => true,
       spawnImpl: () => {
@@ -492,6 +615,7 @@ test('interrupt 요청은 idempotent cleanup으로 수렴한다', async () => {
   const runtime = createLocalRuntime({
     baseEnvironment: { NODE_ENV: 'development' },
     platform: 'win32',
+    javaRuntime: TEST_JAVA_RUNTIME,
     spawnImpl: () => fakeChild(nextPid++),
     terminateProcessTree: async (child) => {
       cleanedPids.push(child.pid);

--- a/scripts/dev/local/launcher.spec.mjs
+++ b/scripts/dev/local/launcher.spec.mjs
@@ -1,0 +1,527 @@
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { EventEmitter } from 'node:events';
+import { createServer } from 'node:net';
+import test from 'node:test';
+
+import {
+  buildChildSpecs,
+  buildRuntimeEnvironment,
+  ChildProcessExitError,
+  checkReadinessOnce,
+  createLocalRuntime,
+  FIXED_PORTS,
+  LOCAL_BROWSER_URLS,
+  LocalRuntimeConfigurationError,
+  LocalRuntimeError,
+  PortCollisionError,
+  parseLauncherOptions,
+  ReadinessTimeoutError,
+  runLocalRuntime,
+  terminateOwnedProcessTree,
+  waitForReadiness,
+} from './launcher.mjs';
+
+function fakeChild(pid) {
+  const child = new EventEmitter();
+  child.pid = pid;
+  child.exitCode = null;
+  child.signalCode = null;
+  child.kill = () => true;
+  return child;
+}
+
+function waitForServerListening(server, port) {
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen({ port, host: '127.0.0.1', exclusive: true }, resolve);
+  });
+}
+
+function closeServer(server) {
+  return new Promise((resolve) => {
+    if (!server.listening) {
+      resolve();
+      return;
+    }
+    server.close(() => resolve());
+  });
+}
+
+function spawnLongLivedProcess() {
+  return spawn(process.execPath, ['-e', 'setInterval(() => {}, 60000)'], {
+    detached: process.platform !== 'win32',
+    stdio: 'ignore',
+    windowsHide: true,
+  });
+}
+
+function isProcessAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitForProcessState(pid, expected, timeoutMs = 5000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() <= deadline) {
+    if (isProcessAlive(pid) === expected) return;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error(`PID ${pid} 상태가 ${expected}가 되지 않았습니다.`);
+}
+
+test('동결된 포트·marker·Firebase identity를 모든 child spec에 투영한다', () => {
+  const specs = buildChildSpecs({
+    baseEnvironment: {
+      PATH: 'test-path',
+      NODE_ENV: 'development',
+      PORTONE_V2_SECRET: '외부 비밀값',
+      ALIGO_API_KEY: '외부 비밀값',
+      KAKAO_CLIENT_SECRET: '외부 비밀값',
+      GEMINI_API_KEY: '외부 비밀값',
+      GOOGLE_API_KEY: '외부 비밀값',
+      FIREBASE_SERVICE_ACCOUNT_JSON: '{"private_key":"외부 비밀값"}',
+      FIREBASE_SERVICE_ACCOUNT_PATH: 'C:\\비밀\\firebase-adminsdk.json',
+      JWT_SECRET: '외부 비밀값',
+      JWT_REFRESH_SECRET: '외부 비밀값',
+      NEXTAUTH_SECRET: '외부 비밀값',
+      NEXT_PUBLIC_KAKAO_MAP_KEY: '외부 비밀값',
+      E2E_TEST: 'true',
+      E2E_TEST_SECRET: '외부 비밀값',
+      CORS_ORIGIN: 'https://production.example',
+      VERCEL_ENV: 'preview',
+    },
+    platform: 'win32',
+    pnpmCommand: 'pnpm.cmd',
+    firebaseCommand: 'firebase.cmd',
+    repositoryRoot: 'C:\\repo',
+  });
+
+  assert.equal(specs.length, 5);
+  assert.deepEqual(
+    specs.map((spec) => spec.name),
+    ['firebase-emulator-suite', 'api', 'consumer', 'seller-admin', 'driver'],
+  );
+  assert.deepEqual(
+    specs.filter((spec) => spec.name !== 'firebase-emulator-suite').map((spec) => spec.env.PORT),
+    ['3000', '3001', '3002', '3003'],
+  );
+  assert.deepEqual(specs.find((spec) => spec.name === 'consumer').args, [
+    '--filter',
+    'consumer',
+    'dev',
+    '--port',
+    '3001',
+  ]);
+  assert.deepEqual(specs.find((spec) => spec.name === 'seller-admin').args, [
+    '--filter',
+    'seller',
+    'dev',
+    '--port',
+    '3002',
+  ]);
+
+  for (const spec of specs) {
+    assert.equal(spec.env.GREENHUB_LOCAL_RUNTIME, 'true');
+    assert.equal(spec.env.NEXT_PUBLIC_GREENHUB_LOCAL_RUNTIME, 'true');
+    assert.equal(spec.env.NODE_ENV, 'development');
+    assert.equal(spec.env.GREENHUB_SCHEDULES_ENABLED, 'false');
+    assert.equal(
+      spec.env.CORS_ORIGIN,
+      'http://localhost:3001,http://localhost:3002,http://localhost:3003',
+    );
+    assert.equal(spec.env.FIREBASE_PROJECT_ID, 'greenhub-local');
+    assert.equal(spec.env.FIREBASE_STORAGE_BUCKET, 'greenhub-local.appspot.com');
+    assert.equal(spec.env.FIRESTORE_EMULATOR_HOST, '127.0.0.1:8080');
+    assert.equal(spec.env.FIREBASE_AUTH_EMULATOR_HOST, '127.0.0.1:9099');
+    assert.equal(spec.env.STORAGE_EMULATOR_HOST, '127.0.0.1:9199');
+    assert.equal(
+      spec.env.GREENHUB_LOCAL_PROVIDER_OUTBOUND_POLICY,
+      'DENY_ALL_EXTERNAL_PROVIDER_DISPATCH',
+    );
+    assert.equal(spec.env.PORTONE_V2_SECRET, '');
+    assert.equal(spec.env.ALIGO_API_KEY, '');
+    assert.equal(spec.env.KAKAO_CLIENT_SECRET, '');
+    assert.equal(spec.env.GEMINI_API_KEY, '');
+    assert.equal(spec.env.GOOGLE_API_KEY, '');
+    assert.equal(spec.env.FIREBASE_SERVICE_ACCOUNT_JSON, '');
+    assert.equal(spec.env.FIREBASE_SERVICE_ACCOUNT_PATH, '');
+    assert.equal(spec.env.JWT_SECRET, 'greenhub-local-jwt-secret');
+    assert.equal(spec.env.JWT_REFRESH_SECRET, 'greenhub-local-jwt-refresh-secret');
+    assert.equal(spec.env.NEXTAUTH_SECRET, '');
+    assert.equal(spec.env.NEXT_PUBLIC_KAKAO_MAP_KEY, '');
+    assert.equal(spec.env.E2E_TEST, '');
+    assert.equal(spec.env.E2E_TEST_SECRET, '');
+    assert.equal('VERCEL_ENV' in spec.env, false);
+  }
+
+  const appUrls = new Map([
+    ['consumer', 'http://localhost:3001'],
+    ['seller-admin', 'http://localhost:3002'],
+    ['driver', 'http://localhost:3003'],
+  ]);
+  for (const spec of specs.filter((candidate) => appUrls.has(candidate.name))) {
+    assert.equal(spec.env.NEXTAUTH_URL, appUrls.get(spec.name));
+    assert.equal(spec.env.AUTH_URL, appUrls.get(spec.name));
+  }
+});
+
+test('production marker가 있으면 local child 환경을 만들지 않고 fail-closed한다', () => {
+  assert.throws(
+    () => buildRuntimeEnvironment({ NODE_ENV: 'production' }),
+    (error) => error instanceof LocalRuntimeConfigurationError,
+  );
+  assert.throws(
+    () => buildRuntimeEnvironment({ VERCEL_ENV: 'production' }),
+    (error) => error instanceof LocalRuntimeConfigurationError,
+  );
+  const environment = buildRuntimeEnvironment(
+    { NODE_ENV: 'development' },
+    { NODE_ENV: 'production', FIREBASE_PROJECT_ID: 'green-e4fe3' },
+  );
+  assert.equal(environment.NODE_ENV, 'development');
+  assert.equal(environment.FIREBASE_PROJECT_ID, 'greenhub-local');
+});
+
+test('production marker가 있으면 launcher도 child spawn 전에 fail-closed한다', async () => {
+  let spawnCount = 0;
+  await assert.rejects(
+    runLocalRuntime({
+      baseEnvironment: { NODE_ENV: 'production' },
+      spawnImpl: () => {
+        spawnCount += 1;
+        return fakeChild(2000 + spawnCount);
+      },
+      signalSource: new EventEmitter(),
+    }),
+    (error) => error instanceof LocalRuntimeConfigurationError,
+  );
+  assert.equal(spawnCount, 0);
+});
+
+test('포트 충돌은 child spawn보다 먼저 실패하고 spawn을 0회로 유지한다', async () => {
+  let spawnCount = 0;
+  await assert.rejects(
+    runLocalRuntime({
+      baseEnvironment: { NODE_ENV: 'development' },
+      portAvailabilityProbe: async (port) => port !== 3000,
+      spawnImpl: () => {
+        spawnCount += 1;
+        return fakeChild(1000 + spawnCount);
+      },
+      signalSource: new EventEmitter(),
+    }),
+    (error) => error instanceof PortCollisionError && error.ports.includes(3000),
+  );
+  assert.equal(spawnCount, 0);
+});
+
+test('실제 점유 listener가 있으면 launcher는 child를 하나도 시작하지 않는다', async () => {
+  const port = 3000;
+  const server = createServer();
+  let spawnCount = 0;
+  await waitForServerListening(server, port);
+
+  try {
+    await assert.rejects(
+      runLocalRuntime({
+        ports: [port],
+        baseEnvironment: { NODE_ENV: 'development' },
+        spawnImpl: () => {
+          spawnCount += 1;
+          return fakeChild(2500 + spawnCount);
+        },
+        signalSource: new EventEmitter(),
+      }),
+      (error) => error instanceof PortCollisionError && error.ports.includes(port),
+    );
+    assert.equal(spawnCount, 0);
+  } finally {
+    await closeServer(server);
+  }
+});
+
+test('readiness aggregate는 세 emulator listener와 네 HTTP 조건을 모두 확인한다', async () => {
+  const probedPorts = [];
+  const requestedUrls = [];
+  const result = await checkReadinessOnce({
+    portProbe: async (port) => {
+      probedPorts.push(port);
+      return true;
+    },
+    fetchImpl: async (url) => {
+      requestedUrls.push(url);
+      return {
+        status: 200,
+        json: async () => (url.endsWith('/health') ? { status: 'ok' } : {}),
+      };
+    },
+  });
+
+  assert.equal(result.ready, true);
+  assert.deepEqual(
+    probedPorts.sort((left, right) => left - right),
+    [8080, 9099, 9199],
+  );
+  assert.deepEqual(requestedUrls.sort(), [
+    'http://localhost:3000/health',
+    'http://localhost:3001/login',
+    'http://localhost:3002/login',
+    'http://localhost:3003/login',
+  ]);
+});
+
+test('readiness timeout은 마지막 aggregate 실패를 보존한다', async () => {
+  await assert.rejects(
+    waitForReadiness({
+      timeoutMs: 1,
+      pollIntervalMs: 0,
+      portProbe: async () => false,
+      fetchImpl: async () => ({ status: 503, json: async () => ({}) }),
+      requestTimeoutMs: 10,
+    }),
+    (error) => error.name === 'ReadinessTimeoutError' && error.result.failures.length > 0,
+  );
+});
+
+test('readiness failure 뒤 owned child cleanup이 실행되고 브라우저는 열지 않는다', async () => {
+  const cleanedPids = [];
+  let nextPid = 4500;
+  let browserOpenCount = 0;
+
+  await assert.rejects(
+    runLocalRuntime({
+      baseEnvironment: { NODE_ENV: 'development' },
+      portAvailabilityProbe: async () => true,
+      spawnImpl: () => fakeChild(nextPid++),
+      readinessOptions: {
+        timeoutMs: 1,
+        pollIntervalMs: 0,
+        portProbe: async () => false,
+        fetchImpl: async () => ({ status: 503, json: async () => ({}) }),
+      },
+      openBrowserImpl: async () => {
+        browserOpenCount += 1;
+      },
+      terminateProcessTree: async (child) => {
+        cleanedPids.push(child.pid);
+      },
+      signalSource: new EventEmitter(),
+      openBrowser: true,
+    }),
+    (error) => error instanceof ReadinessTimeoutError,
+  );
+
+  assert.equal(browserOpenCount, 0);
+  assert.deepEqual(
+    cleanedPids.sort((left, right) => left - right),
+    [4500, 4501, 4502, 4503, 4504],
+  );
+});
+
+test('브라우저 열기는 READY 로그 뒤에만 실행되고 API URL은 포함하지 않는다', async () => {
+  const events = [];
+  const cleanedPids = [];
+  const signalSource = new EventEmitter();
+  let nextPid = 4700;
+
+  const exitCode = await runLocalRuntime({
+    baseEnvironment: { NODE_ENV: 'development' },
+    portAvailabilityProbe: async () => true,
+    spawnImpl: () => fakeChild(nextPid++),
+    readinessOptions: {
+      portProbe: async () => true,
+      fetchImpl: async (url) => ({
+        status: 200,
+        json: async () => (url.endsWith('/health') ? { status: 'ok' } : {}),
+      }),
+    },
+    openBrowser: true,
+    openBrowserImpl: async (urls) => {
+      events.push({ kind: 'browser', urls });
+      signalSource.emit('SIGINT');
+    },
+    terminateProcessTree: async (child) => {
+      cleanedPids.push(child.pid);
+    },
+    signalSource,
+    logger: {
+      log: (message) => events.push({ kind: 'log', message }),
+      error: () => {},
+    },
+  });
+
+  assert.equal(exitCode, 130);
+  assert.equal(events[0].kind, 'log');
+  assert.match(events[0].message, /READY/);
+  assert.equal(events[1].kind, 'browser');
+  assert.deepEqual(events[1].urls, LOCAL_BROWSER_URLS);
+  assert.equal(
+    events[1].urls.some((url) => url.includes(':3000')),
+    false,
+  );
+  assert.deepEqual(
+    cleanedPids.sort((left, right) => left - right),
+    [4700, 4701, 4702, 4703, 4704],
+  );
+});
+
+test('browser 기본값은 닫혀 있고 명시적 옵션만 연다', () => {
+  assert.equal(parseLauncherOptions([], {}).openBrowser, false);
+  assert.equal(parseLauncherOptions(['--open-browser'], {}).openBrowser, true);
+  assert.equal(
+    parseLauncherOptions(['--no-browser'], { GREENHUB_OPEN_BROWSER: 'true' }).openBrowser,
+    false,
+  );
+});
+
+test('owned process tree cleanup은 정확한 child PID만 Windows taskkill에 전달한다', async () => {
+  const calls = [];
+  const child = fakeChild(4242);
+  await terminateOwnedProcessTree(child, {
+    platform: 'win32',
+    execFileImpl: (command, args, options, callback) => {
+      calls.push({ command, args, options });
+      callback(null);
+    },
+  });
+
+  assert.deepEqual(calls, [
+    {
+      command: 'taskkill.exe',
+      args: ['/PID', '4242', '/T', '/F'],
+      options: { windowsHide: true },
+    },
+  ]);
+});
+
+test('실제 OS process cleanup은 launcher가 시작한 process만 종료하고 unrelated process는 보존한다', {
+  timeout: 20000,
+}, async () => {
+  const owned = spawnLongLivedProcess();
+  const unrelated = spawnLongLivedProcess();
+
+  try {
+    await waitForProcessState(owned.pid, true);
+    await waitForProcessState(unrelated.pid, true);
+    await terminateOwnedProcessTree(owned, { platform: process.platform });
+    await waitForProcessState(owned.pid, false);
+    assert.equal(isProcessAlive(unrelated.pid), true);
+  } finally {
+    await terminateOwnedProcessTree(unrelated, { platform: process.platform });
+    await waitForProcessState(unrelated.pid, false).catch(() => {});
+  }
+});
+
+test('startup failure 뒤 launcher가 시작한 child 전부를 정리하고 unrelated PID를 건드리지 않는다', async () => {
+  const children = [];
+  const cleanedPids = [];
+  let spawnCount = 0;
+
+  await assert.rejects(
+    runLocalRuntime({
+      baseEnvironment: { NODE_ENV: 'development' },
+      portAvailabilityProbe: async () => true,
+      spawnImpl: () => {
+        const child = fakeChild(5000 + spawnCount);
+        spawnCount += 1;
+        children.push(child);
+        if (spawnCount === 2) {
+          setTimeout(() => child.emit('error', new Error('기동 실패')), 0);
+        }
+        return child;
+      },
+      terminateProcessTree: async (child) => {
+        cleanedPids.push(child.pid);
+      },
+      signalSource: new EventEmitter(),
+    }),
+    (error) => error instanceof LocalRuntimeError || error instanceof ChildProcessExitError,
+  );
+
+  assert.equal(spawnCount, 5);
+  assert.deepEqual(
+    cleanedPids.sort((left, right) => left - right),
+    [5000, 5001, 5002, 5003, 5004],
+  );
+  assert.equal(cleanedPids.includes(9999), false);
+  assert.equal(children.length, 5);
+});
+
+test('owned child의 정상 코드 조기 종료도 premature termination failure로 처리한다', async () => {
+  const cleanedPids = [];
+  let nextPid = 5500;
+  let firstChild;
+
+  await assert.rejects(
+    runLocalRuntime({
+      baseEnvironment: { NODE_ENV: 'development' },
+      portAvailabilityProbe: async () => true,
+      spawnImpl: () => {
+        const child = fakeChild(nextPid++);
+        if (!firstChild) {
+          firstChild = child;
+          setTimeout(() => {
+            child.exitCode = 0;
+            child.emit('exit', 0, null);
+          }, 0);
+        }
+        return child;
+      },
+      terminateProcessTree: async (child) => {
+        cleanedPids.push(child.pid);
+      },
+      signalSource: new EventEmitter(),
+    }),
+    (error) => error instanceof ChildProcessExitError && error.code === 0,
+  );
+
+  assert.deepEqual(
+    cleanedPids.sort((left, right) => left - right),
+    [5500, 5501, 5502, 5503, 5504],
+  );
+});
+
+test('interrupt 요청은 idempotent cleanup으로 수렴한다', async () => {
+  const cleanedPids = [];
+  let nextPid = 6000;
+  const runtime = createLocalRuntime({
+    baseEnvironment: { NODE_ENV: 'development' },
+    platform: 'win32',
+    spawnImpl: () => fakeChild(nextPid++),
+    terminateProcessTree: async (child) => {
+      cleanedPids.push(child.pid);
+    },
+  });
+
+  runtime.start();
+  runtime.requestStop(130, 'SIGINT');
+  assert.deepEqual(await runtime.waitForTermination(), {
+    kind: 'stop',
+    exitCode: 130,
+    signal: 'SIGINT',
+  });
+  await runtime.cleanup();
+  await runtime.cleanup();
+
+  assert.deepEqual(
+    cleanedPids.sort((left, right) => left - right),
+    [6000, 6001, 6002, 6003, 6004],
+  );
+});
+
+test('브라우저 URL은 API 없이 세 login 화면만 가진다', () => {
+  assert.deepEqual(LOCAL_BROWSER_URLS, [
+    'http://localhost:3001/login',
+    'http://localhost:3002/login',
+    'http://localhost:3003/login',
+  ]);
+});
+
+test('동결된 fixed port 집합을 축소하지 않는다', () => {
+  assert.deepEqual(FIXED_PORTS, [3000, 3001, 3002, 3003, 8080, 9099, 9199]);
+});


### PR DESCRIPTION
## 목적
Issue #77에서 ACCEPT된 frozen local-runtime contract를 소비해 Local Runtime Launcher / Port / Readiness / Process Lifecycle semantic owner를 구현했습니다.

## 변경
- `dev.bat`, `Justfile`, root `package.json`을 하나의 canonical local launcher로 연결했습니다.
- Firebase Auth/Firestore/Storage와 API, Consumer, Seller/Admin, Driver를 고정 포트로 소유합니다.
- 7개 fixed port preflight collision에서 child spawn 0회, 기존 process 미종료, 자동 포트 변경 없음으로 fail-closed합니다.
- emulator listener, API `/health`의 `200 + status=ok`, 세 앱 `/login` HTTP 200을 aggregate readiness로 확인합니다.
- child crash/start failure/readiness timeout 및 Ctrl+C/interrupt/startup error/normal cleanup을 owned process tree에 한정하고 idempotent하게 처리합니다.
- local child 환경에 production/provider credential를 상속하지 않고 local marker, emulator identity, local secret만 주입합니다.
- browser 기본값은 OFF이며 명시적 open 시 READY 이후 Consumer/Seller/Driver login만 엽니다.

## 검증
- `pnpm test:local-launcher`: 17/17 PASS
- 실제 런타임: 3000/3001/3002/3003/8080/9099/9199 listening, API `/health` 및 세 `/login` HTTP 200, READY 로그 확인
- 실제 Ctrl+C 뒤 fixed-port listener 0개 확인
- 실제 OS process ownership: owned process만 종료하고 unrelated process 보존
- `dev.bat` 실제 collision 진입점: exit code 1, 3000 점유에서 child spawn 없음
- `pnpm exec biome check ...`: PASS
- `node --check`: PASS
- `git diff --check`: PASS
- 선택 브라우저 timing: READY 이후 세 login URL만 열리는 focused test PASS; 실제 세 login 화면도 로드 확인

## 경계
- 기준 부모: `0358c8d956fb22064ab93685d46714d2023ef505`
- 후보: `112e8eff06b11925d2e93c36dfde2b1f76ef5f70`
- M2 후보 `da7c1fab51f1d13195d60bfd61972f62a51a3d6c`와 PR #82는 병합하거나 가져오지 않았습니다.
- M2-owned 파일은 수정하지 않았습니다.
- main merge/deploy 및 `FULL LOCAL STACK PROVEN` 선언은 이 PR 범위에 포함하지 않습니다.
- M1+M2 serial full local runtime proof는 Control Tower의 별도 single-flight Goal로 deferred 상태입니다.