### PR TITLE
fix(admin): recover invite read and generation failures

### DIFF
--- a/apps/seller/src/app/admin/invite/_client.test.ts
+++ b/apps/seller/src/app/admin/invite/_client.test.ts
@@ -1,0 +1,100 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+// AdminInviteClient는 '@/hooks/useAdmin' alias를 사용하므로 vitest에서 직접 import하지 않는다.
+// (seller vitest에는 tsconfig paths 매핑이 없어 '@/hooks/useAdmin' 해석이 실패한다.)
+// 따라서 focused test는 _client.tsx 배선(wiring)을 고정하고,
+// 실제 상태 분기는 _lib 순수 함수와 각 컴포넌트 focused test가 소유한다.
+
+const source = readFileSync(new URL('./_client.tsx', import.meta.url), 'utf8');
+const hookSource = readFileSync(
+  new URL('../../../hooks/useAdmin.ts', import.meta.url),
+  'utf8',
+);
+
+// useAdminInvite 블록만 추출 — shared hook 회귀 검증은 이 블록 범위로 한정한다.
+function inviteBlock(): string {
+  const start = hookSource.indexOf('export function useAdminInvite()');
+  if (start === -1) throw new Error('useAdminInvite not found');
+  const nextExport = hookSource.indexOf('export function', start + 1);
+  const nextEnd = hookSource.indexOf('// ──', start + 1);
+  const candidates = [nextExport, nextEnd].filter((i) => i !== -1);
+  return hookSource.slice(start, candidates.length > 0 ? Math.min(...candidates) : undefined);
+}
+
+describe('AdminInviteClient recovery wiring', () => {
+  it('useAdminInvite에서 error/reload를 구조분해한다', () => {
+    expect(source).toContain('useAdminInvite()');
+    expect(source).toMatch(/const\s*\{[\s\S]*?\}\s*=\s*\n?\s*useAdminInvite\(\)/);
+    for (const key of [
+      'invites',
+      'loading',
+      'error',
+      'reload',
+      'generating',
+      'generateError',
+      'generate',
+    ]) {
+      expect(source).toContain(key);
+    }
+  });
+
+  it('history read error를 명시하고 reload로 retry한다', () => {
+    // _client가 error를 table에 전달한다.
+    expect(source).toContain('error={error}');
+    // retry가 reload 경로를 사용한다.
+    expect(source).toContain('onRetry={reload}');
+    // 실패를 invites=[] 성공으로 취급하지 않음 — table 분기가 소유한다.
+    expect(source).not.toContain('발급된 토큰이 없습니다.');
+  });
+
+  it('generate 실패를 사용자에게 알리고 성공한 경우에만 lastToken을 갱신한다', () => {
+    // 발급 실패 UI에 hook의 generateError를 전달한다.
+    expect(source).toContain('generateError={generateError}');
+    // 성공(result non-null)한 경우에만 lastToken 갱신 — 실패가 이전 성공 token을 덮어쓰지 않음.
+    expect(source).toContain('if (result) setLastToken(result)');
+    expect(source).not.toContain('setLastToken(null)');
+  });
+
+  it('기존 token copy 계약을 보존한다', () => {
+    expect(source).toContain('navigator.clipboard.writeText(lastToken.token)');
+    expect(source).toContain('setCopied(true)');
+    expect(source).toContain('setTimeout(() => setCopied(false), 2000)');
+    expect(source).toContain('onCopy={handleCopy}');
+    expect(source).toContain('if (!lastToken) return;');
+  });
+
+  it('기존 generate/copy 컴포넌트 배선을 유지한다', () => {
+    expect(source).toContain('<InviteGenerator');
+    expect(source).toContain('generating={generating}');
+    expect(source).toContain('lastToken={lastToken}');
+    expect(source).toContain('copied={copied}');
+    expect(source).toContain('onGenerate={handleGenerate}');
+    expect(source).toContain('<InviteHistoryTable');
+    expect(source).toContain('invites={invites}');
+    expect(source).toContain('loading={loading}');
+  });
+});
+
+describe('useAdminInvite hook recovery wiring', () => {
+  it('invite history error를 hook 밖으로 노출한다', () => {
+    const block = inviteBlock();
+    expect(block).toContain('error,');
+    expect(block).toContain('return { invites, loading, error, generating, generateError, generate, reload }');
+  });
+
+  it('generate 실패를 silent null로 끝내지 않고 generateError에 기록한다', () => {
+    const block = inviteBlock();
+    expect(block).toContain('setGenerateError(null)');
+    expect(block).toContain("setGenerateError('초대 토큰 발급 중 오류 발생')");
+    expect(block).toContain('return null');
+  });
+
+  it('성공 경로에서만 reload 후 데이터를 반환한다', () => {
+    const block = inviteBlock();
+    const tryIndex = block.indexOf('await reload()');
+    const catchIndex = block.indexOf('} catch {');
+    expect(tryIndex).toBeGreaterThan(-1);
+    expect(catchIndex).toBeGreaterThan(tryIndex);
+  });
+});

--- a/apps/seller/src/app/admin/invite/_client.tsx
+++ b/apps/seller/src/app/admin/invite/_client.tsx
@@ -7,7 +7,8 @@ import { InviteGenerator } from './_components/InviteGenerator';
 import { InviteHistoryTable } from './_components/InviteHistoryTable';
 
 export default function AdminInviteClient() {
-  const { invites, loading, generating, generate } = useAdminInvite();
+  const { invites, loading, error, reload, generating, generateError, generate } =
+    useAdminInvite();
   const [lastToken, setLastToken] = useState<{ token: string; expiresAt: string } | null>(null);
   const [copied, setCopied] = useState(false);
   const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -20,6 +21,7 @@ export default function AdminInviteClient() {
 
   const handleGenerate = async () => {
     const result = await generate();
+    // 성공한 경우에만 lastToken 갱신 — 실패(null)는 이전 성공 token을 덮어쓰지 않는다.
     if (result) setLastToken(result);
   };
 
@@ -41,6 +43,7 @@ export default function AdminInviteClient() {
         generating={generating}
         lastToken={lastToken}
         copied={copied}
+        generateError={generateError}
         onGenerate={handleGenerate}
         onCopy={handleCopy}
       />
@@ -55,7 +58,7 @@ export default function AdminInviteClient() {
       >
         발급 내역
       </Text>
-      <InviteHistoryTable invites={invites} loading={loading} />
+      <InviteHistoryTable invites={invites} loading={loading} error={error} onRetry={reload} />
     </Box>
   );
 }

--- a/apps/seller/src/app/admin/invite/_components/InviteGenerator.test.tsx
+++ b/apps/seller/src/app/admin/invite/_components/InviteGenerator.test.tsx
@@ -1,0 +1,153 @@
+import type { ComponentProps, ReactElement, ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { InviteGenerator } from './InviteGenerator';
+
+type Props = ComponentProps<typeof InviteGenerator>;
+
+const GENERATE_ERROR_MESSAGE = '초대 토큰 발급 중 오류 발생';
+
+const baseProps: Props = {
+  generating: false,
+  lastToken: null,
+  copied: false,
+  generateError: null,
+  onGenerate: () => {},
+  onCopy: () => {},
+};
+
+interface Clickable {
+  children?: ReactNode;
+  onClick?: unknown;
+}
+
+function isElement(node: ReactNode): node is ReactElement<Clickable> {
+  return typeof node === 'object' && node !== null && 'props' in node;
+}
+
+/** 렌더 트리(DOM 불필요)에서 모든 텍스트 리프를 수집한다. */
+function textsOf(node: ReactNode): string[] {
+  const out: string[] = [];
+  const visit = (current: ReactNode): void => {
+    if (typeof current === 'string') {
+      out.push(current);
+      return;
+    }
+    if (typeof current === 'number') {
+      out.push(String(current));
+      return;
+    }
+    if (Array.isArray(current)) {
+      for (const child of current) visit(child);
+      return;
+    }
+    if (isElement(current)) visit(current.props.children);
+  };
+  visit(node);
+  return out;
+}
+
+/** 주어진 라벨을 포함한 버튼의 onClick 핸들러를 수집한다. */
+function handlersFor(tree: ReactNode, label: string): Array<() => void> {
+  const handlers: Array<() => void> = [];
+  const visit = (current: ReactNode): void => {
+    if (Array.isArray(current)) {
+      for (const child of current) visit(child);
+      return;
+    }
+    if (!isElement(current)) return;
+    if (typeof current.props.onClick === 'function' && textsOf(current).includes(label)) {
+      handlers.push(current.props.onClick as () => void);
+    }
+    visit(current.props.children);
+  };
+  visit(tree);
+  return handlers;
+}
+
+describe('InviteGenerator command state', () => {
+  it('대기 상태에서는 생성 버튼을 표시하고 실패 UI를 노출하지 않는다', () => {
+    const tree = InviteGenerator({ ...baseProps });
+    const texts = textsOf(tree);
+    expect(texts).toContain('새 토큰 생성');
+    expect(texts).not.toContain('토큰 발급에 실패했습니다.');
+    expect(texts).not.toContain('생성된 초대 토큰');
+  });
+
+  it('생성 중에는 진행 copy를 표시한다', () => {
+    const tree = InviteGenerator({ ...baseProps, generating: true });
+    expect(textsOf(tree)).toContain('생성중…');
+  });
+
+  it('발급 실패는 성공과 구분되는 실패 UI로 알린다', () => {
+    const tree = InviteGenerator({ ...baseProps, generateError: GENERATE_ERROR_MESSAGE });
+    const texts = textsOf(tree);
+    expect(texts).toContain('토큰 발급에 실패했습니다.');
+    expect(texts).toContain(GENERATE_ERROR_MESSAGE);
+  });
+
+  it('발급 실패가 이전 성공 token 표시를 덮어쓰지 않는다', () => {
+    const tree = InviteGenerator({
+      ...baseProps,
+      generateError: GENERATE_ERROR_MESSAGE,
+      // 보안: 실제 토큰 원문이 아닌 구조 검증용 더미 식별자만 사용한다.
+      lastToken: { token: 'test-issued-aaa', expiresAt: '2026-12-31T00:00:00.000Z' },
+    });
+    const texts = textsOf(tree);
+    expect(texts).toContain('토큰 발급에 실패했습니다.');
+    expect(texts).toContain('생성된 초대 토큰');
+    expect(texts).toContain('test-issued-aaa');
+  });
+
+  it('성공 시 lastToken 블록·복사 버튼·만료 표기를 유지한다', () => {
+    const tree = InviteGenerator({
+      ...baseProps,
+      lastToken: { token: 'test-issued-aaa', expiresAt: '2026-12-31T00:00:00.000Z' },
+    });
+    const texts = textsOf(tree);
+    expect(texts).toContain('생성된 초대 토큰');
+    expect(texts).toContain('test-issued-aaa');
+    expect(texts).toContain('복사');
+    expect(texts.some((t) => t.includes('만료'))).toBe(true);
+    expect(texts).not.toContain('토큰 발급에 실패했습니다.');
+  });
+
+  it('copy feedback 계약을 보존한다(복사/복사됨!)', () => {
+    const idleTree = InviteGenerator({
+      ...baseProps,
+      lastToken: { token: 'test-issued-aaa', expiresAt: '2026-12-31T00:00:00.000Z' },
+      copied: false,
+    });
+    expect(textsOf(idleTree)).toContain('복사');
+    const copiedTree = InviteGenerator({
+      ...baseProps,
+      copied: true,
+      lastToken: { token: 'test-issued-aaa', expiresAt: '2026-12-31T00:00:00.000Z' },
+    });
+    expect(textsOf(copiedTree)).toContain('복사됨!');
+  });
+
+  it('lastToken이 없으면 복사 버튼을 노출하지 않는다', () => {
+    const tree = InviteGenerator({ ...baseProps });
+    expect(handlersFor(tree, '복사')).toHaveLength(0);
+  });
+
+  it('생성 버튼은 onGenerate에, 복사 버튼은 onCopy에 연결된다', () => {
+    const onGenerate = vi.fn();
+    const genTree = InviteGenerator({ ...baseProps, onGenerate });
+    const genHandlers = handlersFor(genTree, '새 토큰 생성');
+    expect(genHandlers.length).toBeGreaterThan(0);
+    genHandlers[0]();
+    expect(onGenerate).toHaveBeenCalledTimes(1);
+
+    const onCopy = vi.fn();
+    const copyTree = InviteGenerator({
+      ...baseProps,
+      onCopy,
+      lastToken: { token: 'test-issued-aaa', expiresAt: '2026-12-31T00:00:00.000Z' },
+    });
+    const copyHandlers = handlersFor(copyTree, '복사');
+    expect(copyHandlers.length).toBeGreaterThan(0);
+    copyHandlers[0]();
+    expect(onCopy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/seller/src/app/admin/invite/_components/InviteGenerator.tsx
+++ b/apps/seller/src/app/admin/invite/_components/InviteGenerator.tsx
@@ -7,6 +7,8 @@ interface InviteGeneratorProps {
   generating: boolean;
   lastToken: { token: string; expiresAt: string } | null;
   copied: boolean;
+  /** useAdminInvite 발급 command 실패 메시지. null이면 마지막 발급이 실패하지 않았음. */
+  generateError: string | null;
   onGenerate: () => void;
   onCopy: () => void;
 }
@@ -15,6 +17,7 @@ export function InviteGenerator({
   generating,
   lastToken,
   copied,
+  generateError,
   onGenerate,
   onCopy,
 }: InviteGeneratorProps) {
@@ -42,6 +45,32 @@ export function InviteGenerator({
       >
         {generating ? '생성중…' : '새 토큰 생성'}
       </Button>
+
+      {/* 발급 command 실패는 성공과 구분해 사용자에게 알린다. 성공한 경우에만 lastToken이 갱신되므로 이 블록은 이전 성공 토큰을 덮어쓰지 않는다. */}
+      {generateError !== null && (
+        <Box
+          mt="md"
+          p="md"
+          style={{
+            border: '1px solid var(--color-border)',
+            borderRadius: 12,
+          }}
+        >
+          <Text
+            style={{
+              fontSize: 'var(--font-size-sm)',
+              fontWeight: 'var(--fw-medium)',
+              color: 'var(--color-error, #e03131)',
+            }}
+            mb={4}
+          >
+            토큰 발급에 실패했습니다.
+          </Text>
+          <Text style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-text-disabled)' }}>
+            {generateError}
+          </Text>
+        </Box>
+      )}
 
       {lastToken && (
         <Box

--- a/apps/seller/src/app/admin/invite/_components/InviteHistoryTable.test.tsx
+++ b/apps/seller/src/app/admin/invite/_components/InviteHistoryTable.test.tsx
@@ -1,0 +1,125 @@
+import type { ComponentProps, ReactElement, ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { InviteHistoryTable } from './InviteHistoryTable';
+
+type Props = ComponentProps<typeof InviteHistoryTable>;
+
+const FETCH_ERROR_MESSAGE = '초대 토큰 조회 중 오류 발생';
+
+const baseProps: Props = {
+  invites: [],
+  loading: false,
+  error: null,
+  onRetry: () => {},
+};
+
+// 보안: 실제 토큰 원문이 아닌 구조 검증용 더미 식별자만 사용한다.
+function invite(token: string): Props['invites'][number] {
+  return {
+    token,
+    createdBy: 'admin-test',
+    usedAt: null,
+    usedBy: null,
+    expiresAt: '2026-12-31T00:00:00.000Z',
+    createdAt: '2026-09-01T00:00:00.000Z',
+  };
+}
+
+interface Clickable {
+  children?: ReactNode;
+  onClick?: unknown;
+}
+
+function isElement(node: ReactNode): node is ReactElement<Clickable> {
+  return typeof node === 'object' && node !== null && 'props' in node;
+}
+
+/** 렌더 트리(DOM 불필요)에서 모든 텍스트 리프를 수집한다. */
+function textsOf(node: ReactNode): string[] {
+  const out: string[] = [];
+  const visit = (current: ReactNode): void => {
+    if (typeof current === 'string') {
+      out.push(current);
+      return;
+    }
+    if (typeof current === 'number') {
+      out.push(String(current));
+      return;
+    }
+    if (Array.isArray(current)) {
+      for (const child of current) visit(child);
+      return;
+    }
+    if (isElement(current)) visit(current.props.children);
+  };
+  visit(node);
+  return out;
+}
+
+/** 주어진 라벨을 포함한 버튼의 onClick 핸들러를 수집한다. */
+function handlersFor(tree: ReactNode, label: string): Array<() => void> {
+  const handlers: Array<() => void> = [];
+  const visit = (current: ReactNode): void => {
+    if (Array.isArray(current)) {
+      for (const child of current) visit(child);
+      return;
+    }
+    if (!isElement(current)) return;
+    if (typeof current.props.onClick === 'function' && textsOf(current).includes(label)) {
+      handlers.push(current.props.onClick as () => void);
+    }
+    visit(current.props.children);
+  };
+  visit(tree);
+  return handlers;
+}
+
+describe('InviteHistoryTable read state', () => {
+  it('loading은 로딩 UI를 표시한다', () => {
+    const tree = InviteHistoryTable({ ...baseProps, loading: true });
+    expect(textsOf(tree)).toContain('불러오는 중...');
+  });
+
+  it('조회 실패 + 0건은 empty copy 대신 error UI와 retry를 표시한다', () => {
+    const tree = InviteHistoryTable({ ...baseProps, error: FETCH_ERROR_MESSAGE });
+    const texts = textsOf(tree);
+    expect(texts).not.toContain('발급된 토큰이 없습니다.');
+    expect(texts).toContain('발급 내역을 불러오지 못했습니다.');
+    expect(texts).toContain(FETCH_ERROR_MESSAGE);
+    expect(handlersFor(tree, '다시 조회').length).toBeGreaterThan(0);
+  });
+
+  it('성공 + 0건은 기존 empty copy를 표시하고 retry를 노출하지 않는다', () => {
+    const tree = InviteHistoryTable({ ...baseProps });
+    expect(textsOf(tree)).toContain('발급된 토큰이 없습니다.');
+    expect(handlersFor(tree, '다시 조회')).toHaveLength(0);
+  });
+
+  it('성공 + 결과 1건은 기존 내역 렌더링을 유지하고 retry를 노출하지 않는다', () => {
+    const tree = InviteHistoryTable({ ...baseProps, invites: [invite('test-invite-aaa')] });
+    const texts = textsOf(tree);
+    expect(texts).toContain('test-invite-aaa');
+    expect(texts).not.toContain('발급된 토큰이 없습니다.');
+    expect(handlersFor(tree, '다시 조회')).toHaveLength(0);
+  });
+
+  it('error는 결과 유무보다 우선한다(실패를 성공으로 취급하지 않음)', () => {
+    const tree = InviteHistoryTable({
+      ...baseProps,
+      error: FETCH_ERROR_MESSAGE,
+      invites: [invite('test-invite-aaa')],
+    });
+    const texts = textsOf(tree);
+    expect(texts).toContain('발급 내역을 불러오지 못했습니다.');
+    expect(handlersFor(tree, '다시 조회').length).toBeGreaterThan(0);
+  });
+
+  it('retry 실행 시 onRetry를 호출한다', () => {
+    const onRetry = vi.fn();
+    const tree = InviteHistoryTable({ ...baseProps, error: FETCH_ERROR_MESSAGE, onRetry });
+    const handlers = handlersFor(tree, '다시 조회');
+    expect(handlers.length).toBeGreaterThan(0);
+    handlers[0]();
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/seller/src/app/admin/invite/_components/InviteHistoryTable.tsx
+++ b/apps/seller/src/app/admin/invite/_components/InviteHistoryTable.tsx
@@ -1,12 +1,16 @@
 'use client';
 
-import { Badge, Box, Group, Paper, Stack, Text } from '@mantine/core';
+import { Badge, Box, Button, Group, Paper, Stack, Text } from '@mantine/core';
 import type { InviteToken } from '@/hooks/useAdmin';
-import { formatExpiry, inviteStatus } from '../_lib';
+import { formatExpiry, getAdminInviteReadState, inviteStatus } from '../_lib';
 
 interface InviteHistoryTableProps {
   invites: InviteToken[];
   loading: boolean;
+  /** useAdminInvite 조회 실패 메시지. null이면 마지막 조회가 실패하지 않았음. */
+  error: string | null;
+  /** 조회 실패 시 재시도 — hook의 reload()에 연결된다. */
+  onRetry: () => void;
 }
 
 const thBase = {
@@ -16,8 +20,10 @@ const thBase = {
   color: 'var(--color-text-secondary)',
 };
 
-export function InviteHistoryTable({ invites, loading }: InviteHistoryTableProps) {
-  if (loading) {
+export function InviteHistoryTable({ invites, loading, error, onRetry }: InviteHistoryTableProps) {
+  const readState = getAdminInviteReadState({ loading, error, invites });
+
+  if (readState === 'LOADING') {
     return (
       <Text ta="center" py={32} style={{ color: 'var(--color-text-disabled)' }}>
         불러오는 중...
@@ -25,7 +31,33 @@ export function InviteHistoryTable({ invites, loading }: InviteHistoryTableProps
     );
   }
 
-  if (invites.length === 0) {
+  // 조회 실패는 성공-empty와 구조적으로 구분 — "발급된 토큰이 없습니다."로 collapse 금지.
+  if (readState === 'FETCH_ERROR') {
+    return (
+      <Paper
+        radius="lg"
+        shadow="xs"
+        style={{ border: '1px solid var(--color-border)', overflow: 'hidden' }}
+      >
+        <Stack gap="sm" align="center" py={48} px="md">
+          <Text style={{ fontWeight: 500, color: 'var(--color-text-secondary)' }}>
+            발급 내역을 불러오지 못했습니다.
+          </Text>
+          <Text
+            ta="center"
+            style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-text-disabled)' }}
+          >
+            {error}
+          </Text>
+          <Button onClick={onRetry} size="sm" variant="outline" radius="md">
+            다시 조회
+          </Button>
+        </Stack>
+      </Paper>
+    );
+  }
+
+  if (readState === 'EMPTY') {
     return (
       <Paper
         radius="lg"

--- a/apps/seller/src/app/admin/invite/_lib.test.ts
+++ b/apps/seller/src/app/admin/invite/_lib.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { getAdminInviteReadState } from './_lib';
+
+const FETCH_ERROR_MESSAGE = '초대 토큰 조회 중 오류 발생';
+
+function invite(id: string) {
+  return { id };
+}
+
+describe('getAdminInviteReadState', () => {
+  it('조회 중에는 LOADING을 반환한다', () => {
+    expect(getAdminInviteReadState({ loading: true, error: null, invites: [] })).toBe('LOADING');
+  });
+
+  it('조회 실패 + 0건은 FETCH_ERROR를 반환한다(EMPTY collapse 방지)', () => {
+    expect(
+      getAdminInviteReadState({ loading: false, error: FETCH_ERROR_MESSAGE, invites: [] }),
+    ).toBe('FETCH_ERROR');
+  });
+
+  it('성공 + 0건만 EMPTY를 반환한다', () => {
+    expect(getAdminInviteReadState({ loading: false, error: null, invites: [] })).toBe('EMPTY');
+  });
+
+  it('성공 + 1건 이상은 HAS_RESULTS를 반환한다', () => {
+    expect(
+      getAdminInviteReadState({ loading: false, error: null, invites: [invite('i1')] }),
+    ).toBe('HAS_RESULTS');
+  });
+
+  it('loading + error는 LOADING이 우선한다', () => {
+    expect(
+      getAdminInviteReadState({ loading: true, error: FETCH_ERROR_MESSAGE, invites: [] }),
+    ).toBe('LOADING');
+  });
+
+  it('error는 결과 유무보다 우선한다', () => {
+    expect(
+      getAdminInviteReadState({
+        loading: false,
+        error: FETCH_ERROR_MESSAGE,
+        invites: [invite('i1')],
+      }),
+    ).toBe('FETCH_ERROR');
+  });
+});

--- a/apps/seller/src/app/admin/invite/_lib.ts
+++ b/apps/seller/src/app/admin/invite/_lib.ts
@@ -23,6 +23,23 @@ export function formatExpiry(expDate: Date | null): string {
   return expDate ? expDate.toLocaleDateString('ko-KR') : '-';
 }
 
+// 초대 이력 read state — 조회 실패와 성공-empty의 구조적 구분.
+// useAdminInvite는 error/reload를 노출하지만 화면이 이를 소비하지 않으면
+// 조회 실패가 빈 내역("발급된 토큰이 없습니다.")으로 collapse된다.
+// 분기 우선순위(loading > error > empty > results)를 순수 함수로 고정한다.
+export type AdminInviteReadState = 'LOADING' | 'FETCH_ERROR' | 'EMPTY' | 'HAS_RESULTS';
+
+export function getAdminInviteReadState(args: {
+  loading: boolean;
+  error: string | null;
+  invites: readonly unknown[];
+}): AdminInviteReadState {
+  if (args.loading) return 'LOADING';
+  if (args.error !== null) return 'FETCH_ERROR';
+  if (args.invites.length === 0) return 'EMPTY';
+  return 'HAS_RESULTS';
+}
+
 // 발급 직후 만료일 긴 표기(년 월 일).
 export function formatExpiryLong(expiresAt: string): string {
   return new Date(expiresAt).toLocaleDateString('ko-KR', {

--- a/apps/seller/src/hooks/useAdmin.ts
+++ b/apps/seller/src/hooks/useAdmin.ts
@@ -359,6 +359,7 @@ export function useAdminInvite() {
   const {
     items: invites,
     loading,
+    error,
     reload,
     token,
   } = useAdminList<InviteToken>(
@@ -367,10 +368,15 @@ export function useAdminInvite() {
     '초대 토큰',
   );
   const [generating, setGenerating] = useState(false);
+  // 발급 command 실패 — silent null로 끝내지 않고 UI에 노출한다.
+  // 성공 시에만 null을 유지하고, 실패가 이전 성공 token을 덮어쓰지 않는 것은
+  // 호출자(_client)가 result null 가드로 lastToken 갱신을 제한해 보장한다.
+  const [generateError, setGenerateError] = useState<string | null>(null);
 
   const generate = async (): Promise<{ token: string; expiresAt: string } | null> => {
     if (!token) return null;
     setGenerating(true);
+    setGenerateError(null);
     try {
       const data = await apiJson<{ token: string; expiresAt: string }>('/admin/invite', token, {
         method: 'POST',
@@ -378,11 +384,12 @@ export function useAdminInvite() {
       await reload();
       return data;
     } catch {
+      setGenerateError('초대 토큰 발급 중 오류 발생');
       return null;
     } finally {
       setGenerating(false);
     }
   };
 
-  return { invites, loading, generating, generate, reload };
+  return { invites, loading, error, generating, generateError, generate, reload };
 }


### PR DESCRIPTION
Root cause:
- useAdminInvite dropped the authoritative list error
- GET failure collapsed into empty history
- generate failure ended as bare null with no user feedback

Fix:
- read error/reload UI wiring
- loading > error > empty > results
- generateError surface
- previous successful token preservation

Proof:
- invite vitest 28/28 PASS
- TypeScript PASS
- Biome PASS
- shared hook unrelated consumers preserved

Out of scope:
- clipboard write failure recovery
- unrelated Admin/Consumer recovery tasks