### PR TITLE
fix(admin): recover orders read failure state

### DIFF
--- a/apps/seller/src/app/admin/orders/_client.test.ts
+++ b/apps/seller/src/app/admin/orders/_client.test.ts
@@ -1,0 +1,60 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { getAdminOrdersReadState } from './_lib';
+
+// AdminOrdersClient는 '@/' alias를 사용하므로 vitest에서 직접 import할 수 없다.
+// (seller vitest에는 tsconfig paths 매핑이 없어 '@/hooks/useAdmin' 해석이 실패한다.)
+// 따라서 본 focused test는 _client.tsx 소스의 배선(wiring)을 고정하고,
+// 실제 상태 분기는 순수 함수인 getAdminOrdersReadState로 증명한다.
+// READ-ONLY인 OrdersTable/_lib의 동작 자체는 각자의 focused test가 소유한다.
+
+const source = readFileSync(new URL('./_client.tsx', import.meta.url), 'utf8');
+
+const FETCH_ERROR_MESSAGE = '주문 목록 조회 중 오류 발생';
+
+describe('AdminOrdersClient read recovery wiring', () => {
+  it('useAdminOrders의 error/reload를 소비한다', () => {
+    expect(source).toContain('useAdminOrders({');
+    expect(source).toMatch(/const\s*\{\s*orders,\s*loading,\s*error,\s*reload,\s*forceRefund\s*\}/);
+  });
+
+  it('error가 존재할 때 empty-only UI로 collapse되지 않는다', () => {
+    // _client가 error를 table로 전달한다.
+    expect(source).toContain('error={error}');
+    // _client 자체가 빈 주문 copy로 Collapse하지 않는다 — 실패 표현은 table이 소유한다.
+    expect(source).not.toContain('주문이 없습니다.');
+    // 전달된 error는 table 분기에서 EMPTY가 아닌 FETCH_ERROR가 된다.
+    expect(
+      getAdminOrdersReadState({ loading: false, error: FETCH_ERROR_MESSAGE, orders: [] }),
+    ).toBe('FETCH_ERROR');
+  });
+
+  it('retry가 reload 경로를 사용한다', () => {
+    expect(source).toContain('onRetry={reload}');
+  });
+
+  it('정상 empty는 기존 정상 empty로 유지된다', () => {
+    // 성공+0건은 EMPTY로 유지되어야 한다.
+    expect(getAdminOrdersReadState({ loading: false, error: null, orders: [] })).toBe('EMPTY');
+    // _client는 orders/loading을 그대로 전달하므로 정상 분기를 가로채지 않는다.
+    expect(source).toContain('orders={orders}');
+    expect(source).toContain('loading={loading}');
+    // 실패 전용 copy/재시도를 _client가 중복 렌더하지 않는다.
+    expect(source).not.toContain('다시 조회');
+    expect(source).not.toContain('불러오지 못했습니다');
+  });
+
+  it('기존 refund callback을 유지한다', () => {
+    expect(source).toContain('forceRefund(orderId');
+    expect(source).toContain('onRefund={handleRefund}');
+    expect(source).toContain('processingId={processingId}');
+  });
+
+  it('기존 filter 배선을 변경하지 않는다', () => {
+    expect(source).toContain('<OrdersFilters');
+    expect(source).toContain('storeFilter={storeFilter}');
+    expect(source).toContain('statusFilter={statusFilter}');
+    expect(source).toContain('onStoreChange={setStoreFilter}');
+    expect(source).toContain('onStatusChange={setStatusFilter}');
+  });
+});

--- a/apps/seller/src/app/admin/orders/_client.tsx
+++ b/apps/seller/src/app/admin/orders/_client.tsx
@@ -10,7 +10,7 @@ import { OrdersTable } from './_components/OrdersTable';
 export default function AdminOrdersClient() {
   const [storeFilter, setStoreFilter] = useState('');
   const [statusFilter, setStatusFilter] = useState('');
-  const { orders, loading, forceRefund } = useAdminOrders({
+  const { orders, loading, error, reload, forceRefund } = useAdminOrders({
     storeId: storeFilter || undefined,
     status: statusFilter || undefined,
   });
@@ -55,8 +55,10 @@ export default function AdminOrdersClient() {
       <OrdersTable
         orders={orders}
         loading={loading}
+        error={error}
         processingId={processingId}
         onRefund={handleRefund}
+        onRetry={reload}
       />
     </Box>
   );

--- a/apps/seller/src/app/admin/orders/_components/OrdersTable.test.tsx
+++ b/apps/seller/src/app/admin/orders/_components/OrdersTable.test.tsx
@@ -1,0 +1,135 @@
+import type { ComponentProps, ReactElement, ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { OrdersTable } from './OrdersTable';
+
+type Props = ComponentProps<typeof OrdersTable>;
+
+const FETCH_ERROR_MESSAGE = '주문 목록 조회 중 오류 발생';
+
+const baseProps: Props = {
+  orders: [],
+  loading: false,
+  error: null,
+  processingId: null,
+  onRefund: () => {},
+  onRetry: () => {},
+};
+
+function order(
+  id: string,
+  orderNumber: string,
+  status = 'ACCEPTED',
+): Props['orders'][number] {
+  return {
+    id,
+    orderNumber,
+    storeId: 'store-abcdef12',
+    userId: 'user-1',
+    status,
+    totalAmount: 12000,
+    deliveryMethod: 'DIRECT',
+    createdAt: '2026-09-01T00:00:00.000Z',
+  };
+}
+
+interface Clickable {
+  children?: ReactNode;
+  onClick?: unknown;
+}
+
+function isElement(node: ReactNode): node is ReactElement<Clickable> {
+  return typeof node === 'object' && node !== null && 'props' in node;
+}
+
+/** 렌더 트리(DOM 불필요)에 포함된 모든 텍스트 리프를 수집한다. */
+function textsOf(node: ReactNode): string[] {
+  const out: string[] = [];
+  const visit = (current: ReactNode): void => {
+    if (typeof current === 'string') {
+      out.push(current);
+      return;
+    }
+    if (Array.isArray(current)) {
+      for (const child of current) visit(child);
+      return;
+    }
+    if (isElement(current)) visit(current.props.children);
+  };
+  visit(node);
+  return out;
+}
+
+/** 주어진 라벨을 포함한 버튼의 onClick 핸들러를 수집한다. */
+function handlersFor(tree: ReactNode, label: string): Array<() => void> {
+  const handlers: Array<() => void> = [];
+  const visit = (current: ReactNode): void => {
+    if (Array.isArray(current)) {
+      for (const child of current) visit(child);
+      return;
+    }
+    if (!isElement(current)) return;
+    if (typeof current.props.onClick === 'function' && textsOf(current).includes(label)) {
+      handlers.push(current.props.onClick as () => void);
+    }
+    visit(current.props.children);
+  };
+  visit(tree);
+  return handlers;
+}
+
+describe('Admin OrdersTable read state', () => {
+  it('loading → 로딩 UI를 표시한다', () => {
+    const tree = OrdersTable({ ...baseProps, loading: true });
+    expect(textsOf(tree)).toContain('불러오는 중...');
+  });
+
+  it('조회 실패 + 0건 → empty copy 없이 error UI와 retry를 표시한다', () => {
+    const tree = OrdersTable({ ...baseProps, error: FETCH_ERROR_MESSAGE });
+    const texts = textsOf(tree);
+    expect(texts).not.toContain('주문이 없습니다.');
+    expect(texts).toContain('주문 목록을 불러오지 못했습니다.');
+    expect(texts).toContain(FETCH_ERROR_MESSAGE);
+    expect(handlersFor(tree, '다시 조회').length).toBeGreaterThan(0);
+  });
+
+  it('성공 + 0건 → 기존 empty copy를 표시하고 retry를 노출하지 않는다', () => {
+    const tree = OrdersTable({ ...baseProps });
+    expect(textsOf(tree)).toContain('주문이 없습니다.');
+    expect(handlersFor(tree, '다시 조회')).toHaveLength(0);
+  });
+
+  it('성공 + 결과 → 기존 order rendering을 유지하고 retry를 노출하지 않는다', () => {
+    const tree = OrdersTable({ ...baseProps, orders: [order('o1', 'ORD-1')] });
+    const texts = textsOf(tree);
+    expect(texts).toContain('ORD-1');
+    expect(texts).not.toContain('주문이 없습니다.');
+    expect(handlersFor(tree, '다시 조회')).toHaveLength(0);
+  });
+
+  it('retry 실행 시 onRetry를 호출한다', () => {
+    const onRetry = vi.fn();
+    const tree = OrdersTable({ ...baseProps, error: FETCH_ERROR_MESSAGE, onRetry });
+    const handlers = handlersFor(tree, '다시 조회');
+    expect(handlers.length).toBeGreaterThan(0);
+    handlers[0]();
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('refund behavior를 보존한다(환불가능 상태만 강제환불, 처리중 표시)', () => {
+    const tree = OrdersTable({
+      ...baseProps,
+      orders: [order('o1', 'ORD-1', 'ACCEPTED'), order('o2', 'ORD-2', 'DELIVERED')],
+    });
+    const texts = textsOf(tree);
+    expect(texts).toContain('ORD-1');
+    expect(texts).toContain('ORD-2');
+    expect(texts).toContain('강제환불');
+
+    const processing = OrdersTable({
+      ...baseProps,
+      orders: [order('o1', 'ORD-1', 'ACCEPTED')],
+      processingId: 'o1',
+    });
+    expect(textsOf(processing)).toContain('처리중…');
+  });
+});

--- a/apps/seller/src/app/admin/orders/_components/OrdersTable.tsx
+++ b/apps/seller/src/app/admin/orders/_components/OrdersTable.tsx
@@ -2,13 +2,17 @@
 
 import { Badge, Box, Button, Group, Paper, Stack, Text } from '@mantine/core';
 import type { AdminOrder } from '@/hooks/useAdmin';
-import { getStatusColor, REFUNDABLE, STATUS_LABEL } from '../_lib';
+import { getAdminOrdersReadState, getStatusColor, REFUNDABLE, STATUS_LABEL } from '../_lib';
 
 interface OrdersTableProps {
   orders: AdminOrder[];
   loading: boolean;
+  /** useAdminOrders 조회 실패 메시지. null이면 마지막 조회가 실패하지 않았음. */
+  error: string | null;
   processingId: string | null;
   onRefund: (orderId: string) => void;
+  /** 조회 실패 시 재시도 — hook의 reload()에 연결된다. */
+  onRetry: () => void;
 }
 
 const thBase = {
@@ -17,8 +21,10 @@ const thBase = {
   color: 'var(--color-text-secondary)',
 };
 
-export function OrdersTable({ orders, loading, processingId, onRefund }: OrdersTableProps) {
-  if (loading) {
+export function OrdersTable({ orders, loading, error, processingId, onRefund, onRetry }: OrdersTableProps) {
+  const readState = getAdminOrdersReadState({ loading, error, orders });
+
+  if (readState === 'LOADING') {
     return (
       <Text ta="center" py={80} style={{ color: 'var(--color-text-disabled)' }}>
         불러오는 중...
@@ -26,7 +32,33 @@ export function OrdersTable({ orders, loading, processingId, onRefund }: OrdersT
     );
   }
 
-  if (orders.length === 0) {
+  // 조회 실패는 성공-empty와 구조적으로 구분 — "주문이 없습니다."로 collapse 금지.
+  if (readState === 'FETCH_ERROR') {
+    return (
+      <Paper
+        radius="lg"
+        shadow="xs"
+        style={{ border: '1px solid var(--color-border)', overflow: 'hidden' }}
+      >
+        <Stack gap="sm" align="center" py={64} px="md">
+          <Text style={{ fontWeight: 500, color: 'var(--color-text-secondary)' }}>
+            주문 목록을 불러오지 못했습니다.
+          </Text>
+          <Text
+            ta="center"
+            style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-text-disabled)' }}
+          >
+            {error}
+          </Text>
+          <Button onClick={onRetry} size="sm" variant="outline" radius="md">
+            다시 조회
+          </Button>
+        </Stack>
+      </Paper>
+    );
+  }
+
+  if (readState === 'EMPTY') {
     return (
       <Paper
         radius="lg"

--- a/apps/seller/src/app/admin/orders/_lib.test.ts
+++ b/apps/seller/src/app/admin/orders/_lib.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { getAdminOrdersReadState } from './_lib';
+
+const FETCH_ERROR_MESSAGE = '주문 목록 조회 중 오류 발생';
+
+function order(id: string) {
+  return { id };
+}
+
+describe('getAdminOrdersReadState', () => {
+  it('조회 중에는 LOADING을 반환한다', () => {
+    expect(getAdminOrdersReadState({ loading: true, error: null, orders: [] })).toBe('LOADING');
+  });
+
+  it('조회 실패 + 0건은 FETCH_ERROR를 반환한다(EMPTY collapse 방지)', () => {
+    expect(
+      getAdminOrdersReadState({ loading: false, error: FETCH_ERROR_MESSAGE, orders: [] }),
+    ).toBe('FETCH_ERROR');
+  });
+
+  it('성공 + 0건만 EMPTY를 반환한다', () => {
+    expect(getAdminOrdersReadState({ loading: false, error: null, orders: [] })).toBe('EMPTY');
+  });
+
+  it('성공 + 1건 이상은 HAS_RESULTS를 반환한다', () => {
+    expect(
+      getAdminOrdersReadState({ loading: false, error: null, orders: [order('o1')] }),
+    ).toBe('HAS_RESULTS');
+  });
+
+  it('loading + error는 LOADING을 우선한다', () => {
+    expect(
+      getAdminOrdersReadState({ loading: true, error: FETCH_ERROR_MESSAGE, orders: [] }),
+    ).toBe('LOADING');
+  });
+
+  it('error는 결과 유무보다 우선한다', () => {
+    expect(
+      getAdminOrdersReadState({
+        loading: false,
+        error: FETCH_ERROR_MESSAGE,
+        orders: [order('o1')],
+      }),
+    ).toBe('FETCH_ERROR');
+  });
+});

--- a/apps/seller/src/app/admin/orders/_lib.ts
+++ b/apps/seller/src/app/admin/orders/_lib.ts
@@ -22,6 +22,23 @@ export function getStatusColor(status: string): string {
 // 강제환불 가능 상태 — 배달 진행 전까지만 허용.
 export const REFUNDABLE = ['ACCEPTED', 'RECRUITING', 'CONFIRMED', 'PREPARING'];
 
+// Admin 주문 목록 read state — 조회 실패와 성공-empty의 구조적 구분.
+// useAdminOrders는 error/reload를 노출하지만 화면이 이를 소비하지 않으면
+// 조회 실패가 빈 목록("주문이 없습니다.")으로 collapse된다.
+// 분기 우선순위(loading > error > empty > results)를 순수 함수로 고정한다.
+export type AdminOrdersReadState = 'LOADING' | 'FETCH_ERROR' | 'EMPTY' | 'HAS_RESULTS';
+
+export function getAdminOrdersReadState(args: {
+  loading: boolean;
+  error: string | null;
+  orders: readonly unknown[];
+}): AdminOrdersReadState {
+  if (args.loading) return 'LOADING';
+  if (args.error !== null) return 'FETCH_ERROR';
+  if (args.orders.length === 0) return 'EMPTY';
+  return 'HAS_RESULTS';
+}
+
 // 상태 필터 Select 옵션 — '전체' + 전 상태.
 export function buildStatusOptions(): { value: string; label: string }[] {
   return [


### PR DESCRIPTION
TASK_ID: ADMIN-ORDERS-READ-RECOVERY-PUBLICATION-01

Root cause: admin orders read failure was indistinguishable from empty state (error/reload from useAdminOrders not consumed; failure collapsed to empty copy).

Exact six-file slice:
- apps/seller/src/app/admin/orders/_client.tsx (M: consume error/reload, wire error={error} onRetry={reload})
- apps/seller/src/app/admin/orders/_lib.ts (M: getAdminOrdersReadState LOADING greater than FETCH_ERROR greater than EMPTY greater than HAS_RESULTS)
- apps/seller/src/app/admin/orders/_components/OrdersTable.tsx (M: error prop + onRetry, FETCH_ERROR vs EMPTY distinction)
- apps/seller/src/app/admin/orders/_client.test.ts (A)
- apps/seller/src/app/admin/orders/_lib.test.ts (A)
- apps/seller/src/app/admin/orders/_components/OrdersTable.test.tsx (A)

Contract:
- FETCH_ERROR / EMPTY distinction: error + [] yields FETCH_ERROR, never EMPTY
- reload retry wiring: onRetry={reload}, retry button calls callback
- refund preservation: forceRefund/REFUNDABLE/processingId intact
- filter preservation: OrdersFilters wiring intact

Focused proof: 18 PASS (6+6+6) via npx vitest run on the three suites.

Foreign dirty files excluded (preserved in working tree, not in this PR).

No useAdmin.ts change required because provider contract (error/reload) already in main.