### PR TITLE
fix(admin): recover banner hydration read save upload state

### DIFF
--- a/apps/seller/src/app/admin/banner/_client.test.ts
+++ b/apps/seller/src/app/admin/banner/_client.test.ts
@@ -1,0 +1,180 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+// AdminBannerClient는 '@/' alias를 사용하므로 vitest에서 직접 import할 수 없다.
+// 따라서 이 focused test는 useAdminBanner 블록과 _client.tsx의 read/save 분기 배선을
+// 소스에서 고정한다. API 계약 근거: AdminService.getBanner는 미설정 시 200 + null을
+// 반환하고 조회 실패만 non-2xx throw이므로, null + error null이 genuine unset의 전부다
+// (404 의미를 새로 정의하지 않는다).
+const clientSource = readFileSync(new URL('./_client.tsx', import.meta.url), 'utf8');
+const hookSource = readFileSync(new URL('../../../hooks/useAdmin.ts', import.meta.url), 'utf8');
+
+const bannerBlock = hookSource.slice(
+  hookSource.indexOf('export function useAdminBanner()'),
+  hookSource.indexOf('export function useAdminInvite()'),
+);
+const beforeBannerBlock = hookSource.slice(
+  0,
+  hookSource.indexOf('export function useAdminBanner()'),
+);
+
+describe('AdminBanner read recovery wiring', () => {
+  it('loading 상태를 표시한다', () => {
+    expect(clientSource).toContain('if (loading)');
+    expect(clientSource).toContain('불러오는 중...');
+    expect(bannerBlock).toContain('setLoading(true)');
+    expect(bannerBlock).toContain('setLoading(false)');
+  });
+
+  it('read success는 banner에 반영된다', () => {
+    expect(bannerBlock).toContain('setBanner(await apiJson<AdminBanner | null>');
+    expect(clientSource).toContain('hydratedRef');
+    expect(clientSource).toContain('hydratedRef.current !== banner');
+    expect(clientSource).toContain('setForm((prev) => ({ ...prev, ...banner }))');
+  });
+
+  it('read failure는 silent null이 아니라 error surface를 가진다', () => {
+    expect(bannerBlock).toContain("setError('배너 조회 중 오류 발생')");
+    expect(bannerBlock).toContain('error, saveError, save, reload');
+    expect(clientSource).toContain('if (error !== null)');
+    expect(clientSource).toContain('배너 정보를 불러오지 못했습니다.');
+    expect(clientSource).toContain('{error}');
+  });
+
+  it('read failure에서 retry는 기존 reload를 호출한다', () => {
+    expect(bannerBlock).toContain('reload: load');
+    // retry는 load를 다시 수행하고 시작 시 error를 내려 retry 성공이 정상 form으로 복귀한다.
+    expect(bannerBlock).toContain('setError(null)');
+    expect(clientSource).toContain('<Button onClick={reload}');
+    expect(clientSource).toContain('다시 조회');
+    expect(clientSource).not.toContain('location.reload');
+  });
+
+  it('genuine unset은 API 계약 범위에서 failure와 구분된다', () => {
+    // 미설정(null + error null)과 실패(null + error set)는 error 존재로만 구분된다.
+    // catch에서 banner를 null로 덮어쓰지 않으므로 이전 성공 값이 실패 증거를 가리지 않는다.
+    expect(bannerBlock).toContain('AdminBanner | null');
+    expect(clientSource).toContain('banner === null');
+    expect(clientSource).toContain('현재 설정된 배너가 없습니다.');
+    // 우선순위: loading > fetch error > unset/success — error 분기가 unset 안내보다 먼저다.
+    const loadingIdx = clientSource.indexOf('if (loading)');
+    const errorIdx = clientSource.indexOf('if (error !== null)');
+    const unsetIdx = clientSource.indexOf('banner === null');
+    expect(loadingIdx).toBeGreaterThan(-1);
+    expect(errorIdx).toBeGreaterThan(-1);
+    expect(unsetIdx).toBeGreaterThan(-1);
+    expect(loadingIdx).toBeLessThan(errorIdx);
+    expect(errorIdx).toBeLessThan(unsetIdx);
+  });
+
+  it('read failure 상태에서 기본 빈 form을 편집/저장 경로로 노출하지 않는다', () => {
+    const errorBranch = clientSource.slice(
+      clientSource.indexOf('if (error !== null)'),
+      clientSource.indexOf('banner === null'),
+    );
+    expect(errorBranch).not.toContain('<BannerImageSection');
+    expect(errorBranch).not.toContain('<BannerTextSection');
+    expect(errorBranch).not.toContain('<BannerCtaSection');
+    expect(errorBranch).not.toContain('onClick={handleSave}');
+    // Filters에 해당하는 편집 섹션은 성공 분기에서만 렌더된다.
+    expect(clientSource.indexOf('<BannerImageSection')).toBeGreaterThan(
+      clientSource.indexOf('banner === null'),
+    );
+  });
+});
+
+describe('AdminBanner save recovery wiring', () => {
+  it('save success는 reload reconciliation 후 confirmed success를 반환한다', () => {
+    expect(bannerBlock).toContain('await load()');
+    expect(bannerBlock).toContain('return true');
+    expect(clientSource).toContain('const ok = await save(form)');
+    expect(clientSource).toContain('if (ok)');
+    expect(clientSource).toContain('setSaved(true)');
+  });
+
+  it('save failure는 사용자 feedback을 제공하고 성공 상태로 보이지 않는다', () => {
+    expect(bannerBlock).toContain("setSaveError('배너 저장 중 오류 발생')");
+    // save 재시도 시작 시 이전 failure를 내려 성공/실패가 잔류 상태로 붕괴하지 않는다.
+    expect(bannerBlock).toContain('setSaveError(null)');
+    expect(bannerBlock).toContain('return false');
+    expect(clientSource).toContain('saveError !== null');
+    expect(clientSource).toContain('배너 저장에 실패했습니다.');
+    expect(clientSource).toContain('{saveError}');
+    // "저장 완료" 표시는 ok confirmed success에서만 설정된다.
+    const handleSaveSrc = clientSource.slice(
+      clientSource.indexOf('const handleSave'),
+      clientSource.indexOf('if (loading)'),
+    );
+    expect(handleSaveSrc).toContain('if (ok)');
+    // action error 표면은 read error 분기 이후(성공 분기)에 있어 read/action collapse가 없다.
+    expect(clientSource.indexOf('saveError !== null')).toBeGreaterThan(
+      clientSource.indexOf('if (error !== null)'),
+    );
+    expect(clientSource.indexOf('uploadError !== null')).toBeGreaterThan(
+      clientSource.indexOf('if (error !== null)'),
+    );
+  });
+
+  it('failed save는 form 입력을 보존한다', () => {
+    const handleSaveSrc = clientSource.slice(
+      clientSource.indexOf('const handleSave'),
+      clientSource.indexOf('if (loading)'),
+    );
+    // 실패 경로에서 form을 초기화·덮어쓰기하지 않는다.
+    expect(handleSaveSrc).not.toContain('setForm');
+    // hydrate는 banner 갱신 시에만 반영되어 편집 중 입력을 덮어쓰지 않는다.
+    expect(clientSource).toContain('}, [banner]);');
+    expect(clientSource).not.toContain('[banner, form]');
+  });
+
+  it('upload failure는 최소 recovery 표면을 가진다', () => {
+    // Firebase upload 계약 자체는 재설계하지 않고 silent만 닫는다.
+    expect(clientSource).toContain('banners/main_hero/');
+    expect(clientSource).toContain('setUploadError(null)');
+    expect(clientSource).toContain('이미지 업로드 중 오류 발생');
+    expect(clientSource).toContain('{uploadError}');
+    const uploadSrc = clientSource.slice(
+      clientSource.indexOf('const handleImageUpload'),
+      clientSource.indexOf('const handleSave'),
+    );
+    // 실패해도 기존 form 입력(imageUrl 포함)은 그대로 보존된다.
+    expect(uploadSrc).toContain('catch');
+    expect(uploadSrc).not.toContain("imageUrl: ''");
+    // uploading은 finally에서 정상 해제되어 action 상태가 고착되지 않는다.
+    expect(uploadSrc).toContain('finally');
+    expect(uploadSrc).toContain('setUploading(false)');
+    // 실제 storage 성공(getDownloadURL) 전에는 URL을 변경하지 않는다.
+    expect(uploadSrc.indexOf('getDownloadURL')).toBeGreaterThan(-1);
+    expect(uploadSrc.indexOf('setForm')).toBeGreaterThan(uploadSrc.indexOf('getDownloadURL'));
+  });
+
+  it('기존 CTA/text/image schema와 섹션 배선을 유지한다', () => {
+    expect(clientSource).toContain('<BannerImageSection');
+    expect(clientSource).toContain('<BannerTextSection');
+    expect(clientSource).toContain('<BannerCtaSection');
+    expect(clientSource).toContain('배너 활성화');
+    expect(clientSource).toContain("saving ? '저장 중...'");
+  });
+});
+
+describe('AdminBanner unrelated useAdmin blocks unchanged', () => {
+  it('다른 useAdmin hook export가 그대로 존재한다', () => {
+    for (const name of [
+      'useAdminStores',
+      'useAdminUsers',
+      'useAdminOrders',
+      'useAdminSettlements',
+      'useAdminDrivers',
+      'useAdminInvite',
+    ]) {
+      expect(hookSource).toContain(`export function ${name}(`);
+    }
+    expect(hookSource).toContain('function useAdminList<T>(');
+  });
+
+  it('banner error 상태가 다른 블록에 스며들지 않았다', () => {
+    expect(beforeBannerBlock).not.toContain('saveError');
+    expect(beforeBannerBlock).not.toContain('배너 조회 중 오류 발생');
+    expect(beforeBannerBlock).not.toContain('배너 저장 중 오류 발생');
+  });
+});

--- a/apps/seller/src/app/admin/banner/_client.tsx
+++ b/apps/seller/src/app/admin/banner/_client.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { Box, Button, Group, Stack, Switch, Text, Title } from '@mantine/core';
+import { Box, Button, Group, Paper, Stack, Switch, Text, Title } from '@mantine/core';
 import { getDownloadURL, ref as storageRef, uploadBytes } from 'firebase/storage';
 import { useSession } from 'next-auth/react';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { type AdminBanner, useAdminBanner } from '@/hooks/useAdmin';
 import { getFirebaseStorage } from '@/lib/firebase';
 import { BannerCtaSection } from './_components/BannerCtaSection';
@@ -12,7 +12,8 @@ import { BannerTextSection } from './_components/BannerTextSection';
 
 export default function AdminBannerClient() {
   const { data: session } = useSession();
-  const { banner, loading, saving, save } = useAdminBanner();
+  // read failure는 error/reload로 소비한다 — banner null만으로 unset을 단정하지 않는다.
+  const { banner, loading, saving, error, saveError, save, reload } = useAdminBanner();
 
   const [form, setForm] = useState<AdminBanner>({
     imageUrl: '',
@@ -24,22 +25,34 @@ export default function AdminBannerClient() {
     isActive: true,
   });
   const [uploading, setUploading] = useState(false);
+  // Firebase image upload는 기존 계약을 재설계하지 않는다.
+  // 다만 완전 silent 실패는 복구 불가이므로 동일 UI 안에서 최소 오류 표면만 제공한다.
+  const [uploadError, setUploadError] = useState<string | null>(null);
   const [saved, setSaved] = useState(false);
 
+  // 서버 상태 hydrate는 banner 갱신(초기 로드·저장 후 reload) 시에만 1회 반영한다.
+  // form을 deps에 넣으면 편집 입력이 서버 값으로 매번 덮어쓰여 실패 후 입력 보존이 깨진다.
+  const hydratedRef = useRef<AdminBanner | null>(null);
   useEffect(() => {
-    if (banner) setForm({ ...form, ...banner });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [banner, form]);
+    if (banner && hydratedRef.current !== banner) {
+      hydratedRef.current = banner;
+      setForm((prev) => ({ ...prev, ...banner }));
+    }
+  }, [banner]);
 
   const handleImageUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file || !session?.user) return;
     setUploading(true);
+    setUploadError(null);
     try {
       const r = storageRef(getFirebaseStorage(), `banners/main_hero/${Date.now()}_${file.name}`);
       await uploadBytes(r, file);
       const url = await getDownloadURL(r);
       setForm((f) => ({ ...f, imageUrl: url }));
+    } catch {
+      // 실패해도 기존 form 입력(imageUrl 포함)은 그대로 보존된다.
+      setUploadError('이미지 업로드 중 오류 발생');
     } finally {
       setUploading(false);
       e.target.value = '';
@@ -47,11 +60,15 @@ export default function AdminBannerClient() {
   };
 
   const handleSave = async () => {
+    // 이전 성공 표시가 실패 건에 잔류하지 않도록 먼저 내린다.
+    setSaved(false);
     const ok = await save(form);
     if (ok) {
       setSaved(true);
       setTimeout(() => setSaved(false), 2000);
     }
+    // 실패 시 form은 그대로 보존되고 saveError 블록이 실패 feedback을 제공한다.
+    // "저장 완료" 표시는 ok confirmed success에서만 설정된다.
   };
 
   if (loading) {
@@ -59,6 +76,37 @@ export default function AdminBannerClient() {
       <Text ta="center" py={80} style={{ color: 'var(--color-text-disabled)' }}>
         불러오는 중...
       </Text>
+    );
+  }
+
+  // read failure 상태에서는 기본 빈 form을 authoritative current state처럼 편집/저장하게 하지 않는다.
+  if (error !== null) {
+    return (
+      <Box>
+        <Group justify="space-between" mb="md">
+          <Title order={4}>히어로 배너 관리</Title>
+        </Group>
+        <Paper
+          radius="lg"
+          shadow="xs"
+          style={{ border: '1px solid var(--color-border)', overflow: 'hidden' }}
+        >
+          <Stack gap="sm" align="center" py={64} px="md">
+            <Text style={{ fontWeight: 500, color: 'var(--color-text-secondary)' }}>
+              배너 정보를 불러오지 못했습니다.
+            </Text>
+            <Text
+              ta="center"
+              style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-text-disabled)' }}
+            >
+              {error}
+            </Text>
+            <Button onClick={reload} size="sm" variant="outline" radius="md">
+              다시 조회
+            </Button>
+          </Stack>
+        </Paper>
+      </Box>
     );
   }
 
@@ -72,6 +120,50 @@ export default function AdminBannerClient() {
           onChange={(e) => setForm({ ...form, isActive: e.currentTarget.checked })}
         />
       </Group>
+
+      {banner === null && (
+        <Text
+          mb="md"
+          style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-text-disabled)' }}
+        >
+          현재 설정된 배너가 없습니다. 아래 양식으로 새 배너를 등록하세요.
+        </Text>
+      )}
+
+      {saveError !== null && (
+        <Paper
+          radius="lg"
+          shadow="xs"
+          mb="md"
+          p="md"
+          style={{ border: '1px solid var(--color-danger)' }}
+        >
+          <Stack gap="xs" align="center">
+            <Text style={{ fontWeight: 500, color: 'var(--color-danger)' }}>
+              배너 저장에 실패했습니다.
+            </Text>
+            <Text
+              ta="center"
+              style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-text-disabled)' }}
+            >
+              {saveError} 입력 내용은 그대로 보존되어 있으니 다시 시도해 주세요.
+            </Text>
+            <Button onClick={handleSave} size="sm" variant="outline" radius="md" disabled={saving}>
+              다시 저장
+            </Button>
+          </Stack>
+        </Paper>
+      )}
+
+      {uploadError !== null && (
+        <Text
+          mb="md"
+          ta="center"
+          style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-danger)' }}
+        >
+          {uploadError} 기존 이미지는 그대로 유지됩니다.
+        </Text>
+      )}
 
       <Stack gap="md">
         <BannerImageSection

--- a/apps/seller/src/hooks/useAdmin.ts
+++ b/apps/seller/src/hooks/useAdmin.ts
@@ -313,14 +313,23 @@ export function useAdminBanner() {
   const [banner, setBanner] = useState<AdminBanner | null>(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
+  // Read failure는 genuine unset과 구분된다.
+  // 백엔드 계약(AdminService.getBanner): 미설정 문서는 200 + null 반환,
+  // 조회 실패만 non-2xx throw → error가 null이 아닌 경우만 FETCH_ERROR다.
+  // 404 의미를 새로 정의하지 않는다 — null + error null이 unset의 전부다.
+  const [error, setError] = useState<string | null>(null);
+  // Save confirmed failure — "저장 완료" 상태로 붕괴하지 않도록 호출자에 노출한다.
+  const [saveError, setSaveError] = useState<string | null>(null);
 
   const load = useCallback(async () => {
     if (!token) return;
     setLoading(true);
+    setError(null);
     try {
-      setBanner(await apiJson<AdminBanner>('/admin/banner', token));
+      setBanner(await apiJson<AdminBanner | null>('/admin/banner', token));
     } catch {
-      // 배너 미설정 등 — 무시
+      // 이전 성공 banner를 null로 덮어쓰지 않는다 — error 존재 자체가 실패의 증거다.
+      setError('배너 조회 중 오류 발생');
     } finally {
       setLoading(false);
     }
@@ -333,6 +342,7 @@ export function useAdminBanner() {
   const save = async (dto: AdminBanner): Promise<boolean> => {
     if (!token) return false;
     setSaving(true);
+    setSaveError(null);
     // 서버 관리 필드 제거 (forbidNonWhitelisted 대응)
     const {
       updatedAt: _u,
@@ -344,13 +354,14 @@ export function useAdminBanner() {
       await load();
       return true;
     } catch {
+      setSaveError('배너 저장 중 오류 발생');
       return false;
     } finally {
       setSaving(false);
     }
   };
 
-  return { banner, loading, saving, save, reload: load };
+  return { banner, loading, saving, error, saveError, save, reload: load };
 }
 
 // ── Invite ───────────────────────────────────────────────────────


### PR DESCRIPTION
Source: ADMIN-BANNER-STATE-RECOVERY-01 (START_HEAD f2989d68e3714ae150de95bf7d027da49daf01ae). Publication-only; no new semantics.

Root cause:
- form dependency hydration overwrite ([banner, form] deps reset edits)
- read failure collapsed into unset/empty editor (silent catch, null overwrite)
- save failure silent (bool only, fake success risk)
- image upload failure silent

Recovery contracts:
- banner-identity hydration only (hydratedRef guard, [banner] deps); reload result wins per minimal contract
- loading > read-error + retry > loaded/unset; error hides edit/save surface; retry calls hook reload/load; no location.reload
- bool result + saveError separated; failed form input preserved; success only on ok; post-success load reconciliation
- Firebase path unchanged (banners/main_hero/); upload failure explicit; existing imageUrl preserved; uploading released in finally

Validation:
- apps/seller: npx vitest run src/app/admin/banner/_client.test.ts -> 13/13 PASS
- apps/seller: npx tsc --noEmit -> PASS
- full suite not run (foreign parallel mutators present; unrelated failures not a blocker)

Scope:
- apps/seller/src/app/admin/banner/_client.tsx
- apps/seller/src/app/admin/banner/_client.test.ts (new)
- apps/seller/src/hooks/useAdmin.ts (useAdminBanner hunks ONLY)
No force-push, no history rewrite, no foreign files.