### PR TITLE
fix(ci): 고정 Vercel Preview metadata 증거 게이트 전환

### DIFF
--- a/.github/workflows/e2e-round-direct.yml
+++ b/.github/workflows/e2e-round-direct.yml
@@ -7,6 +7,18 @@ on:
         description: '세 Preview 앱이 가리켜야 하는 40자리 commit SHA'
         required: true
         type: string
+      consumer_deployment_id:
+        description: 'consumer의 직접 검증 대상 Vercel deployment ID'
+        required: true
+        type: string
+      seller_deployment_id:
+        description: 'seller의 직접 검증 대상 Vercel deployment ID'
+        required: true
+        type: string
+      driver_deployment_id:
+        description: 'driver의 직접 검증 대상 Vercel deployment ID'
+        required: true
+        type: string
       approval:
         description: '비운영 회차 E2E 실행을 승인합니다.'
         required: true
@@ -34,6 +46,9 @@ jobs:
           REPOSITORY_OWNER: ${{ github.repository_owner }}
           APPROVAL: ${{ inputs.approval }}
           EXPECTED_SHA: ${{ inputs.expected_sha }}
+          CONSUMER_DEPLOYMENT_ID: ${{ inputs.consumer_deployment_id }}
+          SELLER_DEPLOYMENT_ID: ${{ inputs.seller_deployment_id }}
+          DRIVER_DEPLOYMENT_ID: ${{ inputs.driver_deployment_id }}
           RUN_ID: ${{ github.run_id }}
           RUN_ATTEMPT: ${{ github.run_attempt }}
           WORKFLOW_SHA: ${{ github.sha }}
@@ -67,6 +82,15 @@ jobs:
             echo '지정 SHA는 40자리 소문자 16진수여야 합니다.' >&2
             exit 1
           fi
+          for deployment_id in \
+            "$CONSUMER_DEPLOYMENT_ID" \
+            "$SELLER_DEPLOYMENT_ID" \
+            "$DRIVER_DEPLOYMENT_ID"; do
+            if [[ ! "$deployment_id" =~ ^dpl_[A-Za-z0-9]+$ ]]; then
+              echo 'pinned Vercel deployment ID 형식이 올바르지 않습니다.' >&2
+              exit 1
+            fi
+          done
 
   e2e:
     name: 지정 SHA 회차 직배송 E2E
@@ -79,11 +103,13 @@ jobs:
       name: round-direct-e2e
     permissions:
       contents: read
-      statuses: read
     env:
       ROUND_DIRECT_E2E_ENABLED: 'true'
       ROUND_DIRECT_E2E_ENV: preview
       ROUND_DIRECT_E2E_EXPECTED_SHA: ${{ inputs.expected_sha }}
+      ROUND_DIRECT_E2E_CONSUMER_DEPLOYMENT_ID: ${{ inputs.consumer_deployment_id }}
+      ROUND_DIRECT_E2E_SELLER_DEPLOYMENT_ID: ${{ inputs.seller_deployment_id }}
+      ROUND_DIRECT_E2E_DRIVER_DEPLOYMENT_ID: ${{ inputs.driver_deployment_id }}
       ROUND_DIRECT_E2E_RUN_ID: task-6-7-${{ github.run_id }}-${{ github.run_attempt }}
       ROUND_DIRECT_E2E_RUN_ATTEMPT: ${{ github.run_attempt }}
       ROUND_DIRECT_E2E_EVENT_NAME: ${{ github.event_name }}
@@ -158,19 +184,21 @@ jobs:
       - name: 의존성 설치
         run: pnpm install --frozen-lockfile
 
-      - name: 세 Preview 앱의 지정 SHA 확인
+      - name: 세 pinned Vercel deployment metadata 직접 확인
         shell: bash
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ROUND_DIRECT_E2E_VERCEL_READ_TOKEN: ${{ secrets.ROUND_DIRECT_E2E_VERCEL_READ_TOKEN }}
         run: |
           set -euo pipefail
           evidence_root=".artifacts/round-direct/$ROUND_DIRECT_E2E_RUN_ID"
           mkdir -p "$evidence_root/evidence"
           set +e
           node scripts/wait-preview-deploy.mjs \
-            --once \
             --json \
             --sha="$ROUND_DIRECT_E2E_EXPECTED_SHA" \
+            --consumer-deployment-id="$ROUND_DIRECT_E2E_CONSUMER_DEPLOYMENT_ID" \
+            --seller-deployment-id="$ROUND_DIRECT_E2E_SELLER_DEPLOYMENT_ID" \
+            --driver-deployment-id="$ROUND_DIRECT_E2E_DRIVER_DEPLOYMENT_ID" \
             > "$evidence_root/deployment-raw.json"
           wait_status=$?
           set -e
@@ -182,22 +210,38 @@ jobs:
             | sed 's/^/ROUND_DIRECT_E2E_DEPLOYMENT_SHAS_JSON=/' >> "$GITHUB_ENV"
           jq -c '.deploymentTargetUrls' "$evidence_root/deployment-raw.json" \
             | sed 's/^/ROUND_DIRECT_E2E_TARGET_URLS_JSON=/' >> "$GITHUB_ENV"
+          if [[ "$wait_status" -eq 0 ]]; then
+            jq -er '.deploymentTargetUrls.consumer' "$evidence_root/deployment-raw.json" \
+              | sed 's/^/CONSUMER_BASE=/' >> "$GITHUB_ENV"
+            jq -er '.deploymentTargetUrls.seller' "$evidence_root/deployment-raw.json" \
+              | sed 's/^/SELLER_BASE=/' >> "$GITHUB_ENV"
+            jq -er '.deploymentTargetUrls.driver' "$evidence_root/deployment-raw.json" \
+              | sed 's/^/DRIVER_BASE=/' >> "$GITHUB_ENV"
+          fi
           jq '{
             ready,
+            evidenceSource,
             checkedAt,
             repository,
             expectedSha,
-            deploymentIds: (.apps | map({key: .app, value: .deploymentId}) | from_entries),
+            pinnedDeploymentIds,
+            deploymentIds,
             deploymentShas,
             deploymentTargetUrls,
-            deploymentStates: (.apps | map({key: .app, value: .state}) | from_entries),
+            deploymentStates,
+            failureCodes,
             apps: [.apps[] | {
               app,
+              project,
+              projectId,
               environment,
               deploymentId,
               deploymentSha,
               state,
+              readyState,
+              target,
               target_url: .targetUrl,
+              failureCode,
               ready
             }]
             }' \

--- a/.github/workflows/e2e-round-direct.yml
+++ b/.github/workflows/e2e-round-direct.yml
@@ -146,6 +146,7 @@ jobs:
           ACTOR: ${{ github.actor }}
           TRIGGERING_ACTOR: ${{ github.triggering_actor }}
           REPOSITORY_OWNER: ${{ github.repository_owner }}
+          WORKFLOW_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
           if [[ "$EVENT_NAME" != 'workflow_dispatch' ]]; then
@@ -182,6 +183,7 @@ jobs:
             '.github/workflows/sync-preview.yml'
             'scripts/wait-preview-deploy.mjs'
             'scripts/wait-preview-deploy.spec.mjs'
+            'scripts/check-round-direct-e2e-readiness.spec.mjs'
           )
           mapfile -t candidate_paths < <(
             git diff --name-only "$ROUND_DIRECT_E2E_EXPECTED_SHA" "$WORKFLOW_SHA"
@@ -197,7 +199,8 @@ jobs:
               .github/workflows/e2e-round-direct.yml|\
               .github/workflows/sync-preview.yml|\
               scripts/wait-preview-deploy.mjs|\
-              scripts/wait-preview-deploy.spec.mjs)
+              scripts/wait-preview-deploy.spec.mjs|\
+              scripts/check-round-direct-e2e-readiness.spec.mjs)
                 ;;
               *)
                 echo "application SHA와 candidate 사이에 허용되지 않은 변경이 있어 실행을 차단합니다: $candidate_path" >&2

--- a/.github/workflows/e2e-round-direct.yml
+++ b/.github/workflows/e2e-round-direct.yml
@@ -132,13 +132,13 @@ jobs:
       PLAYWRIGHT_JSON_OUTPUT_FILE: ${{ github.workspace }}/.artifacts/round-direct/task-6-7-${{ github.run_id }}-${{ github.run_attempt }}/playwright-raw.json
 
     steps:
-      - name: 지정 SHA checkout
+      - name: candidate workflow SHA checkout
         uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.expected_sha }}
+          ref: ${{ github.sha }}
           fetch-depth: 0
 
-      - name: 수동 승인과 checkout SHA 확인
+      - name: 수동 승인과 application/candidate SHA 확인
         shell: bash
         env:
           APPROVAL: ${{ inputs.approval }}
@@ -169,10 +169,42 @@ jobs:
             exit 1
           fi
           actual_sha="$(git rev-parse HEAD)"
-          if [[ "$actual_sha" != "$ROUND_DIRECT_E2E_EXPECTED_SHA" ]]; then
-            echo 'checkout SHA가 지정 SHA와 달라 실행을 차단합니다.' >&2
+          if [[ "$actual_sha" != "$WORKFLOW_SHA" ]]; then
+            echo 'checkout SHA가 workflow candidate SHA와 달라 실행을 차단합니다.' >&2
             exit 1
           fi
+          if ! git merge-base --is-ancestor "$ROUND_DIRECT_E2E_EXPECTED_SHA" "$WORKFLOW_SHA"; then
+            echo 'application SHA가 candidate workflow의 조상이 아니어서 실행을 차단합니다.' >&2
+            exit 1
+          fi
+          required_candidate_paths=(
+            '.github/workflows/e2e-round-direct.yml'
+            '.github/workflows/sync-preview.yml'
+            'scripts/wait-preview-deploy.mjs'
+            'scripts/wait-preview-deploy.spec.mjs'
+          )
+          mapfile -t candidate_paths < <(
+            git diff --name-only "$ROUND_DIRECT_E2E_EXPECTED_SHA" "$WORKFLOW_SHA"
+          )
+          for required_path in "${required_candidate_paths[@]}"; do
+            if [[ ! " ${candidate_paths[*]} " == *" $required_path "* ]]; then
+              echo "candidate에 필요한 CI gate 파일이 없어 실행을 차단합니다: $required_path" >&2
+              exit 1
+            fi
+          done
+          for candidate_path in "${candidate_paths[@]}"; do
+            case "$candidate_path" in
+              .github/workflows/e2e-round-direct.yml|\
+              .github/workflows/sync-preview.yml|\
+              scripts/wait-preview-deploy.mjs|\
+              scripts/wait-preview-deploy.spec.mjs)
+                ;;
+              *)
+                echo "application SHA와 candidate 사이에 허용되지 않은 변경이 있어 실행을 차단합니다: $candidate_path" >&2
+                exit 1
+                ;;
+            esac
+          done
 
       - uses: pnpm/action-setup@v6
 

--- a/.github/workflows/sync-preview.yml
+++ b/.github/workflows/sync-preview.yml
@@ -44,14 +44,14 @@ jobs:
           git merge origin/main --no-edit -m "chore(preview): sync main into preview"
           git push origin preview
 
-      # sync-preview success ≠ Vercel 실배포 완료. 여기서 막지 않으면 아래 e2e
-      # dispatch 가 stale(이전 커밋) preview 를 검사한다(세션39·60·61 race).
-      # 3앱 Vercel commit status가 현재 preview HEAD에서 success 할 때까지 폴링하고,
-      # timeout 시 fail-fast(exit 1)로 e2e dispatch 를 차단해 배포 지연을 노출한다.
-      - name: Wait for preview deploy (SHA-matched Vercel commit statuses poll)
+      # 이 자동 동기화 경로에는 workflow_dispatch로 고정한 deployment ID가 없다.
+      # 따라서 GitHub commit status는 진단 정보로만 남기고 canonical acceptance에는
+      # 사용하지 않는다. pinned metadata 검증은 round-direct workflow가 소유한다.
+      - name: Preview commit status diagnostic (non-blocking)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: node scripts/wait-preview-deploy.mjs
+        continue-on-error: true
+        run: node scripts/wait-preview-deploy.mjs --diagnostic-status
 
       # GITHUB_TOKEN 으로 만든 push 는 다른 워크플로(e2e.yml 의 push 트리거)를
       # 재귀 방지 정책상 발화시키지 않는다. workflow_dispatch 는 발화하므로

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -2,7 +2,7 @@
 
 # Greenhub Backlog
 
-> 기준일: 2026-09-06 KST
+> 기준일: 2026-09-07 KST
 >
 > 현재 미완료·향후 작업만 관리한다. 완료 상세는 Git history, `docs/CRITICAL_LOGIC.md`, `docs/archive/`, 완료 PLAN·REPORT를 사용한다.
 
@@ -26,11 +26,22 @@ S2 → R1 Public Readiness의 accepted 종료 상태와 exact-source Preview 증
 - R1 Combined Public Readiness: `PUBLIC_READINESS_CLOSED`
 - S2 → R1 campaign: `TERMINAL_SUCCESS`
 - #63이 확인한 pre-publication main 기준선: `ffd999423f8a98b0c1f34d020d832d7929feab72` — historical baseline
-- #71이 재확인한 현재 live `main`: `fe5e680fa58c8b3af5e508d07115bb8ab9df272a`
+- 현재 live remote `main`: `0358c8d956fb22064ab93685d46714d2023ef505` — PR #69 merge 후 보호된 기준선
 - #70 `SALE-ROUND-STATE-01`은 `MERGED`; 회차 atomicity/recovery implementation과 직접 proof가 publication되었다.
 - 역사적 exact-source Preview 기준선: `7cc4d9862dd49b68fb1542e49c53fb953bfdf59c` — 현재 main, PR, merge, production 증거로 승격하지 않는다.
 - #63의 accepted closure는 닫힌 semantic work를 다시 열지 않는다는 뜻이며, Preview·Auth.js runtime 검증 잔여와 production/activation은 별도 상태다.
-- 기존 문서 candidate는 PR #69에서 후속 갱신하며, 이 Goal은 PR #69를 merge하지 않고 Control Tower publication queue로 반환한다.
+- Preview Evidence Gate 02 implementation candidate는 `433a1182a377f152d140e9609bd6e15ae0eb6f1c`이며 PR #90은 `OPEN / UNMERGED / PUBLICATION_HOLD`다.
+- PR #90의 pinned Vercel metadata gate와 focused proof는 완료되었고, 이 Goal은 PR #90을 merge하지 않고 Control Tower publication queue로 반환한다.
+
+## PREVIEW-EVIDENCE-GATE-02
+
+- implementation: `IMPLEMENTATION_COMPLETE`
+- proof: `PROOF_COMPLETE` — exact project/source SHA/`READY` metadata와 focused `verify` gate
+- publication: `PUBLICATION_HOLD` — PR #90 `OPEN / UNMERGED`
+- candidate: `433a1182a377f152d140e9609bd6e15ae0eb6f1c`, remote-addressable
+- successor: 생성하지 않음; 이 branch에서 추가 기능 구현을 진행하지 않음
+- exact release distinction: #76 최신 TASK_RECORD는 `RUNTIME_DEFECT_FOUND`; exact Preview binding 이후 Auth.js browser boundary에서 세션 발급이 실패했고 Sale Round runtime은 `NOT_PROVEN`이다.
+- Auth Preview distinction: #88 최신 기록은 `AUTH_PREVIEW_BINDING_PROVEN`; 동일 배포의 stateless JWT revocation은 `NOT_CLOSED`로 post-pilot residual이다.
 
 ---
 
@@ -39,12 +50,12 @@ S2 → R1 Public Readiness의 accepted 종료 상태와 exact-source Preview 증
 | 주장 | 현재 판정 |
 |---|---|
 | implementation | `SALE-ROUND-STATE-ATOMICITY-AND-RECOVERY`는 `IMPLEMENTATION_PROVEN`; #66이 race/recovery proof를 accepted함 |
-| verification | Sale Round implementation/race/recovery proof는 `PROVEN`; exact-release Preview/runtime/browser proof는 `PENDING` |
-| prior candidate | PR #69의 기존 accepted candidate는 `9c921684a26597cb57887b6049288f1143b017c8` |
-| updated candidate | PR #69의 후속 candidate는 remote-addressable 상태로 갱신하며, 정확한 head SHA는 Issue #75 TASK_RECORD에 기록 |
-| PR | 기존 documentation PR #69는 `OPEN`; 이번 Goal은 merge하지 않음 |
-| published / merged | PR #70은 `MERGED`; live `main`은 `fe5e680fa58c8b3af5e508d07115bb8ab9df272a` |
-| Preview runtime proof | exact-release runtime/browser proof는 `PENDING`; historical Preview evidence를 승격하지 않음 |
+| verification | Sale Round implementation/race/recovery proof는 `PROVEN`; Preview Evidence Gate 02 metadata/focused proof는 `PROOF_COMPLETE`; #76 exact-release browser/runtime은 `RUNTIME_DEFECT_FOUND` |
+| candidate | `433a1182a377f152d140e9609bd6e15ae0eb6f1c`, remote-addressable, PR #90 head |
+| PR | PR #90 `OPEN / UNMERGED`; 이번 Goal은 merge하지 않음 |
+| published / merged | 현재 protected `main`은 `0358c8d956fb22064ab93685d46714d2023ef505`; PR #90 candidate는 아직 merge되지 않음 |
+| Auth Preview Binding | #88 `AUTH_PREVIEW_BINDING_PROVEN`; same-deployment stateless JWT revocation은 `NOT_CLOSED` |
+| Preview runtime proof | candidate metadata/focused gate는 `PROOF_COMPLETE`; #76 Sale Round browser/runtime은 `NOT_PROVEN` / `FINAL_BROWSER_RESIDUAL` |
 | production deployment | `PRODUCTION_AUTHORITY_PENDING` |
 | production activation | `PRODUCTION_AUTHORITY_PENDING` |
 | first live round | `PRODUCTION_AUTHORITY_PENDING` |
@@ -353,8 +364,8 @@ repo-side production auto-deploy 차단과 GitHub main 보호를 완료했다. 2
 
 Issue #66이 회차 수정·수동 개방·주문 예약·취소 복구의 race/recovery 구현과 직접 proof를
 accepted했다. semantic candidate `4169bf250d3bdf4a5196209090307ca979e8d32a`는 PR #70으로
-게시되었고, PR #70은 merge되어 현재 live `main` `fe5e680fa58c8b3af5e508d07115bb8ab9df272a`로
-read-back되었다.
+게시되었고, PR #70과 후속 PR #69가 merge되어 현재 live `main`
+`0358c8d956fb22064ab93685d46714d2023ef505`로 read-back되었다.
 
 직접 proof 범위:
 
@@ -366,10 +377,11 @@ read-back되었다.
 | crash recovery, partial cancellation/retry와 duplicate convergence | `PROVEN` |
 | focused/integration/regression proof와 exact candidate publication | `PROVEN` / `PUBLISHED` |
 
-이 상태는 implementation과 repository publication에 대한 proof다. exact-release Preview/browser/runtime
-proof는 `PENDING`이며, production deployment·production activation·`salesMode` 전환·live round·actual
-payment/notification·first live round는 `PRODUCTION_AUTHORITY_PENDING`이다. 이 문서 후보와 PR #69는
-이를 production-ready로 표현하지 않는다.
+이 상태는 implementation과 repository publication에 대한 proof다. Preview Evidence Gate 02의
+metadata/focused proof는 `PROOF_COMPLETE`이지만, #76 exact-release Preview/browser/runtime은
+최신 `RUNTIME_DEFECT_FOUND` / `NOT_PROVEN`이다. production deployment·production activation·
+`salesMode` 전환·live round·actual payment/notification·first live round는
+`PRODUCTION_AUTHORITY_PENDING`이다. PR #90을 production-ready로 표현하지 않는다.
 
 기술 계약은 `docs/specs/mvp-sales-round-direct-delivery.md`, 운영 중단·재개 규칙은
 `docs/specs/ops/mvp-sales-round-runbook.md`에 둔다.
@@ -387,7 +399,7 @@ commit과 경로만 추적 가능한 `HISTORICAL_EVIDENCE`로 남긴다. 현재 
   감사 보고서다. 현재 branch에는 보고서 파일을 복구하지 않으며, 과거 결론을 현재 `VERIFIED`로
   승격하지 않는다.
 - `CURRENT_IMPLEMENTATION_EVIDENCE`: 현재 source·직접 테스트·current spec·runbook을 다시
-  대조한 결과다. Sale Round atomicity/recovery는 #66의 직접 proof와 #70/#71 publication으로
+  대조한 결과다. Sale Round atomicity/recovery는 #66의 직접 proof와 #70/#69 publication으로
   `IMPLEMENTATION_PROVEN` / `PUBLISHED`가 되었으며, 남은 현재 공백은 retention과 operation
   claim fencing의 두 finding으로 분리했다.
 - 위에서 유지된 직접 검증 항목은 `RESOLVED_NOT_PROMOTED`다. 이는 해당 base contract가 현재
@@ -395,7 +407,7 @@ commit과 경로만 추적 가능한 `HISTORICAL_EVIDENCE`로 남긴다. 현재 
   되었다는 뜻이 아니다.
 - `CURRENT_UNRESOLVED_FINDING`: `RETENTION-DELETE-ISSUE-ROUTING`,
   `OPERATION-ACTION-CLAIM-FENCING`만 이번 BR-R3의 current unresolved finding으로
-  canonicalize한다. Sale Round finding은 #66/#70/#71로 implementation proof와 publication이
+  canonicalize한다. Sale Round finding은 #66/#70/#69로 implementation proof와 publication이
   완료되었지만, 이 사실이 exact-release runtime proof나 production 승인을 의미하지는 않는다.
 - `FUTURE_REENABLE_REQUIREMENT`: 역사 보고서의 marketing consent lifecycle 논점은 현재
   `MARKETING_NOT_USED_IN_PILOT` controlled-pilot 정책을 변경하거나 새 finding으로 승격하지 않는다. 향후 marketing을 다시
@@ -406,24 +418,26 @@ commit과 경로만 추적 가능한 `HISTORICAL_EVIDENCE`로 남긴다. 현재 
 
 ## VERIFICATION
 
-### Preview·exact-SHA proof
+### Preview Evidence Gate·exact-SHA proof
 
-상태: `VERIFICATION_PENDING`.
+상태: Preview Evidence Gate 02는 `PROOF_COMPLETE`; #76 exact-release browser/runtime은 `RUNTIME_DEFECT_FOUND` / `NOT_PROVEN`이다.
 
-- #63이 인정한 Preview/browser/fixture 결과는 해당 exact source에 대한 재사용 가능한 역사적 증거다.
+- candidate `433a1182a377f152d140e9609bd6e15ae0eb6f1c`의 pinned Vercel metadata project/source SHA/`READY` 대조와 focused `verify` proof는 완료됐다.
+- #63이 인정한 Preview/browser/fixture 결과는 해당 historical exact source에 대한 재사용 가능한 증거다.
 - `7cc4d9862dd49b68fb1542e49c53fb953bfdf59c`와 그 Preview deployment를 현재 main, 현재 candidate, production deployment로 표현하지 않는다.
-- 현재 release candidate에서 필요한 exact-SHA Preview/browser/fixture proof와 Auth.js session/logout/rotation/stale-claim lifecycle proof는 별도 검증 gate다.
+- #76 최신 TASK_RECORD는 exact deployment/fixture binding 이후 Auth.js Credentials callback/session 경계에서 `RUNTIME_DEFECT_FOUND`를 기록했고, Sale Round runtime은 `NOT_PROVEN`이다.
+- 다음 authorized runtime 진입은 `RUN_NOW / FINAL_BROWSER_RESIDUAL`로 분류하며, 이 docs-only Goal에서는 browser proof를 실행하지 않는다.
 - 구현 완료, 검증 완료, Preview proof, production deployment·activation은 서로 대체하지 않는다.
 
-## BLOCKED_EXTERNAL
+## EXTERNAL_RESIDUALS
 
-### Auth.js session runtime
+### Auth.js Preview binding·session revocation
 
-상태: `EXTERNAL_RUNTIME_BLOCKED`.
+상태: `AUTH_PREVIEW_BINDING_PROVEN` + `PILOT_POLICY_ACCEPTS_CURRENT_BOUNDED_REVOCATION` + `REVOCATION_POLICY_DEFERRED_POST_PILOT`.
 
-- Auth.js session cookie 발급·동일 브라우저 context persistence·logout/rotation·stale claim lifecycle은 runtime/browser proof가 필요하다.
-- static source, fixture, callback 응답만으로 session runtime 성공을 주장하지 않는다.
-- 필요한 runtime/browser authority가 없으면 `UNVERIFIED`로 유지하며 source/runtime mutation을 이 Goal에서 수행하지 않는다.
+- Issue #88 최신 runtime evidence에서 Consumer/Seller/Driver의 Credentials session 발급·동일 브라우저 context persistence·logout·refresh lineage·stale token/revocation·cleanup이 bounded scope에서 `PASS`다.
+- 동일 배포의 stateless Auth.js JWT stale-session revocation은 `NOT_CLOSED`이며 `AUTH-SESSION-CLAIM-REVOCATION` post-pilot high-priority policy/security residual로 유지한다.
+- 이 상태는 #76의 별도 browser runtime defect를 해결한 것으로 보지 않는다.
 
 ### ALIGO provider current metadata
 
@@ -470,7 +484,7 @@ commit과 경로만 추적 가능한 `HISTORICAL_EVIDENCE`로 남긴다. 현재 
 - [ ] authenticated ALIGO metadata read-back
 - [ ] provider metadata와 repository logical 8-code mapping 직접 대조
 - [ ] 별도 authority 후 격리 actual Alimtalk/SMS 및 fallback 검증
-- [ ] exact release SHA 기준 Preview/browser/fixture와 Auth.js session lifecycle 검증
+- [ ] #76 `EXACT-RELEASE-PROOF-01` final browser/runtime residual 해소 — 최신 `RUNTIME_DEFECT_FOUND`; Preview Evidence Gate 02 metadata/focused proof는 완료
 - [ ] production deployment·activation·첫 회차 전용 승인 및 read-back
 
 ### 법무·출시 후보 정합성

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -6,7 +6,7 @@
 
 ## 검증 기준
 
-- Git·GitHub와 #63/#70/#71 release state: `2026-09-06 KST` 직접 재조회
+- Git·GitHub와 #76/#88/#90 release state: `2026-09-07 KST` 직접 재조회
 - Vercel 배포 안전·exact-source Preview: 역사적 증거 snapshot; 현재 release proof로 재사용하지 않는다.
 - ALIGO provider current metadata: `UNVERIFIED` — #65에서 authenticated provider read-back이 없음을 확인했다.
 - 운영 상태 변경은 별도 승인 없이 수행하지 않는다.
@@ -17,7 +17,7 @@
 - 기본 브랜치: `main`; HEAD는 작업 시작 시 직접 재조회한다.
 - 회차 직배송 기능 통합 기준 SHA(역사적 기능 기준선): `e55f25914cc7d01576fbd4639583daaf0fe6385e`
 - #63이 accepted한 pre-publication main 기준 SHA: `ffd999423f8a98b0c1f34d020d832d7929feab72` — historical baseline
-- #70/#71이 publication 후 재확인한 현재 live `main`: `fe5e680fa58c8b3af5e508d07115bb8ab9df272a`
+- 현재 live remote `main`: `0358c8d956fb22064ab93685d46714d2023ef505` — PR #69 merge 후 보호된 기준선
 - `7cc4d9862dd49b68fb1542e49c53fb953bfdf59c`는 historical exact-source Preview 기준선이며 현재 main이나 production source가 아니다.
 - PR #30/#31로 세 프런트의 `main` Vercel Git auto-production과 pure-doc build를 repo-side 차단했다.
 - docs-only main 변경은 Preview sync/일반 E2E 제외.
@@ -45,29 +45,39 @@
 - historical exact-source Preview source: `7cc4d9862dd49b68fb1542e49c53fb953bfdf59c`
 - historical Driver Preview: deployment `dpl_4UVQ2BuTNfrBc1zm68X5Kjbvu9PE`, target `preview`, state `READY`. 당시 metadata가 해당 historical source와 일치했다는 뜻이며 현재 main·candidate·production proof가 아니다.
 - pre-publication main accepted by #63: `ffd999423f8a98b0c1f34d020d832d7929feab72`; PR #60/#61/#62가 merge된 historical publication baseline이다.
-- current live main after #70/#71: `fe5e680fa58c8b3af5e508d07115bb8ab9df272a`; PR #70이 merge된 Sale Round publication state다.
+- current live main: `0358c8d956fb22064ab93685d46714d2023ef505`; PR #69 merge 후의 보호된 publication 기준선이다.
+
+## PREVIEW-EVIDENCE-GATE-02
+
+- implementation candidate: `433a1182a377f152d140e9609bd6e15ae0eb6f1c` — remote-addressable
+- semantic status: `IMPLEMENTATION_COMPLETE` + `PROOF_COMPLETE`
+- publication status: `PUBLICATION_HOLD`
+- PR #90: `OPEN / UNMERGED`; required `verify`와 세 Vercel Preview check는 `PASS`
+- gate 범위: 고정 Vercel Preview deployment metadata의 project/source SHA/`READY` 대조와 focused proof
+- 이 branch에서 추가 기능 구현이나 successor Preview Evidence Gate task를 만들지 않는다.
 
 ## Readiness·publication·production 구분
 
 - `IMPLEMENTATION`: #66이 `SALE-ROUND-STATE-ATOMICITY-AND-RECOVERY`의 구현과 race/recovery proof를 accepted하여 `IMPLEMENTATION_PROVEN`이다.
-- `VERIFICATION`: Sale Round focused/integration/regression proof는 `PROVEN`; exact-release Preview/browser/runtime과 Auth.js session/logout/rotation/stale-claim lifecycle은 별도 `PENDING`/`EXTERNAL_RUNTIME_BLOCKED` gate다.
-- `CANDIDATE`: 기존 documentation candidate는 `9c921684a26597cb57887b6049288f1143b017c8`; 후속 candidate는 PR #69 head로 갱신한다.
-- `REMOTE_ADDRESSABLE`: #70 semantic candidate와 현재 live main `fe5e680fa58c8b3af5e508d07115bb8ab9df272a`는 remote-addressable이며, 문서 후속 candidate도 PR #69 원격 head로 read-back한다.
-- `PR`: PR #70은 `MERGED`; 기존 documentation PR #69는 `OPEN`이며 이번 Goal은 merge하지 않는다.
-- `PUBLISHED/MERGED`: Sale Round publication은 `PUBLISHED`; live main read-back은 `fe5e680fa58c8b3af5e508d07115bb8ab9df272a`다.
-- `PREVIEW_PROOF`: exact-release runtime/browser proof는 `PENDING`; `7cc4d9862dd49b68fb1542e49c53fb953bfdf59c` Preview deployment는 historical evidence다.
+- `VERIFICATION`: Sale Round focused/integration/regression proof는 `PROVEN`; Preview Evidence Gate 02 metadata/focused proof는 `PROOF_COMPLETE`; #76 exact-release browser/runtime proof는 `RUNTIME_DEFECT_FOUND` / `NOT_PROVEN`이다.
+- `AUTH_PREVIEW_BINDING`: #88 최신 runtime evidence는 `AUTH_PREVIEW_BINDING_PROVEN`; 동일 배포의 stateless Auth.js JWT revocation은 `NOT_CLOSED`로 남는다.
+- `CANDIDATE`: Preview Evidence Gate 02 implementation candidate는 `433a1182a377f152d140e9609bd6e15ae0eb6f1c`이며 PR #90 head다.
+- `REMOTE_ADDRESSABLE`: candidate branch ref와 exact candidate object를 원격에서 조회할 수 있고, 현재 live main은 `0358c8d956fb22064ab93685d46714d2023ef505`다.
+- `PR`: PR #90은 `OPEN / UNMERGED`; release SHA freeze 때문에 이번 Goal에서 merge하지 않는다.
+- `PUBLISHED/MERGED`: 현재 protected `main` read-back은 `0358c8d956fb22064ab93685d46714d2023ef505`; Preview Evidence Gate candidate는 아직 main에 merge되지 않았다.
+- `PREVIEW_PROOF`: candidate의 pinned Vercel metadata/focused gate는 `PROOF_COMPLETE`; #76은 exact deployment/fixture binding 이후 Auth.js browser boundary에서 `RUNTIME_DEFECT_FOUND`다.
 - production deployment/activation, live round, actual payment, actual notification, first-round completion: `PRODUCTION_AUTHORITY_PENDING` / `NOT CLAIMED`.
 
 ## 현재 source·publication 기준
 
-#63/#68 작업의 pre-publication 기준과 #71 publication 후 live authority를 read-only로 확인한 결과를 기록한다. 문서 변경 후 생기는 commit은 이 source baseline과 별도의 documentation publication candidate다.
+#90 작업의 implementation candidate와 현재 protected main/live authority를 read-only로 확인한 결과를 기록한다. 문서 변경 후 생기는 commit은 같은 PR branch의 docs-only publication candidate다.
 
-- 작업 시작 branch: `main`
-- 작업 시작 source HEAD/local `main`: `ffd999423f8a98b0c1f34d020d832d7929feab72`
-- 작업 시작 local `origin/main`: `ffd999423f8a98b0c1f34d020d832d7929feab72`
-- 작업 시작 live remote `main`: `fe5e680fa58c8b3af5e508d07115bb8ab9df272a` — #71 publication read-back
+- 작업 시작 branch: `codex/preview-evidence-gate-02`
+- 작업 시작 source HEAD: `433a1182a377f152d140e9609bd6e15ae0eb6f1c`
+- 작업 시작 local `main`: `ffd999423f8a98b0c1f34d020d832d7929feab72`
+- 작업 시작 local `origin/main` 및 live remote `main`: `0358c8d956fb22064ab93685d46714d2023ef505`
 - pre-publication live baseline `ffd999423f8a98b0c1f34d020d832d7929feab72`는 #63/#68의 historical baseline이다.
-- #70 semantic candidate `4169bf250d3bdf4a5196209090307ca979e8d32a`는 `PUBLISHED`; documentation candidate는 PR #69에서 후속 갱신하며 main merge가 아니다.
+- Preview Evidence Gate 02 candidate `433a1182a377f152d140e9609bd6e15ae0eb6f1c`는 PR #90에서 `OPEN / UNMERGED` 상태이며 main merge가 아니다.
 - historical `7cc4d9862dd49b68fb1542e49c53bf953bfdf59c`와 이전 provider snapshot은 current SHA·current provider metadata·production proof로 사용하지 않는다.
 - GitHub main 보호 때문에 direct main commit/push는 금지되며, 문서 변경은 purpose branch + PR 경계를 따른다.
 
@@ -94,24 +104,25 @@
 
 #66이 회차 수정·수동 개방·주문 예약·취소 복구의 fresh state/time/ownership 경계를 직접 검증하고
 구현 proof를 accepted했다. semantic candidate `4169bf250d3bdf4a5196209090307ca979e8d32a`는
-PR #70으로 merge되었고, #71 publication read-back의 현재 live `main`은
-`fe5e680fa58c8b3af5e508d07115bb8ab9df272a`다.
+PR #70으로 merge되었고, 후속 PR #69 publication read-back의 현재 live `main`은
+`0358c8d956fb22064ab93685d46714d2023ef505`다.
 
-이 상태는 implementation과 repository publication에 대한 proof다. exact-release Preview/browser/runtime
-proof는 `PENDING`, production authority는 `PENDING`이며 production deployment·activation·`salesMode`·
-live round·actual payment/notification·first-round completion을 주장하지 않는다.
+이 상태는 implementation과 repository publication에 대한 proof다. #76 최신 exact-release
+Preview/browser 결과는 `RUNTIME_DEFECT_FOUND`이며 Sale Round runtime은 `NOT_PROVEN`이다.
+production authority는 `PENDING`이며 production deployment·activation·`salesMode`·live round·
+actual payment/notification·first-round completion을 주장하지 않는다.
 
-### 2. Preview·exact-SHA proof
+### 2. Preview Evidence Gate·exact-SHA proof
 
-상태: `VERIFICATION_PENDING`.
+상태: Preview Evidence Gate 02는 `IMPLEMENTATION_COMPLETE / PROOF_COMPLETE / PUBLICATION_HOLD`이며, exact-release runtime은 `FINAL_BROWSER_RESIDUAL`이다.
 
-historical exact-source Preview/browser/fixture evidence는 현재 release candidate의 exact-SHA proof를 대체하지 않는다. 필요한 Preview/browser/fixture 검증은 Auth.js session lifecycle과 별도 gate다.
+candidate `433a1182a377f152d140e9609bd6e15ae0eb6f1c`의 pinned Vercel metadata project/source SHA/`READY` 대조와 focused proof는 완료됐다. 이는 #76의 exact-release browser/runtime proof를 대체하지 않는다. #76 최신 기록은 exact deployment/fixture binding 이후 Auth.js Credentials callback/session 경계에서 `RUNTIME_DEFECT_FOUND`이며 Sale Round runtime은 아직 `NOT_PROVEN`이다.
 
-### 3. Auth.js session runtime
+### 3. Auth.js Preview binding·session revocation
 
-상태: `EXTERNAL_RUNTIME_BLOCKED`.
+상태: `AUTH_PREVIEW_BINDING_PROVEN` + `PILOT_POLICY_ACCEPTS_CURRENT_BOUNDED_REVOCATION` + `REVOCATION_POLICY_DEFERRED_POST_PILOT`.
 
-cookie 발급·동일 browser context persistence·logout/rotation·stale-claim lifecycle은 runtime/browser proof가 없으므로 `UNVERIFIED`다. static source나 callback 응답으로 승격하지 않는다.
+#88 최신 runtime evidence에서 Consumer/Seller/Driver의 Credentials session 발급·동일 browser context persistence·logout·refresh lineage·stale token/revocation 및 cleanup이 bounded scope에서 검증됐다. 동일 배포의 stateless Auth.js JWT stale-session revocation은 `NOT_CLOSED`이며 `AUTH-SESSION-CLAIM-REVOCATION` post-pilot high-priority policy/security residual로 보존한다. 이 결과를 #76의 browser runtime defect 해결로 승격하지 않는다.
 
 ### 4. ALIGO provider metadata
 
@@ -313,7 +324,7 @@ repo-side 배포 방어와 GitHub main 보호를 직접 재확인했다. `protec
 
 ## 다음 작업
 
-1. exact-SHA Preview/browser/fixture와 Auth.js session lifecycle을 필요한 runtime/browser authority에서 검증한다.
+1. #76 `EXACT-RELEASE-PROOF-01`의 최신 `RUNTIME_DEFECT_FOUND`를 기준으로 final browser residual을 재입장한다. Preview binding 대기 상태로 되돌리지 않으며, 이 docs-only Goal에서는 browser proof를 실행하지 않는다.
 2. authenticated ALIGO provider metadata read-back → repository 8-code mapping 대조 → 별도 authority 후 actual send 검증.
 3. production deployment·activation·live round·actual payment·actual notification·first-round completion은 각각 별도 authority와 read-back으로 판정한다.
 4. consumer self-cancel `ORDER_CANCELLED` notification은 `PRODUCT_POLICY_DECISION_REQUIRED`로 유지한다.

--- a/docs/specs/mvp-sales-round-direct-delivery.md
+++ b/docs/specs/mvp-sales-round-direct-delivery.md
@@ -38,7 +38,7 @@
 위 회차 atomicity·recovery 항목은 current contract이며, #66에서 fresh edit gate,
 pre-open reservation gate, cancellation recovery/fencing의 구현과 직접 proof가
 `IMPLEMENTATION_PROVEN`으로 accepted되었다. PR #70 publication 후 현재 live `main`은
-`fe5e680fa58c8b3af5e508d07115bb8ab9df272a`이다. 이 상태는 exact-release Preview/browser/runtime
+`0358c8d956fb22064ab93685d46714d2023ef505`이다. 이 상태는 exact-release Preview/browser/runtime
 proof나 production deployment·activation·first live round를 의미하지 않으며, 해당 gate는
 `docs/BACKLOG.md`에서 별도로 판정한다.
 

--- a/scripts/check-round-direct-e2e-readiness.spec.mjs
+++ b/scripts/check-round-direct-e2e-readiness.spec.mjs
@@ -1,5 +1,7 @@
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
 import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
 import {
   evaluateReadiness,
   evaluateTargetReadiness,
@@ -9,6 +11,10 @@ import {
 } from './check-round-direct-e2e-readiness.mjs';
 
 const SHA = 'a'.repeat(40);
+const ROUND_DIRECT_WORKFLOW = fs.readFileSync(
+  fileURLToPath(new URL('../.github/workflows/e2e-round-direct.yml', import.meta.url)),
+  'utf8',
+);
 
 function validInput(overrides = {}) {
   return {
@@ -125,9 +131,7 @@ describe('회차 직배송 E2E 준비조건 실패 계약', () => {
     assert.equal(live.ready, false);
     assert.ok(live.failureCodes.includes('PROVIDER_MODE_NOT_STUB'));
 
-    const egress = evaluateReadiness(
-      validInput({ providerEgressHosts: ['api.portone.io'] }),
-    );
+    const egress = evaluateReadiness(validInput({ providerEgressHosts: ['api.portone.io'] }));
     assert.equal(egress.ready, false);
     assert.ok(egress.failureCodes.includes('PROVIDER_EGRESS_DETECTED'));
   });
@@ -158,6 +162,16 @@ describe('회차 직배송 E2E 준비조건 실패 계약', () => {
     const result = evaluateReadiness(validInput({ fixtureProjects: ['chromium'] }));
     assert.equal(result.ready, false);
     assert.ok(result.failureCodes.includes('FIXTURE_PROJECTS_NOT_ISOLATED'));
+  });
+});
+
+describe('회차 직배송 workflow candidate source binding', () => {
+  it('application SHA를 검증하면서 candidate SHA의 gate 구현을 실행한다', () => {
+    assert.match(ROUND_DIRECT_WORKFLOW, /ref:\s+\$\{\{\s*github\.sha\s*\}\}/);
+    assert.doesNotMatch(ROUND_DIRECT_WORKFLOW, /ref:\s+\$\{\{\s*inputs\.expected_sha\s*\}\}/);
+    assert.match(ROUND_DIRECT_WORKFLOW, /git merge-base --is-ancestor/);
+    assert.match(ROUND_DIRECT_WORKFLOW, /git diff --name-only/);
+    assert.match(ROUND_DIRECT_WORKFLOW, /candidate workflow SHA checkout/);
   });
 });
 
@@ -327,9 +341,7 @@ describe('환경 입력과 JPEG 판독', () => {
   });
 
   it('JPEG magic bytes와 크기를 판독한다', () => {
-    const result = inspectJpegBuffer(
-      Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0xff, 0xd9]),
-    );
+    const result = inspectJpegBuffer(Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0xff, 0xd9]));
     assert.deepEqual(result, {
       exists: true,
       mime: 'image/jpeg',

--- a/scripts/check-round-direct-e2e-readiness.spec.mjs
+++ b/scripts/check-round-direct-e2e-readiness.spec.mjs
@@ -171,6 +171,7 @@ describe('회차 직배송 workflow candidate source binding', () => {
     assert.doesNotMatch(ROUND_DIRECT_WORKFLOW, /ref:\s+\$\{\{\s*inputs\.expected_sha\s*\}\}/);
     assert.match(ROUND_DIRECT_WORKFLOW, /git merge-base --is-ancestor/);
     assert.match(ROUND_DIRECT_WORKFLOW, /git diff --name-only/);
+    assert.match(ROUND_DIRECT_WORKFLOW, /WORKFLOW_SHA:\s+\$\{\{\s*github\.sha\s*\}\}/);
     assert.match(ROUND_DIRECT_WORKFLOW, /candidate workflow SHA checkout/);
   });
 });

--- a/scripts/wait-preview-deploy.mjs
+++ b/scripts/wait-preview-deploy.mjs
@@ -1,66 +1,98 @@
 /**
- * Preview 배포 완료 대기 게이트 — sync-preview.yml 의 E2E 트리거 직전에 호출.
+ * 고정된 Vercel Preview deployment metadata를 확인하는 회차 E2E 증거 게이트.
  *
- * sync-preview 가 success 로 떨어져도 Vercel 의 실제 Preview 재배포는 더 늦게
- * 끝날 수 있다. 그 사이 E2E 를 dispatch 하면 stale(이전 커밋) 배포본을 검사한다.
- * 이 스크립트는 GitHub 에 기록된 Vercel commit status가 현재 Preview HEAD를
- * 가리키며 성공할 때까지 폴링해 그 race 를 트리거 단계에서 차단한다.
+ * application runtime의 source SHA와 이 workflow 자체의 candidate SHA는 서로
+ * 다른 identity다. 따라서 이 스크립트는 workflow checkout의 HEAD나 최신
+ * deployment를 추정하지 않고, 호출자가 전달한 expected SHA와 세 deployment ID를
+ * 그대로 사용한다.
  *
- * 매칭 기준 = SHA와 정확한 status context. GitHub commit status API 요청 자체가
- * expected SHA에 고정되며, 각 status의 context와 state, 안전한 target_url을
- * 함께 검증한다. 시각만으로 이전 증거를 현재 배포로 승격하지 않는다.
- *
- * 사용법: GH_TOKEN=... node scripts/wait-preview-deploy.mjs
- *   (preview 브랜치 체크아웃 상태에서 실행 — git rev-parse HEAD 로 대상 SHA 결정)
+ * canonical acceptance source는 Vercel deployment GET metadata다. GitHub commit
+ * status는 별도 diagnostic 경로에서만 읽을 수 있으며 canonical ready 판정에는
+ * 참여하지 않는다.
  *
  * 종료 코드:
- *   0  3앱 모두 SHA-매칭 Vercel commit status success
- *   1  timeout 초과(fail-fast) 또는 gh api 오류 — E2E dispatch 안 됨
+ *   0  세 pinned deployment가 모두 직접 검증됨
+ *   1  metadata 불일치, credential/API 오류 또는 timeout
  */
 import { execSync } from 'node:child_process';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 export const REPO = 'booker-lab/greenhub';
+export const VERCEL_API_ORIGIN = 'https://api.vercel.com';
+export const VERCEL_TEAM_ID = 'team_J91VWI0TqcHdcF36T7qVgiT1';
+export const VERCEL_CREDENTIAL_NAME = 'ROUND_DIRECT_E2E_VERCEL_READ_TOKEN';
 
-// Vercel GitHub integration이 생성하는 exact status context 3종.
-export const PREVIEW_APPS = [
-  {
-    app: 'seller',
-    project: 'greenhub-seller',
-    context: 'Vercel – greenhub-seller',
-    env: 'Preview – greenhub-seller',
-  },
+export const PREVIEW_APPS = Object.freeze([
   {
     app: 'consumer',
     project: 'greenhubconsumer',
+    projectId: 'prj_ttIlOxV4e2Xb1sf1xhpSXibzph2w',
     context: 'Vercel – greenhubconsumer',
-    env: 'Preview – greenhubconsumer',
+  },
+  {
+    app: 'seller',
+    project: 'greenhub-seller',
+    projectId: 'prj_OPOveVw4QADTbTE7mt32mo14H5dv',
+    context: 'Vercel – greenhub-seller',
   },
   {
     app: 'driver',
     project: 'greenhub-driver',
+    projectId: 'prj_e3OU9YIAGTkDcrWQdpTvkbHnJ4XW',
     context: 'Vercel – greenhub-driver',
-    env: 'Preview – greenhub-driver',
   },
-];
+]);
 
-// 기존 import 소비자와 로그 계약을 위한 호환 export. 새 판정은 env가 아니라 context를 사용한다.
+// 기존 import 소비자와 진단 출력의 호환을 위해 유지한다.
 export const ENVIRONMENTS = PREVIEW_APPS;
 
 const APP_BY_NAME = new Map(PREVIEW_APPS.map((config) => [config.app, config]));
+const SHA_PATTERN = /^[0-9a-f]{40}$/;
+const DEPLOYMENT_ID_PATTERN = /^dpl_[A-Za-z0-9]+$/;
+const RETRYABLE_STATES = new Set(['BUILDING', 'QUEUED']);
 
-// 기본 timeout 10분 / 간격 15초. env 로 오버라이드 가능(로컬 검증·튜닝용).
 const TIMEOUT_MS = Number(process.env.WAIT_TIMEOUT_MS) || 10 * 60 * 1000;
 const INTERVAL_MS = Number(process.env.WAIT_INTERVAL_MS) || 15 * 1000;
 
-const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+export class PreviewEvidenceError extends Error {
+  constructor(code, message) {
+    super(message);
+    this.name = 'PreviewEvidenceError';
+    this.code = code;
+  }
+}
+
+function fail(code, message) {
+  throw new PreviewEvidenceError(code, message);
+}
+
+export function assertHeadSha(value) {
+  if (typeof value !== 'string' || !SHA_PATTERN.test(value)) {
+    fail('EXPECTED_SHA_MALFORMED', 'expected SHA는 40자리 소문자 16진수여야 합니다.');
+  }
+  return value;
+}
+
+export function assertDeploymentId(value, label = 'Vercel deployment ID') {
+  if (typeof value !== 'string' || !DEPLOYMENT_ID_PATTERN.test(value)) {
+    fail('DEPLOYMENT_ID_MALFORMED', `${label}가 올바른 형식이 아닙니다.`);
+  }
+  return value;
+}
 
 export function normalizeTargetUrl(value) {
   if (typeof value !== 'string' || !value.trim()) return null;
   try {
     const url = new URL(value.trim());
-    if (url.protocol !== 'https:' || url.username || url.password || url.search || url.hash) {
+    if (
+      url.protocol !== 'https:' ||
+      url.username ||
+      url.password ||
+      url.port ||
+      url.search ||
+      url.hash
+    ) {
       return null;
     }
     return url.toString().replace(/\/$/, '');
@@ -69,9 +101,349 @@ export function normalizeTargetUrl(value) {
   }
 }
 
+function normalizeVercelDeploymentUrl(value, app) {
+  if (typeof value !== 'string' || !value.trim()) {
+    fail('VERCEL_URL_MISSING', `${app} Vercel deployment URL이 없습니다.`);
+  }
+
+  const raw = value.trim();
+  const candidate = /^[A-Za-z][A-Za-z0-9+.-]*:\/\//.test(raw) ? raw : `https://${raw}`;
+  const normalized = normalizeTargetUrl(candidate);
+  if (!normalized) {
+    fail('VERCEL_URL_UNSAFE', `${app} Vercel deployment URL이 안전한 HTTPS 주소가 아닙니다.`);
+  }
+
+  const url = new URL(normalized);
+  if (!url.hostname.endsWith('.vercel.app') || url.hostname === 'vercel.app') {
+    fail('VERCEL_URL_HOST_MISMATCH', `${app} Vercel deployment URL host가 올바르지 않습니다.`);
+  }
+  if (url.pathname !== '/') {
+    fail('VERCEL_URL_PATH_MISMATCH', `${app} Vercel deployment URL path가 올바르지 않습니다.`);
+  }
+  return normalized;
+}
+
+export function vercelDeploymentPath(deploymentId) {
+  assertDeploymentId(deploymentId);
+  const query = new URLSearchParams({ teamId: VERCEL_TEAM_ID });
+  return `/v13/deployments/${encodeURIComponent(deploymentId)}?${query}`;
+}
+
+function vercelHeaders(token) {
+  return {
+    Accept: 'application/json',
+    Authorization: `Bearer ${token}`,
+  };
+}
+
+export async function requestVercelDeployment(deploymentId, token, fetchImpl = fetch) {
+  assertDeploymentId(deploymentId);
+  if (typeof token !== 'string' || !token.trim()) {
+    fail(
+      'VERCEL_READ_TOKEN_REQUIRED',
+      `${VERCEL_CREDENTIAL_NAME}가 없어 Vercel metadata를 읽을 수 없습니다.`,
+    );
+  }
+
+  let response;
+  try {
+    response = await fetchImpl(VERCEL_API_ORIGIN + vercelDeploymentPath(deploymentId), {
+      method: 'GET',
+      headers: vercelHeaders(token),
+    });
+  } catch {
+    fail('VERCEL_API_UNAVAILABLE', 'Vercel metadata 읽기 요청에 실패했습니다.');
+  }
+
+  if (!response?.ok) {
+    const status = Number(response?.status);
+    const suffix = Number.isInteger(status) && status > 0 ? `_${status}` : '';
+    fail(
+      `VERCEL_API_HTTP${suffix}`,
+      `Vercel metadata API가 성공 응답을 반환하지 않았습니다${suffix ? ` (HTTP ${status})` : ''}.`,
+    );
+  }
+
+  try {
+    return await response.json();
+  } catch {
+    fail('VERCEL_API_INVALID_JSON', 'Vercel metadata JSON 응답이 잘못되었습니다.');
+  }
+}
+
+function unwrapDeployment(payload) {
+  if (payload?.deployment && typeof payload.deployment === 'object') {
+    return payload.deployment;
+  }
+  return payload && typeof payload === 'object' ? payload : null;
+}
+
+function deploymentIdentifier(deployment) {
+  const id = deployment?.id;
+  const uid = deployment?.uid;
+  if (id !== undefined && uid !== undefined && id !== uid) {
+    return { value: id, mismatch: true };
+  }
+  return { value: id ?? uid ?? null, mismatch: false };
+}
+
+function deploymentProjectId(deployment) {
+  return deployment?.projectId ?? deployment?.project?.id ?? null;
+}
+
+function deploymentProjectName(deployment) {
+  return deployment?.project?.name ?? deployment?.name ?? null;
+}
+
+function deploymentState(deployment) {
+  const state = typeof deployment?.state === 'string' ? deployment.state : null;
+  const readyState = typeof deployment?.readyState === 'string' ? deployment.readyState : null;
+  const values = [state, readyState].filter(Boolean);
+  return {
+    state: state ?? readyState ?? 'missing',
+    readyState,
+    hasState: values.length > 0,
+    ready: values.length > 0 && values.every((value) => value === 'READY'),
+    retryable: values.length > 0 && values.every((value) => RETRYABLE_STATES.has(value)),
+  };
+}
+
+function baseAppEvidence(config, pinnedDeploymentId, expectedSha, deployment) {
+  const identifier = deploymentIdentifier(deployment);
+  const state = deploymentState(deployment);
+  return {
+    app: config.app,
+    project: deploymentProjectName(deployment),
+    projectId: deploymentProjectId(deployment),
+    context: config.context,
+    environment: 'preview',
+    expectedSha,
+    pinnedDeploymentId,
+    deploymentId: identifier.value ?? pinnedDeploymentId,
+    deploymentSha: deployment?.meta?.githubCommitSha ?? null,
+    state: state.state,
+    readyState: state.readyState,
+    target: Object.hasOwn(deployment ?? {}, 'target') ? deployment.target : null,
+    targetUrl: null,
+    ready: false,
+    failureCode: null,
+    failureMessage: null,
+    retryable: state.retryable,
+  };
+}
+
+function failedAppEvidence(base, code, message, retryable = false) {
+  return {
+    ...base,
+    ready: false,
+    failureCode: code,
+    failureMessage: message,
+    retryable,
+  };
+}
+
+function inspectDeploymentMetadata(config, pinnedDeploymentId, expectedSha, payload) {
+  const deployment = unwrapDeployment(payload);
+  const base = baseAppEvidence(config, pinnedDeploymentId, expectedSha, deployment);
+
+  if (!deployment) {
+    return failedAppEvidence(
+      base,
+      'VERCEL_METADATA_MISSING',
+      `${config.app} Vercel metadata가 없습니다.`,
+    );
+  }
+
+  const identifier = deploymentIdentifier(deployment);
+  if (identifier.mismatch || identifier.value !== pinnedDeploymentId) {
+    return failedAppEvidence(
+      base,
+      'VERCEL_DEPLOYMENT_ID_MISMATCH',
+      `${config.app} Vercel deployment ID가 pinned ID와 다릅니다.`,
+    );
+  }
+
+  if (
+    deploymentProjectId(deployment) !== config.projectId ||
+    deploymentProjectName(deployment) !== config.project
+  ) {
+    return failedAppEvidence(
+      base,
+      'VERCEL_PROJECT_MISMATCH',
+      `${config.app} Vercel project identity가 예상값과 다릅니다.`,
+    );
+  }
+
+  const deploymentSha = deployment?.meta?.githubCommitSha;
+  if (deploymentSha !== expectedSha) {
+    return failedAppEvidence(
+      base,
+      'VERCEL_GITHUB_COMMIT_SHA_MISMATCH',
+      `${config.app} Vercel githubCommitSha가 expected SHA와 다릅니다.`,
+    );
+  }
+
+  if (!Object.hasOwn(deployment, 'target') || deployment.target !== null) {
+    return failedAppEvidence(
+      base,
+      'VERCEL_TARGET_NOT_PREVIEW',
+      `${config.app} Vercel deployment가 Preview target이 아닙니다.`,
+    );
+  }
+
+  const state = deploymentState(deployment);
+  if (!state.hasState) {
+    return failedAppEvidence(
+      base,
+      'VERCEL_STATE_MISSING',
+      `${config.app} Vercel deployment 상태가 없습니다.`,
+    );
+  }
+  if (!state.ready) {
+    return failedAppEvidence(
+      base,
+      'VERCEL_NOT_READY',
+      `${config.app} Vercel deployment가 READY가 아닙니다.`,
+      state.retryable,
+    );
+  }
+
+  let targetUrl;
+  try {
+    targetUrl = normalizeVercelDeploymentUrl(deployment.url, config.app);
+  } catch (error) {
+    const safeError =
+      error instanceof PreviewEvidenceError
+        ? error
+        : new PreviewEvidenceError(
+            'VERCEL_URL_UNSAFE',
+            `${config.app} Vercel URL 검증에 실패했습니다.`,
+          );
+    return failedAppEvidence(base, safeError.code, safeError.message);
+  }
+
+  return {
+    ...base,
+    targetUrl,
+    ready: true,
+    failureCode: null,
+    failureMessage: null,
+    retryable: false,
+  };
+}
+
+export function inspectAppDeployment(app, pinnedDeploymentId, expectedSha, payload) {
+  assertHeadSha(expectedSha);
+  const config = APP_BY_NAME.get(app);
+  if (!config) fail('UNKNOWN_PREVIEW_APP', `알 수 없는 Preview 앱입니다: ${app}`);
+  assertDeploymentId(pinnedDeploymentId, `${app} Vercel deployment ID`);
+  return inspectDeploymentMetadata(config, pinnedDeploymentId, expectedSha, payload);
+}
+
+function normalizeDeploymentIds(deploymentIds) {
+  const normalized = {};
+  for (const config of PREVIEW_APPS) {
+    const value = deploymentIds?.[config.app];
+    if (typeof value !== 'string' || !value.trim()) {
+      fail('DEPLOYMENT_ID_REQUIRED', `${config.app} pinned Vercel deployment ID가 필요합니다.`);
+    }
+    normalized[config.app] = assertDeploymentId(value.trim(), `${config.app} Vercel deployment ID`);
+  }
+  return normalized;
+}
+
+function isRetryableErrorCode(code) {
+  return (
+    code === 'VERCEL_API_UNAVAILABLE' ||
+    code === 'VERCEL_API_INVALID_JSON' ||
+    /^VERCEL_API_HTTP_(429|5\d\d)$/.test(code)
+  );
+}
+
+function safeError(error) {
+  if (error instanceof PreviewEvidenceError) return error;
+  return new PreviewEvidenceError('VERCEL_API_UNAVAILABLE', 'Vercel metadata 읽기에 실패했습니다.');
+}
+
+export async function collectDeploymentEvidence(
+  expectedSha,
+  deploymentIds,
+  {
+    vercelToken = process.env[VERCEL_CREDENTIAL_NAME],
+    fetchImpl = fetch,
+    request = null,
+    checkedAt = () => new Date().toISOString(),
+  } = {},
+) {
+  assertHeadSha(expectedSha);
+  const pinnedDeploymentIds = normalizeDeploymentIds(deploymentIds);
+  if (typeof request !== 'function' && (typeof vercelToken !== 'string' || !vercelToken.trim())) {
+    fail(
+      'VERCEL_READ_TOKEN_REQUIRED',
+      `${VERCEL_CREDENTIAL_NAME}가 없어 Vercel metadata를 읽을 수 없습니다.`,
+    );
+  }
+
+  const apps = await Promise.all(
+    PREVIEW_APPS.map(async (config) => {
+      const pinnedDeploymentId = pinnedDeploymentIds[config.app];
+      try {
+        const payload =
+          typeof request === 'function'
+            ? await request(pinnedDeploymentId, config.app)
+            : await requestVercelDeployment(pinnedDeploymentId, vercelToken, fetchImpl);
+        return inspectDeploymentMetadata(config, pinnedDeploymentId, expectedSha, payload);
+      } catch (error) {
+        const failure = safeError(error);
+        return failedAppEvidence(
+          baseAppEvidence(config, pinnedDeploymentId, expectedSha, null),
+          failure.code,
+          failure.message,
+          isRetryableErrorCode(failure.code),
+        );
+      }
+    }),
+  );
+
+  const notReadyApps = apps.filter(({ ready }) => !ready);
+  const retryable =
+    notReadyApps.length > 0 && notReadyApps.every(({ retryable: canRetry }) => canRetry);
+  const deploymentShas = Object.fromEntries(
+    apps.map(({ app, deploymentSha }) => [app, deploymentSha]),
+  );
+  const deploymentTargetUrls = Object.fromEntries(
+    apps.map(({ app, targetUrl }) => [app, targetUrl]),
+  );
+  const deploymentIdsByApp = Object.fromEntries(
+    apps.map(({ app, deploymentId }) => [app, deploymentId]),
+  );
+  const deploymentStates = Object.fromEntries(apps.map(({ app, state }) => [app, state]));
+
+  return {
+    ready: apps.length === PREVIEW_APPS.length && apps.every(({ ready }) => ready),
+    retryable,
+    checkedAt: checkedAt(),
+    repository: REPO,
+    evidenceSource: 'vercel-deployment-metadata',
+    vercelCredentialName: VERCEL_CREDENTIAL_NAME,
+    credentialValueRecorded: false,
+    vercelTeamId: VERCEL_TEAM_ID,
+    expectedSha,
+    pinnedDeploymentIds,
+    deploymentIds: deploymentIdsByApp,
+    deploymentShas,
+    deploymentTargetUrls,
+    deploymentStates,
+    failureCodes: apps
+      .filter(({ ready }) => !ready)
+      .map(({ app, failureCode }) => ({ app, code: failureCode })),
+    apps,
+  };
+}
+
+// GitHub status는 필요할 때만 남기는 비권위 진단 정보다.
 export function gh(apiPath) {
-  // gh api 는 URL 인코딩된 query 를 그대로 받는다.
-  const out = execSync('gh api "' + apiPath + '"', {
+  const out = execSync(`gh api "${apiPath}"`, {
     encoding: 'utf-8',
     stdio: ['ignore', 'pipe', 'pipe'],
   });
@@ -79,19 +451,7 @@ export function gh(apiPath) {
 }
 
 function commitStatusesPath(headSha) {
-  return 'repos/' + REPO + '/commits/' + headSha + '/statuses?per_page=100';
-}
-
-function assertHeadSha(headSha) {
-  if (typeof headSha !== 'string' || !/^[0-9a-f]{40}$/.test(headSha)) {
-    throw new Error('대상 SHA는 40자리 소문자 16진수여야 합니다.');
-  }
-}
-
-function statusBelongsToExpectedSha(status, headSha) {
-  // 실제 GitHub commit status 응답은 요청 경로가 SHA 권위를 소유하며 sha 필드가 없을 수 있다.
-  // 응답에 sha가 있으면 추가 방어로 exact match를 요구한다.
-  return typeof status?.sha !== 'string' || status.sha === headSha;
+  return `repos/${REPO}/commits/${headSha}/statuses?per_page=100`;
 }
 
 function statusTimestamp(status) {
@@ -116,17 +476,12 @@ function latestStatus(statuses) {
       latest = candidate;
       continue;
     }
-
     const candidateTime = statusTimestamp(candidate);
     const latestTime = statusTimestamp(latest);
-    if (
-      candidateTime !== null &&
-      (latestTime === null || candidateTime > latestTime)
-    ) {
+    if (candidateTime !== null && (latestTime === null || candidateTime > latestTime)) {
       latest = candidate;
       continue;
     }
-
     if (candidateTime !== null && latestTime !== null && candidateTime === latestTime) {
       const candidateId = comparableStatusId(candidate?.id);
       const latestId = comparableStatusId(latest?.id);
@@ -134,252 +489,182 @@ function latestStatus(statuses) {
         latest = candidate;
       }
     }
-    // timestamp가 없거나 같고 id도 없으면 GitHub API의 최신순 배열 순서를 유지한다.
   }
   return latest;
 }
 
-function inspectStatus(config, headSha, statuses) {
-  const contextStatuses = (Array.isArray(statuses) ? statuses : []).filter(
-    (status) => status && status.context === config.context,
-  );
-  const exactStatuses = contextStatuses.filter((status) =>
-    statusBelongsToExpectedSha(status, headSha),
-  );
-  const latestExactStatus = latestStatus(exactStatuses);
-  const latestContextStatus = latestStatus(contextStatuses);
-
-  // API 응답에 다른 SHA가 섞인 경우에도 성공으로 추정하지 않는다.
-  if (
-    !latestExactStatus &&
-    latestContextStatus &&
-    typeof latestContextStatus.sha === 'string' &&
-    latestContextStatus.sha !== headSha
-  ) {
+export function collectCommitStatusDiagnostic(headSha, request = gh) {
+  assertHeadSha(headSha);
+  const statuses = request(commitStatusesPath(headSha));
+  const apps = PREVIEW_APPS.map((config) => {
+    const matches = (Array.isArray(statuses) ? statuses : []).filter(
+      (status) => status?.context === config.context,
+    );
+    const latest = latestStatus(matches);
     return {
       app: config.app,
-      project: config.project,
       context: config.context,
-      environment: null,
-      expectedSha: headSha,
-      statusId: latestContextStatus.id ?? null,
-      statusSha: latestContextStatus.sha,
-      deploymentId: null,
-      deploymentSha: latestContextStatus.sha,
-      state: 'stale',
-      targetUrl: null,
-      ready: false,
+      statusId: latest?.id ?? null,
+      statusSha: typeof latest?.sha === 'string' ? latest.sha : null,
+      state: latest?.state ?? 'missing',
+      targetUrl: normalizeTargetUrl(latest?.target_url),
     };
-  }
-
-  const statusSha = latestExactStatus
-    ? typeof latestExactStatus.sha === 'string'
-      ? latestExactStatus.sha
-      : headSha
-    : null;
-  const targetUrl = normalizeTargetUrl(latestExactStatus?.target_url);
-
+  });
   return {
-    app: config.app,
-    project: config.project,
-    context: config.context,
-    environment: null,
-    expectedSha: headSha,
-    statusId: latestExactStatus?.id ?? null,
-    statusSha,
-    // round-direct의 기존 readiness 입력 이름과 호환하되 값의 source는 commit status다.
-    deploymentId: null,
-    deploymentSha: statusSha,
-    state: latestExactStatus?.state ?? 'missing',
-    targetUrl,
-    ready:
-      latestExactStatus?.state === 'success' &&
-      statusSha === headSha &&
-      Boolean(targetUrl),
-  };
-}
-
-export function inspectAppCommitStatus(app, headSha, statuses) {
-  assertHeadSha(headSha);
-  const config = APP_BY_NAME.get(app);
-  if (!config) throw new Error('알 수 없는 Preview 앱입니다: ' + app);
-  return inspectStatus(config, headSha, statuses);
-}
-
-// 기존 함수 이름을 사용하는 로컬 소비자를 위해 유지한다. 조회 source는 commit status로 바뀌었다.
-export function inspectAppDeployment(app, _environment, headSha, request = gh) {
-  assertHeadSha(headSha);
-  return inspectAppCommitStatus(app, headSha, request(commitStatusesPath(headSha)));
-}
-
-export function collectCommitStatusEvidence(headSha, request = gh) {
-  assertHeadSha(headSha);
-  const response = request(commitStatusesPath(headSha));
-  const statuses = Array.isArray(response) ? response : [];
-  const apps = PREVIEW_APPS.map(({ app }) => inspectAppCommitStatus(app, headSha, statuses));
-  const statusShas = Object.fromEntries(apps.map(({ app, statusSha }) => [app, statusSha]));
-  const targetUrls = Object.fromEntries(apps.map(({ app, targetUrl }) => [app, targetUrl]));
-  const statusStates = Object.fromEntries(apps.map(({ app, state }) => [app, state]));
-  const statusContexts = Object.fromEntries(
-    PREVIEW_APPS.map(({ app, context }) => [app, context]),
-  );
-
-  return {
-    ready: apps.length === PREVIEW_APPS.length && apps.every(({ ready }) => ready),
-    checkedAt: new Date().toISOString(),
+    diagnostic: true,
+    evidenceSource: 'github-commit-status-diagnostic',
     repository: REPO,
     expectedSha: headSha,
-    evidenceSource: 'github-commit-status',
-    statusContexts,
-    statusShas,
-    statusStates,
-    statusTargetUrls: targetUrls,
-    // 기존 round-direct readiness 계약을 보존하는 source-agnostic alias.
-    deploymentShas: statusShas,
-    deploymentTargetUrls: targetUrls,
+    checkedAt: new Date().toISOString(),
     apps,
   };
 }
 
-// 현재 직접 호출자와 기존 artifact 소비자 이름을 함께 보존한다.
-export const collectDeploymentEvidence = collectCommitStatusEvidence;
+// 기존 진단 import 이름을 유지하되 canonical deployment evidence와 분리한다.
+export const collectCommitStatusEvidence = collectCommitStatusDiagnostic;
+
+function argumentValue(args, name) {
+  const prefix = `--${name}=`;
+  return args.find((arg) => arg.startsWith(prefix))?.slice(prefix.length);
+}
 
 function resolveHeadSha(args) {
-  const shaArgument = args.find((arg) => arg.startsWith('--sha='));
   return (
-    shaArgument?.slice('--sha='.length).trim().toLowerCase() ||
+    argumentValue(args, 'sha')?.trim().toLowerCase() ||
     process.env.PREVIEW_HEAD_SHA?.trim().toLowerCase() ||
     execSync('git rev-parse HEAD', { encoding: 'utf-8' }).trim().toLowerCase()
   );
 }
 
-function unavailableEvidence(headSha) {
-  return PREVIEW_APPS.map(({ app, project, context }) => ({
-    app,
-    project,
-    context,
-    environment: null,
-    expectedSha: headSha,
-    statusId: null,
-    statusSha: null,
-    deploymentId: null,
-    deploymentSha: null,
-    state: 'unavailable',
-    targetUrl: null,
-    ready: false,
-  }));
+function resolveDeploymentIds(args) {
+  return Object.fromEntries(
+    PREVIEW_APPS.map((config) => [
+      config.app,
+      argumentValue(args, `${config.app}-deployment-id`)?.trim() ||
+        process.env[`ROUND_DIRECT_E2E_${config.app.toUpperCase()}_DEPLOYMENT_ID`]?.trim() ||
+        '',
+    ]),
+  );
 }
 
-function timeoutDetails(evidence, headSha) {
-  const apps = evidence?.apps ?? unavailableEvidence(headSha);
-  return apps
-    .filter(({ ready }) => !ready)
-    .map(
-      ({ app, state, statusSha, expectedSha, targetUrl }) =>
-        app +
-        ': state=' +
-        (state ?? 'missing') +
-        ', observed_sha=' +
-        (statusSha ?? '없음') +
-        ', expected_sha=' +
-        (expectedSha ?? headSha) +
-        ', target_url=' +
-        (targetUrl ? 'safe' : 'missing-or-unsafe'),
-    )
-    .join('; ');
+function failureEvidence(expectedSha, deploymentIds, error) {
+  const safeFailure = safeError(error);
+  const validSha =
+    typeof expectedSha === 'string' && SHA_PATTERN.test(expectedSha) ? expectedSha : null;
+  const pinnedDeploymentIds = Object.fromEntries(
+    PREVIEW_APPS.map((config) => [config.app, deploymentIds?.[config.app] || null]),
+  );
+  return {
+    ready: false,
+    retryable: false,
+    checkedAt: new Date().toISOString(),
+    repository: REPO,
+    evidenceSource: 'vercel-deployment-metadata',
+    vercelCredentialName: VERCEL_CREDENTIAL_NAME,
+    credentialValueRecorded: false,
+    vercelTeamId: VERCEL_TEAM_ID,
+    expectedSha: validSha,
+    pinnedDeploymentIds,
+    deploymentIds: {},
+    deploymentShas: {},
+    deploymentTargetUrls: {},
+    deploymentStates: {},
+    failureCodes: [{ app: null, code: safeFailure.code }],
+    failure: { code: safeFailure.code, message: safeFailure.message },
+    apps: [],
+  };
+}
+
+function writeJson(value) {
+  process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
 }
 
 async function main() {
   const args = process.argv.slice(2);
   const jsonOnly = args.includes('--json');
   const once = args.includes('--once');
+  const diagnostic = args.includes('--diagnostic-status');
   const headSha = resolveHeadSha(args);
 
+  if (diagnostic) {
+    try {
+      writeJson(collectCommitStatusDiagnostic(headSha));
+      return;
+    } catch (error) {
+      const failure = failureEvidence(headSha, {}, error);
+      writeJson(failure);
+      // 진단이므로 status 불가 여부로 전체 sync workflow를 차단하지 않는다.
+      process.exitCode = 0;
+      return;
+    }
+  }
+
+  const deploymentIds = resolveDeploymentIds(args);
   if (once) {
-    const evidence = collectCommitStatusEvidence(headSha);
-    process.stdout.write(JSON.stringify(evidence, null, 2) + '\n');
-    process.exitCode = evidence.ready ? 0 : 1;
+    try {
+      const evidence = await collectDeploymentEvidence(headSha, deploymentIds);
+      writeJson(evidence);
+      process.exitCode = evidence.ready ? 0 : 1;
+    } catch (error) {
+      const failure = failureEvidence(headSha, deploymentIds, error);
+      writeJson(failure);
+      console.error(`[wait-preview-deploy] ${failure.failure.code}: ${failure.failure.message}`);
+      process.exitCode = 1;
+    }
     return;
   }
 
   if (!jsonOnly) {
-    console.log('[wait-preview-deploy] 대상 Preview HEAD = ' + headSha);
+    console.log(`[wait-preview-deploy] expected application SHA = ${headSha}`);
     console.log(
-      '[wait-preview-deploy] 앱 ' +
-        PREVIEW_APPS.length +
-        '개 확인, 제한 ' +
-        TIMEOUT_MS / 1000 +
-        '초, 간격 ' +
-        INTERVAL_MS / 1000 +
-        '초',
+      `[wait-preview-deploy] pinned deployment ${PREVIEW_APPS.length}개 확인, 제한 ${TIMEOUT_MS / 1000}초, 간격 ${INTERVAL_MS / 1000}초`,
     );
   }
 
   const deadline = Date.now() + TIMEOUT_MS;
-  const announcedReadyApps = new Set();
   let latestEvidence = null;
+  let terminalFailure = null;
 
   while (Date.now() < deadline) {
     try {
-      latestEvidence = collectCommitStatusEvidence(headSha);
+      latestEvidence = await collectDeploymentEvidence(headSha, deploymentIds);
+      if (latestEvidence.ready || !latestEvidence.retryable) break;
     } catch (error) {
-      if (!jsonOnly) {
-        const message = error instanceof Error ? error.message : String(error);
-        console.warn(
-          '[wait-preview-deploy] GitHub API 일시 오류 — ' + message.split('\n')[0],
-        );
-      }
-      await sleep(INTERVAL_MS);
-      continue;
+      const failure = safeError(error);
+      terminalFailure = failure;
+      if (!isRetryableErrorCode(failure.code)) break;
+      if (!jsonOnly)
+        console.warn(`[wait-preview-deploy] 일시적 Vercel API 오류 — ${failure.message}`);
     }
-
-    for (const appEvidence of latestEvidence.apps) {
-      const { app } = appEvidence;
-      if (appEvidence.ready) {
-        if (!announcedReadyApps.has(app) && !jsonOnly) {
-          console.log(
-            '[wait-preview-deploy] ' +
-              app +
-              ' commit status 확인 (' +
-              (announcedReadyApps.size + 1) +
-              '/' +
-              PREVIEW_APPS.length +
-              ') @ ' +
-              new Date().toISOString(),
-          );
-        }
-        announcedReadyApps.add(app);
-      } else {
-        announcedReadyApps.delete(app);
-      }
-    }
-
-    if (latestEvidence.ready) {
-      if (jsonOnly) {
-        process.stdout.write(JSON.stringify(latestEvidence, null, 2) + '\n');
-      } else {
-        console.log(
-          '[wait-preview-deploy] 세 앱의 Vercel commit status가 모두 확인되어 E2E 실행을 허용합니다.',
-        );
-      }
-      return;
-    }
-    await sleep(INTERVAL_MS);
+    await new Promise((resolve) => setTimeout(resolve, INTERVAL_MS));
   }
 
-  // fail-fast: timeout 시 앱별 상태와 SHA를 노출해 배포 지연 원인을 식별한다.
-  if (jsonOnly && latestEvidence) {
-    process.stdout.write(JSON.stringify(latestEvidence, null, 2) + '\n');
+  if (latestEvidence?.ready) {
+    if (jsonOnly) writeJson(latestEvidence);
+    else
+      console.log(
+        '[wait-preview-deploy] 세 pinned Vercel deployment metadata가 모두 검증되었습니다.',
+      );
+    return;
+  }
+
+  if (latestEvidence) {
+    if (jsonOnly) writeJson(latestEvidence);
+    else {
+      console.error(
+        '[wait-preview-deploy] Vercel deployment evidence가 준비되지 않아 E2E 실행을 차단했습니다.',
+      );
+      console.error(JSON.stringify(latestEvidence.failureCodes));
+    }
   } else {
-    console.error(
-      '[wait-preview-deploy] ' +
-        TIMEOUT_MS / 1000 +
-        '초 초과 — 미완료 앱: ' +
-        timeoutDetails(latestEvidence, headSha),
+    const failure = failureEvidence(
+      headSha,
+      deploymentIds,
+      terminalFailure ??
+        new PreviewEvidenceError('VERCEL_API_UNAVAILABLE', 'Vercel metadata 읽기에 실패했습니다.'),
     );
-    console.error(
-      '[wait-preview-deploy] E2E 실행을 차단했습니다. Preview commit status를 확인하세요.',
-    );
+    if (jsonOnly) writeJson(failure);
+    else console.error(`[wait-preview-deploy] ${failure.failure.code}: ${failure.failure.message}`);
   }
   process.exitCode = 1;
 }
@@ -388,8 +673,9 @@ const isDirectRun =
   process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
 if (isDirectRun) {
   main().catch((error) => {
-    const message = error instanceof Error ? error.message : String(error);
-    console.error('[wait-preview-deploy] 치명적 오류: ' + message);
+    const failure = failureEvidence(null, {}, error);
+    writeJson(failure);
+    console.error(`[wait-preview-deploy] ${failure.failure.code}: ${failure.failure.message}`);
     process.exitCode = 1;
   });
 }

--- a/scripts/wait-preview-deploy.spec.mjs
+++ b/scripts/wait-preview-deploy.spec.mjs
@@ -1,60 +1,89 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import {
-  collectCommitStatusEvidence,
+  collectCommitStatusDiagnostic,
   collectDeploymentEvidence,
-  inspectAppCommitStatus,
+  inspectAppDeployment,
   normalizeTargetUrl,
-  REPO,
+  PREVIEW_APPS,
+  requestVercelDeployment,
+  VERCEL_API_ORIGIN,
+  VERCEL_CREDENTIAL_NAME,
+  VERCEL_TEAM_ID,
+  vercelDeploymentPath,
 } from './wait-preview-deploy.mjs';
 
 const SHA = 'a'.repeat(40);
-const OLD_SHA = 'b'.repeat(40);
-const APPS = [
-  {
-    app: 'consumer',
-    context: 'Vercel – greenhubconsumer',
-    targetUrl: 'https://consumer-preview.example.test/',
-  },
-  {
-    app: 'seller',
-    context: 'Vercel – greenhub-seller',
-    targetUrl: 'https://seller-preview.example.test/',
-  },
-  {
-    app: 'driver',
-    context: 'Vercel – greenhub-driver',
-    targetUrl: 'https://driver-preview.example.test/',
-  },
-];
+const OTHER_SHA = 'b'.repeat(40);
+const DEPLOYMENT_IDS = {
+  consumer: 'dpl_An5V2zjbSeSHddGx74hgc1stTpn1',
+  seller: 'dpl_9QnoA76oQd9NxFHnQhGQh3iGKNX6',
+  driver: 'dpl_Hn8EBp56x5ayyMVEPoeD8AiJUhja',
+};
 
-function makeStatus(app, overrides = {}) {
-  const config = APPS.find((candidate) => candidate.app === app);
+function response(body, status = 200) {
   return {
-    id: app.length,
-    sha: SHA,
-    context: config.context,
-    state: 'success',
-    target_url: config.targetUrl,
-    created_at: '2026-09-02T00:00:00Z',
-    updated_at: '2026-09-02T00:00:00Z',
+    ok: status >= 200 && status < 300,
+    status,
+    async json() {
+      return body;
+    },
+  };
+}
+
+function validDeployment(app, overrides = {}) {
+  const config = PREVIEW_APPS.find(({ app: name }) => name === app);
+  const deploymentId = DEPLOYMENT_IDS[app];
+  return {
+    id: deploymentId,
+    uid: deploymentId,
+    name: config.project,
+    projectId: config.projectId,
+    project: {
+      id: config.projectId,
+      name: config.project,
+    },
+    state: 'READY',
+    readyState: 'READY',
+    target: null,
+    url: `${config.project}-abc123.vercel.app`,
+    meta: {
+      githubCommitSha: SHA,
+      githubCommitRef: 'preview',
+      githubCommitOrg: 'booker-lab',
+      githubCommitRepo: 'greenhub',
+    },
     ...overrides,
   };
 }
 
-function allSuccessStatuses() {
-  return APPS.map(({ app }) => makeStatus(app));
+function validDeployments(overrides = {}) {
+  return Object.fromEntries(
+    PREVIEW_APPS.map(({ app }) => [app, validDeployment(app, overrides[app])]),
+  );
 }
 
-function collectWith(statuses, observedPaths = []) {
-  return collectCommitStatusEvidence(SHA, (apiPath) => {
-    observedPaths.push(apiPath);
-    return statuses;
-  });
+function collectWith(deployments = validDeployments(), options = {}) {
+  const calls = [];
+  const request = async (deploymentId, app) => {
+    calls.push({ deploymentId, app });
+    return deployments[app];
+  };
+  return {
+    calls,
+    promise: collectDeploymentEvidence(SHA, DEPLOYMENT_IDS, {
+      request,
+      ...options,
+    }),
+  };
 }
 
-describe('Preview commit status 증거 계약', () => {
-  it('target_url은 안전한 HTTPS 주소만 trailing slash을 제거한다', () => {
+async function assertFailure(promise, code) {
+  await assert.rejects(promise, (error) => error?.code === code);
+}
+
+describe('Vercel pinned Preview deployment metadata 증거 계약', () => {
+  it('일반 target URL은 안전한 HTTPS 주소만 정규화한다', () => {
     assert.equal(
       normalizeTargetUrl(' https://preview.example.test/ '),
       'https://preview.example.test',
@@ -62,196 +91,294 @@ describe('Preview commit status 증거 계약', () => {
     assert.equal(normalizeTargetUrl('http://preview.example.test'), null);
     assert.equal(normalizeTargetUrl('https://preview.example.test/?x=1'), null);
     assert.equal(normalizeTargetUrl('https://user:pass@preview.example.test'), null);
-    assert.equal(normalizeTargetUrl('https://preview.example.test/#fragment'), null);
+    assert.equal(normalizeTargetUrl('https://preview.example.test:8443'), null);
   });
 
-  it('세 exact Vercel context가 expected SHA에서 모두 success이면 통과한다', () => {
-    const observedPaths = [];
-    const evidence = collectWith(allSuccessStatuses(), observedPaths);
+  it('Vercel GET 경로는 team과 pinned deployment ID에 고정된다', () => {
+    assert.equal(
+      vercelDeploymentPath(DEPLOYMENT_IDS.consumer),
+      `/v13/deployments/${DEPLOYMENT_IDS.consumer}?teamId=${VERCEL_TEAM_ID}`,
+    );
+  });
+
+  it('세 pinned deployment가 프로젝트·SHA·READY·Preview·안전 URL이면 통과한다', async () => {
+    const { promise, calls } = collectWith();
+    const evidence = await promise;
 
     assert.equal(evidence.ready, true);
-    assert.equal(observedPaths.length, 1);
-    assert.equal(
-      observedPaths[0],
-      'repos/' + REPO + '/commits/' + SHA + '/statuses?per_page=100',
-    );
-    assert.deepEqual(evidence.statusShas, {
+    assert.equal(evidence.retryable, false);
+    assert.equal(evidence.evidenceSource, 'vercel-deployment-metadata');
+    assert.equal(evidence.expectedSha, SHA);
+    assert.deepEqual(evidence.pinnedDeploymentIds, DEPLOYMENT_IDS);
+    assert.deepEqual(evidence.deploymentIds, DEPLOYMENT_IDS);
+    assert.deepEqual(evidence.deploymentShas, {
       consumer: SHA,
       seller: SHA,
       driver: SHA,
     });
-    assert.deepEqual(evidence.deploymentShas, evidence.statusShas);
-    assert.equal(evidence.evidenceSource, 'github-commit-status');
-  });
-
-  it('consumer status가 없으면 불완전 상태로 fail closed한다', () => {
-    const evidence = collectWith(
-      allSuccessStatuses().filter((status) => status.context !== 'Vercel – greenhubconsumer'),
-    );
-    const consumer = evidence.apps.find(({ app }) => app === 'consumer');
-
-    assert.equal(evidence.ready, false);
-    assert.equal(consumer.state, 'missing');
-    assert.equal(consumer.statusSha, null);
-  });
-
-  it('driver pending은 success로 추정하지 않는다', () => {
-    const evidence = collectWith(
-      allSuccessStatuses().map((status) =>
-        status.context === 'Vercel – greenhub-driver'
-          ? { ...status, state: 'pending' }
-          : status,
-      ),
-    );
-    const driver = evidence.apps.find(({ app }) => app === 'driver');
-
-    assert.equal(evidence.ready, false);
-    assert.equal(driver.state, 'pending');
-    assert.equal(driver.statusSha, SHA);
-  });
-
-  it('seller failure와 error 상태를 모두 거부한다', () => {
-    for (const state of ['failure', 'error']) {
-      const evidence = collectWith(
-        allSuccessStatuses().map((status) =>
-          status.context === 'Vercel – greenhub-seller' ? { ...status, state } : status,
-        ),
-      );
-      const seller = evidence.apps.find(({ app }) => app === 'seller');
-
-      assert.equal(evidence.ready, false);
-      assert.equal(seller.state, state);
-      assert.equal(seller.ready, false);
-    }
-  });
-
-  it('old SHA success는 현재 SHA의 성공 증거로 사용하지 않는다', () => {
-    const statuses = allSuccessStatuses().map((status) =>
-      status.context === 'Vercel – greenhubconsumer'
-        ? { ...status, sha: OLD_SHA, updated_at: '2026-09-02T00:00:03Z' }
-        : status,
-    );
-    const evidence = collectWith(statuses);
-    const consumer = evidence.apps.find(({ app }) => app === 'consumer');
-
-    assert.equal(evidence.ready, false);
-    assert.equal(consumer.state, 'stale');
-    assert.equal(consumer.statusSha, OLD_SHA);
-    assert.equal(consumer.targetUrl, null);
-  });
-
-  it('unrelated context는 무시하고 exact context 세 개만 판정한다', () => {
-    const evidence = collectWith([
-      ...allSuccessStatuses(),
-      {
-        id: 999,
-        sha: SHA,
-        context: 'Vercel – unrelated-project',
-        state: 'success',
-        target_url: 'https://unrelated.example.test/',
-      },
-    ]);
-
-    assert.equal(evidence.ready, true);
-    assert.equal(evidence.apps.length, 3);
+    assert.deepEqual(evidence.deploymentStates, {
+      consumer: 'READY',
+      seller: 'READY',
+      driver: 'READY',
+    });
     assert.deepEqual(
-      evidence.apps.map(({ context }) => context).sort(),
-      APPS.map(({ context }) => context).sort(),
+      calls.map(({ deploymentId }) => deploymentId),
+      [DEPLOYMENT_IDS.consumer, DEPLOYMENT_IDS.seller, DEPLOYMENT_IDS.driver],
     );
-  });
-
-  it('duplicate context는 최신 updated_at 상태를 사용한다', () => {
-    const statuses = [
-      ...allSuccessStatuses().filter((status) => status.context !== 'Vercel – greenhubconsumer'),
-      makeStatus('consumer', {
-        id: 11,
-        state: 'pending',
-        created_at: '2026-09-02T00:00:01Z',
-        updated_at: '2026-09-02T00:00:01Z',
-      }),
-      makeStatus('consumer', {
-        id: 12,
-        state: 'success',
-        created_at: '2026-09-02T00:00:02Z',
-        updated_at: '2026-09-02T00:00:02Z',
-      }),
-    ];
-    const consumer = collectWith(statuses).apps.find(({ app }) => app === 'consumer');
-
-    assert.equal(consumer.ready, true);
-    assert.equal(consumer.state, 'success');
-    assert.equal(consumer.statusId, 12);
-  });
-
-  it('unsafe target_url은 success status와 함께 있어도 거부한다', () => {
-    const evidence = collectWith(
-      allSuccessStatuses().map((status) =>
-        status.context === 'Vercel – greenhub-seller'
-          ? { ...status, target_url: 'https://seller-preview.example.test/?blocked=1' }
-          : status,
+    assert.deepEqual(
+      evidence.apps.map(
+        ({ app, project, deploymentId, deploymentSha, target, targetUrl, ready }) => ({
+          app,
+          project,
+          deploymentId,
+          deploymentSha,
+          target,
+          targetUrl,
+          ready,
+        }),
       ),
+      PREVIEW_APPS.map(({ app, project }) => ({
+        app,
+        project,
+        deploymentId: DEPLOYMENT_IDS[app],
+        deploymentSha: SHA,
+        target: null,
+        targetUrl: `https://${project}-abc123.vercel.app`,
+        ready: true,
+      })),
     );
+  });
+
+  it('Vercel API의 중첩 deployment 응답도 직접 metadata로 검증한다', () => {
+    const result = inspectAppDeployment('consumer', DEPLOYMENT_IDS.consumer, SHA, {
+      deployment: validDeployment('consumer'),
+    });
+
+    assert.equal(result.ready, true);
+    assert.equal(result.projectId, 'prj_ttIlOxV4e2Xb1sf1xhpSXibzph2w');
+  });
+
+  it('잘못된 project identity는 거부한다', async () => {
+    const deployments = validDeployments({
+      seller: {
+        projectId: 'prj_wrong',
+        project: { id: 'prj_wrong', name: 'wrong-project' },
+        name: 'wrong-project',
+      },
+    });
+    const evidence = await collectWith(deployments).promise;
     const seller = evidence.apps.find(({ app }) => app === 'seller');
 
     assert.equal(evidence.ready, false);
-    assert.equal(seller.state, 'success');
-    assert.equal(seller.targetUrl, null);
-    assert.equal(seller.ready, false);
+    assert.equal(seller.failureCode, 'VERCEL_PROJECT_MISMATCH');
   });
 
-  it('historical Deployment 객체가 없어도 세 commit status success이면 통과한다', () => {
-    const observedPaths = [];
-    const evidence = collectWith(allSuccessStatuses(), observedPaths);
-
-    assert.equal(evidence.ready, true);
-    assert.equal(observedPaths.some((apiPath) => apiPath.includes('/deployments')), false);
-    assert.equal(observedPaths[0].includes('/commits/' + SHA + '/statuses'), true);
-  });
-
-  it('commit status 응답 자체가 없으면 성공으로 추정하지 않는다', () => {
-    const evidence = collectWith([]);
+  it('잘못된 githubCommitSha는 거부한다', async () => {
+    const deployments = validDeployments({
+      consumer: { meta: { githubCommitSha: OTHER_SHA } },
+    });
+    const evidence = await collectWith(deployments).promise;
+    const consumer = evidence.apps.find(({ app }) => app === 'consumer');
 
     assert.equal(evidence.ready, false);
+    assert.equal(consumer.deploymentSha, OTHER_SHA);
+    assert.equal(consumer.failureCode, 'VERCEL_GITHUB_COMMIT_SHA_MISMATCH');
+  });
+
+  it('ERROR와 CANCELED 상태는 READY로 추정하지 않는다', async () => {
+    for (const state of ['ERROR', 'CANCELED']) {
+      const deployments = validDeployments({
+        driver: { state, readyState: state },
+      });
+      const evidence = await collectWith(deployments).promise;
+      const driver = evidence.apps.find(({ app }) => app === 'driver');
+
+      assert.equal(evidence.ready, false);
+      assert.equal(driver.state, state);
+      assert.equal(driver.failureCode, 'VERCEL_NOT_READY');
+      assert.equal(driver.retryable, false);
+    }
+  });
+
+  it('BUILDING 상태만 재조회 가능한 미완료 상태로 남긴다', async () => {
+    const evidence = await collectWith(
+      validDeployments({ consumer: { state: 'BUILDING', readyState: 'BUILDING' } }),
+    ).promise;
+    const consumer = evidence.apps.find(({ app }) => app === 'consumer');
+
+    assert.equal(evidence.ready, false);
+    assert.equal(evidence.retryable, true);
+    assert.equal(consumer.failureCode, 'VERCEL_NOT_READY');
+    assert.equal(consumer.retryable, true);
+  });
+
+  it('production target는 SHA와 READY가 맞아도 거부한다', async () => {
+    const evidence = await collectWith(validDeployments({ seller: { target: 'production' } }))
+      .promise;
+    const seller = evidence.apps.find(({ app }) => app === 'seller');
+
+    assert.equal(evidence.ready, false);
+    assert.equal(seller.failureCode, 'VERCEL_TARGET_NOT_PREVIEW');
+  });
+
+  it('URL이 없거나 안전하지 않으면 거부한다', async () => {
+    for (const url of [
+      undefined,
+      'http://seller-abc123.vercel.app',
+      'https://seller-abc123.vercel.app/?x=1',
+    ]) {
+      const evidence = await collectWith(validDeployments({ seller: { url } })).promise;
+      const seller = evidence.apps.find(({ app }) => app === 'seller');
+
+      assert.equal(evidence.ready, false);
+      assert.match(seller.failureCode, /^VERCEL_URL_/);
+      assert.equal(seller.targetUrl, null);
+    }
+  });
+
+  it('Vercel read credential이 없으면 fail-closed한다', async () => {
+    await assertFailure(
+      collectDeploymentEvidence(SHA, DEPLOYMENT_IDS, {
+        vercelToken: '',
+        fetchImpl: async () => {
+          throw new Error('호출되면 안 됨');
+        },
+      }),
+      'VERCEL_READ_TOKEN_REQUIRED',
+    );
+  });
+
+  it('잘못된 credential의 HTTP 401은 성공으로 숨기지 않는다', async () => {
+    const calls = [];
+    const evidence = await collectDeploymentEvidence(SHA, DEPLOYMENT_IDS, {
+      vercelToken: 'opaque-test-token',
+      fetchImpl: async (url, init) => {
+        calls.push({ url, init });
+        return response({ error: { code: 'forbidden' } }, 401);
+      },
+    });
+
+    assert.equal(evidence.ready, false);
+    assert.equal(evidence.retryable, false);
     assert.deepEqual(
-      evidence.apps.map(({ state, ready }) => ({ state, ready })),
-      [
-        { state: 'missing', ready: false },
-        { state: 'missing', ready: false },
-        { state: 'missing', ready: false },
-      ],
+      evidence.failureCodes,
+      PREVIEW_APPS.map(({ app }) => ({ app, code: 'VERCEL_API_HTTP_401' })),
     );
+    assert.equal(JSON.stringify(evidence).includes('opaque-test-token'), false);
+    assert.equal(calls.length, 3);
+    assert.equal(calls[0].init.headers.Authorization, 'Bearer opaque-test-token');
   });
 
-  it('status 응답에 sha 필드가 없어도 exact SHA 요청 경로를 증거로 사용한다', () => {
-    const statuses = allSuccessStatuses().map((status) =>
-      Object.fromEntries(Object.entries(status).filter(([key]) => key !== 'sha')),
-    );
-    const evidence = collectWith(statuses);
-
-    assert.equal(evidence.ready, true);
-    assert.deepEqual(evidence.statusShas, {
-      consumer: SHA,
-      seller: SHA,
-      driver: SHA,
-    });
-  });
-
-  it('기존 collectDeploymentEvidence export도 status source를 사용한다', () => {
-    const paths = [];
-    const evidence = collectDeploymentEvidence(SHA, (apiPath) => {
-      paths.push(apiPath);
-      return allSuccessStatuses();
+  it('직접 fetch는 Vercel deployment GET만 호출한다', async () => {
+    const calls = [];
+    const deployments = validDeployments();
+    const evidence = await collectDeploymentEvidence(SHA, DEPLOYMENT_IDS, {
+      vercelToken: 'opaque-test-token',
+      fetchImpl: async (url, init) => {
+        calls.push({ url, init });
+        const deploymentId = decodeURIComponent(new URL(url).pathname.split('/').at(-1));
+        const app = Object.entries(DEPLOYMENT_IDS).find(([, id]) => id === deploymentId)?.[0];
+        return response(deployments[app]);
+      },
     });
 
     assert.equal(evidence.ready, true);
-    assert.equal(paths.length, 1);
-    assert.equal(paths[0].includes('/commits/' + SHA + '/statuses'), true);
+    assert.equal(calls.length, 3);
+    for (const { url, init } of calls) {
+      assert.equal(url.startsWith(`${VERCEL_API_ORIGIN}/v13/deployments/`), true);
+      assert.equal(new URL(url).searchParams.get('teamId'), VERCEL_TEAM_ID);
+      assert.equal(init.method, 'GET');
+      assert.equal(init.headers.Accept, 'application/json');
+    }
   });
 
-  it('직접 검사도 알 수 없는 앱을 명시적으로 거부한다', () => {
-    assert.throws(
-      () => inspectAppCommitStatus('unknown', SHA, []),
-      /알 수 없는 Preview 앱입니다/,
+  it('더 최신 deployment가 있어도 전달한 pinned ID만 조회한다', async () => {
+    const calls = [];
+    const deployments = validDeployments();
+    const newerDeployment = validDeployment('consumer', {
+      id: 'dpl_newerDeploymentIgnored',
+      uid: 'dpl_newerDeploymentIgnored',
+      meta: { githubCommitSha: 'c'.repeat(40) },
+    });
+    const evidence = await collectDeploymentEvidence(SHA, DEPLOYMENT_IDS, {
+      request: async (deploymentId, app) => {
+        calls.push(deploymentId);
+        assert.equal(deploymentId, DEPLOYMENT_IDS[app]);
+        return deployments[app];
+      },
+    });
+
+    assert.equal(evidence.ready, true);
+    assert.equal(newerDeployment.meta.githubCommitSha, 'c'.repeat(40));
+    assert.deepEqual(calls, [
+      DEPLOYMENT_IDS.consumer,
+      DEPLOYMENT_IDS.seller,
+      DEPLOYMENT_IDS.driver,
+    ]);
+    assert.deepEqual(evidence.deploymentIds, DEPLOYMENT_IDS);
+  });
+
+  it('stale GitHub status는 직접 Vercel evidence의 결과를 override하지 않는다', async () => {
+    const evidence = await collectWith().promise;
+
+    assert.equal(evidence.ready, true);
+    assert.equal(evidence.evidenceSource, 'vercel-deployment-metadata');
+    assert.equal(Object.hasOwn(evidence, 'statusStates'), false);
+  });
+
+  it('GitHub status diagnostic은 canonical deployment evidence와 별도로 표시한다', () => {
+    const diagnostic = collectCommitStatusDiagnostic(SHA, (apiPath) => {
+      assert.equal(apiPath, `repos/booker-lab/greenhub/commits/${SHA}/statuses?per_page=100`);
+      return [
+        {
+          id: 1,
+          context: 'Vercel – greenhubconsumer',
+          sha: OTHER_SHA,
+          state: 'failure',
+          target_url: 'https://status.example.test',
+        },
+      ];
+    });
+
+    assert.equal(diagnostic.diagnostic, true);
+    assert.equal(diagnostic.evidenceSource, 'github-commit-status-diagnostic');
+    assert.equal(Object.hasOwn(diagnostic, 'ready'), false);
+    assert.equal(diagnostic.apps.find(({ app }) => app === 'consumer').state, 'failure');
+  });
+
+  it('pinned ID와 expected SHA가 없으면 contract를 거부한다', async () => {
+    await assertFailure(
+      collectDeploymentEvidence(
+        SHA,
+        { ...DEPLOYMENT_IDS, driver: '' },
+        { request: async () => ({}) },
+      ),
+      'DEPLOYMENT_ID_REQUIRED',
     );
+    await assertFailure(
+      collectDeploymentEvidence(OTHER_SHA.slice(0, 39), DEPLOYMENT_IDS, {
+        request: async () => ({}),
+      }),
+      'EXPECTED_SHA_MALFORMED',
+    );
+  });
+
+  it('requestVercelDeployment은 token 값을 결과나 오류에 넣지 않는다', async () => {
+    const calls = [];
+    const payload = { deployment: validDeployment('consumer') };
+    const result = await requestVercelDeployment(
+      DEPLOYMENT_IDS.consumer,
+      'opaque-test-token',
+      async (url, init) => {
+        calls.push({ url, init });
+        return response(payload);
+      },
+    );
+
+    assert.deepEqual(result, payload);
+    assert.equal(JSON.stringify(result).includes('opaque-test-token'), false);
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].init.headers.Authorization, 'Bearer opaque-test-token');
+    assert.equal(VERCEL_CREDENTIAL_NAME, 'ROUND_DIRECT_E2E_VERCEL_READ_TOKEN');
   });
 });


### PR DESCRIPTION
## 목적

Issue #89 `PREVIEW-EVIDENCE-GATE-02` 구현 후보입니다. release app SHA `0358c8d956fb22064ab93685d46714d2023ef505`에 대해 Consumer/Seller/Driver의 명시적으로 pinned된 Vercel Preview deployment metadata를 직접 검증하는 canonical evidence owner로 전환합니다.

## 구현

- `scripts/wait-preview-deploy.mjs`: GitHub commit status/latest discovery 대신 pinned deployment ID의 Vercel metadata를 직접 검증
- `.github/workflows/e2e-round-direct.yml`: app expected SHA와 harness candidate SHA를 분리하고 deployment IDs를 required input으로 고정
- `.github/workflows/sync-preview.yml`: commit-status path를 non-blocking diagnostic으로 격하
- exact project/SHA/READY/non-production/safe URL/fail-closed focused coverage

## 검증

- focused deployment/readiness specs: 32/32 PASS
- `node --check`, Biome, `git diff --check`: PASS
- candidate workflow run `34054792691`:
  - approval/preflight: PASS
  - pinned Vercel deployment metadata gate: PASS
  - readiness: PASS
  - chromium/mobile fixture seed + verify: PASS
  - browser stage reached
  - first Consumer Credentials callback: `CredentialsSignin / authorize-rejected`, no Auth.js session cookie
  - cleanup chromium/mobile: PASS

따라서 Preview evidence gate 자체는 PROVEN이고, remaining release blocker는 기존 Issue #88의 Auth Preview runtime binding으로 재분류됩니다.

## Publication boundary

PR은 OPEN / unmerged 상태를 유지합니다. main merge, production deploy/promote, production Firebase, salesMode, 실결제, ALIGO/Kakao 발송 없음.