### PR TITLE
fix(driver): preserve map read failure state

### DIFF
--- a/apps/driver/src/app/map/map-read-recovery.test.mjs
+++ b/apps/driver/src/app/map/map-read-recovery.test.mjs
@@ -1,0 +1,235 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+const mapSource = await readFile(new URL('./page.tsx', import.meta.url), 'utf8');
+
+// Regression reference: verbatim behavioral copy of page.tsx nearestNeighbor.
+// Source-containment assertions below pin the implementation; behavioral
+// assertions below pin its semantics. Production/Kakao calls are never made.
+function nearestNeighborReference(orders) {
+  if (orders.length <= 1) return orders;
+  const visited = new Set();
+  const result = [];
+  let current = orders[0];
+  result.push(current);
+  visited.add(current.id);
+
+  while (result.length < orders.length) {
+    let nearest = null;
+    let minDist = Infinity;
+    for (const o of orders) {
+      if (visited.has(o.id)) continue;
+      if (!o.lat || !o.lng || !current.lat || !current.lng) {
+        nearest = o;
+        break;
+      }
+      const dist = Math.hypot(o.lat - current.lat, o.lng - current.lng);
+      if (dist < minDist) {
+        minDist = dist;
+        nearest = o;
+      }
+    }
+    if (!nearest) break;
+    result.push(nearest);
+    visited.add(nearest.id);
+    current = nearest;
+  }
+  return result;
+}
+
+// 1. initial loading: first authoritative GET before empty.
+test('Map initial loading precedes any empty render', () => {
+  assert.match(mapSource, /const \[loading, setLoading\] = useState\(true\)/);
+  assert.match(mapSource, /배송 경로를 불러오는 중입니다/);
+  assert.match(mapSource, /\{loading \?/);
+  const loadingPos = mapSource.indexOf('{loading ?');
+  const emptyPos = mapSource.indexOf('오늘 배송 주문이 없습니다');
+  assert.ok(loadingPos !== -1 && emptyPos !== -1 && loadingPos < emptyPos);
+  assert.match(mapSource, /if \(background\) \{\s*setRefreshing\(true\);\s*\} else \{\s*setLoading\(true\);\s*\}/s);
+});
+
+// 2. successful results: authoritative GET + filter renders route list.
+test('Map successful results render filtered route list', () => {
+  assert.match(mapSource, /apiFetch\(\s*['"]\/driver\/orders['"]/);
+  assert.match(
+    mapSource,
+    /order\.status\s*===\s*['"]PREPARING['"]\s*\|\|\s*order\.status\s*===\s*['"]DELIVERING['"]/,
+  );
+  assert.match(mapSource, /setHasSuccessfulRead\(true\)/);
+  assert.match(mapSource, /hasSuccessfulReadRef\.current = true/);
+  assert.match(mapSource, /sorted\.map\(\(order, idx\)/);
+  assert.match(mapSource, /buildKakaoNaviUrl\(\)/);
+});
+
+// 3. successful empty: only after authoritative success with zero filtered rows.
+test('Map successful empty requires prior success and is separated from error', () => {
+  assert.match(mapSource, /오늘 배송 주문이 없습니다/);
+  assert.match(mapSource, /error && !hasSuccessfulRead/);
+  const errorOnlyPos = mapSource.indexOf('error && !hasSuccessfulRead');
+  const emptyPos = mapSource.indexOf('오늘 배송 주문이 없습니다');
+  assert.ok(errorOnlyPos !== -1 && emptyPos !== -1 && errorOnlyPos < emptyPos);
+  assert.match(mapSource, /setError\(null\)/);
+});
+
+// 4. initial fetch failure is not collapsed into empty.
+test('Map initial fetch failure shows error with retry, not empty', () => {
+  assert.match(mapSource, /배송 경로를 불러오지 못했습니다\. 잠시 후 다시 시도해주세요\./);
+  assert.match(mapSource, /다시 시도/);
+  // Initial failure clears to [] AND records an error (never a silent empty).
+  assert.match(
+    mapSource,
+    /hasSuccessfulReadRef\.current\) \{\s*\/\/ refresh 실패/s,
+  );
+  assert.match(mapSource, /\} else \{\s*setOrders\(\[\]\);\s*setError\('배송 경로를 불러오지 못했습니다/s);
+  // The old collapse (catch -> setOrders([]) with no setError) must be gone.
+  assert.doesNotMatch(mapSource, /\.catch\(\(cause[^)]*\) => \{\s*if \(!active[^}]*return;\s*setOrders\(\[\]\);\s*\}\);/s);
+});
+
+// 5. retry re-executes the same /driver/orders GET.
+test('Map retry re-executes the same orders GET', () => {
+  assert.match(mapSource, /const \[reloadKey, setReloadKey\] = useState\(0\)/);
+  assert.match(mapSource, /setReloadKey\(\(key\)\s*=>\s*key\s*\+\s*1\)/);
+  assert.match(mapSource, /sessionStatus,\s*reloadKey\]/);
+  const retryCount = (mapSource.match(/setReloadKey\(\(key\) => key \+ 1\)/g) ?? []).length;
+  assert.ok(retryCount >= 2, `expected retry on initial-error and stale branches, found ${retryCount}`);
+});
+
+// 6. auth loss clears protected route data and never shows normal empty.
+test('Map auth loss clears protected route data and shows auth state', () => {
+  assert.match(mapSource, /const \[authRequired, setAuthRequired\] = useState\(false\)/);
+  assert.match(mapSource, /if \(!token\) \{/);
+  assert.match(mapSource, /setOrders\(\[\]\)/);
+  assert.match(mapSource, /setAuthRequired\(true\)/);
+  assert.match(mapSource, /로그인이 필요합니다\. 세션을 다시 확인해 주세요\./);
+  assert.match(mapSource, /\) : authRequired \? \(/);
+  const authPos = mapSource.indexOf(') : authRequired ?');
+  const emptyPos = mapSource.indexOf('오늘 배송 주문이 없습니다');
+  assert.ok(authPos !== -1 && emptyPos !== -1 && authPos < emptyPos);
+  // Success memory resets so the next authed read starts as initial loading.
+  assert.match(mapSource, /hasSuccessfulReadRef\.current = false/);
+  assert.match(mapSource, /setHasSuccessfulRead\(false\)/);
+  // In-flight reads are invalidated on auth loss.
+  assert.match(mapSource, /requestIdRef\.current \+= 1;/);
+});
+
+// 7. token scope change / overlapping retry cannot be overwritten by stale responses.
+test('Map token change and overlapping retry are guarded by request sequence', () => {
+  assert.match(mapSource, /const requestIdRef = useRef\(0\)/);
+  assert.match(mapSource, /requestId === requestIdRef\.current/);
+  assert.match(mapSource, /const isCurrent = \(\) => active && requestId === requestIdRef\.current/);
+  assert.match(mapSource, /if \(!isCurrent\(\)\) return;/);
+  assert.match(mapSource, /new AbortController\(\)/);
+  assert.match(mapSource, /controller\.abort\(\)/);
+  assert.match(mapSource, /session\?\.user\.accessToken, sessionStatus, reloadKey\]/);
+  assert.match(mapSource, /if \(sessionStatus === 'loading'\) return;/);
+});
+
+// 8. malformed payload is handled as fetch error, not success/empty.
+test('Map malformed payload is a fetch error, not an empty list', () => {
+  assert.match(mapSource, /if \(!Array\.isArray\(payload\)\) throw new Error/);
+  assert.match(mapSource, /if \(!response\.ok\)/);
+  assert.match(mapSource, /error && !hasSuccessfulRead/);
+});
+
+// 9. stale route failure policy: keep previous route, mark stale, offer retry.
+test('Map refresh failure keeps previous route as stale with retry', () => {
+  assert.match(mapSource, /const \[refreshing, setRefreshing\] = useState\(false\)/);
+  assert.match(mapSource, /setRefreshing\(true\)/);
+  assert.match(mapSource, /최신 정보를 확인하는 중입니다/);
+  assert.match(mapSource, /hasSuccessfulReadRef/);
+  assert.match(mapSource, /최신 경로를 불러오지 못했습니다\. 이전 경로를 보여줍니다\./);
+  assert.match(mapSource, /\(이전 경로 표시 중\)/);
+  // Stale branch must not clear the retained route.
+  const staleIfStart = mapSource.indexOf('if (hasSuccessfulReadRef.current) {');
+  const staleSetErrorPos = mapSource.indexOf("setError('최신 경로를 불러오지 못했습니다");
+  const staleSetErrorEnd = mapSource.indexOf("');", staleSetErrorPos) + 3;
+  const staleBranch = mapSource.slice(staleIfStart, staleSetErrorEnd);
+  assert.doesNotMatch(staleBranch, /setOrders\(\[\]\)/);
+});
+
+// 10. error/stale navigation is fail-closed.
+test('Map navigation is fail-closed on error and stale states', () => {
+  // Active navigation requires a fresh success with no error.
+  assert.match(
+    mapSource,
+    /sorted\.length > 0 && !loading && !authRequired && !error && hasSuccessfulRead/,
+  );
+  assert.match(mapSource, /component="a"/);
+  assert.match(mapSource, /href=\{buildKakaoNaviUrl\(\)\}/);
+  // Stale navigation renders disabled with an explicit safety notice.
+  assert.match(mapSource, /sorted\.length > 0 && error && hasSuccessfulRead/);
+  assert.match(mapSource, /disabled/);
+  assert.match(
+    mapSource,
+    /최신 경로 확인에 실패해 주행을 시작할 수 없습니다\. 다시 시도 후 최신 경로에서/,
+  );
+});
+
+// 10b. loading/auth/initial-error states expose no navigation action.
+test('Map loading, auth, and initial-error states expose no navigation', () => {
+  const navActivePos = mapSource.indexOf('!error && hasSuccessfulRead');
+  assert.ok(navActivePos !== -1);
+  // Loading branch contains no navigation link.
+  const loadingBranch = mapSource.slice(
+    mapSource.indexOf('{loading ?'),
+    mapSource.indexOf(') : authRequired ?'),
+  );
+  assert.doesNotMatch(loadingBranch, /buildKakaoNaviUrl|component="a"/);
+  // Auth branch contains no navigation link.
+  const authBranch = mapSource.slice(
+    mapSource.indexOf(') : authRequired ?'),
+    mapSource.indexOf(') : error && !hasSuccessfulRead ?'),
+  );
+  assert.doesNotMatch(authBranch, /buildKakaoNaviUrl|component="a"/);
+});
+
+// 11a. nearestNeighbor implementation is preserved (regression pins).
+test('Map nearestNeighbor implementation is preserved', () => {
+  assert.match(mapSource, /function nearestNeighbor/);
+  assert.match(mapSource, /Math\.hypot\(o\.lat - current\.lat, o\.lng - current\.lng\)/);
+  assert.match(mapSource, /visited\.has\(o\.id\)/);
+  assert.match(mapSource, /if \(!o\.lat \|\| !o\.lng \|\| !current\.lat \|\| !current\.lng\)/);
+});
+
+// 11b. nearestNeighbor: empty and single inputs are identity.
+test('nearestNeighbor handles empty and single orders', () => {
+  assert.deepEqual(nearestNeighborReference([]), []);
+  const single = [{ id: 'a', lat: 5, lng: 5 }];
+  assert.deepEqual(nearestNeighborReference(single), single);
+});
+
+// 11c. nearestNeighbor: orders by proximity from the first order.
+// NOTE: the preserved implementation treats 0 coordinates as missing
+// (falsy `!o.lat` guard), so regression fixtures use non-zero coordinates.
+test('nearestNeighbor orders by proximity from the first order', () => {
+  const orders = [
+    { id: 'start', lat: 5, lng: 5 },
+    { id: 'far', lat: 15, lng: 5 },
+    { id: 'near', lat: 6, lng: 5 },
+  ];
+  const ids = nearestNeighborReference(orders).map((o) => o.id);
+  assert.deepEqual(ids, ['start', 'near', 'far']);
+});
+
+// 11d. nearestNeighbor: greedy chain follows the closest unvisited order.
+test('nearestNeighbor follows the greedy closest chain', () => {
+  const orders = [
+    { id: 'a', lat: 5, lng: 5 },
+    { id: 'b', lat: 10, lng: 5 },
+    { id: 'c', lat: 11, lng: 5 },
+  ];
+  const ids = nearestNeighborReference(orders).map((o) => o.id);
+  assert.deepEqual(ids, ['a', 'b', 'c']);
+});
+
+// 11e. nearestNeighbor: orders without coordinates fall through in input order.
+test('nearestNeighbor keeps input order fallback for missing coordinates', () => {
+  const orders = [
+    { id: 'a', lat: 5, lng: 5 },
+    { id: 'no-geo' },
+    { id: 'b', lat: 6, lng: 6 },
+  ];
+  const ids = nearestNeighborReference(orders).map((o) => o.id);
+  assert.deepEqual(ids, ['a', 'no-geo', 'b']);
+});

--- a/apps/driver/src/app/map/page.tsx
+++ b/apps/driver/src/app/map/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useSession } from 'next-auth/react';
 import { apiFetch } from '@/lib/api';
 import { Box, Stack, Text, Title, Badge, Button } from '@mantine/core';
@@ -49,46 +49,94 @@ function nearestNeighbor(orders: Order[]): Order[] {
 }
 
 export default function MapPage() {
-  const { data: session } = useSession();
+  const { data: session, status: sessionStatus } = useSession();
   const [orders, setOrders] = useState<Order[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [authRequired, setAuthRequired] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [reloadKey, setReloadKey] = useState(0);
+  const [hasSuccessfulRead, setHasSuccessfulRead] = useState(false);
+  const requestIdRef = useRef(0);
+  const hasSuccessfulReadRef = useRef(false);
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: reloadKey is an intentional manual-refresh trigger for the error-state retry button
   useEffect(() => {
+    if (sessionStatus === 'loading') return;
+
     const token = session?.user.accessToken;
     if (!token) {
+      // usable token 없음을 0건 성공으로 표시하지 않는다. 보호된 stale도 유지하지 않는다.
+      // 다음 인증된 조회가 initial loading으로 시작하도록 성공 기억도 초기화한다.
+      requestIdRef.current += 1;
+      hasSuccessfulReadRef.current = false;
       setOrders([]);
+      setHasSuccessfulRead(false);
+      setAuthRequired(true);
+      setError(null);
+      setLoading(false);
+      setRefreshing(false);
       return;
     }
 
     const controller = new AbortController();
     let active = true;
+    // Abort에만 의존하지 않는 stale-wins 방어: 오래된 응답이 최신 요청을 덮지 못한다.
+    requestIdRef.current += 1;
+    const requestId = requestIdRef.current;
+    const isCurrent = () => active && requestId === requestIdRef.current;
+    // 성공한 0건도 성공한 조회다. 이전 성공이 있으면 기존 route를 유지하고 background로 갱신한다.
+    const background = hasSuccessfulReadRef.current;
+    if (background) {
+      setRefreshing(true);
+    } else {
+      setLoading(true);
+    }
+    setAuthRequired(false);
+    setError(null);
 
     apiFetch('/driver/orders', token, { signal: controller.signal })
       .then(async (response) => {
         if (!response.ok) {
-          throw new Error('driver map orders request failed: ' + response.status);
+          throw new Error(`driver map orders request failed: ${response.status}`);
         }
         const payload: unknown = await response.json();
         if (!Array.isArray(payload)) throw new Error('driver map orders response is not a list');
         return payload as Order[];
       })
       .then((driverOrders) => {
-        if (!active) return;
+        if (!isCurrent()) return;
         setOrders(
           driverOrders.filter(
             (order) => order.status === 'PREPARING' || order.status === 'DELIVERING',
           ),
         );
+        hasSuccessfulReadRef.current = true;
+        setHasSuccessfulRead(true);
+        setError(null);
       })
       .catch((cause: unknown) => {
-        if (!active || (cause instanceof DOMException && cause.name === 'AbortError')) return;
-        setOrders([]);
+        if (!isCurrent() || (cause instanceof DOMException && cause.name === 'AbortError')) return;
+        if (hasSuccessfulReadRef.current) {
+          // refresh 실패는 마지막 정상 route를 지우지 않고 stale로 유지한다.
+          // stale route를 최신 경로로 오인시키지 않도록 navigation은 fail-closed한다.
+          setError('최신 경로를 불러오지 못했습니다. 이전 경로를 보여줍니다.');
+        } else {
+          setOrders([]);
+          setError('배송 경로를 불러오지 못했습니다. 잠시 후 다시 시도해주세요.');
+        }
+      })
+      .finally(() => {
+        if (!isCurrent()) return;
+        setLoading(false);
+        setRefreshing(false);
       });
 
     return () => {
       active = false;
       controller.abort();
     };
-  }, [session?.user.accessToken]);
+  }, [session?.user.accessToken, sessionStatus, reloadKey]);
 
   const sorted = nearestNeighbor(orders);
 
@@ -174,7 +222,43 @@ export default function MapPage() {
 
       {/* 경유지 목록 */}
       <Box style={{ flex: 1, padding: '16px' }}>
-        {sorted.length === 0 ? (
+        {loading ? (
+          <Box
+            style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: 128 }}
+          >
+            <Text style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-text-disabled)' }}>
+              배송 경로를 불러오는 중입니다
+            </Text>
+          </Box>
+        ) : authRequired ? (
+          <Stack align="center" justify="center" h={128} gap="xs">
+            <Text style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-danger)' }}>
+              로그인이 필요합니다. 세션을 다시 확인해 주세요.
+            </Text>
+            <Button
+              variant="outline"
+              color="brand"
+              radius="xl"
+              onClick={() => setReloadKey((key) => key + 1)}
+            >
+              다시 시도
+            </Button>
+          </Stack>
+        ) : error && !hasSuccessfulRead ? (
+          <Stack align="center" justify="center" h={128} gap="xs">
+            <Text style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-danger)' }}>
+              {error}
+            </Text>
+            <Button
+              variant="outline"
+              color="brand"
+              radius="xl"
+              onClick={() => setReloadKey((key) => key + 1)}
+            >
+              다시 시도
+            </Button>
+          </Stack>
+        ) : sorted.length === 0 ? (
           <Box
             style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: 128 }}
           >
@@ -184,6 +268,28 @@ export default function MapPage() {
           </Box>
         ) : (
           <Stack gap="xs">
+            {refreshing && (
+              <Text
+                style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-text-disabled)' }}
+              >
+                최신 정보를 확인하는 중입니다…
+              </Text>
+            )}
+            {error && (
+              <Stack align="center" justify="center" gap="xs">
+                <Text style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-danger)' }}>
+                  {error} (이전 경로 표시 중)
+                </Text>
+                <Button
+                  variant="outline"
+                  color="brand"
+                  radius="xl"
+                  onClick={() => setReloadKey((key) => key + 1)}
+                >
+                  다시 시도
+                </Button>
+              </Stack>
+            )}
             {sorted.map((order, idx) => {
               const addr =
                 order.deliveryMethod === 'hub'
@@ -250,8 +356,8 @@ export default function MapPage() {
         )}
       </Box>
 
-      {/* 주행 시작 버튼 */}
-      {sorted.length > 0 && (
+      {/* 주행 시작 버튼: error/stale에서는 fail-closed로 비활성화한다 */}
+      {sorted.length > 0 && !loading && !authRequired && !error && hasSuccessfulRead && (
         <Box style={{ position: 'sticky', bottom: 72, padding: '0 16px 16px' }}>
           <Button
             component="a"
@@ -263,6 +369,25 @@ export default function MapPage() {
           >
             주행 시작 (카카오내비)
           </Button>
+        </Box>
+      )}
+      {sorted.length > 0 && error && hasSuccessfulRead && (
+        <Box style={{ position: 'sticky', bottom: 72, padding: '0 16px 16px' }}>
+          <Stack gap="xs">
+            <Button fullWidth size="lg" radius="xl" color="gray" disabled>
+              주행 시작 (카카오내비)
+            </Button>
+            <Text
+              style={{
+                fontSize: 'var(--font-size-sm)',
+                color: 'var(--color-danger)',
+                textAlign: 'center',
+              }}
+            >
+              최신 경로 확인에 실패해 주행을 시작할 수 없습니다. 다시 시도 후 최신 경로에서
+              시작해 주세요.
+            </Text>
+          </Stack>
         </Box>
       )}
     </Box>


### PR DESCRIPTION
Publication of DRIVER-MAP-ORDERS-READ-RECOVERY-01 (COMPLETE). No source semantics expanded.

- initial read failure no longer collapses to empty
- successful empty remains authoritative
- auth loss clears protected route data
- post-success refresh failure preserves stale route with warning/retry
- stale routes cannot start navigation
- focused Map recovery tests PASS (16/16)
- Driver Board regression PASS (42/42) + detail PASS (7/7)
- no production/provider calls

Owned files only:
- apps/driver/src/app/map/page.tsx
- apps/driver/src/app/map/map-read-recovery.test.mjs