### PR TITLE
fix(seller): harden order detail read recovery

### DIFF
--- a/apps/seller/src/app/orders/[id]/_hooks/useOrderDetail.recovery.test.ts
+++ b/apps/seller/src/app/orders/[id]/_hooks/useOrderDetail.recovery.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   buildOrderDetailPath,
   getOrderDetailMutationOutcomeMessage,
+  isOrderDetailAuthError,
   isOrderDetailBackgroundRefresh,
   isOrderDetailNotFoundError,
   resolveOrderDetailAuthState,
@@ -9,6 +10,8 @@ import {
   resolveOrderDetailView,
   SELLER_ORDER_DETAIL_AUTH_ERROR,
   shouldIgnoreOrderDetailResponse,
+  shouldInvalidateOrderDetailScope,
+  shouldInvalidateOrderDetailSupplementary,
   shouldReconcileOrderDetailAfterMutation,
   shouldRevalidateOrderDetailOnVisibilityChange,
   shouldRevalidateOrderDetailOnWindowFocus,
@@ -210,5 +213,221 @@ describe('Seller 주문 상세 recovery — mutation reconciliation (E/F)', () =
     expect(message).toContain('최신');
     // 동일 위험 command 반복을 유도하는 실패 문구가 아니다.
     expect(message).not.toContain('상태 변경에 실패');
+  });
+});
+
+describe('Seller 주문 상세 read-recovery — authoritative read 분리 (TASK 1-6)', () => {
+  it('1. found: authoritative 성공은 order 존재 + READY로만 표현된다', () => {
+    expect(
+      resolveOrderDetailView({
+        authState: 'ready',
+        hasOrder: true,
+        isLoading: false,
+        error: null,
+        notFound: false,
+        authFailed: false,
+      }),
+    ).toBe('READY');
+  });
+
+  it('2. genuine 404: 404만 NOT_FOUND이며 주문 없음 문구로 닫는다', () => {
+    expect(isOrderDetailNotFoundError({ status: 404 })).toBe(true);
+    expect(
+      resolveOrderDetailView({
+        authState: 'ready',
+        hasOrder: false,
+        isLoading: false,
+        error: null,
+        notFound: true,
+        authFailed: false,
+      }),
+    ).toBe('NOT_FOUND');
+  });
+
+  it('3. 401/403: auth-error는 not-found·fetch-error와 분리되고 AUTH_FAILED로 닫는다', () => {
+    expect(isOrderDetailAuthError({ status: 401 })).toBe(true);
+    expect(isOrderDetailAuthError({ status: 403 })).toBe(true);
+    expect(isOrderDetailNotFoundError({ status: 401 })).toBe(false);
+    expect(isOrderDetailNotFoundError({ status: 403 })).toBe(false);
+    // 주문 없음 + API auth 거부 → AUTH_FAILED (NOT_FOUND 금지).
+    expect(
+      resolveOrderDetailView({
+        authState: 'ready',
+        hasOrder: false,
+        isLoading: false,
+        error: SELLER_ORDER_DETAIL_AUTH_ERROR,
+        notFound: false,
+        authFailed: true,
+      }),
+    ).toBe('AUTH_FAILED');
+    // stale이 있어도 protected data를 가리고 AUTH_FAILED (READY/stale 보존 금지).
+    expect(
+      resolveOrderDetailView({
+        authState: 'ready',
+        hasOrder: true,
+        isLoading: false,
+        error: SELLER_ORDER_DETAIL_AUTH_ERROR,
+        notFound: false,
+        authFailed: true,
+      }),
+    ).toBe('AUTH_FAILED');
+  });
+
+  it('4. network/5xx: fetch-error는 READ_FAILED이며 주문 없음으로 확정하지 않는다', () => {
+    expect(isOrderDetailNotFoundError({ status: 500 })).toBe(false);
+    expect(isOrderDetailAuthError({ status: 500 })).toBe(false);
+    expect(isOrderDetailNotFoundError(new Error('fetch failed'))).toBe(false);
+    expect(isOrderDetailAuthError(new Error('fetch failed'))).toBe(false);
+    expect(isOrderDetailNotFoundError({ status: 503 })).toBe(false);
+    expect(
+      resolveOrderDetailView({
+        authState: 'ready',
+        hasOrder: false,
+        isLoading: false,
+        error: '주문을 불러오지 못했습니다.',
+        notFound: false,
+        authFailed: false,
+      }),
+    ).toBe('READ_FAILED');
+    // 기존 detail + refresh 5xx는 stale READY를 유지하고 제거하지 않는다.
+    expect(
+      resolveOrderDetailView({
+        authState: 'ready',
+        hasOrder: true,
+        isLoading: false,
+        error: '서버 오류 (500)',
+        notFound: false,
+        authFailed: false,
+      }),
+    ).toBe('READY');
+  });
+
+  it('5. error → retry → success: retry는 동일한 authoritative GET 경로를 재사용한다', () => {
+    const first = buildOrderDetailPath('store-1', 'order-1');
+    const retry = buildOrderDetailPath('store-1', 'order-1');
+    expect(retry).toBe(first);
+    expect(retry).toBe('/stores/store-1/orders/order-1');
+  });
+
+  it('6. failure ≠ not-found: 401/403/5xx/network는 NOT_FOUND가 아니다', () => {
+    for (const err of [
+      { status: 401 },
+      { status: 403 },
+      { status: 500 },
+      { status: 503 },
+      new Error('network failure'),
+      null,
+    ]) {
+      expect(isOrderDetailNotFoundError(err)).toBe(false);
+    }
+    expect(isOrderDetailNotFoundError({ status: 404 })).toBe(true);
+  });
+});
+
+describe('Seller 주문 상세 read-recovery — ordering/scope (TASK 7-8)', () => {
+  it('7. stale request는 최신 orderId scope를 덮지 못한다', () => {
+    // retry/재조회로 최신 요청 id가 2가 된 뒤 늦게 도착한 요청 1의 성공/실패는 모두 무시.
+    expect(shouldIgnoreOrderDetailResponse(true, 2, 1)).toBe(true);
+    expect(shouldIgnoreOrderDetailResponse(true, 2, 2)).toBe(false);
+    // 취소된 effect의 응답도 무시.
+    expect(shouldIgnoreOrderDetailResponse(false, 2, 2)).toBe(true);
+  });
+
+  it('8. auth/store scope 변경은 이전 order를 무효화하고 동일 scope retry는 유지한다', () => {
+    const base = { orderId: 'order-1', storeId: 'store-1', token: 'token-1' };
+    expect(shouldInvalidateOrderDetailScope(null, base)).toBe(false);
+    expect(shouldInvalidateOrderDetailScope(base, { ...base })).toBe(false);
+    expect(
+      shouldInvalidateOrderDetailScope(base, { ...base, orderId: 'order-2' }),
+    ).toBe(true);
+    expect(
+      shouldInvalidateOrderDetailScope(base, { ...base, storeId: 'store-2' }),
+    ).toBe(true);
+    expect(shouldInvalidateOrderDetailScope(base, { ...base, token: 'token-2' })).toBe(true);
+    expect(
+      shouldInvalidateOrderDetailScope(base, { orderId: 'order-1', storeId: null, token: 'token-1' }),
+    ).toBe(true);
+  });
+});
+
+describe('Seller 주문 상세 read-recovery — supplementary degrade (TASK 9-11)', () => {
+  it('9. supplementary product read 실패는 authoritative order를 지우지 않는다', () => {
+    // 보조 read는 authoritative view 입력(hasOrder/error/notFound/authFailed)을 바꾸지 않는다.
+    // productName fetch 실패 → productName만 null, order는 READY 유지.
+    expect(
+      resolveOrderDetailView({
+        authState: 'ready',
+        hasOrder: true,
+        isLoading: false,
+        error: null,
+        notFound: false,
+        authFailed: false,
+      }),
+    ).toBe('READY');
+    expect(isOrderDetailNotFoundError(new Error('products getDoc failed'))).toBe(false);
+    expect(isOrderDetailAuthError(new Error('products getDoc failed'))).toBe(false);
+  });
+
+  it('10. supplementary groupConfig 실패는 authoritative order를 지우지 않는다', () => {
+    expect(
+      resolveOrderDetailView({
+        authState: 'ready',
+        hasOrder: true,
+        isLoading: false,
+        error: null,
+        notFound: false,
+        authFailed: false,
+      }),
+    ).toBe('READY');
+    expect(isOrderDetailNotFoundError(new Error('groupProductConfig getDoc failed'))).toBe(false);
+    expect(isOrderDetailAuthError(new Error('groupProductConfig getDoc failed'))).toBe(false);
+  });
+
+  it('11. order 변경은 이전 productName/groupConfig를 leak하지 않는다', () => {
+    expect(shouldInvalidateOrderDetailSupplementary(null, null)).toBe(false);
+    expect(shouldInvalidateOrderDetailSupplementary('p-1', 'p-1')).toBe(false);
+    // 다른 productId로 바뀌면 이전 보조 정보를 clear해야 한다.
+    expect(shouldInvalidateOrderDetailSupplementary('p-1', 'p-2')).toBe(true);
+    expect(shouldInvalidateOrderDetailSupplementary(null, 'p-1')).toBe(true);
+    expect(shouldInvalidateOrderDetailSupplementary('p-1', null)).toBe(true);
+    // group → normal 전환도 이전 group config를 표시하지 않는다(호출부는 null로 degrade).
+  });
+});
+
+describe('Seller 주문 상세 read-recovery — action safety (TASK 12)', () => {
+  it('12. found가 아니면 order action surface를 노출하지 않는다 (READY만 허용)', () => {
+    const nonReady: Array<Parameters<typeof resolveOrderDetailView>[0]> = [
+      { authState: 'ready', hasOrder: false, isLoading: true, error: null, notFound: false },
+      {
+        authState: 'missing',
+        hasOrder: false,
+        isLoading: false,
+        error: SELLER_ORDER_DETAIL_AUTH_ERROR,
+        notFound: false,
+      },
+      {
+        authState: 'ready',
+        hasOrder: false,
+        isLoading: false,
+        error: SELLER_ORDER_DETAIL_AUTH_ERROR,
+        notFound: false,
+        authFailed: true,
+      },
+      {
+        authState: 'ready',
+        hasOrder: false,
+        isLoading: false,
+        error: '주문을 불러오지 못했습니다.',
+        notFound: false,
+      },
+      { authState: 'ready', hasOrder: false, isLoading: false, error: null, notFound: true },
+    ];
+    for (const input of nonReady) {
+      expect(resolveOrderDetailView(input)).not.toBe('READY');
+    }
+    // mutation semantics는 변경하지 않는다.
+    expect(shouldReconcileOrderDetailAfterMutation(true)).toBe(true);
+    expect(shouldReconcileOrderDetailAfterMutation(false)).toBe(false);
+    expect(resolveOrderDetailMutationOutcome(false, true)).toBe('COMMAND_FAILED');
   });
 });

--- a/apps/seller/src/app/orders/[id]/_hooks/useOrderDetail.recovery.ts
+++ b/apps/seller/src/app/orders/[id]/_hooks/useOrderDetail.recovery.ts
@@ -76,22 +76,69 @@ export function isOrderDetailNotFoundError(error: unknown): boolean {
   return (error as { status?: unknown }).status === 404;
 }
 
+/**
+ * authoritative 인증/권한 실패 판정.
+ * `GET /stores/:storeId/orders/:orderId`가 401/403을 반환한 경우에만 true다.
+ * 404(not-found)나 network/5xx(fetch-error)와 섞지 않는다.
+ */
+export function isOrderDetailAuthError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+  const status = (error as { status?: unknown }).status;
+  return status === 401 || status === 403;
+}
+
+export interface OrderDetailScope {
+  orderId: string;
+  storeId: string | null;
+  token: string | null | undefined;
+}
+
+/**
+ * scope가 바뀌면 이전 scope의 authoritative order를 새 scope처럼 노출하지 않는다.
+ * - orderId/storeId/token 중 하나라도 바뀌면 무효화.
+ * - 최초 마운트(prev null)는 무효화 대상이 아니다(초기 상태가 이미 비어 있음).
+ * - 동일 scope의 retry(tick/focus)는 무효화하지 않고 stale 보존한다.
+ */
+export function shouldInvalidateOrderDetailScope(
+  prev: OrderDetailScope | null,
+  next: OrderDetailScope,
+): boolean {
+  if (!prev) return false;
+  return prev.orderId !== next.orderId || prev.storeId !== next.storeId || prev.token !== next.token;
+}
+
+/**
+ * 보조 read(productName/groupConfig) scope 판정.
+ * order 변경 시 이전 productId의 보조 정보를 새 주문에 노출하지 않는다.
+ * - 둘 다 null이면 무효화하지 않는다.
+ * - 하나라도 다르면 이전 보조 정보를 clear해야 한다.
+ */
+export function shouldInvalidateOrderDetailSupplementary(
+  prevProductId: string | null,
+  nextProductId: string | null,
+): boolean {
+  return prevProductId !== nextProductId;
+}
+
 export interface ResolveOrderDetailViewInput {
   authState: SellerOrderDetailAuthState;
   hasOrder: boolean;
   isLoading: boolean;
   error: string | null;
   notFound: boolean;
+  /** authoritative GET이 401/403으로 거부된 경우 true. stale READY로 보존하지 않고 AUTH_FAILED로 닫는다. */
+  authFailed?: boolean;
 }
 
 /**
  * Detail read의 사용자 의미를 판정한다.
- * - auth 확정 실패는 stale이 있어도 AUTH_FAILED (protected data 예외).
- * - order 존재는 refresh 실패와 무관하게 READY (stale 보존, 호출부가 별도 indication).
+ * - auth 확정 실패(prereq missing)나 API 401/403(authFailed)은 stale이 있어도 AUTH_FAILED (protected data 예외).
+ * - order 존재 + auth 실패 없음 → READY (refresh 실패와 무관하게 stale 보존, 호출부가 별도 indication).
  * - order 없음 + error → READ_FAILED, order 없음 + authoritative 404 → NOT_FOUND.
  */
 export function resolveOrderDetailView(input: ResolveOrderDetailViewInput): OrderDetailViewState {
   if (input.authState === 'missing') return 'AUTH_FAILED';
+  if (input.authFailed === true) return 'AUTH_FAILED';
   if (input.hasOrder) return 'READY';
   if (input.authState === 'loading') return 'LOADING';
   if (input.isLoading) return 'LOADING';

--- a/apps/seller/src/app/orders/[id]/_hooks/useOrderDetail.ts
+++ b/apps/seller/src/app/orders/[id]/_hooks/useOrderDetail.ts
@@ -9,6 +9,7 @@ import { apiJson } from '@/lib/api';
 import { db } from '@/lib/firebase';
 import {
   buildOrderDetailPath,
+  isOrderDetailAuthError,
   isOrderDetailBackgroundRefresh,
   isOrderDetailNotFoundError,
   resolveOrderDetailAuthState,
@@ -16,6 +17,8 @@ import {
   SELLER_ORDER_DETAIL_AUTH_ERROR,
   SELLER_ORDER_DETAIL_READ_ERROR,
   shouldIgnoreOrderDetailResponse,
+  shouldInvalidateOrderDetailScope,
+  shouldInvalidateOrderDetailSupplementary,
   shouldRevalidateOrderDetailOnVisibilityChange,
   shouldRevalidateOrderDetailOnWindowFocus,
   type OrderDetailViewState,
@@ -23,6 +26,7 @@ import {
 
 export {
   buildOrderDetailPath,
+  isOrderDetailAuthError,
   isOrderDetailBackgroundRefresh,
   isOrderDetailNotFoundError,
   resolveOrderDetailAuthState,
@@ -30,6 +34,8 @@ export {
   SELLER_ORDER_DETAIL_AUTH_ERROR,
   SELLER_ORDER_DETAIL_READ_ERROR,
   shouldIgnoreOrderDetailResponse,
+  shouldInvalidateOrderDetailScope,
+  shouldInvalidateOrderDetailSupplementary,
   shouldRevalidateOrderDetailOnVisibilityChange,
   shouldRevalidateOrderDetailOnWindowFocus,
 } from './useOrderDetail.recovery';
@@ -43,6 +49,7 @@ export interface UseOrderDetailResult {
   refreshing: boolean;
   error: string | null;
   notFound: boolean;
+  authFailed: boolean;
   isStale: boolean;
   view: OrderDetailViewState;
   refresh: () => void;
@@ -67,9 +74,13 @@ export function useOrderDetail(orderId: string): UseOrderDetailResult {
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [notFound, setNotFound] = useState(false);
+  const [authFailed, setAuthFailed] = useState(false);
   const [tick, setTick] = useState(0);
   const requestIdRef = useRef(0);
   const hasDataRef = useRef(false);
+  const scopeRef = useRef<{ orderId: string; storeId: string | null; token: string | null | undefined } | null>(null);
+  const productNameProductIdRef = useRef<string | null>(null);
+  const groupConfigProductIdRef = useRef<string | null>(null);
 
   const refresh = useCallback(() => {
     setTick((t) => t + 1);
@@ -92,12 +103,38 @@ export function useOrderDetail(orderId: string): UseOrderDetailResult {
     if (authState === 'missing') {
       requestIdRef.current += 1;
       hasDataRef.current = false;
+      scopeRef.current = { orderId, storeId, token };
+      productNameProductIdRef.current = null;
+      groupConfigProductIdRef.current = null;
       setOrder(null);
+      setProductName(null);
+      setGroupConfig(null);
       setNotFound(false);
+      setAuthFailed(false);
       setError(SELLER_ORDER_DETAIL_AUTH_ERROR);
       setLoading(false);
       setRefreshing(false);
       return;
+    }
+
+    const nextScope = { orderId, storeId, token };
+    if (shouldInvalidateOrderDetailScope(scopeRef.current, nextScope)) {
+      // orderId/storeId/token 변경: 이전 scope의 order·보조 정보를 새 scope로 leak하지 않는다.
+      requestIdRef.current += 1;
+      hasDataRef.current = false;
+      scopeRef.current = nextScope;
+      productNameProductIdRef.current = null;
+      groupConfigProductIdRef.current = null;
+      setOrder(null);
+      setProductName(null);
+      setGroupConfig(null);
+      setNotFound(false);
+      setAuthFailed(false);
+      setError(null);
+      setLoading(true);
+      setRefreshing(false);
+    } else if (!scopeRef.current) {
+      scopeRef.current = nextScope;
     }
 
     const isBackground = isOrderDetailBackgroundRefresh(hasDataRef.current);
@@ -108,6 +145,7 @@ export function useOrderDetail(orderId: string): UseOrderDetailResult {
     }
     setError(null);
     setNotFound(false);
+    setAuthFailed(false);
     const myId = requestIdRef.current + 1;
     requestIdRef.current = myId;
     let active = true;
@@ -117,18 +155,41 @@ export function useOrderDetail(orderId: string): UseOrderDetailResult {
         hasDataRef.current = true;
         setOrder(payload);
         setNotFound(false);
+        setAuthFailed(false);
+        setError(null);
       })
       .catch((err: unknown) => {
         if (shouldIgnoreOrderDetailResponse(active, requestIdRef.current, myId)) return;
+        if (isOrderDetailAuthError(err)) {
+          // 401/403은 not-found나 일반 fetch-error와 섞지 않고 AUTH_FAILED로 닫는다.
+          // stale order를 보존하지 않고 protected data를 가린다.
+          hasDataRef.current = false;
+          productNameProductIdRef.current = null;
+          groupConfigProductIdRef.current = null;
+          setOrder(null);
+          setProductName(null);
+          setGroupConfig(null);
+          setNotFound(false);
+          setAuthFailed(true);
+          setError(SELLER_ORDER_DETAIL_AUTH_ERROR);
+          return;
+        }
         if (isOrderDetailNotFoundError(err)) {
           hasDataRef.current = false;
+          productNameProductIdRef.current = null;
+          groupConfigProductIdRef.current = null;
           setOrder(null);
+          setProductName(null);
+          setGroupConfig(null);
           setNotFound(true);
+          setAuthFailed(false);
           setError(null);
           return;
         }
         // 기존 detail이 있으면 제거하지 않고 stale로 보존한다.
+        // 단 최초 조회 실패(데이터 없음)는 order null + READ_FAILED로 닫는다.
         setNotFound(false);
+        setAuthFailed(false);
         if (!hasDataRef.current) {
           setOrder(null);
         }
@@ -161,34 +222,102 @@ export function useOrderDetail(orderId: string): UseOrderDetailResult {
   }, [refresh]);
 
   useEffect(() => {
-    if (!order || !firebaseReady) return;
+    if (!order) {
+      // authoritative order가 없으면 이전 보조 정보를 leak하지 않는다.
+      productNameProductIdRef.current = null;
+      setProductName((prev) => (prev === null ? prev : null));
+      return;
+    }
     if (order.productName) {
+      productNameProductIdRef.current = order.productId;
       setProductName(order.productName);
       return;
     }
     const snapshotProductName = order.orderItems?.[0]?.productName;
     if (snapshotProductName) {
+      productNameProductIdRef.current = order.productId;
       setProductName(snapshotProductName);
       return;
     }
-    getDoc(doc(db, 'products', order.productId)).then((snap) => {
-      if (snap.exists()) setProductName((snap.data() as { name: string }).name ?? null);
-    });
+    if (!firebaseReady) return;
+    // Firestore fallback: 이전 productId의 이름을 새 주문에 노출하지 않도록 먼저 clear.
+    if (shouldInvalidateOrderDetailSupplementary(productNameProductIdRef.current, order.productId)) {
+      setProductName(null);
+    }
+    productNameProductIdRef.current = order.productId;
+    const productId = order.productId;
+    let active = true;
+    getDoc(doc(db, 'products', productId))
+      .then((snap) => {
+        if (!active) return;
+        // 늦은 응답이 최신 order scope를 덮지 않게 한다.
+        if (productNameProductIdRef.current !== productId) return;
+        if (snap.exists()) {
+          setProductName((snap.data() as { name: string }).name ?? null);
+        } else {
+          setProductName(null);
+        }
+      })
+      .catch(() => {
+        if (!active) return;
+        if (productNameProductIdRef.current !== productId) return;
+        // 보조 read 실패는 order를 지우지 않고 이름만 비운다.
+        setProductName(null);
+      });
+    return () => {
+      active = false;
+    };
   }, [order, firebaseReady]);
 
   useEffect(() => {
-    if (!order || !firebaseReady || order.saleType !== 'group') return;
-    const ref = doc(db, 'groupProductConfig', order.productId);
-    getDoc(ref).then((snap) => {
-      if (snap.exists()) {
-        const data = snap.data();
-        if (data.recruitDeadline?.toDate)
-          data.recruitDeadline = data.recruitDeadline.toDate().toISOString();
-        if (data.groupDeliveryDate?.toDate)
-          data.groupDeliveryDate = data.groupDeliveryDate.toDate().toISOString();
-        setGroupConfig(data as GroupProductConfig);
-      }
-    });
+    if (!order) {
+      // order 없음에서는 이전 group config를 표시하지 않는다.
+      groupConfigProductIdRef.current = null;
+      setGroupConfig((prev) => (prev === null ? prev : null));
+      return;
+    }
+    if (order.saleType !== 'group') {
+      // group이 아닌 주문에서는 이전 group config를 표시하지 않는다.
+      // firebase 준비 여부와 무관하게 즉시 가린다.
+      groupConfigProductIdRef.current = null;
+      setGroupConfig((prev) => (prev === null ? prev : null));
+      return;
+    }
+    if (!firebaseReady) return;
+    // productId 변경 시 이전 group config를 새 상품에 표시하지 않도록 먼저 clear.
+    // 동일 productId 재조회에서는 기존 값을 유지하고 fetch를 생략하지 않는다(실패 후 재시도 대비).
+    // 단 이미 같은 productId로 로드된 값이 있으면 불필요한 clear를 피한다.
+    if (shouldInvalidateOrderDetailSupplementary(groupConfigProductIdRef.current, order.productId)) {
+      setGroupConfig(null);
+    }
+    groupConfigProductIdRef.current = order.productId;
+    const productId = order.productId;
+    let active = true;
+    const ref = doc(db, 'groupProductConfig', productId);
+    getDoc(ref)
+      .then((snap) => {
+        if (!active) return;
+        if (groupConfigProductIdRef.current !== productId) return;
+        if (snap.exists()) {
+          const data = snap.data();
+          if (data.recruitDeadline?.toDate)
+            data.recruitDeadline = data.recruitDeadline.toDate().toISOString();
+          if (data.groupDeliveryDate?.toDate)
+            data.groupDeliveryDate = data.groupDeliveryDate.toDate().toISOString();
+          setGroupConfig(data as GroupProductConfig);
+        } else {
+          setGroupConfig(null);
+        }
+      })
+      .catch(() => {
+        if (!active) return;
+        if (groupConfigProductIdRef.current !== productId) return;
+        // 보조 read 실패는 order를 지우지 않고 group 현황만 비운다.
+        setGroupConfig(null);
+      });
+    return () => {
+      active = false;
+    };
   }, [order, firebaseReady]);
 
   const view = resolveOrderDetailView({
@@ -197,8 +326,9 @@ export function useOrderDetail(orderId: string): UseOrderDetailResult {
     isLoading: loading,
     error,
     notFound,
+    authFailed,
   });
   const isStale = view === 'READY' && error !== null;
 
-  return { order, productName, groupConfig, loading, refreshing, error, notFound, isStale, view, refresh, reconcile };
+  return { order, productName, groupConfig, loading, refreshing, error, notFound, authFailed, isStale, view, refresh, reconcile };
 }


### PR DESCRIPTION
Publication of SELLER-ORDER-DETAIL-READ-RECOVERY-01 owned changes only (3 files). Source baseline 57ebcce, rebased onto 809e312 (PR #110 driver-only, unrelated).

Scope (only):
- apps/seller/src/app/orders/[id]/_hooks/useOrderDetail.recovery.ts
- apps/seller/src/app/orders/[id]/_hooks/useOrderDetail.ts
- apps/seller/src/app/orders/[id]/_hooks/useOrderDetail.recovery.test.ts
- page.tsx untouched (existing LOADING/AUTH_FAILED/READ_FAILED/NOT_FOUND early-return reused)

Contract:
- 404 only NOT_FOUND (isOrderDetailNotFoundError status===404); 401/403/network/5xx/plain Error are not NOT_FOUND; 404 clears authoritative order+supplementary
- API 401/403 AUTH_FAILED (isOrderDetailAuthError); stale order cleared, protected data hidden, notFound=false authFailed=true
- network/5xx/contract failure READ_FAILED; same-scope refresh with existing order keeps stale READY; never mixed with auth failure
- orderId/storeId/token any change invalidates: order/productName/groupConfig cleared, hasData=false, refs reset, no overwrite from old scope; same-scope retry does not invalidate
- supplementary Firestore (productName/groupConfig) failure never changes authoritative order/error/notFound/view; productId change clears previous supplementary; stale async race guard kept; saleType!=group clears groupConfig immediately; rejected promises handled (no unhandled rejection)
- retry uses same buildOrderDetailPath(storeId,orderId) GET via tick/reconcile, no window.location.reload, stale/cancelled responses ignored
- page action safety: non-READY never exposes order actions

Verification (candidate 106f4a4d on base 809e312):
- focused recovery: 35/35 PASS (src/app/orders/[id]/_hooks/useOrderDetail.recovery.test.ts)
- orders regression: 4 files / 67 tests PASS (order-priority 6, orders-view-model 23, operation-issues 3, recovery 35)
- tsc --noEmit (apps/seller): PASS
- biome lint (3 changed files): clean
- git diff --check: clean; candidate diff limited to 3 owned files

Foreign dirty excluded (preserved in shared checkout, not in PR):
- driver board/client/lib/test, seller orders/page, useGroupConfigs + recovery files

No force-push, no main direct push.