### PR TITLE
fix(admin): recover drivers read failure state

### DIFF
--- a/apps/seller/src/app/admin/drivers/_client.test.ts
+++ b/apps/seller/src/app/admin/drivers/_client.test.ts
@@ -1,0 +1,78 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { filterByTab, getAdminDriversReadState } from './_lib';
+
+// DriversClient는 '@/' alias를 사용하므로 vitest에서 직접 import할 수 없다.
+// (seller vitest에는 tsconfig paths 매핑이 없어 '@/hooks/useAdmin' 해석이 실패한다.)
+// 따라서 본 focused test는 _client.tsx 소스의 배선(wiring)을 고정하고,
+// 실제 상태 분기는 순수 함수인 getAdminDriversReadState로 증명한다.
+// READ-ONLY인 DriverList/_lib의 동작 자체는 각자의 focused test가 소유한다.
+
+const source = readFileSync(new URL('./_client.tsx', import.meta.url), 'utf8');
+
+const FETCH_ERROR_MESSAGE = '드라이버 목록 조회 중 오류 발생';
+
+describe('DriversClient read recovery wiring', () => {
+  it('useAdminDrivers의 error/reload를 소비한다', () => {
+    expect(source).toContain('useAdminDrivers()');
+    expect(source).toMatch(
+      /const\s*\{\s*drivers:\s*allDrivers,\s*loading,\s*error,\s*reload,\s*approve,\s*toggleSuspend\s*\}/,
+    );
+  });
+
+  it('error가 존재할 때 empty-only UI로 collapse되지 않는다', () => {
+    // _client가 error를 list로 전달한다.
+    expect(source).toContain('error={error}');
+    // _client 자체가 빈 드라이버 copy로 collapse하지 않는다 — 실패 표현은 list가 소유한다.
+    expect(source).not.toContain('드라이버가 없습니다.');
+    // 전달된 error는 list 분기에서 EMPTY가 아닌 FETCH_ERROR가 된다.
+    expect(
+      getAdminDriversReadState({ loading: false, error: FETCH_ERROR_MESSAGE, drivers: [] }),
+    ).toBe('FETCH_ERROR');
+  });
+
+  it('retry가 reload 경로를 사용하고 전체 페이지 reload를 사용하지 않는다', () => {
+    expect(source).toContain('onRetry={reload}');
+    expect(source).not.toContain('window.location');
+    expect(source).not.toContain('다시 조회');
+    expect(source).not.toContain('불러오지 못했습니다');
+  });
+
+  it('retry 시 현재 탭을 유지한다(reload가 tab 상태를 건드리지 않는다)', () => {
+    // 탭 상태는 _client가 소유하고 retry(reload)는 tab setter를 호출하지 않는다.
+    expect(source).toContain('useState<DriverStatus>');
+    expect(source).toContain('setTab');
+    expect(source).not.toMatch(/reload\(\);\s*\n?\s*setTab/);
+    expect(source).not.toMatch(/onRetry=\{[^}]*setTab/);
+    // 필터는 현재 탭 기준으로 그대로 유지된다.
+    expect(source).toContain('filterByTab(allDrivers, tab)');
+  });
+
+  it('정상 목록 filter를 유지한다', () => {
+    expect(source).toContain('STATUS_TABS');
+    expect(source).toContain('filterByTab');
+    expect(source).toContain('drivers={drivers}');
+    expect(source).toContain('loading={loading}');
+    // 성공+0건은 EMPTY로 유지되어야 한다.
+    expect(getAdminDriversReadState({ loading: false, error: null, drivers: [] })).toBe('EMPTY');
+    // 탭별 필터 semantics를 변경하지 않는다.
+    const all = [
+      { id: 'p', name: 'p', email: 'p@example.com', driverApproved: false, suspended: false, createdAt: '2026-09-01T00:00:00.000Z' },
+      { id: 'a', name: 'a', email: 'a@example.com', driverApproved: true, suspended: false, createdAt: '2026-09-01T00:00:00.000Z' },
+      { id: 's', name: 's', email: 's@example.com', driverApproved: true, suspended: true, createdAt: '2026-09-01T00:00:00.000Z' },
+    ];
+    expect(filterByTab(all, 'pending').map((d) => d.id)).toEqual(['p']);
+    expect(filterByTab(all, 'approved').map((d) => d.id)).toEqual(['a']);
+    expect(filterByTab(all, 'suspended').map((d) => d.id)).toEqual(['s']);
+    expect(filterByTab(all, 'all').map((d) => d.id)).toEqual(['p', 'a', 's']);
+  });
+
+  it('approve/suspend wiring을 유지한다', () => {
+    expect(source).toContain('approve(pending.userId)');
+    expect(source).toContain('toggleSuspend(pending.userId');
+    expect(source).toContain('onAction={handleAction}');
+    expect(source).toContain('processingId={processingId}');
+    expect(source).toContain('<ConfirmModal');
+    expect(source).toContain('ACTION_META');
+  });
+});

--- a/apps/seller/src/app/admin/drivers/_client.tsx
+++ b/apps/seller/src/app/admin/drivers/_client.tsx
@@ -17,7 +17,7 @@ export default function DriversClient() {
   const [tab, setTab] = useState<DriverStatus>('pending');
   const [processingId, setProcessingId] = useState<string | null>(null);
   const [pending, setPending] = useState<PendingAction | null>(null);
-  const { drivers: allDrivers, loading, approve, toggleSuspend } = useAdminDrivers();
+  const { drivers: allDrivers, loading, error, reload, approve, toggleSuspend } = useAdminDrivers();
 
   const drivers = useMemo(() => filterByTab(allDrivers, tab), [allDrivers, tab]);
 
@@ -71,8 +71,10 @@ export default function DriversClient() {
       <DriverList
         drivers={drivers}
         loading={loading}
+        error={error}
         processingId={processingId}
         onAction={handleAction}
+        onRetry={reload}
       />
 
       <ConfirmModal

--- a/apps/seller/src/app/admin/drivers/_components/DriverList.test.tsx
+++ b/apps/seller/src/app/admin/drivers/_components/DriverList.test.tsx
@@ -1,0 +1,135 @@
+import type { ComponentProps, ReactElement, ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { DriverList } from './DriverList';
+
+type Props = ComponentProps<typeof DriverList>;
+
+const FETCH_ERROR_MESSAGE = '드라이버 목록 조회 중 오류 발생';
+
+const baseProps: Props = {
+  drivers: [],
+  loading: false,
+  error: null,
+  processingId: null,
+  onAction: () => {},
+  onRetry: () => {},
+};
+
+function driver(
+  id: string,
+  overrides: Partial<Props['drivers'][number]> = {},
+): Props['drivers'][number] {
+  return {
+    id,
+    name: `드라이버 ${id}`,
+    email: `${id}@example.com`,
+    driverApproved: false,
+    suspended: false,
+    createdAt: '2026-09-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+interface Clickable {
+  children?: ReactNode;
+  onClick?: unknown;
+}
+
+function isElement(node: ReactNode): node is ReactElement<Clickable> {
+  return typeof node === 'object' && node !== null && 'props' in node;
+}
+
+/** 렌더 트리(DOM 불필요)에 포함된 모든 텍스트 리프를 수집한다. */
+function textsOf(node: ReactNode): string[] {
+  const out: string[] = [];
+  const visit = (current: ReactNode): void => {
+    if (typeof current === 'string') {
+      out.push(current);
+      return;
+    }
+    if (Array.isArray(current)) {
+      for (const child of current) visit(child);
+      return;
+    }
+    if (isElement(current)) visit(current.props.children);
+  };
+  visit(node);
+  return out;
+}
+
+/** 주어진 라벨을 포함한 버튼의 onClick 핸들러를 수집한다. */
+function handlersFor(tree: ReactNode, label: string): Array<() => void> {
+  const handlers: Array<() => void> = [];
+  const visit = (current: ReactNode): void => {
+    if (Array.isArray(current)) {
+      for (const child of current) visit(child);
+      return;
+    }
+    if (!isElement(current)) return;
+    if (typeof current.props.onClick === 'function' && textsOf(current).includes(label)) {
+      handlers.push(current.props.onClick as () => void);
+    }
+    visit(current.props.children);
+  };
+  visit(tree);
+  return handlers;
+}
+
+describe('Admin DriverList read state', () => {
+  it('loading → 로딩 UI를 표시한다', () => {
+    const tree = DriverList({ ...baseProps, loading: true });
+    expect(textsOf(tree)).toContain('불러오는 중...');
+  });
+
+  it('조회 실패 + 0건 → empty copy 없이 error UI와 retry를 표시한다', () => {
+    const tree = DriverList({ ...baseProps, error: FETCH_ERROR_MESSAGE });
+    const texts = textsOf(tree);
+    expect(texts).not.toContain('드라이버가 없습니다.');
+    expect(texts).toContain('드라이버 목록을 불러오지 못했습니다.');
+    expect(texts).toContain(FETCH_ERROR_MESSAGE);
+    expect(handlersFor(tree, '다시 조회').length).toBeGreaterThan(0);
+  });
+
+  it('성공 + 0건 → 기존 empty copy를 표시하고 retry를 노출하지 않는다', () => {
+    const tree = DriverList({ ...baseProps });
+    expect(textsOf(tree)).toContain('드라이버가 없습니다.');
+    expect(handlersFor(tree, '다시 조회')).toHaveLength(0);
+  });
+
+  it('성공 + 결과 → 기존 driver rendering을 유지하고 retry를 노출하지 않는다', () => {
+    const tree = DriverList({ ...baseProps, drivers: [driver('d1')] });
+    const texts = textsOf(tree);
+    expect(texts).toContain('드라이버 d1');
+    expect(texts).not.toContain('드라이버가 없습니다.');
+    expect(handlersFor(tree, '다시 조회')).toHaveLength(0);
+  });
+
+  it('retry 실행 시 onRetry를 호출한다', () => {
+    const onRetry = vi.fn();
+    const tree = DriverList({ ...baseProps, error: FETCH_ERROR_MESSAGE, onRetry });
+    const handlers = handlersFor(tree, '다시 조회');
+    expect(handlers.length).toBeGreaterThan(0);
+    handlers[0]();
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('approve/suspend wiring을 보존한다(대기=승인+정지, 정지됨=정지 해제, 처리중 표시)', () => {
+    const pendingTree = DriverList({ ...baseProps, drivers: [driver('p1')] });
+    const pendingTexts = textsOf(pendingTree);
+    expect(pendingTexts).toContain('승인');
+    expect(pendingTexts).toContain('정지');
+
+    const suspendedTree = DriverList({
+      ...baseProps,
+      drivers: [driver('s1', { driverApproved: true, suspended: true })],
+    });
+    expect(textsOf(suspendedTree)).toContain('정지 해제');
+
+    const processingTree = DriverList({
+      ...baseProps,
+      drivers: [driver('p1')],
+      processingId: 'p1',
+    });
+    expect(textsOf(processingTree)).toContain('처리중…');
+  });
+});

--- a/apps/seller/src/app/admin/drivers/_components/DriverList.tsx
+++ b/apps/seller/src/app/admin/drivers/_components/DriverList.tsx
@@ -2,18 +2,31 @@
 
 import { Box, Button, Group, Paper, Stack, Text } from '@mantine/core';
 import type { AdminDriver } from '@/hooks/useAdmin';
-import type { DriverAction } from '../_lib';
+import { type AdminDriversReadState, type DriverAction, getAdminDriversReadState } from '../_lib';
 import { DriverBadge } from './DriverBadge';
 
 interface DriverListProps {
   drivers: AdminDriver[];
   loading: boolean;
+  /** useAdminDrivers 조회 실패 메시지. null이면 마지막 조회가 실패하지 않았음. */
+  error: string | null;
   processingId: string | null;
   onAction: (userId: string, action: DriverAction) => void;
+  /** 조회 실패 시 재시도 — hook의 reload()에 연결된다. 현재 탭을 유지한다. */
+  onRetry: () => void;
 }
 
-export function DriverList({ drivers, loading, processingId, onAction }: DriverListProps) {
-  if (loading) {
+export function DriverList({
+  drivers,
+  loading,
+  error,
+  processingId,
+  onAction,
+  onRetry,
+}: DriverListProps) {
+  const readState: AdminDriversReadState = getAdminDriversReadState({ loading, error, drivers });
+
+  if (readState === 'LOADING') {
     return (
       <Text ta="center" py={80} style={{ color: 'var(--color-text-disabled)' }}>
         불러오는 중...
@@ -21,7 +34,27 @@ export function DriverList({ drivers, loading, processingId, onAction }: DriverL
     );
   }
 
-  if (drivers.length === 0) {
+  // 조회 실패는 성공-empty와 구조적으로 구분 — "드라이버가 없습니다."로 collapse 금지.
+  if (readState === 'FETCH_ERROR') {
+    return (
+      <Stack gap="sm" align="center" py={64} px="md">
+        <Text style={{ fontWeight: 500, color: 'var(--color-text-secondary)' }}>
+          드라이버 목록을 불러오지 못했습니다.
+        </Text>
+        <Text
+          ta="center"
+          style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-text-disabled)' }}
+        >
+          {error}
+        </Text>
+        <Button onClick={onRetry} size="sm" variant="outline" radius="md">
+          다시 조회
+        </Button>
+      </Stack>
+    );
+  }
+
+  if (readState === 'EMPTY') {
     return (
       <Text ta="center" py={80} style={{ color: 'var(--color-text-disabled)' }}>
         드라이버가 없습니다.

--- a/apps/seller/src/app/admin/drivers/_lib.test.ts
+++ b/apps/seller/src/app/admin/drivers/_lib.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import { filterByTab, getAdminDriversReadState } from './_lib';
+
+const FETCH_ERROR_MESSAGE = '드라이버 목록 조회 중 오류 발생';
+
+function driver(id: string) {
+  return { id };
+}
+
+describe('getAdminDriversReadState', () => {
+  it('조회 중에는 LOADING을 반환한다', () => {
+    expect(getAdminDriversReadState({ loading: true, error: null, drivers: [] })).toBe('LOADING');
+  });
+
+  it('조회 실패 + 0건은 FETCH_ERROR를 반환한다(EMPTY collapse 방지)', () => {
+    expect(
+      getAdminDriversReadState({ loading: false, error: FETCH_ERROR_MESSAGE, drivers: [] }),
+    ).toBe('FETCH_ERROR');
+  });
+
+  it('성공 + 0건만 EMPTY를 반환한다', () => {
+    expect(getAdminDriversReadState({ loading: false, error: null, drivers: [] })).toBe('EMPTY');
+  });
+
+  it('성공 + 1건 이상은 HAS_RESULTS를 반환한다', () => {
+    expect(
+      getAdminDriversReadState({ loading: false, error: null, drivers: [driver('d1')] }),
+    ).toBe('HAS_RESULTS');
+  });
+
+  it('loading + error는 LOADING을 우선한다', () => {
+    expect(
+      getAdminDriversReadState({ loading: true, error: FETCH_ERROR_MESSAGE, drivers: [] }),
+    ).toBe('LOADING');
+  });
+
+  it('error는 결과 유무보다 우선한다', () => {
+    expect(
+      getAdminDriversReadState({
+        loading: false,
+        error: FETCH_ERROR_MESSAGE,
+        drivers: [driver('d1')],
+      }),
+    ).toBe('FETCH_ERROR');
+  });
+});
+
+describe('filterByTab semantics (unchanged)', () => {
+  const pending = {
+    id: 'p1',
+    name: '대기',
+    email: 'p@example.com',
+    driverApproved: false,
+    suspended: false,
+    createdAt: '2026-09-01T00:00:00.000Z',
+  };
+  const approved = {
+    id: 'a1',
+    name: '승인',
+    email: 'a@example.com',
+    driverApproved: true,
+    suspended: false,
+    createdAt: '2026-09-01T00:00:00.000Z',
+  };
+  const suspended = {
+    id: 's1',
+    name: '정지',
+    email: 's@example.com',
+    driverApproved: true,
+    suspended: true,
+    createdAt: '2026-09-01T00:00:00.000Z',
+  };
+  const all = [pending, approved, suspended];
+
+  it('pending 탭은 미승인+미정지만 반환한다', () => {
+    expect(filterByTab(all, 'pending')).toEqual([pending]);
+  });
+
+  it('approved 탭은 승인+미정지만 반환한다', () => {
+    expect(filterByTab(all, 'approved')).toEqual([approved]);
+  });
+
+  it('suspended 탭은 정지만 반환한다', () => {
+    expect(filterByTab(all, 'suspended')).toEqual([suspended]);
+  });
+
+  it('all 탭은 전체를 반환한다', () => {
+    expect(filterByTab(all, 'all')).toEqual(all);
+  });
+});

--- a/apps/seller/src/app/admin/drivers/_lib.ts
+++ b/apps/seller/src/app/admin/drivers/_lib.ts
@@ -46,3 +46,20 @@ export function filterByTab(drivers: AdminDriver[], tab: DriverStatus): AdminDri
   if (tab === 'suspended') return drivers.filter((d) => d.suspended);
   return drivers;
 }
+
+// Admin 드라이버 목록 read state — 조회 실패와 성공-empty의 구조적 구분.
+// useAdminDrivers는 error/reload를 노출하지만 화면이 이를 소비하지 않으면
+// 조회 실패가 빈 목록("드라이버가 없습니다.")으로 collapse된다.
+// 분기 우선순위(loading > error > empty > results)를 순수 함수로 고정한다.
+export type AdminDriversReadState = 'LOADING' | 'FETCH_ERROR' | 'EMPTY' | 'HAS_RESULTS';
+
+export function getAdminDriversReadState(args: {
+  loading: boolean;
+  error: string | null;
+  drivers: readonly unknown[];
+}): AdminDriversReadState {
+  if (args.loading) return 'LOADING';
+  if (args.error !== null) return 'FETCH_ERROR';
+  if (args.drivers.length === 0) return 'EMPTY';
+  return 'HAS_RESULTS';
+}


### PR DESCRIPTION
TASK_ID: ADMIN-DRIVERS-READ-RECOVERY-PUBLICATION-01

Root cause: admin drivers initial read failure collapsed into genuine empty state because DriversClient did not consume authoritative error/reload.

Exact six-file slice:
- apps/seller/src/app/admin/drivers/_client.tsx
- apps/seller/src/app/admin/drivers/_components/DriverList.tsx
- apps/seller/src/app/admin/drivers/_lib.ts
- apps/seller/src/app/admin/drivers/_client.test.ts
- apps/seller/src/app/admin/drivers/_components/DriverList.test.tsx
- apps/seller/src/app/admin/drivers/_lib.test.ts

Contract:
* FETCH_ERROR != EMPTY
* loading precedence preserved (LOADING > FETCH_ERROR > EMPTY > HAS_RESULTS)
* retry delegates to existing reload (onRetry={reload}, no window.location reload)
* active tab preserved (filterByTab(allDrivers, tab) unchanged)
* driver filtering semantics unchanged (pending/approved/suspended/all)
* useAdmin.ts unchanged

Focused proof:
* 3 files / 22 tests PASS (vitest: _lib 10 + _client 6 + DriverList 6)
* Biome lint owned surface CLEAN; format shows 2 pre-existing deviations in owned test files (no --write applied per task policy)
* TypeScript owned surface 0 errors (seller tsc --noEmit EXIT 0); invite diagnostic absent after prior invite recovery merge (NO_TYPE_ERROR)
* useAdmin working tree clean; invite _client already wires error/onRetry

Foreign dirty excluded and preserved (consumer mypage/addresses/orders, admin settlements/stores/orders, firebase.binding, etc.).