### PR TITLE
fix(consumer): recover order reads and retries

### DIFF
--- a/apps/consumer/src/app/mypage/_client.tsx
+++ b/apps/consumer/src/app/mypage/_client.tsx
@@ -226,7 +226,7 @@ function OrderCard({ order, onClick }: { order: Order; onClick: () => void }) {
 export default function MyPageClient() {
   const { data: session, status } = useSession();
   const router = useRouter();
-  const { orders, loading, error } = useOrders();
+  const { orders, loading, error, refetch } = useOrders();
 
   useEffect(() => {
     if (status === 'unauthenticated') {
@@ -284,7 +284,7 @@ export default function MyPageClient() {
           </Title>
           <Divider />
         </Stack>
-        {loading && (
+        {loading && orders.length === 0 && (
           <Text
             ta="center"
             style={{ color: 'var(--color-text-disabled)', fontSize: 'var(--font-size-sm)' }}
@@ -293,10 +293,21 @@ export default function MyPageClient() {
             불러오는 중...
           </Text>
         )}
-        {!loading && error && (
-          <Text style={{ color: 'var(--color-danger)', fontSize: 'var(--font-size-sm)' }} py="xs">
-            주문 내역을 불러올 수 없습니다.
-          </Text>
+        {!loading && error && orders.length === 0 && (
+          <Stack gap="xs" py="xs">
+            <Text style={{ color: 'var(--color-danger)', fontSize: 'var(--font-size-sm)' }}>
+              주문 내역을 불러올 수 없습니다.
+            </Text>
+            <Button
+              variant="default"
+              size="xs"
+              radius="sm"
+              onClick={refetch}
+              data-testid="orders-retry"
+            >
+              다시 시도
+            </Button>
+          </Stack>
         )}
         {!loading && !error && orders.length === 0 && (
           <Text
@@ -307,8 +318,32 @@ export default function MyPageClient() {
             주문 내역이 없습니다.
           </Text>
         )}
-        {!loading && orders.length > 0 && (
+        {orders.length > 0 && (
           <Stack gap="sm">
+            {loading && (
+              <Text
+                ta="center"
+                style={{ color: 'var(--color-text-disabled)', fontSize: 'var(--font-size-sm)' }}
+              >
+                업데이트 중...
+              </Text>
+            )}
+            {error && (
+              <Group justify="space-between" align="center">
+                <Text style={{ color: 'var(--color-danger)', fontSize: 'var(--font-size-sm)' }}>
+                  최신 주문 내역을 불러오지 못했습니다.
+                </Text>
+                <Button
+                  variant="default"
+                  size="xs"
+                  radius="sm"
+                  onClick={refetch}
+                  data-testid="orders-retry"
+                >
+                  다시 시도
+                </Button>
+              </Group>
+            )}
             {orders.map((order) => (
               <OrderCard
                 key={order.id}

--- a/apps/consumer/src/hooks/useOrders.test.mjs
+++ b/apps/consumer/src/hooks/useOrders.test.mjs
@@ -1,0 +1,372 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+import ts from 'typescript';
+
+// CONSUMER-ORDERS-REFETCH-RECOVERY-01 focused test.
+// CONSUMER-ORDERS-READ-RECOVERY-02 root-cause-complete closure (scope 격리 포함).
+// refetch() public contract가 실제 authoritative order GET을 다시 실행하는지,
+// 복구 경로(성공/실패/재시도/stale/scope)가 데이터·error 규율을 지키는지 검증한다.
+
+const hookSource = await readFile(new URL('./useOrders.ts', import.meta.url), 'utf8');
+const clientSource = await readFile(
+  new URL('../app/mypage/_client.tsx', import.meta.url),
+  'utf8',
+);
+
+const compiled = ts.transpileModule(hookSource, {
+  compilerOptions: {
+    esModuleInterop: true,
+    module: ts.ModuleKind.CommonJS,
+    target: ts.ScriptTarget.ES2022,
+  },
+  fileName: 'useOrders.ts',
+}).outputText;
+
+const SESSION = { user: { id: 'user-1', accessToken: 'token-1' } };
+const API_BASE_URL = 'https://api.example.test';
+const EXPECTED_URL = `${API_BASE_URL}/orders?userId=user-1`;
+
+const originalFetch = globalThis.fetch;
+test.after(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function okResponse(data) {
+  return { ok: true, status: 200, json: async () => data };
+}
+
+function errorResponse(status = 500) {
+  return { ok: false, status, json: async () => ({}) };
+}
+
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function mountHook({ session = SESSION, fetchImpl }) {
+  globalThis.fetch = fetchImpl;
+  let currentSession = session;
+  const hookModule = { exports: {} };
+  const stateSlots = [];
+  const refSlots = [];
+  const effectSlots = [];
+  let cursor = 0;
+  let renderScheduled = true;
+  let latest = null;
+
+  const scheduleRender = () => {
+    renderScheduled = true;
+  };
+
+  function useState(initial) {
+    const index = cursor++;
+    if (stateSlots[index] === undefined) stateSlots[index] = { value: initial };
+    const slot = stateSlots[index];
+    const setState = (next) => {
+      const value = typeof next === 'function' ? next(slot.value) : next;
+      if (Object.is(value, slot.value)) return;
+      slot.value = value;
+      scheduleRender();
+    };
+    return [slot.value, setState];
+  }
+
+  function useRef(initial) {
+    const index = cursor++;
+    if (refSlots[index] === undefined) refSlots[index] = { current: initial };
+    return refSlots[index];
+  }
+
+  function useCallback(fn) {
+    return fn;
+  }
+
+  function useEffect(create, deps) {
+    const index = cursor++;
+    if (effectSlots[index] === undefined) {
+      effectSlots[index] = { deps: undefined, cleanup: undefined, hasRun: false };
+    }
+    effectSlots[index].pendingCreate = create;
+    effectSlots[index].pendingDeps = deps;
+  }
+
+  const requireForTest = (specifier) => {
+    if (specifier === 'react') return { useCallback, useEffect, useRef, useState };
+    if (specifier === 'next-auth/react') return { useSession: () => ({ data: currentSession }) };
+    if (specifier === '@/lib/api-base-url') {
+      return { getApiBaseUrl: () => API_BASE_URL };
+    }
+    throw new Error(`예상하지 못한 주문 조회 모듈 요청: ${specifier}`);
+  };
+  new Function('require', 'module', 'exports', compiled)(
+    requireForTest,
+    hookModule,
+    hookModule.exports,
+  );
+
+  function flushEffects() {
+    for (const slot of effectSlots) {
+      if (!slot || slot.pendingCreate === undefined) continue;
+      const prevDeps = slot.deps;
+      const nextDeps = slot.pendingDeps;
+      const changed =
+        !slot.hasRun ||
+        prevDeps === undefined ||
+        nextDeps === undefined ||
+        nextDeps.length !== prevDeps.length ||
+        nextDeps.some((dep, i) => !Object.is(dep, prevDeps[i]));
+      if (!changed) continue;
+      if (typeof slot.cleanup === 'function') {
+        const cleanup = slot.cleanup;
+        slot.cleanup = undefined;
+        cleanup();
+      }
+      slot.deps = nextDeps;
+      slot.hasRun = true;
+      const nextCleanup = slot.pendingCreate();
+      slot.cleanup = typeof nextCleanup === 'function' ? nextCleanup : undefined;
+    }
+  }
+
+  function render() {
+    cursor = 0;
+    renderScheduled = false;
+    // biome-ignore lint/correctness/useHookAtTopLevel: React를 모의한 훅 계약 단위 테스트다.
+    latest = hookModule.exports.useOrders();
+    flushEffects();
+  }
+
+  async function settle(passes = 25) {
+    for (let i = 0; i < passes; i += 1) {
+      if (renderScheduled) render();
+      await new Promise((resolve) => setImmediate(resolve));
+      if (renderScheduled) render();
+    }
+    if (renderScheduled) render();
+  }
+
+  const get = () => latest;
+  const setSession = (next) => {
+    currentSession = next;
+    scheduleRender();
+  };
+  return { get, settle, render, setSession };
+}
+
+const orderA = { id: 'order-A' };
+const orderB = { id: 'order-B' };
+
+test('initial success는 authoritative GET 1회로 주문을 적재하고 error를 비운다', async () => {
+  const calls = [];
+  const harness = mountHook({
+    fetchImpl: async (url, init) => {
+      calls.push({ url, init });
+      return okResponse([orderA]);
+    },
+  });
+  await harness.settle();
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].url, EXPECTED_URL);
+  assert.equal(calls[0].init.headers.Authorization, 'Bearer token-1');
+  assert.deepEqual(harness.get().orders, [orderA]);
+  assert.equal(harness.get().loading, false);
+  assert.equal(harness.get().error, null);
+});
+
+test('initial failure는 error를 세우고 빈 성공으로 위장하지 않는다', async () => {
+  const harness = mountHook({ fetchImpl: async () => errorResponse(500) });
+  await harness.settle();
+
+  assert.match(harness.get().error ?? '', /500/);
+  assert.deepEqual(harness.get().orders, []);
+  assert.equal(harness.get().loading, false);
+});
+
+test('정상 empty([])는 error 없이 성공으로 확정한다', async () => {
+  const harness = mountHook({ fetchImpl: async () => okResponse([]) });
+  await harness.settle();
+
+  assert.deepEqual(harness.get().orders, []);
+  assert.equal(harness.get().error, null);
+  assert.equal(harness.get().loading, false);
+});
+
+test('manual refetch는 동일한 authoritative GET을 다시 실행한다', async () => {
+  const calls = [];
+  const harness = mountHook({
+    fetchImpl: async (url) => {
+      calls.push(url);
+      return okResponse([orderA]);
+    },
+  });
+  await harness.settle();
+  assert.equal(calls.length, 1);
+
+  harness.get().refetch();
+  await harness.settle();
+
+  assert.equal(calls.length, 2);
+  assert.equal(calls[1], EXPECTED_URL);
+  assert.deepEqual(harness.get().orders, [orderA]);
+  assert.equal(harness.get().error, null);
+});
+
+test('failure → retry → success는 error를 clear하고 주문을 적재한다', async () => {
+  let mode = 'failure';
+  const harness = mountHook({
+    fetchImpl: async () => (mode === 'failure' ? errorResponse(500) : okResponse([orderB])),
+  });
+  await harness.settle();
+  assert.notEqual(harness.get().error, null);
+  assert.deepEqual(harness.get().orders, []);
+
+  mode = 'success';
+  harness.get().refetch();
+  await harness.settle();
+
+  assert.deepEqual(harness.get().orders, [orderB]);
+  assert.equal(harness.get().error, null);
+  assert.equal(harness.get().loading, false);
+});
+
+test('기존 주문이 있을 때 transient retry failure는 데이터를 삭제하지 않는다', async () => {
+  let mode = 'success';
+  const harness = mountHook({
+    fetchImpl: async () => (mode === 'success' ? okResponse([orderA]) : errorResponse(500)),
+  });
+  await harness.settle();
+  assert.deepEqual(harness.get().orders, [orderA]);
+
+  mode = 'failure';
+  harness.get().refetch();
+  await harness.settle();
+
+  assert.deepEqual(harness.get().orders, [orderA]);
+  assert.notEqual(harness.get().error, null);
+  assert.equal(harness.get().loading, false);
+});
+
+test('stale 응답은 더 최신 refetch 결과를 덮지 않는다', async () => {
+  const calls = [];
+  const first = deferred();
+  const second = deferred();
+  let n = 0;
+  const harness = mountHook({
+    fetchImpl: async (url) => {
+      n += 1;
+      calls.push(url);
+      return n === 1 ? first.promise : second.promise;
+    },
+  });
+  await harness.settle(5);
+  assert.equal(calls.length, 1);
+
+  harness.get().refetch();
+  await harness.settle(5);
+  assert.equal(calls.length, 2);
+
+  second.resolve(okResponse([orderB]));
+  await harness.settle();
+  assert.deepEqual(harness.get().orders, [orderB]);
+
+  first.resolve(okResponse([orderA]));
+  await harness.settle();
+  assert.deepEqual(harness.get().orders, [orderB]);
+  assert.equal(harness.get().error, null);
+});
+
+test('refetch trigger가 fetch effect에 연결되어 dead tick이 아니다', () => {
+  assert.doesNotMatch(hookSource, /_tick/);
+  assert.match(hookSource, /\[\s*session\?\.user\?\.id,\s*session\?\.user\?\.accessToken,\s*tick\s*\]/);
+  // dummy state를 effect와 명시적으로 연결한다: warning 억제(biome-ignore)로 끝내지 않는다.
+  assert.match(hookSource, /void\s+tick/);
+  assert.doesNotMatch(hookSource, /biome-ignore.*useExhaustiveDependencies/);
+});
+
+test('MyPage는 주문 조회 실패에 실제 동작하는 retry를 제공한다', () => {
+  assert.match(clientSource, /const \{ orders, loading, error, refetch \} = useOrders\(\)/);
+  assert.match(clientSource, /data-testid="orders-retry"/);
+  assert.match(clientSource, /onClick=\{refetch\}/);
+  assert.match(clientSource, /다시 시도/);
+});
+
+test('MyPage는 refetch 중 기존 주문을 숨기지 않고 error와 정상 empty를 구분한다', () => {
+  assert.doesNotMatch(clientSource, /!loading && orders\.length > 0/);
+  assert.match(clientSource, /!loading && !error && orders\.length === 0/);
+});
+
+test('user/token scope 변경은 이전 사용자의 주문을 재사용하지 않는다', async () => {
+  const calls = [];
+  const userA = { user: { id: 'user-1', accessToken: 'token-1' } };
+  const userB = { user: { id: 'user-2', accessToken: 'token-2' } };
+  const harness = mountHook({
+    session: userA,
+    fetchImpl: async (url, init) => {
+      calls.push({ url, auth: init?.headers?.Authorization });
+      if (url.includes('userId=user-1')) return okResponse([orderA]);
+      if (url.includes('userId=user-2')) return okResponse([orderB]);
+      return errorResponse(404);
+    },
+  });
+  await harness.settle();
+  assert.deepEqual(harness.get().orders, [orderA]);
+
+  harness.setSession(userB);
+  await harness.settle();
+
+  assert.ok(calls.some((c) => c.url === `${API_BASE_URL}/orders?userId=user-2`));
+  assert.equal(calls[calls.length - 1].auth, 'Bearer token-2');
+  assert.deepEqual(harness.get().orders, [orderB]);
+  assert.equal(harness.get().error, null);
+});
+
+test('scope 변경 후 실패는 이전 사용자의 주문을 노출하지 않는다', async () => {
+  const userA = { user: { id: 'user-1', accessToken: 'token-1' } };
+  const userB = { user: { id: 'user-2', accessToken: 'token-2' } };
+  const harness = mountHook({
+    session: userA,
+    fetchImpl: async (url) => {
+      if (url.includes('userId=user-1')) return okResponse([orderA]);
+      return errorResponse(500);
+    },
+  });
+  await harness.settle();
+  assert.deepEqual(harness.get().orders, [orderA]);
+
+  harness.setSession(userB);
+  await harness.settle();
+
+  assert.deepEqual(harness.get().orders, []);
+  assert.notEqual(harness.get().error, null);
+  assert.equal(harness.get().loading, false);
+});
+
+test('session 소멸(logout)은 이전 주문 잔재를 비운다', async () => {
+  const userA = { user: { id: 'user-1', accessToken: 'token-1' } };
+  const harness = mountHook({
+    session: userA,
+    fetchImpl: async () => okResponse([orderA]),
+  });
+  await harness.settle();
+  assert.deepEqual(harness.get().orders, [orderA]);
+
+  harness.setSession(null);
+  await harness.settle();
+
+  assert.deepEqual(harness.get().orders, []);
+  assert.equal(harness.get().error, null);
+  assert.equal(harness.get().loading, false);
+});
+
+test('MyPage retry는 window.location.reload를 사용하지 않는다', () => {
+  assert.doesNotMatch(clientSource, /location\.reload/);
+  assert.doesNotMatch(hookSource, /location\.reload/);
+});

--- a/apps/consumer/src/hooks/useOrders.ts
+++ b/apps/consumer/src/hooks/useOrders.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useSession } from 'next-auth/react';
 import type { Order } from '@greenhub/shared';
 import { getApiBaseUrl } from '@/lib/api-base-url';
@@ -19,16 +19,39 @@ export function useOrders(): UseOrdersResult {
   const [orders, setOrders] = useState<Order[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [_tick, setTick] = useState(0);
+  const [tick, setTick] = useState(0);
+  // 최신 요청 식별자: cleanup된 이전 effect의 stale 응답이 최신 결과를 덮지 않게 한다.
+  const requestSequenceRef = useRef(0);
+  // session/user scope: 이전 사용자의 주문이 새 scope 결과로 노출되지 않게 한다.
+  // useAddresses의 token scope 격리와 동일한 계약이다.
+  const prevScopeRef = useRef<string | null>(null);
+
+  const refetch = useCallback(() => {
+    setTick((t) => t + 1);
+  }, []);
 
   useEffect(() => {
+    // tick은 의도적인 수동 refetch 트리거다: 아래 void 참조로 effect와 명시적으로 연결한다.
+    void tick;
     const userId = session?.user?.id;
     const token = session?.user?.accessToken;
-    if (!userId || !token) {
+    const scopeKey = userId && token ? `${userId}\0${token}` : null;
+    if (!userId || !token || !scopeKey) {
+      prevScopeRef.current = null;
+      setOrders([]);
+      setError(null);
       setLoading(false);
       return;
     }
 
+    if (prevScopeRef.current !== scopeKey) {
+      prevScopeRef.current = scopeKey;
+      setOrders([]);
+      setError(null);
+    }
+
+    const requestId = requestSequenceRef.current + 1;
+    requestSequenceRef.current = requestId;
     let cancelled = false;
     setLoading(true);
 
@@ -38,15 +61,18 @@ export function useOrders(): UseOrdersResult {
         const res = await fetch(url, {
           headers: { Authorization: `Bearer ${token}` },
         });
-        if (cancelled) return;
+        if (cancelled || requestSequenceRef.current !== requestId) return;
         if (!res.ok) throw new Error(`주문 조회 오류: ${res.status}`);
 
         const data = (await res.json()) as Order[];
+        if (cancelled || requestSequenceRef.current !== requestId) return;
+        // 성공만 상태를 교체한다: error clear + 정상 empty([])도 성공으로 확정한다.
         setOrders(data);
-        setLoading(false);
         setError(null);
+        setLoading(false);
       } catch (e: unknown) {
-        if (cancelled) return;
+        if (cancelled || requestSequenceRef.current !== requestId) return;
+        // 실패는 기존 성공 데이터를 삭제하지 않는다: orders 유지, error만 교체한다.
         setError(e instanceof Error ? e.message : '오류가 발생했습니다.');
         setLoading(false);
       }
@@ -56,7 +82,7 @@ export function useOrders(): UseOrdersResult {
     return () => {
       cancelled = true;
     };
-  }, [session?.user?.id, session?.user?.accessToken]);
+  }, [session?.user?.id, session?.user?.accessToken, tick]);
 
-  return { orders, loading, error, refetch: () => setTick((t) => t + 1) };
+  return { orders, loading, error, refetch };
 }


### PR DESCRIPTION
TASK_ID: CONSUMER-ORDERS-READ-RECOVERY-PUBLICATION-02

Root cause: dead tick / retry lifecycle disconnect. useOrders exposed refetch via _tick state that was never in the fetch effect deps, so manual retry never triggered a second authoritative GET.

Exact three-file slice:
- apps/consumer/src/hooks/useOrders.ts
- apps/consumer/src/app/mypage/_client.tsx
- apps/consumer/src/hooks/useOrders.test.mjs

Contract:
* refetch lifecycle: refetch() increments tick, tick in useEffect deps, void tick links trigger, second fetch verified
* stale-response protection: requestSequenceRef + cancelled guard, stale resolve cannot overwrite newer refetch result
* scope isolation: user id + access token scopeKey change clears previous orders and error, authoritative fetch per scope; logout/session null clears previous user orders
* empty/error distinction: failure != genuine empty; genuine empty only when !loading && !error && orders.length === 0
* retry behavior: same-scope retry preserves existing orders on transient failure, sets error; success retry clears error and loads orders
* UI recovery: initial loading, initial error + retry, genuine empty, stale list + refresh indicator, stale list + error banner + retry; no window.location.reload
* domain preservation: STATUS_LABELS, STATUS_COLORS, OrderCard, order filtering/domain interpretation unchanged

Focused proof:
* 14 focused tests PASS (node --test apps/consumer/src/hooks/useOrders.test.mjs)
* Biome lint owned surface CLEAN (2 files, no fixes)
* TypeScript owned surface 0 errors (tsc --noEmit -p apps/consumer/tsconfig.json EXIT 0)
* git diff --check owned surface PASS

Foreign dirty excluded and preserved (consumer addresses, seller admin/banner/settlements/stores/orders, useAdmin, firebase.binding, etc.). Selective staging verified: only the three owned files committed.