### PR TITLE
fix(seller): recover group config auxiliary reads

### DIFF
--- a/apps/seller/src/app/orders/page.tsx
+++ b/apps/seller/src/app/orders/page.tsx
@@ -128,7 +128,8 @@ export default function OrdersPage() {
     () => deriveOrdersFetchInput(orders, saleType, activeTab),
     [orders, saleType, activeTab],
   );
-  const groupConfigMap = useGroupConfigs(fetchInput.groupProductIds, saleType === 'group');
+  const groupConfigs = useGroupConfigs(fetchInput.groupProductIds, saleType === 'group');
+  const groupConfigMap = groupConfigs.map;
   const view = useMemo(
     () =>
       buildOrdersScopedViewModel({
@@ -483,6 +484,53 @@ export default function OrdersPage() {
               </Group>
             </Paper>
           )}
+
+          {/* 공구 배송일 auxiliary metadata — core 주문 목록과 분리.
+              실패해도 주문 목록을 숨기거나 정상 empty로 속이지 않고,
+              saleType/activeTab/filter state를 보존한 채 작은 warning/retry만 노출한다. */}
+          {!loading &&
+            firebaseReady &&
+            saleType === 'group' &&
+            groupConfigs.error && (
+              <Paper radius="lg" shadow="xs" p="md">
+                <Group justify="space-between" gap="xs" wrap="nowrap">
+                  <Text
+                    style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-text-secondary)' }}
+                  >
+                    {groupConfigs.isStale
+                      ? '공구 배송일 정보를 새로 불러오지 못했습니다. 이전 정보를 표시합니다.'
+                      : '공구 배송일 정보를 불러오지 못했습니다. 주문 목록은 그대로 표시됩니다.'}
+                  </Text>
+                  <UnstyledButton
+                    onClick={groupConfigs.retry}
+                    aria-label="공구 배송일 다시 불러오기"
+                    style={{
+                      padding: '6px 14px',
+                      fontSize: 'var(--font-size-sm)',
+                      borderRadius: 99,
+                      backgroundColor: 'var(--color-text)',
+                      color: 'var(--color-bg)',
+                      flexShrink: 0,
+                    }}
+                  >
+                    다시 시도
+                  </UnstyledButton>
+                </Group>
+              </Paper>
+            )}
+
+          {!loading &&
+            firebaseReady &&
+            saleType === 'group' &&
+            !groupConfigs.error &&
+            groupConfigs.loading && (
+              <Text
+                aria-live="polite"
+                style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-text-disabled)' }}
+              >
+                공구 배송일 정보를 불러오는 중입니다…
+              </Text>
+            )}
 
           {!loading &&
             firebaseReady &&

--- a/apps/seller/src/hooks/useGroupConfigs.recovery.test.ts
+++ b/apps/seller/src/hooks/useGroupConfigs.recovery.test.ts
@@ -1,0 +1,289 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  buildGroupConfigKey,
+  buildGroupConfigMapFromEntries,
+  dedupeGroupProductIds,
+  fetchGroupConfigMap,
+  GROUP_CONFIGS_ERROR_MESSAGE,
+  isGroupConfigStale,
+  nextGroupConfigRetryKey,
+  normalizeGroupDeliveryDate,
+  resolveGroupConfigMapAfterFailure,
+  resolveGroupConfigView,
+  shouldIgnoreGroupConfigResponse,
+} from './useGroupConfigs.recovery';
+
+describe('GroupConfigs auxiliary read — disabled → empty clean state (1)', () => {
+  it('disabled면 key가 비어 조회 scope가 없다', () => {
+    expect(buildGroupConfigKey(['p-1', 'p-2'], false)).toBe('');
+    expect(buildGroupConfigKey([], false)).toBe('');
+  });
+
+  it('disabled/no-ids는 map/error/loading clean (DISABLED)', () => {
+    expect(
+      resolveGroupConfigView({ enabled: false, key: '', loading: false, error: null, hasLoaded: false }),
+    ).toBe('DISABLED');
+    expect(
+      resolveGroupConfigView({ enabled: true, key: '', loading: false, error: null, hasLoaded: false }),
+    ).toBe('DISABLED');
+    expect(isGroupConfigStale(null, false)).toBe(false);
+  });
+
+  it('빈 productIds(enabled여도)는 fetch하지 않는다', () => {
+    expect(buildGroupConfigKey([], true)).toBe('');
+  });
+});
+
+describe('GroupConfigs auxiliary read — ids success (2)', () => {
+  it('authoritative fetch 성공 결과를 그대로 map으로 사용한다', async () => {
+    const map = await fetchGroupConfigMap(['p-1', 'p-2'], async (id) => `${id}-date`);
+    expect(map).toEqual({
+      'p-1': { groupDeliveryDate: 'p-1-date' },
+      'p-2': { groupDeliveryDate: 'p-2-date' },
+    });
+  });
+
+  it('성공 뒤 view는 READY다', () => {
+    expect(
+      resolveGroupConfigView({
+        enabled: true,
+        key: 'p-1|p-2',
+        loading: false,
+        error: null,
+        hasLoaded: true,
+      }),
+    ).toBe('READY');
+  });
+});
+
+describe('GroupConfigs auxiliary read — missing config document (3)', () => {
+  it('문서 없음(null)은 map에서 제외하고 실패가 아니다', () => {
+    const map = buildGroupConfigMapFromEntries([
+      ['p-1', null],
+      ['p-2', '2026-09-05T12:00:00'],
+    ]);
+    expect(map).toEqual({ 'p-2': { groupDeliveryDate: '2026-09-05T12:00:00' } });
+  });
+
+  it('전부 missing이어도 빈 map 성공(READY)이지 READ_FAILED가 아니다', async () => {
+    const map = await fetchGroupConfigMap(['p-missing'], async () => null);
+    expect(map).toEqual({});
+    expect(
+      resolveGroupConfigView({
+        enabled: true,
+        key: 'p-missing',
+        loading: false,
+        error: null,
+        hasLoaded: true,
+      }),
+    ).toBe('READY');
+  });
+});
+
+describe('GroupConfigs auxiliary read — one/multiple getDoc failure (4)', () => {
+  it('하나의 getDoc 실패도 전체 보조 조회를 reject한다 (개별 missing과 구분)', async () => {
+    await expect(
+      fetchGroupConfigMap(['p-ok', 'p-bad'], async (id) => {
+        if (id === 'p-bad') throw new Error('firestore boom');
+        return '2026-09-05T12:00:00';
+      }),
+    ).rejects.toThrow('firestore boom');
+  });
+
+  it('여러 개 실패도 reject이며 빈 map으로 승격하지 않는다', async () => {
+    await expect(
+      fetchGroupConfigMap(['p-1', 'p-2'], async () => {
+        throw new Error('boom');
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('첫 조회 실패 view는 READ_FAILED이며 정상 empty가 아니다', () => {
+    const view = resolveGroupConfigView({
+      enabled: true,
+      key: 'p-1',
+      loading: false,
+      error: GROUP_CONFIGS_ERROR_MESSAGE,
+      hasLoaded: false,
+    });
+    expect(view).toBe('READ_FAILED');
+    expect(view).not.toBe('READY');
+  });
+});
+
+describe('GroupConfigs auxiliary read — failure → retry → success (5)', () => {
+  it('실패 뒤 같은 scope retry가 성공하면 READY로 회복한다', async () => {
+    let attempt = 0;
+    const fetchOne = async (id: string): Promise<string | null> => {
+      attempt += 1;
+      if (attempt === 1) throw new Error('first boom');
+      return `${id}-date`;
+    };
+
+    await expect(fetchGroupConfigMap(['p-1'], fetchOne)).rejects.toThrow('first boom');
+    expect(
+      resolveGroupConfigView({
+        enabled: true,
+        key: 'p-1',
+        loading: false,
+        error: GROUP_CONFIGS_ERROR_MESSAGE,
+        hasLoaded: false,
+      }),
+    ).toBe('READ_FAILED');
+
+    const recovered = await fetchGroupConfigMap(['p-1'], fetchOne);
+    expect(recovered).toEqual({ 'p-1': { groupDeliveryDate: 'p-1-date' } });
+    expect(
+      resolveGroupConfigView({
+        enabled: true,
+        key: 'p-1',
+        loading: false,
+        error: null,
+        hasLoaded: true,
+      }),
+    ).toBe('READY');
+  });
+
+  it('retry 키는 단조 증가하고 scope key와 독립이다', () => {
+    const k1 = nextGroupConfigRetryKey(0);
+    const k2 = nextGroupConfigRetryKey(k1);
+    expect(k1).toBe(1);
+    expect(k2).toBe(2);
+    // retry가 scope를 바꾸지 않는다 — 같은 입력이면 같은 key.
+    expect(buildGroupConfigKey(['p-1'], true)).toBe(buildGroupConfigKey(['p-1'], true));
+  });
+});
+
+describe('GroupConfigs auxiliary read — failure does not erase core orders (6)', () => {
+  it('실패 시 이전 map을 지우지 않는다 (EMPTY collapse 금지)', () => {
+    const prev = { 'p-1': { groupDeliveryDate: '2026-09-05T12:00:00' } };
+    expect(resolveGroupConfigMapAfterFailure(prev, true)).toBe(prev);
+    expect(resolveGroupConfigMapAfterFailure(prev, true)).toEqual(prev);
+  });
+
+  it('첫 실패도 {}를 성공 empty로 승격하지 않는다 — error와 함께 다룬다', () => {
+    const prev: Record<string, { groupDeliveryDate: string }> = {};
+    const kept = resolveGroupConfigMapAfterFailure(prev, false);
+    expect(kept).toEqual({});
+    // map이 비어도 error가 있으면 READY/EMPTY가 아니다.
+    expect(
+      resolveGroupConfigView({
+        enabled: true,
+        key: 'p-1',
+        loading: false,
+        error: GROUP_CONFIGS_ERROR_MESSAGE,
+        hasLoaded: false,
+      }),
+    ).toBe('READ_FAILED');
+  });
+});
+
+describe('GroupConfigs auxiliary read — stale map policy (7)', () => {
+  it('이전 성공 + 재조회 실패만 stale이다', () => {
+    expect(isGroupConfigStale('boom', true)).toBe(true);
+    expect(isGroupConfigStale('boom', false)).toBe(false);
+    expect(isGroupConfigStale(null, true)).toBe(false);
+    expect(isGroupConfigStale(null, false)).toBe(false);
+  });
+
+  it('stale view는 READY가 아니며 최신 확정값처럼 쓰지 않는다', () => {
+    const view = resolveGroupConfigView({
+      enabled: true,
+      key: 'p-1',
+      loading: false,
+      error: GROUP_CONFIGS_ERROR_MESSAGE,
+      hasLoaded: true,
+    });
+    expect(view).toBe('STALE');
+    expect(view).not.toBe('READY');
+    expect(view).not.toBe('READ_FAILED');
+  });
+});
+
+describe('GroupConfigs auxiliary read — ids scope A→B stale 차단 (8)', () => {
+  it('race guard는 취소·stale 응답을 무시하고 최신 응답만 허용한다', () => {
+    expect(shouldIgnoreGroupConfigResponse(false, 2, 2)).toBe(true);
+    expect(shouldIgnoreGroupConfigResponse(true, 2, 1)).toBe(true);
+    expect(shouldIgnoreGroupConfigResponse(true, 1, 2)).toBe(true);
+    expect(shouldIgnoreGroupConfigResponse(true, 2, 2)).toBe(false);
+  });
+
+  it('scope key가 다르면 이전 scope 응답을 버린다', () => {
+    const keyA = buildGroupConfigKey(['p-a'], true);
+    const keyB = buildGroupConfigKey(['p-b'], true);
+    expect(keyA).not.toBe(keyB);
+    // A의 늦은 응답(myId=1)이 B(current=2)를 덮지 않는다.
+    expect(shouldIgnoreGroupConfigResponse(true, 2, 1)).toBe(true);
+  });
+});
+
+describe('GroupConfigs auxiliary read — dedupe 유지 (9)', () => {
+  it('중복 productId를 제거하고 정렬한다', () => {
+    expect(dedupeGroupProductIds(['p-b', 'p-a', 'p-b', 'p-a'])).toEqual(['p-a', 'p-b']);
+    expect(buildGroupConfigKey(['p-b', 'p-a', 'p-b'], true)).toBe('p-a|p-b');
+    expect(buildGroupConfigKey(['p-a', 'p-b'], true)).toBe(
+      buildGroupConfigKey(['p-b', 'p-a', 'p-b'], true),
+    );
+  });
+
+  it('fetch는 unique id당 한 번만 호출한다', async () => {
+    const fetchOne = vi.fn(async (id: string) => `${id}-date`);
+    await fetchGroupConfigMap(['p-1', 'p-1', 'p-2'], fetchOne);
+    expect(fetchOne).toHaveBeenCalledTimes(2);
+    expect(fetchOne).toHaveBeenCalledWith('p-1');
+    expect(fetchOne).toHaveBeenCalledWith('p-2');
+  });
+});
+
+describe('GroupConfigs auxiliary read — timestamp → ISO normalization 유지 (10)', () => {
+  it('Firestore Timestamp는 ISO 문자열로 정규화한다', () => {
+    const date = new Date('2026-09-05T12:00:00.000Z');
+    expect(normalizeGroupDeliveryDate({ toDate: () => date })).toBe('2026-09-05T12:00:00.000Z');
+  });
+
+  it('string은 그대로 사용한다', () => {
+    expect(normalizeGroupDeliveryDate('2026-09-05T12:00:00')).toBe('2026-09-05T12:00:00');
+  });
+
+  it('null/undefined/number/toDate 없는 객체는 null이다', () => {
+    expect(normalizeGroupDeliveryDate(null)).toBeNull();
+    expect(normalizeGroupDeliveryDate(undefined)).toBeNull();
+    expect(normalizeGroupDeliveryDate(123)).toBeNull();
+    expect(normalizeGroupDeliveryDate({})).toBeNull();
+    expect(normalizeGroupDeliveryDate({ toDate: 'not-fn' })).toBeNull();
+  });
+
+  it('toDate throw·invalid Date는 null이다', () => {
+    expect(
+      normalizeGroupDeliveryDate({
+        toDate: () => {
+          throw new Error('bad');
+        },
+      }),
+    ).toBeNull();
+    expect(
+      normalizeGroupDeliveryDate({ toDate: () => new Date('invalid') }),
+    ).toBeNull();
+  });
+});
+
+describe('GroupConfigs auxiliary read — saleType toggle/filter 회귀 없음 (11)', () => {
+  it('일반 토글(enabled=false)은 조회하지 않고 DISABLED다', () => {
+    const key = buildGroupConfigKey(['p-1'], false);
+    expect(key).toBe('');
+    expect(
+      resolveGroupConfigView({ enabled: false, key, loading: false, error: null, hasLoaded: false }),
+    ).toBe('DISABLED');
+  });
+
+  it('공구 토글로 돌아오면 같은 scope key로 재조회한다', () => {
+    expect(buildGroupConfigKey(['p-1', 'p-2'], true)).toBe('p-1|p-2');
+  });
+
+  it('retry는 saleType/tab/filter scope를 바꾸지 않는다', () => {
+    const before = buildGroupConfigKey(['p-1'], true);
+    const retryKey = nextGroupConfigRetryKey(0);
+    expect(retryKey).toBe(1);
+    expect(buildGroupConfigKey(['p-1'], true)).toBe(before);
+  });
+});

--- a/apps/seller/src/hooks/useGroupConfigs.recovery.ts
+++ b/apps/seller/src/hooks/useGroupConfigs.recovery.ts
@@ -1,0 +1,153 @@
+/**
+ * Seller 주문 목록 공구 배송일 auxiliary read 순수 계약 (seller-only).
+ * `useGroupConfigs.ts`의 runtime effect와 동일한 판정을 공유하되,
+ * vitest에서 `@/` alias 없이 직접 검증할 수 있도록 framework 의존성을 두지 않는다.
+ *
+ * 이 파일은 SELLER_ORDER_GROUP_CONFIG_AUXILIARY_READ 전용이다.
+ * Consumer Legacy Group Config (`apps/consumer`)와 collection을 읽더라도
+ * 파일·semantic owner를 공유하지 않으며, 공통 helper로 결합하지 않는다.
+ * groupProductConfig backend/schema·배송 정책은 변경하지 않는다.
+ *
+ * Collapse 방지 원칙:
+ * - core order read와 auxiliary group-config read를 분리한다.
+ * - Firestore 성공(문서 없음 포함)만 map을 갱신한다.
+ * - getDoc 실패는 map을 `{}`로 지우지 않고 error + retry로 닫는다.
+ * - 이전 성공 뒤 같은 scope 재조회 실패는 stale로 보존하되 최신 확정값처럼 쓰지 않는다.
+ * - scope(product ID set) 변경 시 이전 scope 데이터를 새 scope 값처럼 노출하지 않는다.
+ */
+
+export const GROUP_CONFIGS_ERROR_MESSAGE = '공구 배송일 정보를 불러오지 못했습니다.';
+
+export type GroupConfigEntry = readonly [productId: string, iso: string | null];
+
+export type GroupConfigMapData = Record<string, { groupDeliveryDate: string }>;
+
+export type GroupConfigView = 'DISABLED' | 'LOADING' | 'READY' | 'READ_FAILED' | 'STALE';
+
+/** 중복 productId를 제거하고 정렬된 배열로 반환한다. */
+export function dedupeGroupProductIds(productIds: string[]): string[] {
+  return [...new Set(productIds.filter(Boolean))].sort();
+}
+
+/**
+ * effect 의존성 안정화를 위한 scope key.
+ * disabled면 `''`, enabled면 dedupe+정렬된 join key.
+ * 같은 key는 같은 scope이며 재fetch가 필요 없다.
+ */
+export function buildGroupConfigKey(productIds: string[], enabled: boolean): string {
+  if (!enabled) return '';
+  return dedupeGroupProductIds(productIds).join('|');
+}
+
+/**
+ * Firestore Timestamp → ISO 정규화 (기존 useGroupConfigs 패턴 유지).
+ * - `{ toDate(): Date }`면 `toDate().toISOString()`
+ * - string이면 그대로 사용
+ * - 그 외(null/undefined/number/object without toDate 등)는 null
+ */
+export function normalizeGroupDeliveryDate(raw: unknown): string | null {
+  if (raw && typeof raw === 'object' && 'toDate' in raw) {
+    const toDate = (raw as { toDate: unknown }).toDate;
+    if (typeof toDate === 'function') {
+      try {
+        const date = (toDate as () => unknown).call(raw);
+        if (date instanceof Date && !Number.isNaN(date.getTime())) {
+          return date.toISOString();
+        }
+      } catch {
+        return null;
+      }
+      return null;
+    }
+    return null;
+  }
+  return typeof raw === 'string' ? raw : null;
+}
+
+/**
+ * fetch 성공 entries → authoritative map.
+ * iso가 null인 productId(문서 없음·날짜 없음)는 "read failure"가 아니라
+ * map에서 제외한다. 호출부는 빈 map을 실패와 혼동하지 않는다.
+ */
+export function buildGroupConfigMapFromEntries(entries: GroupConfigEntry[]): GroupConfigMapData {
+  const next: GroupConfigMapData = {};
+  for (const [productId, iso] of entries) {
+    if (iso) next[productId] = { groupDeliveryDate: iso };
+  }
+  return next;
+}
+
+/**
+ * 보조 조회 오케스트레이션 (순수 async, Firestore 의존성 없음).
+ * - ids는 hook이 전달한 dedupe済み scope다. 여기서도 Set으로 이중 보장한다.
+ * - `fetchOne`은 productId당 정규화된 ISO 또는 null(missing)을 반환한다.
+ * - `fetchOne`이 throw하면 Promise.all이 reject되며 호출부(hook)가
+ *   error + retry로 닫는다. `.catch(() => ({}))`로 빈 map 승격을 금지한다.
+ */
+export async function fetchGroupConfigMap(
+  ids: string[],
+  fetchOne: (productId: string) => Promise<string | null>,
+): Promise<GroupConfigMapData> {
+  const unique = [...new Set(ids.filter(Boolean))];
+  const entries = await Promise.all(
+    unique.map(async (productId) => {
+      const iso = await fetchOne(productId);
+      return [productId, iso] as const;
+    }),
+  );
+  return buildGroupConfigMapFromEntries(entries);
+}
+
+/**
+ * 보조 조회 상태를 단일 view로 판정한다.
+ * 우선순위: DISABLED > 첫 조회 실패(READ_FAILED) > stale(STALE) > 초기 로딩(LOADING) > 성공(READY).
+ * - DISABLED: enabled=false 또는 key 없음 — map/error/loading 모두 clean이어야 한다.
+ * - READ_FAILED: 첫 조회 실패 — 빈 map을 정상 empty로 승격 금지.
+ * - STALE: 이전 성공 뒤 재조회 실패 — 이전 map 보존 + error, 최신 확정값 아님.
+ * - READY: 마지막 authoritative 성공 — map이 비어도(전부 missing) 실패가 아니다.
+ */
+export function resolveGroupConfigView(input: {
+  enabled: boolean;
+  key: string;
+  loading: boolean;
+  error: string | null;
+  hasLoaded: boolean;
+}): GroupConfigView {
+  const { enabled, key, error, hasLoaded } = input;
+  if (!enabled || !key) return 'DISABLED';
+  if (error && !hasLoaded) return 'READ_FAILED';
+  if (error && hasLoaded) return 'STALE';
+  if (!hasLoaded) return 'LOADING';
+  return 'READY';
+}
+
+/** stale은 "이전 성공 map + 현재 error"일 때만 true다. 최신 확정값처럼 쓰지 않는다. */
+export function isGroupConfigStale(error: string | null, hasLoaded: boolean): boolean {
+  return error !== null && hasLoaded;
+}
+
+/** race guard: 취소됐거나 최신 요청이 아니면 응답을 무시한다. */
+export function shouldIgnoreGroupConfigResponse(
+  active: boolean,
+  currentRequestId: number,
+  responseRequestId: number,
+): boolean {
+  return !active || currentRequestId !== responseRequestId;
+}
+
+/** auxiliary retry 키. retry 호출마다 단조 증가하며 effect deps로 사용된다. */
+export function nextGroupConfigRetryKey(current: number): number {
+  return current + 1;
+}
+
+/**
+ * 실패 시 map 판정: 이전 map을 그대로 보존한다.
+ * 첫 실패(prev empty + !hasLoaded)도 `{}`를 "정상 empty"로 승격하지 않도록
+ * 호출부는 반드시 error와 함께 다룬다.
+ */
+export function resolveGroupConfigMapAfterFailure(
+  prevMap: GroupConfigMapData,
+  _hasLoaded: boolean,
+): GroupConfigMapData {
+  return prevMap;
+}

--- a/apps/seller/src/hooks/useGroupConfigs.ts
+++ b/apps/seller/src/hooks/useGroupConfigs.ts
@@ -1,61 +1,144 @@
 'use client';
 
 import { doc, getDoc } from 'firebase/firestore';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { GroupConfigMap } from '@/app/orders/_constants';
 import { db } from '@/lib/firebase';
+import {
+  buildGroupConfigKey,
+  fetchGroupConfigMap,
+  GROUP_CONFIGS_ERROR_MESSAGE,
+  isGroupConfigStale,
+  normalizeGroupDeliveryDate,
+  shouldIgnoreGroupConfigResponse,
+} from './useGroupConfigs.recovery';
+
+export {
+  buildGroupConfigKey,
+  dedupeGroupProductIds,
+  fetchGroupConfigMap,
+  GROUP_CONFIGS_ERROR_MESSAGE,
+  isGroupConfigStale,
+  nextGroupConfigRetryKey,
+  normalizeGroupDeliveryDate,
+  resolveGroupConfigMapAfterFailure,
+  resolveGroupConfigView,
+  shouldIgnoreGroupConfigResponse,
+} from './useGroupConfigs.recovery';
+export type { GroupConfigEntry, GroupConfigMapData, GroupConfigView } from './useGroupConfigs.recovery';
 
 /**
- * productId 리스트의 groupProductConfig 문서를 일괄 fetch해 productId → { groupDeliveryDate }
- * 맵으로 반환. 중복 productId는 Set으로 제거 후 Promise.all로 병렬 fetch.
- * Firestore Timestamp는 ISO 문자열로 정규화 (useGroupProduct와 동일 패턴).
+ * productId 리스트의 groupProductConfig 문서를 일괄 fetch하는 auxiliary read.
+ *
+ * 이 데이터는 "주문 자체"가 아니라 공동구매 배송일 그룹화/표시용 보조 메타데이터다.
+ * 따라서 core order read를 가리지 않는다:
+ * - 실패해도 unhandled rejection 없이 error + retry로 닫고, core 목록은 호출부가 유지한다.
+ * - 문서 없음(missing)은 실패가 아니라 map 제외다.
+ * - 이전 성공 뒤 같은 scope 재조회 실패는 이전 map을 stale로 보존한다.
+ * - scope(product ID set) 변경 시 이전 scope 데이터를 새 값처럼 노출하지 않고,
+ *   늦은 응답이 새 scope를 덮지 않는다.
  */
-export function useGroupConfigs(productIds: string[], enabled: boolean): GroupConfigMap {
+export interface UseGroupConfigsResult {
+  /** 마지막 authoritative 성공 map. 실패 시 이전 map(stale) 또는 `{}`. */
+  map: GroupConfigMap;
+  /** 조회 중 여부. stale background 갱신 중에도 true가 될 수 있다. */
+  loading: boolean;
+  /** 보조 조회 실패 메시지. 성공·disabled·로딩 시작 시 null. */
+  error: string | null;
+  /** error + 이전 성공. 최신 확정값이 아니므로 주문 존재/상태 판단에 쓰지 않는다. */
+  isStale: boolean;
+  /** 같은 scope를 다시 조회한다. saleType/tab/filter state를 건드리지 않는다. */
+  retry: () => void;
+}
+
+export function useGroupConfigs(productIds: string[], enabled: boolean): UseGroupConfigsResult {
   const [map, setMap] = useState<GroupConfigMap>({});
-  // 의존성 안정화를 위해 정렬된 join key 사용
-  const key = enabled ? [...new Set(productIds)].sort().join('|') : '';
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [hasLoaded, setHasLoaded] = useState(false);
+  const [retryKey, setRetryKey] = useState(0);
+  const requestIdRef = useRef(0);
+  const scopeRef = useRef<string>('');
+
+  // 의존성 안정화를 위해 정렬된 join key 사용 (dedupe 포함)
+  const key = buildGroupConfigKey(productIds, enabled);
+
+  const retry = useCallback(() => {
+    setRetryKey((k) => k + 1);
+  }, []);
+
+  const isStale = isGroupConfigStale(error, hasLoaded);
 
   useEffect(() => {
+    void retryKey;
     if (!enabled || !key) {
+      // A. Disabled / no IDs — map/error/loading clean state.
+      requestIdRef.current += 1;
+      scopeRef.current = '';
       setMap({});
+      setError(null);
+      setLoading(false);
+      setHasLoaded(false);
       return;
     }
     const ids = key.split('|').filter(Boolean);
     if (ids.length === 0) {
+      requestIdRef.current += 1;
+      scopeRef.current = '';
       setMap({});
+      setError(null);
+      setLoading(false);
+      setHasLoaded(false);
       return;
     }
 
-    let cancelled = false;
+    const isScopeChange = scopeRef.current !== key;
+    scopeRef.current = key;
+    if (isScopeChange) {
+      // 새 scope는 이전 scope 데이터를 authoritative처럼 노출하지 않는다.
+      setMap({});
+      setHasLoaded(false);
+    }
+    // 같은 scope retry는 이전 map을 유지한 채 background 갱신한다.
+    setError(null);
+    setLoading(true);
+    const myId = requestIdRef.current + 1;
+    requestIdRef.current = myId;
+    const scopeKey = key;
+    let active = true;
+
     (async () => {
-      const entries = await Promise.all(
-        ids.map(async (productId) => {
+      let next: GroupConfigMap | null = null;
+      let failed = false;
+      try {
+        next = await fetchGroupConfigMap(ids, async (productId) => {
           const snap = await getDoc(doc(db, 'groupProductConfig', productId));
-          if (!snap.exists()) return [productId, null] as const;
+          if (!snap.exists()) return null;
           const data = snap.data() as { groupDeliveryDate?: unknown };
-          const raw = data.groupDeliveryDate;
-          // Firestore Timestamp → ISO 정규화
-          const iso =
-            raw && typeof raw === 'object' && 'toDate' in raw
-              ? (raw as { toDate(): Date }).toDate().toISOString()
-              : typeof raw === 'string'
-                ? raw
-                : null;
-          return [productId, iso] as const;
-        }),
-      );
-      if (cancelled) return;
-      const next: GroupConfigMap = {};
-      for (const [productId, iso] of entries) {
-        if (iso) next[productId] = { groupDeliveryDate: iso };
+          return normalizeGroupDeliveryDate(data.groupDeliveryDate);
+        });
+      } catch {
+        failed = true;
+      }
+      if (shouldIgnoreGroupConfigResponse(active, requestIdRef.current, myId)) return;
+      if (scopeRef.current !== scopeKey) return;
+      if (failed || next === null) {
+        // D/E. 실패는 이전 map을 지우지 않는다 (stale 보존, EMPTY collapse 금지).
+        // 단순 `.catch(() => setMap({}))` 금지 — READ_FAILED를 EMPTY로 승격시키기 때문이다.
+        setError(GROUP_CONFIGS_ERROR_MESSAGE);
+        setLoading(false);
+        return;
       }
       setMap(next);
+      setError(null);
+      setHasLoaded(true);
+      setLoading(false);
     })();
 
     return () => {
-      cancelled = true;
+      active = false;
     };
-  }, [key, enabled]);
+  }, [key, enabled, retryKey]);
 
-  return map;
+  return { map, loading, error, isStale, retry };
 }


### PR DESCRIPTION
## Purpose
Publication-only transport of completed SELLER-GROUP-CONFIGS-READ-RECOVERY-01 onto protected `main`.
Temporary publication branch only; shared checkout foreign dirty is never included.

## Root cause
Seller `useGroupConfigs` auxiliary read collapsed distinct outcomes (disabled / loading / confirmed-empty / failure / stale) and risked promoting `getDoc` failure to empty-map success, hiding retry and mixing auxiliary failure with core order state.

## Auxiliary read state contract
- `DISABLED / LOADING / READY / READ_FAILED / STALE` via `resolveGroupConfigView`
- Priority: `DISABLED > READ_FAILED (first failure) > STALE > LOADING > READY`
- `isStale = error != null && hasLoaded`

## Confirmed empty vs failure separation
- Missing document / null date is excluded from map, not a read failure
- All-missing still resolves to `{}` success and `READY` (with `hasLoaded=true`, `error=null`)
- `getDoc` throw rejects `fetchGroupConfigMap`; hook surfaces `GROUP_CONFIGS_ERROR_MESSAGE` + retry and never collapses to `{}` success

## Stale preservation policy
- Same-scope refresh failure preserves previous map (`resolveGroupConfigMapAfterFailure` returns `prevMap`)
- `STALE` = previous success + current error; never used as authoritative value for order existence/status

## Scope invalidation
- Scope key = deduped + sorted `productIds` join (`buildGroupConfigKey`); `enabled=false` yields `''`
- Scope change clears previous `map`/`hasLoaded` so old scope is never exposed as new
- Late response blocked by `requestId + scope key + active` guard (`shouldIgnoreGroupConfigResponse` + `scopeRef` check)

## Retry contract
- `retry` only bumps `retryKey` and re-runs group-config auxiliary read
- `saleType / tab / filter / order` core state untouched; same-scope retry keeps previous map during background refresh

## Core orders separation
- `useOrders` read contract unchanged
- Seller orders page exposes auxiliary warning/retry separately from core order `loading / error`; auxiliary failure never hides the order list or fabricates empty

## Validation (publication candidate)
- Focused Vitest 4 files: **68 passed** (`useGroupConfigs.recovery` 27, `useOrders` 12, `orders-view-model` 23, `order-priority` 6) with repo Vitest v3.2.4
- `apps/seller` TypeScript `--noEmit`: **clean**
- Biome lint on 4 owned files: **clean**

## Files (owned only, 4)
- `apps/seller/src/hooks/useGroupConfigs.ts`
- `apps/seller/src/hooks/useGroupConfigs.recovery.ts` (new)
- `apps/seller/src/hooks/useGroupConfigs.recovery.test.ts` (new)
- `apps/seller/src/app/orders/page.tsx`

## Foreign dirty exclusion
Foreign dirty in shared checkout (driver board/map, seller `useOrderDetail` family) is **0 files included** in this branch. Verified via `git diff --cached --name-only` = owned 4 only. No reset/stash/restore/force-push/history-rewrite.

## Task
SELLER-GROUP-CONFIGS-READ-RECOVERY-PUBLICATION-01
BASELINE: `57ebcce7801072520276cdee8a47cd98249f00e0`
CANDIDATE_PARENT: `57ebcce7801072520276cdee8a47cd98249f00e0`
