### PR TITLE
fix(seller): recover admin users read failures

### DIFF
--- a/apps/seller/src/app/admin/users/_client.test.ts
+++ b/apps/seller/src/app/admin/users/_client.test.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+// AdminUsersClient는 '@/' alias를 사용하므로 vitest에서 직접 import할 수 없다.
+// 따라서 이 focused test는 화면의 read-state 분기와 기존 action 배선을 소스에서 고정한다.
+const source = readFileSync(new URL('./_client.tsx', import.meta.url), 'utf8');
+
+describe('AdminUsersClient 조회 실패/복구 배선', () => {
+  it('useAdminUsers의 error/reload를 소비한다', () => {
+    expect(source).toContain('useAdminUsers()');
+    expect(source).toMatch(
+      /const\s*\{\s*users,\s*loading,\s*error,\s*reload,\s*toggleSuspend\s*\}/,
+    );
+  });
+
+  it('조회 실패 메시지와 명시적 retry를 표시한다', () => {
+    expect(source).toContain('error !== null && !loading');
+    expect(source).toContain('소비자 목록을 불러오지 못했습니다.');
+    expect(source).toContain('{error}');
+    expect(source).toContain('<Button onClick={reload}');
+    expect(source).toContain('다시 조회');
+  });
+
+  it('retry가 authoritative reload를 사용하고 우회하지 않는다', () => {
+    expect(source).toContain('onClick={reload}');
+    expect(source).not.toContain('window.location.reload');
+    expect(source).not.toContain('setError');
+    expect(source).not.toContain('setLoading');
+  });
+
+  it('loading/정상 목록 경로를 보존한다', () => {
+    expect(source).toContain('불러오는 중...');
+    expect(source).toContain('<UsersTable');
+    expect(source).toContain('users={users}');
+    expect(source).toContain('({users.length})');
+  });
+
+  it('조회 실패를 빈 목록과 구분한다', () => {
+    // 실패 분기는 UsersTable(성공 0건 경로)과 분리된 early return이다.
+    const errorBranch = source.indexOf('error !== null && !loading');
+    const tableUsage = source.indexOf('<UsersTable');
+    expect(errorBranch).toBeGreaterThanOrEqual(0);
+    expect(tableUsage).toBeGreaterThan(errorBranch);
+  });
+
+  it('기존 suspend 확인·처리 경로를 유지한다', () => {
+    expect(source).toContain('const runPending = async () =>');
+    expect(source).toContain('await toggleSuspend(pending.userId, !pending.currentlySuspended)');
+    expect(source).toContain('setPending(null)');
+    expect(source).toContain('opened={pending !== null}');
+    expect(source).toContain('onConfirm={runPending}');
+    expect(source).toContain("onToggle={handleToggle}");
+  });
+});

--- a/apps/seller/src/app/admin/users/_client.tsx
+++ b/apps/seller/src/app/admin/users/_client.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Box, Group, Text, Title } from '@mantine/core';
+import { Box, Button, Group, Paper, Stack, Text, Title } from '@mantine/core';
 import { useState } from 'react';
 import { ConfirmModal } from '@/components/ConfirmModal';
 import type { AdminUser } from '@/hooks/useAdmin';
@@ -13,7 +13,7 @@ interface PendingUserAction {
 }
 
 export default function AdminUsersClient() {
-  const { users, loading, toggleSuspend } = useAdminUsers();
+  const { users, loading, error, reload, toggleSuspend } = useAdminUsers();
   const [processingId, setProcessingId] = useState<string | null>(null);
   const [pending, setPending] = useState<PendingUserAction | null>(null);
 
@@ -36,6 +36,36 @@ export default function AdminUsersClient() {
       <Text ta="center" py={80} style={{ color: 'var(--color-text-disabled)' }}>
         불러오는 중...
       </Text>
+    );
+  }
+
+  if (error !== null && !loading) {
+    return (
+      <Box>
+        <Group justify="space-between" mb="md">
+          <Title order={4}>소비자 계정</Title>
+        </Group>
+        <Paper
+          radius="lg"
+          shadow="xs"
+          style={{ border: '1px solid var(--color-border)', overflow: 'hidden' }}
+        >
+          <Stack gap="sm" align="center" py={64} px="md">
+            <Text style={{ fontWeight: 500, color: 'var(--color-text-secondary)' }}>
+              소비자 목록을 불러오지 못했습니다.
+            </Text>
+            <Text
+              ta="center"
+              style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-text-disabled)' }}
+            >
+              {error}
+            </Text>
+            <Button onClick={reload} size="sm" variant="outline" radius="md">
+              다시 조회
+            </Button>
+          </Stack>
+        </Paper>
+      </Box>
     );
   }
 


### PR DESCRIPTION
## Scope (ADMIN-USERS-READ-RECOVERY-01 publication only)\n\nAdmin Users read recovery only. No feature expansion.\n\nOwned files (2):\n- apps/seller/src/app/admin/users/_client.tsx\n- apps/seller/src/app/admin/users/_client.test.ts\n\nForeign dirty explicitly NOT included.\n\n## Root cause\n\nAdminUsersClient consumed only \users/loading/toggleSuspend\ from \useAdminUsers()\. When the users fetch failed, there was no error branch: failure collapsed into the success path (genuine empty vs failure indistinguishable) with no retry affordance.\n\n## Fix\n\n- Consume \error\/\eload\ from \useAdminUsers()\ (hook-authoritative).\n- Keep \loading\ branch unchanged.\n- Render explicit failure UI only when \error !== null && !loading\: message '\uc18c\ube44\uc790 \ubaa9\ub85d\uc744 \ubd88\ub7ec\uc624\uc9c0 \ubabb\ud588\uc2b5\ub2c8\ub2e4.' + \{error}\ + '\ub2e4\uc2dc \uc870\ud68c' button wired to \onClick={reload}\.\n- Failure branch is an early return before \<UsersTable>\, so failure and genuine empty state are separated.\n- No \window.location.reload\, no extra \setError\/\setLoading\ state machine.\n- suspend / ConfirmModal / runPending / toggleSuspend wiring preserved.\n\n## Verification\n\n- apps/seller: \
px vitest run src/app/admin/users/_client.test.ts\ -> 6/6 PASS (fresh session re-run).\n- \
px biome lint\ on the two owned files -> clean.\n- Full seller suite not run (source task scope; not expanded for publication).\n\n## Freshness\n\n- Source END_HEAD 9621a44 == live remote main at publication; no baseline movement.\n- \useAdminUsers\ contract (users/loading/error/reload/toggleSuspend) intact; working-tree dirty in \useAdmin.ts\ touches only \useAdminInvite\ (unrelated).\n- No overlapping semantic mutation on the owned surface.