### PR TITLE
fix(admin): recover stores read failure state

### DIFF
--- a/apps/seller/src/app/admin/stores/_client.test.ts
+++ b/apps/seller/src/app/admin/stores/_client.test.ts
@@ -1,0 +1,121 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { getAdminStoresReadState } from './_lib';
+
+// AdminStoresClient는 '@/' alias를 사용하므로 vitest에서 직접 import할 수 없다.
+// (seller vitest에는 tsconfig paths 매핑이 없어 '@/hooks/useAdmin' 해석이 실패한다.)
+// 따라서 본 focused test는 _client.tsx 소스의 배선(wiring)을 고정하고,
+// 실제 상태 분기는 순수 함수인 getAdminStoresReadState로 증명한다.
+// READ-ONLY인 StoresTable/_lib의 기존 동작 자체는 각자의 focused test가 소유한다.
+
+const source = readFileSync(new URL('./_client.tsx', import.meta.url), 'utf8');
+
+const FETCH_ERROR_MESSAGE = '판매자 목록 조회 중 오류 발생';
+
+describe('AdminStoresClient read-error recovery wiring', () => {
+  it('useAdminStores의 error/reload를 소비한다', () => {
+    expect(source).toContain('useAdminStores()');
+    expect(source).toMatch(
+      /const\s*\{\s*stores,\s*loading,\s*error,\s*reload,\s*setCommission,\s*archiveStore,\s*restoreStore\s*\}/,
+    );
+    expect(source).toContain('getAdminStoresReadState');
+  });
+
+  it('initial read failure → error state를 표시한다', () => {
+    expect(
+      getAdminStoresReadState({ loading: false, error: FETCH_ERROR_MESSAGE, stores: [], visible: [] }),
+    ).toBe('FETCH_ERROR');
+    expect(source).toContain('판매자 목록을 불러오지 못했습니다.');
+    expect(source).toContain('{error}');
+  });
+
+  it('read failure ≠ unfiltered empty', () => {
+    expect(
+      getAdminStoresReadState({ loading: false, error: FETCH_ERROR_MESSAGE, stores: [], visible: [] }),
+    ).toBe('FETCH_ERROR');
+    expect(
+      getAdminStoresReadState({ loading: false, error: null, stores: [], visible: [] }),
+    ).toBe('EMPTY_UNFILTERED');
+    // _client 자체가 빈 판매자 copy를 렌더하지 않는다 — 실패 표현은 error 분기가 소유한다.
+    expect(source).not.toContain('등록된 판매자가 없습니다.');
+    // 조회 실패에서는 0건 수로 표시하지 않는다.
+    expect(source).toContain('error === null');
+  });
+
+  it('read failure ≠ filtered empty', () => {
+    expect(
+      getAdminStoresReadState({
+        loading: false,
+        error: FETCH_ERROR_MESSAGE,
+        stores: [{ id: 's1' }],
+        visible: [],
+      }),
+    ).toBe('FETCH_ERROR');
+    expect(
+      getAdminStoresReadState({
+        loading: false,
+        error: null,
+        stores: [{ id: 's1' }],
+        visible: [],
+      }),
+    ).toBe('EMPTY_FILTERED');
+    // 필터 결과 없음 copy도 _client가 중복 렌더하지 않는다(테이블이 성공 분기에서만 소유).
+    expect(source).not.toContain('조건에 맞는 판매자가 없습니다.');
+  });
+
+  it('retry wiring을 보존한다(기존 reload 경로 재사용)', () => {
+    // 기존 수동 reload UI 경로를 그대로 사용한다.
+    expect(source).toContain('onReload={reload}');
+    // 오류 상태의 명시적 재시도도 동일한 authoritative reload에 연결된다.
+    expect(source).toContain('<Button onClick={reload}');
+    expect(source).toContain('다시 조회');
+    // 새 refresh 함수를 만들지 않는다.
+    expect(source).not.toMatch(/const\s+(retry|refresh|refetch)\s*=/);
+  });
+
+  it('오류 상태에서도 filter/query state를 임의 초기화하지 않는다', () => {
+    // Filters는 error 분기 밖에서 항상 유지된다.
+    expect(source).toContain('<StoresFilters');
+    expect(source.indexOf('<StoresFilters')).toBeLessThan(source.indexOf('isFetchError ?'));
+    // 기존 query 동기화 경로를 유지한다.
+    expect(source).toContain("searchParams.get('keyword')");
+    expect(source).toContain('parseStatusFilter');
+    expect(source).toContain('parseSort');
+    expect(source).toContain('router.push');
+    expect(source).toContain('onKeywordChange={(keyword) => updateView({ keyword })}');
+    expect(source).toContain('onStatusChange={(status) => updateView({ status })}');
+    expect(source).toContain('onSortChange={(sort) => updateView({ sort })}');
+    // error 분기는 필터를 초기화하지 않는다.
+    const errorBranch = source.slice(
+      source.indexOf('isFetchError ?'),
+      source.indexOf(': (', source.indexOf('isFetchError ?')),
+    );
+    expect(errorBranch).not.toContain('resetFilters');
+    expect(errorBranch).not.toContain('setView');
+    expect(errorBranch).not.toContain('updateView');
+    // 기존 filterStores/sortStores/getEmptyKind 계약을 그대로 사용한다.
+    expect(source).toContain('filterStores(stores,');
+    expect(source).toContain('sortStores(filtered,');
+    expect(source).toContain('getEmptyKind(stores, visible)');
+    expect(source).toContain('onResetFilters={resetFilters}');
+  });
+
+  it('mutation controls 회귀가 없다', () => {
+    // 수수료 변경 경로를 유지한다.
+    expect(source).toContain('setCommission(storeId');
+    expect(source).toContain('onSave={handleSave}');
+    expect(source).toContain('onStartEdit={handleStartEdit}');
+    expect(source).toContain('onCancelEdit={handleCancelEdit}');
+    // archive/restore 경로와 기존 서버 오류 notification을 유지한다.
+    expect(source).toContain('archiveStore(store.id)');
+    expect(source).toContain('restoreStore(store.id)');
+    expect(source).toContain('onArchive={handleArchive}');
+    expect(source).toContain('onRestore={handleRestore}');
+    expect(source).toContain('정리할 수 없습니다');
+    expect(source).toContain('복구할 수 없습니다');
+    // 성공 분기의 테이블 배선을 가로채지 않는다.
+    expect(source).toContain('stores={visible}');
+    expect(source).toContain('loading={loading}');
+    expect(source).toContain('emptyKind={emptyKind}');
+  });
+});

--- a/apps/seller/src/app/admin/stores/_client.tsx
+++ b/apps/seller/src/app/admin/stores/_client.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Box, Group, Text, Title } from '@mantine/core';
+import { Box, Button, Group, Paper, Stack, Text, Title } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
@@ -12,6 +12,7 @@ import {
   DEFAULT_SORT,
   DEFAULT_STATUS_FILTER,
   filterStores,
+  getAdminStoresReadState,
   getEmptyKind,
   parseRate,
   parseSort,
@@ -28,7 +29,8 @@ interface StoreViewState {
 }
 
 export default function AdminStoresClient() {
-  const { stores, loading, reload, setCommission, archiveStore, restoreStore } = useAdminStores();
+  const { stores, loading, error, reload, setCommission, archiveStore, restoreStore } =
+    useAdminStores();
   const pathname = usePathname();
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -129,18 +131,25 @@ export default function AdminStoresClient() {
   const filtered = filterStores(stores, { keyword: view.keyword, status: view.status });
   const visible = sortStores(filtered, view.sort);
   const emptyKind = getEmptyKind(stores, visible);
+  // 조회 실패는 정상 빈 결과로 collapse하지 않는다.
+  // useAdminList는 실패 시 이전 stores를 보존하므로 stale 유무와 무관하게 error를 우선한다.
+  // filter/query state는 초기화하지 않고 Filters는 항상 유지된다.
+  const readState = getAdminStoresReadState({ loading, error, stores, visible });
+  const isFetchError = readState === 'FETCH_ERROR';
 
   return (
     <Box>
       <Group justify="space-between" mb="md">
         <Title order={4}>
           판매자 목록{' '}
-          <Text
-            component="span"
-            style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-text-disabled)' }}
-          >
-            ({visible.length})
-          </Text>
+          {error === null && (
+            <Text
+              component="span"
+              style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-text-disabled)' }}
+            >
+              ({visible.length})
+            </Text>
+          )}
         </Title>
       </Group>
 
@@ -155,23 +164,46 @@ export default function AdminStoresClient() {
         onReload={reload}
       />
 
-      <StoresTable
-        stores={visible}
-        loading={loading}
-        emptyKind={emptyKind}
-        sort={view.sort}
-        editId={editId}
-        rateInput={rateInput}
-        saving={saving}
-        onRateInput={setRateInput}
-        onStartEdit={handleStartEdit}
-        onCancelEdit={handleCancelEdit}
-        onSave={handleSave}
-        onArchive={handleArchive}
-        onRestore={handleRestore}
-        onResetFilters={resetFilters}
-        onSortChange={(sort) => updateView({ sort })}
-      />
+      {isFetchError ? (
+        <Paper
+          radius="lg"
+          shadow="xs"
+          style={{ border: '1px solid var(--color-border)', overflow: 'hidden' }}
+        >
+          <Stack gap="sm" align="center" py={64} px="md">
+            <Text style={{ fontWeight: 500, color: 'var(--color-text-secondary)' }}>
+              판매자 목록을 불러오지 못했습니다.
+            </Text>
+            <Text
+              ta="center"
+              style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-text-disabled)' }}
+            >
+              {error}
+            </Text>
+            <Button onClick={reload} size="sm" variant="outline" radius="md">
+              다시 조회
+            </Button>
+          </Stack>
+        </Paper>
+      ) : (
+        <StoresTable
+          stores={visible}
+          loading={loading}
+          emptyKind={emptyKind}
+          sort={view.sort}
+          editId={editId}
+          rateInput={rateInput}
+          saving={saving}
+          onRateInput={setRateInput}
+          onStartEdit={handleStartEdit}
+          onCancelEdit={handleCancelEdit}
+          onSave={handleSave}
+          onArchive={handleArchive}
+          onRestore={handleRestore}
+          onResetFilters={resetFilters}
+          onSortChange={(sort) => updateView({ sort })}
+        />
+      )}
     </Box>
   );
 }

--- a/apps/seller/src/app/admin/stores/_lib.test.ts
+++ b/apps/seller/src/app/admin/stores/_lib.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { parseRate } from './_lib';
+import { getAdminStoresReadState, parseRate } from './_lib';
 
 describe('parseRate', () => {
   it('소수 수수료율을 정상 값으로 변환한다', () => {
@@ -36,5 +36,100 @@ describe('parseRate', () => {
 
   it('앞뒤 공백을 제거한 값으로 변환한다', () => {
     expect(parseRate(' 0.5 ')).toEqual({ ok: true, rate: 0.5 });
+  });
+});
+
+const FETCH_ERROR_MESSAGE = '판매자 목록 조회 중 오류 발생';
+
+function store(id: string) {
+  return { id };
+}
+
+describe('getAdminStoresReadState', () => {
+  it('조회 중에는 LOADING을 반환한다', () => {
+    expect(
+      getAdminStoresReadState({ loading: true, error: null, stores: [], visible: [] }),
+    ).toBe('LOADING');
+  });
+
+  it('loading + error는 LOADING을 우선한다(재시도 중 error 잔존)', () => {
+    expect(
+      getAdminStoresReadState({
+        loading: true,
+        error: FETCH_ERROR_MESSAGE,
+        stores: [],
+        visible: [],
+      }),
+    ).toBe('LOADING');
+  });
+
+  it('initial read failure → FETCH_ERROR를 반환한다', () => {
+    expect(
+      getAdminStoresReadState({
+        loading: false,
+        error: FETCH_ERROR_MESSAGE,
+        stores: [],
+        visible: [],
+      }),
+    ).toBe('FETCH_ERROR');
+  });
+
+  it('read failure ≠ unfiltered empty', () => {
+    // 실패 + 0건은 FETCH_ERROR이며 실제 0건 copy로 collapse되지 않는다.
+    expect(
+      getAdminStoresReadState({
+        loading: false,
+        error: FETCH_ERROR_MESSAGE,
+        stores: [],
+        visible: [],
+      }),
+    ).toBe('FETCH_ERROR');
+    // 성공 + 0건만 실제 0건이다.
+    expect(
+      getAdminStoresReadState({ loading: false, error: null, stores: [], visible: [] }),
+    ).toBe('EMPTY_UNFILTERED');
+  });
+
+  it('read failure ≠ filtered empty', () => {
+    // 실패 + 필터 결과 0건(stale stores 유지)도 FETCH_ERROR이다.
+    expect(
+      getAdminStoresReadState({
+        loading: false,
+        error: FETCH_ERROR_MESSAGE,
+        stores: [store('s1')],
+        visible: [],
+      }),
+    ).toBe('FETCH_ERROR');
+    // 성공 + 동일 shape만 필터 결과 0건이다.
+    expect(
+      getAdminStoresReadState({
+        loading: false,
+        error: null,
+        stores: [store('s1')],
+        visible: [],
+      }),
+    ).toBe('EMPTY_FILTERED');
+  });
+
+  it('error는 stale 결과보다 우선한다(useAdminList 이전 결과 보존 기준)', () => {
+    expect(
+      getAdminStoresReadState({
+        loading: false,
+        error: FETCH_ERROR_MESSAGE,
+        stores: [store('s1')],
+        visible: [store('s1')],
+      }),
+    ).toBe('FETCH_ERROR');
+  });
+
+  it('성공 + 결과는 HAS_RESULTS를 반환한다', () => {
+    expect(
+      getAdminStoresReadState({
+        loading: false,
+        error: null,
+        stores: [store('s1')],
+        visible: [store('s1')],
+      }),
+    ).toBe('HAS_RESULTS');
   });
 });

--- a/apps/seller/src/app/admin/stores/_lib.ts
+++ b/apps/seller/src/app/admin/stores/_lib.ts
@@ -108,6 +108,35 @@ export function getEmptyKind(stores: AdminStore[], filtered: AdminStore[]): Stor
   return filtered.length === 0 ? 'no-match' : 'has-data';
 }
 
+// Admin 판매자 목록 read state — 조회 실패와 정상 빈 결과의 구조적 구분.
+// useAdminStores는 error/reload를 노출하지만 화면이 이를 소비하지 않으면
+// 조회 실패가 빈 목록("등록된 판매자가 없습니다."/"조건에 맞는 판매자가 없습니다.")으로 collapse된다.
+// filterStores/sortStores/getEmptyKind 계약은 재설계하지 않고,
+// 분기 우선순위(loading > error > empty > results)만 순수 함수로 고정한다.
+// 매핑은 getEmptyKind와 일치한다: stores 0건 → EMPTY_UNFILTERED(실제 0건),
+// stores 유지 + visible 0건 → EMPTY_FILTERED(필터 결과 0건).
+// useAdminList는 조회 실패 시 items를 비우지 않고 이전 결과를 보존하므로,
+// error가 존재하면 stale 유무와 무관하게 FETCH_ERROR를 우선한다(성공-empty로 collapse 금지).
+export type AdminStoresReadState =
+  | 'LOADING'
+  | 'FETCH_ERROR'
+  | 'EMPTY_UNFILTERED'
+  | 'EMPTY_FILTERED'
+  | 'HAS_RESULTS';
+
+export function getAdminStoresReadState(args: {
+  loading: boolean;
+  error: string | null;
+  stores: readonly unknown[];
+  visible: readonly unknown[];
+}): AdminStoresReadState {
+  if (args.loading) return 'LOADING';
+  if (args.error !== null) return 'FETCH_ERROR';
+  if (args.stores.length === 0) return 'EMPTY_UNFILTERED';
+  if (args.visible.length === 0) return 'EMPTY_FILTERED';
+  return 'HAS_RESULTS';
+}
+
 export function parseRate(input: string): ParseRateResult {
   const trimmed = input.trim();
   if (trimmed === '') return { ok: false, errorCode: 'EMPTY' };


### PR DESCRIPTION
ADMIN-STORES-READ-RECOVERY-01 publication. READ_STATE_PRECEDENCE LOADING greater than FETCH_ERROR greater than EMPTY_UNFILTERED greater than EMPTY_FILTERED greater than HAS_RESULTS. Focused: _lib 16 plus _client 7 equals 23 passed, tsc pass. Owned only 4 files.