### PR TITLE
fix(consumer): recover notification reads safely

### DIFF
--- a/apps/consumer/src/app/mypage/notifications/_client.tsx
+++ b/apps/consumer/src/app/mypage/notifications/_client.tsx
@@ -178,13 +178,16 @@ function NotificationItem({
 export default function NotificationsClient() {
   const { status } = useSession();
   const router = useRouter();
-  const { notifications, readIds, loading, error, markAllRead, markRead } = useNotifications();
+  const { notifications, readIds, loading, error, refetch, markAllRead, markRead } =
+    useNotifications();
 
   useEffect(() => {
-    if (!loading && notifications.length > 0) {
+    // authoritative successful load에서만 자동 읽음 처리한다.
+    // stale list + failure 상태에서는 read receipt 의미를 바꾸지 않는다.
+    if (!loading && !error && notifications.length > 0) {
       markAllRead();
     }
-  }, [loading, notifications.length, markAllRead]);
+  }, [loading, error, notifications.length, markAllRead]);
 
   if (status === 'unauthenticated') {
     router.replace('/login');
@@ -231,13 +234,7 @@ export default function NotificationsClient() {
         )}
       </Group>
 
-      {error && (
-        <Alert color="red" variant="light" m="md">
-          <Text style={{ fontSize: 'var(--font-size-sm)' }}>{error}</Text>
-        </Alert>
-      )}
-
-      {loading && (
+      {loading && notifications.length === 0 && (
         <Text
           ta="center"
           style={{ color: 'var(--color-text-disabled)', fontSize: 'var(--font-size-sm)' }}
@@ -245,6 +242,23 @@ export default function NotificationsClient() {
         >
           불러오는 중...
         </Text>
+      )}
+
+      {!loading && error && notifications.length === 0 && (
+        <Stack gap="xs" p="md">
+          <Alert color="red" variant="light">
+            <Text style={{ fontSize: 'var(--font-size-sm)' }}>{error}</Text>
+          </Alert>
+          <Button
+            variant="default"
+            size="xs"
+            radius="sm"
+            onClick={refetch}
+            data-testid="notifications-retry"
+          >
+            다시 시도
+          </Button>
+        </Stack>
       )}
 
       {!loading && !error && notifications.length === 0 && (
@@ -256,8 +270,39 @@ export default function NotificationsClient() {
         </Stack>
       )}
 
-      {!loading && notifications.length > 0 && (
+      {notifications.length > 0 && (
         <Box>
+          {loading && (
+            <Text
+              ta="center"
+              style={{ color: 'var(--color-text-disabled)', fontSize: 'var(--font-size-sm)' }}
+              py="sm"
+            >
+              업데이트 중...
+            </Text>
+          )}
+          {error && (
+            <Box p="md">
+              <Alert color="red" variant="light">
+                <Text style={{ fontSize: 'var(--font-size-sm)' }}>
+                  최신 알림을 불러오지 못했습니다. 이전 목록을 표시합니다.
+                </Text>
+                <Text style={{ fontSize: 'var(--font-size-sm)' }} mt={4}>
+                  {error}
+                </Text>
+              </Alert>
+              <Button
+                variant="default"
+                size="xs"
+                radius="sm"
+                mt="xs"
+                onClick={refetch}
+                data-testid="notifications-retry"
+              >
+                다시 시도
+              </Button>
+            </Box>
+          )}
           {notifications.map((n) => (
             <NotificationItem
               key={n.id}

--- a/apps/consumer/src/hooks/useNotifications.test.mjs
+++ b/apps/consumer/src/hooks/useNotifications.test.mjs
@@ -1,0 +1,396 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+import ts from 'typescript';
+
+// CONSUMER-NOTIFICATIONS-READ-RECOVERY-01 focused test.
+// Consumer 알림 목록 읽기 lifecycle만 소유한다:
+// auth scope, request race, read states, retry, auto-read guard, scoped storage.
+
+const hookSource = await readFile(new URL('./useNotifications.ts', import.meta.url), 'utf8');
+const clientSource = await readFile(
+  new URL('../app/mypage/notifications/_client.tsx', import.meta.url),
+  'utf8',
+);
+
+const compiled = ts.transpileModule(hookSource, {
+  compilerOptions: {
+    esModuleInterop: true,
+    module: ts.ModuleKind.CommonJS,
+    target: ts.ScriptTarget.ES2022,
+  },
+  fileName: 'useNotifications.ts',
+}).outputText;
+
+const API_BASE_URL = 'https://api.example.test';
+const EXPECTED_URL = `${API_BASE_URL}/notifications/me`;
+const USER_A = { user: { id: 'user-a', accessToken: 'token-a' } };
+const USER_B = { user: { id: 'user-b', accessToken: 'token-b' } };
+
+const originalFetch = globalThis.fetch;
+const originalLocalStorage = globalThis.localStorage;
+test.after(() => {
+  globalThis.fetch = originalFetch;
+  globalThis.localStorage = originalLocalStorage;
+});
+
+function createStorage() {
+  const store = new Map();
+  return {
+    __store: store,
+    getItem(key) {
+      return store.has(key) ? store.get(key) : null;
+    },
+    setItem(key, value) {
+      store.set(key, String(value));
+    },
+    removeItem(key) {
+      store.delete(key);
+    },
+    clear() {
+      store.clear();
+    },
+  };
+}
+
+function okItems(items) {
+  return { ok: true, status: 200, json: async () => ({ items, total: items.length }) };
+}
+
+function errorResponse(status = 500) {
+  return { ok: false, status, json: async () => ({}) };
+}
+
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function mountHook({ session = USER_A, fetchImpl }) {
+  globalThis.fetch = fetchImpl;
+  globalThis.localStorage = createStorage();
+  let currentSession = session;
+  const hookModule = { exports: {} };
+  const stateSlots = [];
+  const refSlots = [];
+  const effectSlots = [];
+  let cursor = 0;
+  let renderScheduled = true;
+  let latest = null;
+
+  const scheduleRender = () => {
+    renderScheduled = true;
+  };
+
+  function useState(initial) {
+    const index = cursor++;
+    if (stateSlots[index] === undefined) stateSlots[index] = { value: initial };
+    const slot = stateSlots[index];
+    const setState = (next) => {
+      const value = typeof next === 'function' ? next(slot.value) : next;
+      if (Object.is(value, slot.value)) return;
+      slot.value = value;
+      scheduleRender();
+    };
+    return [slot.value, setState];
+  }
+
+  function useRef(initial) {
+    const index = cursor++;
+    if (refSlots[index] === undefined) refSlots[index] = { current: initial };
+    return refSlots[index];
+  }
+
+  function useCallback(fn) {
+    return fn;
+  }
+
+  function useEffect(create, deps) {
+    const index = cursor++;
+    if (effectSlots[index] === undefined) {
+      effectSlots[index] = { deps: undefined, cleanup: undefined, hasRun: false };
+    }
+    effectSlots[index].pendingCreate = create;
+    effectSlots[index].pendingDeps = deps;
+  }
+
+  const requireForTest = (specifier) => {
+    if (specifier === 'react') return { useCallback, useEffect, useRef, useState };
+    if (specifier === 'next-auth/react') return { useSession: () => ({ data: currentSession }) };
+    if (specifier === '@/lib/api-base-url') return { getApiBaseUrl: () => API_BASE_URL };
+    throw new Error(`예상하지 못한 알림 조회 모듈 요청: ${specifier}`);
+  };
+  new Function('require', 'module', 'exports', compiled)(
+    requireForTest,
+    hookModule,
+    hookModule.exports,
+  );
+
+  function flushEffects() {
+    for (const slot of effectSlots) {
+      if (!slot || slot.pendingCreate === undefined) continue;
+      const prevDeps = slot.deps;
+      const nextDeps = slot.pendingDeps;
+      const changed =
+        !slot.hasRun ||
+        prevDeps === undefined ||
+        nextDeps === undefined ||
+        nextDeps.length !== prevDeps.length ||
+        nextDeps.some((dep, i) => !Object.is(dep, prevDeps[i]));
+      if (!changed) continue;
+      if (typeof slot.cleanup === 'function') {
+        const cleanup = slot.cleanup;
+        slot.cleanup = undefined;
+        cleanup();
+      }
+      slot.deps = nextDeps;
+      slot.hasRun = true;
+      const nextCleanup = slot.pendingCreate();
+      slot.cleanup = typeof nextCleanup === 'function' ? nextCleanup : undefined;
+    }
+  }
+
+  function render() {
+    cursor = 0;
+    renderScheduled = false;
+    // biome-ignore lint/correctness/useHookAtTopLevel: React를 모의한 훅 계약 단위 테스트다.
+    latest = hookModule.exports.useNotifications();
+    flushEffects();
+  }
+
+  async function settle(passes = 25) {
+    for (let i = 0; i < passes; i += 1) {
+      if (renderScheduled) render();
+      await new Promise((resolve) => setImmediate(resolve));
+      if (renderScheduled) render();
+    }
+    if (renderScheduled) render();
+  }
+
+  const get = () => latest;
+  const setSession = (next) => {
+    currentSession = next;
+    scheduleRender();
+  };
+  const storage = () => globalThis.localStorage;
+  return { get, settle, render, setSession, storage };
+}
+
+const notifA1 = { id: 'notif-a1' };
+const notifA2 = { id: 'notif-a2' };
+const notifB1 = { id: 'notif-b1' };
+
+// 1. success with items
+test('1. success with items: authoritative GET 1회로 목록을 적재하고 error를 비운다', async () => {
+  const calls = [];
+  const harness = mountHook({
+    fetchImpl: async (url, init) => {
+      calls.push({ url, init });
+      return okItems([notifA1, notifA2]);
+    },
+  });
+  await harness.settle();
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].url, EXPECTED_URL);
+  assert.equal(calls[0].init.headers.Authorization, 'Bearer token-a');
+  assert.deepEqual(harness.get().notifications, [notifA1, notifA2]);
+  assert.equal(harness.get().loading, false);
+  assert.equal(harness.get().error, null);
+});
+
+// 2. successful empty
+test('2. successful empty: 빈 목록은 error 없이 성공으로 확정한다', async () => {
+  const harness = mountHook({ fetchImpl: async () => okItems([]) });
+  await harness.settle();
+
+  assert.deepEqual(harness.get().notifications, []);
+  assert.equal(harness.get().error, null);
+  assert.equal(harness.get().loading, false);
+});
+
+// 3. initial error !== empty
+test('3. initial error는 빈 성공으로 위장하지 않는다', async () => {
+  const harness = mountHook({ fetchImpl: async () => errorResponse(500) });
+  await harness.settle();
+
+  assert.match(harness.get().error ?? '', /500/);
+  assert.deepEqual(harness.get().notifications, []);
+  assert.equal(harness.get().loading, false);
+});
+
+// 4. error -> retry -> success
+test('4. error → retry → success: refetch는 동일 GET을 재실행하고 error를 clear한다', async () => {
+  let mode = 'failure';
+  const calls = [];
+  const harness = mountHook({
+    fetchImpl: async (url) => {
+      calls.push(url);
+      return mode === 'failure' ? errorResponse(500) : okItems([notifA1]);
+    },
+  });
+  await harness.settle();
+  assert.notEqual(harness.get().error, null);
+  assert.equal(calls.length, 1);
+
+  mode = 'success';
+  harness.get().refetch();
+  await harness.settle();
+
+  assert.equal(calls.length, 2);
+  assert.equal(calls[1], EXPECTED_URL);
+  assert.deepEqual(harness.get().notifications, [notifA1]);
+  assert.equal(harness.get().error, null);
+  assert.equal(harness.get().loading, false);
+});
+
+// 5. auth/token loss clears protected list
+test('5. auth/token loss는 이전 사용자의 protected 목록·readIds·error를 제거한다', async () => {
+  const harness = mountHook({ fetchImpl: async () => okItems([notifA1]) });
+  await harness.settle();
+  assert.deepEqual(harness.get().notifications, [notifA1]);
+
+  harness.get().markAllRead();
+  await harness.settle();
+  assert.ok(harness.get().readIds.has('notif-a1'));
+
+  harness.setSession(null);
+  await harness.settle();
+
+  assert.deepEqual(harness.get().notifications, []);
+  assert.deepEqual([...harness.get().readIds], []);
+  assert.equal(harness.get().error, null);
+  assert.equal(harness.get().loading, false);
+});
+
+// 6. A -> B stale response blocked
+test('6. account A → B 전환에서 늦은 A 응답이 B state를 덮지 않는다', async () => {
+  const first = deferred();
+  const second = deferred();
+  let n = 0;
+  const harness = mountHook({
+    session: USER_A,
+    fetchImpl: async () => {
+      n += 1;
+      return n === 1 ? first.promise : second.promise;
+    },
+  });
+  await harness.settle(5);
+
+  harness.setSession(USER_B);
+  await harness.settle(5);
+
+  second.resolve(okItems([notifB1]));
+  await harness.settle();
+  assert.deepEqual(harness.get().notifications, [notifB1]);
+  assert.equal(harness.get().error, null);
+
+  first.resolve(okItems([notifA1]));
+  await harness.settle();
+  assert.deepEqual(harness.get().notifications, [notifB1]);
+  assert.equal(harness.get().error, null);
+});
+
+// 7. previous success -> refresh failure keeps stale
+test('7. previous success → refresh failure는 stale 목록을 유지하고 failure를 명시한다', async () => {
+  let mode = 'success';
+  const harness = mountHook({
+    fetchImpl: async () => (mode === 'success' ? okItems([notifA1]) : errorResponse(500)),
+  });
+  await harness.settle();
+  assert.deepEqual(harness.get().notifications, [notifA1]);
+  assert.equal(harness.get().error, null);
+
+  mode = 'failure';
+  harness.get().refetch();
+  await harness.settle();
+
+  assert.deepEqual(harness.get().notifications, [notifA1]);
+  assert.notEqual(harness.get().error, null);
+  assert.equal(harness.get().loading, false);
+});
+
+// 8. failure state에서는 automatic markAllRead가 실행되지 않는다
+test('8. failure state에서 automatic markAllRead가 실행되지 않는다', () => {
+  assert.match(
+    clientSource,
+    /if\s*\(\s*!loading\s*&&\s*!error\s*&&\s*notifications\.length\s*>\s*0\s*\)/,
+  );
+  assert.match(clientSource, /markAllRead\(\)/);
+  assert.doesNotMatch(clientSource, /if\s*\(\s*!loading\s*&&\s*notifications\.length\s*>\s*0\s*\)/);
+});
+
+// 9. authoritative success 이후에만 intended mark-all behavior
+test('9. authoritative success 이후에만 현재 intended mark-all behavior가 동작한다', async () => {
+  // hook: markAllRead는 현재 scope 목록을 readIds에 적재한다
+  const harness = mountHook({ fetchImpl: async () => okItems([notifA1, notifA2]) });
+  await harness.settle();
+  assert.equal(harness.get().readIds.size, 0);
+
+  harness.get().markAllRead();
+  await harness.settle();
+  assert.ok(harness.get().readIds.has('notif-a1'));
+  assert.ok(harness.get().readIds.has('notif-a2'));
+
+  // client: auto-read effect는 error를 의존하고 성공 가드 뒤에만 호출한다
+  assert.match(clientSource, /\[\s*loading,\s*error,\s*notifications\.length,\s*markAllRead\s*\]/);
+});
+
+// 10. readIds scope isolation
+test('10. readIds 저장소는 계정별로 격리되고 기존 공통 key를 공유하지 않는다', async () => {
+  const harness = mountHook({
+    fetchImpl: async (url, init) => {
+      const auth = init?.headers?.Authorization;
+      if (auth === 'Bearer token-b') return okItems([notifB1]);
+      return okItems([notifA1]);
+    },
+  });
+  await harness.settle();
+  assert.deepEqual(harness.get().notifications, [notifA1]);
+
+  harness.get().markAllRead();
+  await harness.settle();
+  const store = harness.storage().__store;
+  assert.equal(store.get('gh_read_notifications:user-a'), JSON.stringify(['notif-a1']));
+  assert.equal(store.has('gh_read_notifications'), false);
+
+  harness.setSession(USER_B);
+  await harness.settle();
+
+  assert.deepEqual(harness.get().notifications, [notifB1]);
+  assert.deepEqual([...harness.get().readIds], []);
+  // B scope에는 A의 읽음 표시가 넘어오지 않는다
+  assert.equal(harness.storage().__store.get('gh_read_notifications:user-a'), JSON.stringify(['notif-a1']));
+  assert.ok(!harness.get().readIds.has('notif-a1'));
+});
+
+test('hook은 userId+token scope·sequence race guard·tick refetch 계약을 가진다', () => {
+  assert.match(hookSource, /session\?\.user\?\.id/);
+  assert.match(hookSource, /requestSequenceRef/);
+  assert.match(hookSource, /requestSequenceRef\.current !== requestId/);
+  assert.match(hookSource, /void\s+tick/);
+  assert.match(hookSource, /\[\s*session\?\.user\?\.id,\s*session\?\.user\?\.accessToken,\s*tick\s*\]/);
+  assert.match(hookSource, /gh_read_notifications/);
+  assert.match(hookSource, /readKeyFor\(userId\)/);
+  assert.match(hookSource, /LEGACY_READ_KEY/);
+  assert.match(hookSource, /\/notifications\/me/);
+  assert.doesNotMatch(hookSource, /biome-ignore.*useExhaustiveDependencies/);
+  assert.doesNotMatch(hookSource, /location\.reload/);
+});
+
+test('client retry는 실제 fetch lifecycle에 연결되고 상태 우선순위를 지킨다', () => {
+  assert.match(clientSource, /refetch/);
+  assert.match(clientSource, /data-testid="notifications-retry"/);
+  assert.match(clientSource, /onClick=\{refetch\}/);
+  assert.match(clientSource, /다시 시도/);
+  assert.match(clientSource, /!loading && error && notifications\.length === 0/);
+  assert.match(clientSource, /!loading && !error && notifications\.length === 0/);
+  assert.match(clientSource, /loading && notifications\.length === 0/);
+  assert.match(clientSource, /이전 목록을 표시합니다/);
+  assert.doesNotMatch(clientSource, /location\.reload/);
+});

--- a/apps/consumer/src/hooks/useNotifications.ts
+++ b/apps/consumer/src/hooks/useNotifications.ts
@@ -1,25 +1,48 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { useSession } from 'next-auth/react';
 import type { Notification } from '@greenhub/shared';
 import { getApiBaseUrl } from '@/lib/api-base-url';
 
 const API_URL = getApiBaseUrl();
-const READ_KEY = 'gh_read_notifications';
+const LEGACY_READ_KEY = 'gh_read_notifications';
 
-function getReadIds(): Set<string> {
+function readKeyFor(userId: string): string {
+  return `${LEGACY_READ_KEY}:${userId}`;
+}
+
+function parseIdArray(raw: string | null): Set<string> | null {
+  if (raw === null) return null;
   try {
-    const raw = localStorage.getItem(READ_KEY);
-    return new Set(raw ? (JSON.parse(raw) as string[]) : []);
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return new Set();
+    return new Set(parsed.filter((v): v is string => typeof v === 'string'));
   } catch {
     return new Set();
   }
 }
 
-function saveReadIds(ids: Set<string>) {
+function getReadIdsFor(userId: string): Set<string> {
   try {
-    localStorage.setItem(READ_KEY, JSON.stringify([...ids]));
+    const scoped = parseIdArray(localStorage.getItem(readKeyFor(userId)));
+    if (scoped !== null) return scoped;
+    const legacy = parseIdArray(localStorage.getItem(LEGACY_READ_KEY));
+    const ids = legacy ?? new Set<string>();
+    try {
+      localStorage.setItem(readKeyFor(userId), JSON.stringify([...ids]));
+    } catch {
+      // ignore migration write failure: in-memory ids still apply
+    }
+    return ids;
+  } catch {
+    return new Set();
+  }
+}
+
+function saveReadIdsFor(userId: string, ids: Set<string>) {
+  try {
+    localStorage.setItem(readKeyFor(userId), JSON.stringify([...ids]));
   } catch {
     // ignore
   }
@@ -30,6 +53,7 @@ interface UseNotificationsResult {
   readIds: Set<string>;
   loading: boolean;
   error: string | null;
+  refetch: () => void;
   markAllRead: () => void;
   markRead: (id: string) => void;
 }
@@ -40,19 +64,41 @@ export function useNotifications(): UseNotificationsResult {
   const [readIds, setReadIds] = useState<Set<string>>(new Set());
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [tick, setTick] = useState(0);
+  // 최신 요청 식별자: cleanup된 이전 effect의 stale 응답이 최신 결과를 덮지 않게 한다.
+  const requestSequenceRef = useRef(0);
+  // session/user scope: 이전 사용자의 protected notifications가 새 scope에 노출되지 않게 한다.
+  // useOrders의 userId+token scope 격리와 동일한 계약이다.
+  const prevScopeRef = useRef<string | null>(null);
 
-  const token = session?.user?.accessToken;
-
-  useEffect(() => {
-    setReadIds(getReadIds());
+  const refetch = useCallback(() => {
+    setTick((t) => t + 1);
   }, []);
 
   useEffect(() => {
-    if (!token) {
+    // tick은 의도적인 수동 refetch 트리거다: 아래 void 참조로 effect와 명시적으로 연결한다.
+    void tick;
+    const userId = session?.user?.id;
+    const token = session?.user?.accessToken;
+    const scopeKey = userId && token ? `${userId}\0${token}` : null;
+    if (!userId || !token || !scopeKey) {
+      prevScopeRef.current = null;
+      setNotifications([]);
+      setReadIds(new Set());
+      setError(null);
       setLoading(false);
       return;
     }
 
+    if (prevScopeRef.current !== scopeKey) {
+      prevScopeRef.current = scopeKey;
+      setNotifications([]);
+      setError(null);
+      setReadIds(getReadIdsFor(userId));
+    }
+
+    const requestId = requestSequenceRef.current + 1;
+    requestSequenceRef.current = requestId;
     let cancelled = false;
     setLoading(true);
 
@@ -61,16 +107,20 @@ export function useNotifications(): UseNotificationsResult {
         const res = await fetch(`${API_URL}/notifications/me`, {
           headers: { Authorization: `Bearer ${token}` },
         });
-        if (cancelled) return;
+        if (cancelled || requestSequenceRef.current !== requestId) return;
         if (!res.ok) throw new Error(`조회 오류: ${res.status}`);
         const data = await res.json();
+        if (cancelled || requestSequenceRef.current !== requestId) return;
+        // 성공만 상태를 교체한다: error clear + 정상 empty([])도 성공으로 확정한다.
         setNotifications(data.items ?? []);
         setError(null);
+        setLoading(false);
       } catch (e: unknown) {
-        if (cancelled) return;
+        if (cancelled || requestSequenceRef.current !== requestId) return;
+        // 실패는 기존 성공 데이터를 삭제하지 않는다: notifications 유지, error만 교체한다.
+        // previous success + refresh failure는 stale list + failure로 표현된다.
         setError(e instanceof Error ? e.message : '오류가 발생했습니다.');
-      } finally {
-        if (!cancelled) setLoading(false);
+        setLoading(false);
       }
     }
 
@@ -78,27 +128,34 @@ export function useNotifications(): UseNotificationsResult {
     return () => {
       cancelled = true;
     };
-  }, [token]);
+  }, [session?.user?.id, session?.user?.accessToken, tick]);
 
-  const markRead = useCallback((id: string) => {
-    setReadIds((prev) => {
-      const next = new Set(prev);
-      next.add(id);
-      saveReadIds(next);
-      return next;
-    });
-  }, []);
+  const markRead = useCallback(
+    (id: string) => {
+      const userId = session?.user?.id;
+      if (!userId) return;
+      setReadIds((prev) => {
+        const next = new Set(prev);
+        next.add(id);
+        saveReadIdsFor(userId, next);
+        return next;
+      });
+    },
+    [session?.user?.id],
+  );
 
   const markAllRead = useCallback(() => {
+    const userId = session?.user?.id;
+    if (!userId) return;
     setReadIds((prev) => {
       const next = new Set(prev);
       notifications.forEach((notification) => {
         next.add(notification.id);
       });
-      saveReadIds(next);
+      saveReadIdsFor(userId, next);
       return next;
     });
-  }, [notifications]);
+  }, [notifications, session?.user?.id]);
 
-  return { notifications, readIds, loading, error, markAllRead, markRead };
+  return { notifications, readIds, loading, error, refetch, markAllRead, markRead };
 }


### PR DESCRIPTION
CONSUMER-NOTIFICATIONS-READ-RECOVERY republication (read-only preflight + ordinary publication).

Root cause:
- Prior notifications hook lacked auth scope isolation, race guard, retry lifecycle, and auto-read guard. Initial failure was indistinguishable from empty success; refresh failure wiped stale list; auto mark-all could fire on loading/error; readIds used a global key shared across accounts.

Auth scope isolation:
- userId + accessToken scopeKey; auth loss clears notifications/readIds/error; scope change drops previous protected state via prevScopeRef (same contract as useOrders).

Stale response protection:
- requestSequenceRef + cancelled flag; late A response cannot overwrite B scope (test 6).

Retry contract:
- tick + void tick + deps [id, token, tick]; refetch re-runs authoritative GET /notifications/me; no location.reload; retry buttons wired via data-testid notifications-retry.

Stale-list failure semantics:
- Success replaces state + clears error (empty [] is success); failure preserves notifications and sets error (stale list + failure). Initial failure != successful empty.

Automatic read guard:
- Client effect only when !loading && !error && notifications.length>0 with deps [loading, error, notifications.length, markAllRead].

Scoped readIds:
- gh_read_notifications:<userId> with legacy migration; no cross-account sharing (test 10).

Focused regression:
- node --test src/hooks/useOrders.test.mjs src/hooks/useAddresses.test.mjs src/hooks/useNotifications.test.mjs => 35/35 PASS (notifications 12/12).

Callback stability proof:
- markAllRead = useCallback deps [notifications, userId], excludes readIds/loading/error.
- Realistic memoized-React lifecycle check: success autoCalls=1, identities=2 then stable, extra settles no retrigger; failure autoCalls=0; success->refresh-failure adds 0 calls; localStorage write stable. No markAllRead->setReadIds->new identity->repeat loop.

Base: origin/main 505e3df9 (PR #101 banner, unrelated). No overlapping semantic mutator.
