### PR TITLE
fix(seller): recover store product read states

### DIFF
--- a/apps/seller/src/app/_components/StatusCards.tsx
+++ b/apps/seller/src/app/_components/StatusCards.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import type { Product } from '@greenhub/shared';
-import { Group, Stack, Text, UnstyledButton } from '@mantine/core';
-import { ChevronRight } from 'lucide-react';
+import { Button, Group, Stack, Text, UnstyledButton } from '@mantine/core';
+import { ChevronRight, RefreshCcw } from 'lucide-react';
 import Link from 'next/link';
 import { Fragment } from 'react';
 import type { OrderGroup } from '@/app/orders/_constants';
@@ -113,10 +113,62 @@ export function SettlementCard({
 }
 
 // ─── 상품 현황 카드 ──────────────────────────────────────────────
+// 상품 조회 실패·로딩 중을 정상 0건으로 표시하지 않는다.
+// 첫 실패는 counts 대신 오류 + retry, stale은 이전 수치 + 갱신 실패 표시.
 
-export function ProductStatusCard({ products }: { products: Product[] }) {
+export function ProductStatusCard({
+  products,
+  loading,
+  error,
+  hasLoaded,
+  onRetry,
+}: {
+  products: Product[];
+  loading: boolean;
+  error: string | null;
+  hasLoaded: boolean;
+  onRetry?: () => void;
+}) {
+  if (!hasLoaded && loading) {
+    return (
+      <DashboardCard title="상품 현황" moreHref="/products">
+        <Text style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-text-disabled)' }}>
+          불러오는 중…
+        </Text>
+      </DashboardCard>
+    );
+  }
+
+  if (error && !hasLoaded) {
+    return (
+      <DashboardCard title="상품 현황" moreHref="/products">
+        <Stack gap="xs">
+          <Text
+            role="alert"
+            style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-text-disabled)' }}
+          >
+            상품 정보를 불러오지 못했습니다.
+          </Text>
+          {onRetry && (
+            <Button
+              size="xs"
+              variant="light"
+              color="red"
+              leftSection={<RefreshCcw size={14} />}
+              onClick={onRetry}
+              style={{ alignSelf: 'flex-start' }}
+            >
+              다시 조회
+            </Button>
+          )}
+        </Stack>
+      </DashboardCard>
+    );
+  }
+
   const activeCount = products.filter((p) => p.isActive).length;
   const inactiveCount = products.length - activeCount;
+  const isStale = hasLoaded && error !== null;
   return (
     <DashboardCard title="상품 현황" moreHref="/products">
       <Group gap="lg">
@@ -144,6 +196,28 @@ export function ProductStatusCard({ products }: { products: Product[] }) {
           </Text>
         </Group>
       </Group>
+      {isStale && (
+        <Stack gap="xs" mt="xs">
+          <Text
+            role="alert"
+            style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-text-disabled)' }}
+          >
+            최신 정보를 확인하지 못했습니다. 이전 수치입니다.
+          </Text>
+          {onRetry && (
+            <Button
+              size="xs"
+              variant="light"
+              color="yellow"
+              leftSection={<RefreshCcw size={14} />}
+              onClick={onRetry}
+              style={{ alignSelf: 'flex-start' }}
+            >
+              다시 조회
+            </Button>
+          )}
+        </Stack>
+      )}
     </DashboardCard>
   );
 }

--- a/apps/seller/src/app/_components/TodayTasksCard.tsx
+++ b/apps/seller/src/app/_components/TodayTasksCard.tsx
@@ -19,13 +19,25 @@ interface TaskRow {
  * 홈 최상단 "오늘 할 일" 체크리스트.
  * 각 줄은 건수 > 0일 때만 렌더, 전부 0이면 완료 메시지.
  * 모든 항목은 홈이 이미 로드하는 데이터로 계산 — 신규 API 없음.
+ * 상품 집계는 신뢰 가능할 때만 사용한다. 상품 조회 실패·로딩 중에는
+ * 비활성 상품 0건으로 오인하지 않고 경고로 분리한다.
  */
-export function TodayTasksCard({ orders, products }: { orders: Order[]; products: Product[] }) {
+export function TodayTasksCard({
+  orders,
+  products,
+  productsError,
+  productsTrustworthy,
+}: {
+  orders: Order[];
+  products: Product[];
+  productsError: string | null;
+  productsTrustworthy: boolean;
+}) {
   const newOrderCount = orders.filter(
     (o) => STATUS_GROUP_MAP[o.status] === 'ACTION_REQUIRED',
   ).length;
   const delayedCount = orders.filter((o) => isDelayed(o)).length;
-  const inactiveCount = products.filter((p) => !p.isActive).length;
+  const inactiveCount = productsTrustworthy ? products.filter((p) => !p.isActive).length : 0;
 
   const tasks: TaskRow[] = [];
   if (newOrderCount > 0)
@@ -42,7 +54,7 @@ export function TodayTasksCard({ orders, products }: { orders: Order[]; products
       label: `발송 지연 ${delayedCount}건 확인`,
       href: '/prep',
     });
-  if (inactiveCount > 0)
+  if (productsTrustworthy && inactiveCount > 0)
     tasks.push({
       key: 'inactive',
       icon: '⚠️',
@@ -50,11 +62,31 @@ export function TodayTasksCard({ orders, products }: { orders: Order[]; products
       href: '/products',
     });
 
+  const showProductWarning = !productsTrustworthy;
+
   return (
     <DashboardCard title="☀️ 오늘 할 일">
-      {tasks.length === 0 ? (
+      {showProductWarning && (
+        <Text
+          role={productsError ? 'alert' : 'status'}
+          style={{
+            fontSize: 'var(--font-size-sm)',
+            color: 'var(--color-text-disabled)',
+            marginBottom: tasks.length === 0 ? 0 : 8,
+          }}
+        >
+          {productsError
+            ? '상품 정보를 불러오지 못했습니다. 비활성 상품 점검을 건너뜁니다.'
+            : '상품 상태 확인 중… 비활성 상품 점검을 잠시 건너뜁니다.'}
+        </Text>
+      )}
+      {tasks.length === 0 && productsTrustworthy ? (
         <Text style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-text-secondary)' }}>
           오늘 할 일을 모두 마쳤어요 🎉
+        </Text>
+      ) : tasks.length === 0 && !productsTrustworthy ? (
+        <Text style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-text-secondary)' }}>
+          주문 할 일은 없습니다.
         </Text>
       ) : (
         <Stack gap={0}>

--- a/apps/seller/src/app/page.tsx
+++ b/apps/seller/src/app/page.tsx
@@ -14,6 +14,7 @@ import { LoadingState } from '@/components/StateViews';
 import { useDashboardSummary } from '@/hooks/useDashboardSummary';
 import { useOrders } from '@/hooks/useOrders';
 import { useStoreProducts } from '@/hooks/useStoreProducts';
+import { areStoreProductCountsTrustworthy } from '@/hooks/useStoreProducts.recovery';
 
 export default function Home() {
   const { data: session, status } = useSession();
@@ -21,8 +22,19 @@ export default function Home() {
   const storeId = session?.user.storeId ?? null;
   const firebaseReady = useFirebaseReady();
   const { orders, loading, error, groupCounts } = useOrders(storeId);
-  const { products } = useStoreProducts(storeId);
+  const {
+    products,
+    loading: productsLoading,
+    error: productsError,
+    retry: retryProducts,
+    hasLoaded: productsHasLoaded,
+  } = useStoreProducts(storeId);
   const { summary, loading: summaryLoading, error: summaryError } = useDashboardSummary();
+  const productsTrustworthy = areStoreProductCountsTrustworthy({
+    hasLoaded: productsHasLoaded,
+    loading: productsLoading,
+    error: productsError,
+  });
 
   useEffect(() => {
     if (status === 'loading') return;
@@ -52,10 +64,21 @@ export default function Home() {
 
       <Container size="sm" py="md">
         <Stack gap="md">
-          <TodayTasksCard orders={orders} products={products} />
+          <TodayTasksCard
+            orders={orders}
+            products={products}
+            productsError={productsError}
+            productsTrustworthy={productsTrustworthy}
+          />
           <OrderStatusCard groupCounts={groupCounts} />
           <SettlementCard summary={summary} loading={summaryLoading} error={summaryError} />
-          <ProductStatusCard products={products} />
+          <ProductStatusCard
+            products={products}
+            loading={productsLoading}
+            error={productsError}
+            hasLoaded={productsHasLoaded}
+            onRetry={retryProducts}
+          />
         </Stack>
       </Container>
     </PageShell>

--- a/apps/seller/src/app/prep/page.tsx
+++ b/apps/seller/src/app/prep/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { Box, Container, Group, Paper, Stack, Text, UnstyledButton } from '@mantine/core';
-import { ChevronRight } from 'lucide-react';
+import { Alert, Box, Button, Container, Group, Paper, Stack, Text, UnstyledButton } from '@mantine/core';
+import { ChevronRight, RefreshCcw } from 'lucide-react';
 import Link from 'next/link';
 import { useSession } from 'next-auth/react';
 import { useMemo } from 'react';
@@ -12,6 +12,7 @@ import { PageShell } from '@/components/PageShell';
 import { EmptyState, LoadingState } from '@/components/StateViews';
 import { useOrders } from '@/hooks/useOrders';
 import { useStoreProducts } from '@/hooks/useStoreProducts';
+import { resolveStoreProductsView } from '@/hooks/useStoreProducts.recovery';
 import { aggregatePrep, type PrepLine } from '@/lib/prep';
 
 function PrepRow({ line, index, accent }: { line: PrepLine; index: number; accent?: boolean }) {
@@ -57,11 +58,26 @@ export default function PrepPage() {
   const storeId = session?.user.storeId ?? null;
   const firebaseReady = useFirebaseReady();
   const { orders, loading, error } = useOrders(storeId);
-  const { products } = useStoreProducts(storeId);
+  const {
+    products,
+    loading: productsLoading,
+    error: productsError,
+    retry: retryProducts,
+    hasLoaded: productsHasLoaded,
+  } = useStoreProducts(storeId);
 
   const { today, delayed } = useMemo(() => aggregatePrep(orders, products), [orders, products]);
 
-  const isConnecting = loading || !firebaseReady;
+  const productsView = resolveStoreProductsView({
+    storeId,
+    loading: productsLoading,
+    error: productsError,
+    productCount: products.length,
+    hasLoaded: productsHasLoaded,
+  });
+  // 상품 첫 조회가 끝나기 전에는 준비 목록을 확정 0건처럼 표시하지 않는다.
+  const isProductsConnecting = !!storeId && productsView === 'LOADING';
+  const isConnecting = loading || isProductsConnecting || !firebaseReady;
 
   const todayLabel = new Date().toLocaleDateString('ko-KR', { month: 'long', day: 'numeric' });
   const todayTotal = today.reduce((sum, l) => sum + l.quantity, 0);
@@ -81,6 +97,45 @@ export default function PrepPage() {
       />
 
       <Container size="sm" px="md" py="md">
+        {!!storeId && productsView === 'READ_FAILED' && !isConnecting && (
+          <Alert color="red" title="상품 정보를 불러오지 못했습니다" role="alert" mb="md">
+            <Stack gap="xs">
+              <Text style={{ fontSize: 'var(--font-size-sm)' }}>
+                준비 수량의 상품 이름이 &lsquo;상품 정보 없음&rsquo;으로 표시될 수 있습니다.
+                수량 자체는 주문 기준으로 집계됩니다.
+              </Text>
+              <Button
+                size="xs"
+                variant="light"
+                color="red"
+                leftSection={<RefreshCcw size={14} />}
+                onClick={retryProducts}
+              >
+                상품 다시 조회
+              </Button>
+            </Stack>
+          </Alert>
+        )}
+
+        {!!storeId && productsView === 'STALE' && !isConnecting && (
+          <Alert color="yellow" title="최신 상품 정보를 확인하지 못했습니다" role="alert" mb="md">
+            <Stack gap="xs">
+              <Text style={{ fontSize: 'var(--font-size-sm)' }}>
+                이전 상품 이름으로 표시합니다. 준비 수량 자체는 주문 기준으로 집계됩니다.
+              </Text>
+              <Button
+                size="xs"
+                variant="light"
+                color="yellow"
+                leftSection={<RefreshCcw size={14} />}
+                onClick={retryProducts}
+              >
+                상품 다시 조회
+              </Button>
+            </Stack>
+          </Alert>
+        )}
+
         {isConnecting && <LoadingState />}
 
         {!isConnecting && today.length === 0 && delayed.length === 0 && (

--- a/apps/seller/src/app/products/page.tsx
+++ b/apps/seller/src/app/products/page.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import type { Product } from '@greenhub/shared';
-import { Box, Button, Container, Group, Paper, Stack, Switch, Text } from '@mantine/core';
+import { Alert, Box, Button, Container, Group, Paper, Stack, Switch, Text } from '@mantine/core';
+import { RefreshCcw } from 'lucide-react';
 import Image from 'next/image';
 import Link from 'next/link';
 import { useSession } from 'next-auth/react';
@@ -12,6 +13,10 @@ import { PageShell } from '@/components/PageShell';
 import { SegmentedTabs } from '@/components/SegmentedTabs';
 import { EmptyState, LoadingState } from '@/components/StateViews';
 import { useStoreProducts } from '@/hooks/useStoreProducts';
+import {
+  resolveStoreProductsFilteredView,
+  resolveStoreProductsView,
+} from '@/hooks/useStoreProducts.recovery';
 import { ApiError, apiJson } from '@/lib/api';
 
 type ProductFilter = 'all' | 'active' | 'inactive';
@@ -23,9 +28,9 @@ const CATEGORY_LABEL: Record<string, string> = {
 };
 
 export default function ProductsPage() {
-  const { data: session } = useSession();
+  const { data: session, status: sessionStatus } = useSession();
   const storeId = session?.user.storeId ?? null;
-  const { products, loading } = useStoreProducts(storeId);
+  const { products, loading, error, retry, hasLoaded, isStale } = useStoreProducts(storeId);
   const [filter, setFilter] = useState<ProductFilter>('all');
 
   const filtered = products.filter((p) => {
@@ -33,6 +38,19 @@ export default function ProductsPage() {
     if (filter === 'inactive') return !p.isActive;
     return true;
   });
+
+  const view = resolveStoreProductsView({
+    storeId,
+    loading,
+    error,
+    productCount: products.length,
+    hasLoaded,
+  });
+  const listView = resolveStoreProductsFilteredView(view, filtered.length);
+  // 초기 로딩·첫 조회 실패 단계에서는 0건 카운트를 확정 수치처럼 노출하지 않는다.
+  const countLabel = (count: number) => (hasLoaded && !error ? String(count) : '…');
+  const activeCount = products.filter((p) => p.isActive).length;
+  const inactiveCount = products.length - activeCount;
 
   return (
     <PageShell>
@@ -54,20 +72,73 @@ export default function ProductsPage() {
       {/* 필터 탭 */}
       <SegmentedTabs<ProductFilter>
         tabs={[
-          { key: 'all', label: `전체 ${products.length}` },
-          { key: 'active', label: `판매 중 ${products.filter((p) => p.isActive).length}` },
-          { key: 'inactive', label: `비활성 ${products.filter((p) => !p.isActive).length}` },
+          { key: 'all', label: `전체 ${countLabel(products.length)}` },
+          { key: 'active', label: `판매 중 ${countLabel(activeCount)}` },
+          { key: 'inactive', label: `비활성 ${countLabel(inactiveCount)}` },
         ]}
         value={filter}
         onChange={setFilter}
       />
 
-      {/* 상품 목록 */}
+      {/* 상품 목록 — error/empty/filter-empty 분리. 첫 조회 실패는 empty로 collapse하지 않는다. */}
       <Container size="sm" px="md" py="md">
         <Stack gap="sm">
-          {loading && <LoadingState />}
+          {!storeId && sessionStatus === 'loading' && <LoadingState />}
 
-          {!loading && filtered.length === 0 && (
+          {!storeId && sessionStatus !== 'loading' && (
+            <Alert color="red" title="스토어 정보를 확인할 수 없습니다" role="alert">
+              로그인된 셀러 스토어 정보를 확인한 뒤 다시 시도해 주세요.
+            </Alert>
+          )}
+
+          {!!storeId && listView === 'loading' && <LoadingState />}
+
+          {!!storeId && listView === 'error' && (
+            <Alert
+              color="red"
+              title="상품을 불러오지 못했습니다"
+              role="alert"
+            >
+              <Stack gap="xs">
+                <Text style={{ fontSize: 'var(--font-size-sm)' }}>{error}</Text>
+                <Button
+                  size="xs"
+                  variant="light"
+                  color="red"
+                  leftSection={<RefreshCcw size={14} />}
+                  onClick={retry}
+                >
+                  다시 조회
+                </Button>
+              </Stack>
+            </Alert>
+          )}
+
+          {!!storeId && isStale && (
+            <Alert
+              color="yellow"
+              title="최신 상품 정보를 확인하지 못했습니다"
+              role="alert"
+            >
+              <Stack gap="xs">
+                <Text style={{ fontSize: 'var(--font-size-sm)' }}>
+                  이전 목록을 표시합니다. 상태 변경·삭제는 서버 기준으로 처리되며 목록이
+                  오래된 상태일 수 있습니다.
+                </Text>
+                <Button
+                  size="xs"
+                  variant="light"
+                  color="yellow"
+                  leftSection={<RefreshCcw size={14} />}
+                  onClick={retry}
+                >
+                  다시 조회
+                </Button>
+              </Stack>
+            </Alert>
+          )}
+
+          {!!storeId && listView === 'empty' && (
             <EmptyState
               icon={
                 <svg
@@ -102,9 +173,15 @@ export default function ProductsPage() {
             />
           )}
 
-          {filtered.map((product) => (
-            <ProductCard key={product.id} product={product} storeId={storeId} />
-          ))}
+          {!!storeId && listView === 'filter-empty' && (
+            <EmptyState text="조건에 맞는 상품이 없습니다" />
+          )}
+
+          {!!storeId && (listView === 'list' || listView === 'stale') && (
+            filtered.map((product) => (
+              <ProductCard key={product.id} product={product} storeId={storeId} />
+            ))
+          )}
         </Stack>
       </Container>
     </PageShell>

--- a/apps/seller/src/app/sale-rounds/[id]/page.tsx
+++ b/apps/seller/src/app/sale-rounds/[id]/page.tsx
@@ -211,12 +211,19 @@ function RoundEditor({
   onSave: (input: CreateSaleRoundInput) => Promise<void>;
   onRetry: () => void;
 }) {
-  const { products, loading, error } = useStoreProducts(round.storeId);
+  const { products, loading, error, retry: retryProducts } = useStoreProducts(round.storeId);
 
   if (loading) return <LoadingState />;
   if (error) {
     return (
-      <ErrorState title="스토어 상품을 불러오지 못했습니다" message={error} onRetry={onRetry} />
+      <ErrorState
+        title="스토어 상품을 불러오지 못했습니다"
+        message={error}
+        onRetry={() => {
+          retryProducts();
+          onRetry();
+        }}
+      />
     );
   }
 

--- a/apps/seller/src/hooks/useStoreProducts.recovery.test.ts
+++ b/apps/seller/src/hooks/useStoreProducts.recovery.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, it } from 'vitest';
+import {
+  areStoreProductCountsTrustworthy,
+  isStoreProductsBackgroundRefresh,
+  nextStoreProductsRetryKey,
+  resolveStoreProductsFilteredView,
+  resolveStoreProductsView,
+  shouldIgnoreStoreProductsCallback,
+  shouldInvalidateStoreProductsScope,
+  shouldResubscribeStoreProducts,
+} from './useStoreProducts.recovery';
+
+describe('Seller 상품 read recovery — scope invalidation (A/B)', () => {
+  it('store A 성공 snapshot은 READY로 표시된다', () => {
+    expect(
+      resolveStoreProductsView({
+        storeId: 'store-a',
+        loading: false,
+        error: null,
+        productCount: 2,
+        hasLoaded: true,
+      }),
+    ).toBe('READY');
+  });
+
+  it('scope 변경(A→B, A→null, null→A)은 이전 데이터를 무효화한다', () => {
+    expect(shouldInvalidateStoreProductsScope('store-a', 'store-b')).toBe(true);
+    expect(shouldInvalidateStoreProductsScope('store-a', null)).toBe(true);
+    expect(shouldInvalidateStoreProductsScope(null, 'store-a')).toBe(true);
+  });
+
+  it('동일 scope는 무효화하지 않는다', () => {
+    expect(shouldInvalidateStoreProductsScope('store-a', 'store-a')).toBe(false);
+    expect(shouldInvalidateStoreProductsScope(null, null)).toBe(false);
+  });
+
+  it('scope 미확정(null)은 어떤 products 길이라도 empty/ready로 승격하지 않는다', () => {
+    expect(
+      resolveStoreProductsView({
+        storeId: null,
+        loading: false,
+        error: null,
+        productCount: 0,
+        hasLoaded: false,
+      }),
+    ).toBe('LOADING');
+    expect(
+      resolveStoreProductsView({
+        storeId: null,
+        loading: false,
+        error: null,
+        productCount: 3,
+        hasLoaded: false,
+      }),
+    ).toBe('LOADING');
+  });
+
+  it('usable previous data가 없는 첫 조회는 loading이다', () => {
+    expect(
+      resolveStoreProductsView({
+        storeId: 'store-a',
+        loading: true,
+        error: null,
+        productCount: 0,
+        hasLoaded: false,
+      }),
+    ).toBe('LOADING');
+  });
+});
+
+describe('Seller 상품 read recovery — failure vs empty (C/D)', () => {
+  it('첫 조회 실패는 empty가 아니라 READ_FAILED다', () => {
+    expect(
+      resolveStoreProductsView({
+        storeId: 'store-a',
+        loading: false,
+        error: '상품을 불러오지 못했습니다.',
+        productCount: 0,
+        hasLoaded: false,
+      }),
+    ).toBe('READ_FAILED');
+  });
+
+  it('Firestore 성공 0건만 true empty다', () => {
+    expect(
+      resolveStoreProductsView({
+        storeId: 'store-a',
+        loading: false,
+        error: null,
+        productCount: 0,
+        hasLoaded: true,
+      }),
+    ).toBe('EMPTY');
+  });
+
+  it('로딩 중 0건·실패 0건을 성공 empty로 승격하지 않는다', () => {
+    expect(
+      resolveStoreProductsView({
+        storeId: 'store-a',
+        loading: true,
+        error: null,
+        productCount: 0,
+        hasLoaded: false,
+      }),
+    ).not.toBe('EMPTY');
+    expect(
+      resolveStoreProductsView({
+        storeId: 'store-a',
+        loading: false,
+        error: 'boom',
+        productCount: 0,
+        hasLoaded: false,
+      }),
+    ).not.toBe('EMPTY');
+  });
+});
+
+describe('Seller 상품 read recovery — stale preservation (E)', () => {
+  it('이전 성공 뒤 listener 실패는 STALE이며 []로 지우지 않는다', () => {
+    expect(
+      resolveStoreProductsView({
+        storeId: 'store-a',
+        loading: false,
+        error: 'listener failed',
+        productCount: 2,
+        hasLoaded: true,
+      }),
+    ).toBe('STALE');
+  });
+
+  it('stale은 background 갱신으로 취급하고 initial loading으로 되돌리지 않는다', () => {
+    expect(isStoreProductsBackgroundRefresh(true)).toBe(true);
+    expect(isStoreProductsBackgroundRefresh(false)).toBe(false);
+  });
+
+  it('stale 집계는 신뢰 가능한 0으로 취급하지 않는다', () => {
+    expect(
+      areStoreProductCountsTrustworthy({ hasLoaded: true, loading: false, error: 'boom' }),
+    ).toBe(false);
+  });
+
+  it('늦은 scope의 snapshot/error 콜백은 무시하고 최신 scope만 허용한다', () => {
+    expect(shouldIgnoreStoreProductsCallback(false, 'store-a', 'store-a')).toBe(true);
+    expect(shouldIgnoreStoreProductsCallback(true, 'store-a', 'store-b')).toBe(true);
+    expect(shouldIgnoreStoreProductsCallback(true, 'store-a', 'store-a')).toBe(false);
+  });
+});
+
+describe('Seller 상품 read recovery — retry resubscribe (F)', () => {
+  it('retry 키는 단조 증가하고 키 변경이 재구독을 의미한다', () => {
+    const prev = 0;
+    const next = nextStoreProductsRetryKey(prev);
+    expect(next).not.toBe(prev);
+    expect(next).toBe(1);
+    expect(shouldResubscribeStoreProducts(prev, next)).toBe(true);
+    expect(shouldResubscribeStoreProducts(next, next)).toBe(false);
+  });
+
+  it('연속 retry가 guard를 깨지 않는다', () => {
+    const k1 = nextStoreProductsRetryKey(0);
+    const k2 = nextStoreProductsRetryKey(k1);
+    expect(shouldResubscribeStoreProducts(0, k2)).toBe(true);
+    expect(shouldResubscribeStoreProducts(k2, k2)).toBe(false);
+  });
+});
+
+describe('Seller 상품 read recovery — ProductsPage error precedence / filter-empty (G/H)', () => {
+  it('read error가 empty/filter-empty보다 우선한다', () => {
+    const view = resolveStoreProductsView({
+      storeId: 'store-a',
+      loading: false,
+      error: 'boom',
+      productCount: 0,
+      hasLoaded: false,
+    });
+    expect(resolveStoreProductsFilteredView(view, 0)).toBe('error');
+  });
+
+  it('filter 0건은 read error와 별개다', () => {
+    const ready = resolveStoreProductsView({
+      storeId: 'store-a',
+      loading: false,
+      error: null,
+      productCount: 2,
+      hasLoaded: true,
+    });
+    expect(resolveStoreProductsFilteredView(ready, 0)).toBe('filter-empty');
+    expect(resolveStoreProductsFilteredView(ready, 1)).toBe('list');
+  });
+
+  it('성공 empty와 filter-empty를 구분한다', () => {
+    const empty = resolveStoreProductsView({
+      storeId: 'store-a',
+      loading: false,
+      error: null,
+      productCount: 0,
+      hasLoaded: true,
+    });
+    expect(resolveStoreProductsFilteredView(empty, 0)).toBe('empty');
+  });
+
+  it('stale + 목록 있음은 stale을 유지하고 지우지 않는다', () => {
+    const stale = resolveStoreProductsView({
+      storeId: 'store-a',
+      loading: false,
+      error: 'boom',
+      productCount: 2,
+      hasLoaded: true,
+    });
+    expect(resolveStoreProductsFilteredView(stale, 2)).toBe('stale');
+  });
+});
+
+describe('Seller 상품 read recovery — Prep/Home 집계 신뢰도 (I)', () => {
+  it('hasLoaded + error 없음일 때만 집계가 신뢰 가능하다', () => {
+    expect(
+      areStoreProductCountsTrustworthy({ hasLoaded: true, loading: false, error: null }),
+    ).toBe(true);
+  });
+
+  it('초기 로딩·첫 실패는 정상 0으로 오인하지 않는다', () => {
+    expect(
+      areStoreProductCountsTrustworthy({ hasLoaded: false, loading: true, error: null }),
+    ).toBe(false);
+    expect(
+      areStoreProductCountsTrustworthy({ hasLoaded: false, loading: false, error: 'boom' }),
+    ).toBe(false);
+  });
+
+  it('stale은 신뢰 불가이므로 홈 완료 메시지와 0/0 현황으로 승격하지 않는다', () => {
+    expect(
+      areStoreProductCountsTrustworthy({ hasLoaded: true, loading: false, error: 'boom' }),
+    ).toBe(false);
+    expect(
+      areStoreProductCountsTrustworthy({ hasLoaded: true, loading: true, error: null }),
+    ).toBe(false);
+  });
+});

--- a/apps/seller/src/hooks/useStoreProducts.recovery.ts
+++ b/apps/seller/src/hooks/useStoreProducts.recovery.ts
@@ -1,0 +1,117 @@
+/**
+ * Seller 상품 조회 read recovery 순수 계약.
+ * `useStoreProducts.ts`의 runtime effect와 동일한 판정을 공유하되,
+ * vitest에서 `@/` alias 없이 직접 검증할 수 있도록 framework 의존성을 두지 않는다.
+ *
+ * Collapse 방지 원칙:
+ * - Firestore 성공 0건만 true empty.
+ * - 첫 조회 실패는 상품 0건으로 표시하지 않고 visible error + retry.
+ * - 이전 정상 snapshot 뒤 listener 실패는 stale을 유지하고 []로 지우지 않는다.
+ * - scope(storeId) 변경 시 이전 store 데이터를 새 scope의 authoritative data처럼 노출하지 않는다.
+ */
+
+export type StoreProductsScope = string | null;
+
+export type StoreProductsView = 'LOADING' | 'READ_FAILED' | 'STALE' | 'EMPTY' | 'READY';
+
+export interface StoreProductsViewInput {
+  storeId: StoreProductsScope;
+  loading: boolean;
+  error: string | null;
+  productCount: number;
+  hasLoaded: boolean;
+}
+
+/** scope가 바뀌면 이전 scope 데이터를 무효화해야 한다 (A→B, A→null, null→A 포함). */
+export function shouldInvalidateStoreProductsScope(
+  prevStoreId: StoreProductsScope,
+  nextStoreId: StoreProductsScope,
+): boolean {
+  return prevStoreId !== nextStoreId;
+}
+
+/** 이전 정상 데이터가 있으면 initial loading으로 되돌리지 않고 background 갱신으로 취급한다. */
+export function isStoreProductsBackgroundRefresh(hasLoaded: boolean): boolean {
+  return hasLoaded;
+}
+
+/**
+ * 상품 목록 읽기 상태를 단일 view로 판정한다.
+ * 우선순위: SCOPE 미확정/초기 로딩 > 첫 조회 실패 > stale > 성공 empty > 정상 목록.
+ */
+export function resolveStoreProductsView(input: StoreProductsViewInput): StoreProductsView {
+  const { storeId, loading, error, productCount, hasLoaded } = input;
+
+  if (!storeId) {
+    return 'LOADING';
+  }
+  if (!hasLoaded && loading && !error) {
+    return 'LOADING';
+  }
+  if (error && !hasLoaded) {
+    return 'READ_FAILED';
+  }
+  if (error && hasLoaded) {
+    return 'STALE';
+  }
+  if (!error && hasLoaded && productCount === 0) {
+    return 'EMPTY';
+  }
+  if (!error && hasLoaded && productCount > 0) {
+    return 'READY';
+  }
+  // hasLoaded=false인데 loading도 error도 없는 transient (scope 전환 직후 등)는 로딩으로 닫는다.
+  if (!hasLoaded) {
+    return 'LOADING';
+  }
+  return 'READY';
+}
+
+/** 목록 view에서 필터 0건은 read error와 별개로 판정한다. */
+export function resolveStoreProductsFilteredView(
+  view: StoreProductsView,
+  filteredCount: number,
+): 'error' | 'stale' | 'loading' | 'empty' | 'filter-empty' | 'list' {
+  if (view === 'LOADING') return 'loading';
+  if (view === 'READ_FAILED') return 'error';
+  if (view === 'STALE') return filteredCount === 0 ? 'filter-empty' : 'stale';
+  if (view === 'EMPTY') return 'empty';
+  if (filteredCount === 0) return 'filter-empty';
+  return 'list';
+}
+
+/**
+ * 상품 기반 집계(준비 수량·홈 현황)를 신뢰 가능한 수치로 취급해도 되는지 판정한다.
+ * - hasLoaded + error 없음일 때만 신뢰.
+ * - 초기 로딩·첫 실패·stale 모두 신뢰 불가(정상 0으로 오인 금지).
+ */
+export function areStoreProductCountsTrustworthy(input: {
+  hasLoaded: boolean;
+  loading: boolean;
+  error: string | null;
+}): boolean {
+  if (input.error) return false;
+  if (!input.hasLoaded) return false;
+  if (input.loading) return false;
+  return true;
+}
+
+/** listener 재구독 키. retry 호출마다 단조 증가하며 effect deps로 사용된다. */
+export function nextStoreProductsRetryKey(current: number): number {
+  return current + 1;
+}
+
+/** retry 키가 바뀌면 기존 listener를 정리하고 재구독해야 한다. */
+export function shouldResubscribeStoreProducts(prevKey: number, nextKey: number): boolean {
+  return prevKey !== nextKey;
+}
+
+/** race guard: 취소됐거나 최신 scope/구독이 아니면 snapshot/error 콜백을 무시한다. */
+export function shouldIgnoreStoreProductsCallback(
+  active: boolean,
+  subscribedStoreId: StoreProductsScope,
+  currentStoreId: StoreProductsScope,
+): boolean {
+  if (!active) return true;
+  return subscribedStoreId !== currentStoreId;
+}

--- a/apps/seller/src/hooks/useStoreProducts.ts
+++ b/apps/seller/src/hooks/useStoreProducts.ts
@@ -2,31 +2,78 @@
 
 import type { Product } from '@greenhub/shared';
 import { collection, onSnapshot, query, where } from 'firebase/firestore';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { db } from '@/lib/firebase';
+import {
+  isStoreProductsBackgroundRefresh,
+  shouldIgnoreStoreProductsCallback,
+} from './useStoreProducts.recovery';
 
 interface UseStoreProductsResult {
   products: Product[];
   loading: boolean;
   error: string | null;
+  retry: () => void;
+  /** 현재 scope에서 Firestore 성공 snapshot을 1회 이상 수신했는지. 성공 0건도 true. */
+  hasLoaded: boolean;
+  /** 이전 정상 데이터가 있는 상태에서 listener가 실패한 stale 상태. */
+  isStale: boolean;
 }
 
 export function useStoreProducts(storeId: string | null): UseStoreProductsResult {
   const [products, setProducts] = useState<Product[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [hasLoaded, setHasLoaded] = useState(false);
+  const [retryKey, setRetryKey] = useState(0);
+  const [scope, setScope] = useState(storeId);
+  const scopeRef = useRef(storeId);
+  const hasLoadedRef = useRef(false);
+
+  // Scope 변경(A→B, A→null, null→A)이면 이전 store 데이터를
+  // 새 scope의 authoritative data처럼 노출하지 않도록 렌더 단계에서 무효화한다.
+  if (scope !== storeId) {
+    scopeRef.current = storeId;
+    hasLoadedRef.current = false;
+    setScope(storeId);
+    setProducts([]);
+    setError(null);
+    setHasLoaded(false);
+    setLoading(true);
+  }
+
+  const retry = useCallback(() => {
+    setRetryKey((key) => key + 1);
+  }, []);
 
   useEffect(() => {
-    if (!storeId) {
+    void retryKey;
+    const subscribedStoreId = scope;
+    scopeRef.current = subscribedStoreId;
+
+    if (!subscribedStoreId) {
       setLoading(false);
       return;
     }
 
-    const q = query(collection(db, 'products'), where('storeId', '==', storeId));
+    if (isStoreProductsBackgroundRefresh(hasLoadedRef.current)) {
+      // stale 유지 중 재구독은 initial loading으로 되돌리지 않고
+      // 이전 오류를 성공 snapshot까지 유지해 fresh처럼 보이지 않게 한다.
+      setLoading(false);
+    } else {
+      setLoading(true);
+      setError(null);
+    }
 
+    const q = query(collection(db, 'products'), where('storeId', '==', subscribedStoreId));
+
+    let active = true;
     const unsubscribe = onSnapshot(
       q,
       (snap) => {
+        if (shouldIgnoreStoreProductsCallback(active, subscribedStoreId, scopeRef.current)) {
+          return;
+        }
         const items = snap.docs
           .map((d) => {
             const data = d.data();
@@ -35,18 +82,33 @@ export function useStoreProducts(storeId: string | null): UseStoreProductsResult
             return { id: d.id, ...data } as Product;
           })
           .sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+        hasLoadedRef.current = true;
         setProducts(items);
+        setHasLoaded(true);
         setLoading(false);
         setError(null);
       },
       (err) => {
-        setError(err.message);
+        if (shouldIgnoreStoreProductsCallback(active, subscribedStoreId, scopeRef.current)) {
+          return;
+        }
+        // 첫 조회 실패는 []를 성공 empty로 승격하지 않도록 hasLoaded=false를 유지한다.
+        // 이전 정상 snapshot이 있으면 stale 데이터를 지우지 않고 오류만 기록한다.
+        setError(err instanceof Error ? err.message : '상품을 불러오지 못했습니다.');
         setLoading(false);
+        if (!hasLoadedRef.current) {
+          setProducts([]);
+          setHasLoaded(false);
+        }
       },
     );
 
-    return unsubscribe;
-  }, [storeId]);
+    return () => {
+      active = false;
+      unsubscribe();
+    };
+  }, [scope, retryKey]);
 
-  return { products, loading, error };
+  const isStale = hasLoaded && error !== null;
+  return { products, loading, error, retry, hasLoaded, isStale };
 }


### PR DESCRIPTION
Task: SELLER-PRODUCTS-READ-RECOVERY-01

Root cause:
useStoreProducts가 scope invalidation, 최초 성공 여부, stale-data, 실제 resubscribe retry 계약을 갖지 않아 read failure가 empty/0/success 상태로 축소되었다.

주요 변경:
- scoped invalidation (A→B, A→null, null→A 렌더 단계 무효화)
- hasLoaded read authority (최초 실패 EMPTY collapse 방지)
- READ_FAILED / STALE / EMPTY / READY 분리 (+ FILTER_EMPTY/LOADING)
- listener retry/resubscribe (retryKey 재구독)
- Products/Prep/Home/Sale-round 소비면 복구 (TodayTasksCard 오성공 방지, ProductStatusCard 0/0 축소 방지)

Proof:
- seller tsc --noEmit PASS
- focused recovery tests 21 PASS
- prior: seller vitest 237 PASS, focused 48 PASS, biome clean

Foreign dirty: NOT_INCLUDED (all unrelated working-tree changes preserved locally, not in this PR)