### PR TITLE
fix(driver): scope order-detail stale recovery to same auth-scope

### DIFF
--- a/apps/driver/src/app/board/[orderId]/page.tsx
+++ b/apps/driver/src/app/board/[orderId]/page.tsx
@@ -20,7 +20,9 @@ import { use, useCallback, useEffect, useRef, useState } from 'react';
 import { apiFetch } from '@/lib/api';
 import {
   type DriverOrderReadErrorKind,
+  isDriverOrderCommandAllowed,
   isDriverOrderStatusAck,
+  shouldPreserveDriverOrderOnReadError,
   toDriverOrderNetworkError,
   toDriverOrderReadError,
 } from '../_lib/driver-order-detail';
@@ -80,6 +82,8 @@ export default function OrderDetailPage({ params }: { params: Promise<{ orderId:
   const [readKey, setReadKey] = useState(0);
   const readSeqRef = useRef(0);
   const hasOrderRef = useRef(false);
+  // orderId·auth token scope가 바뀌면 이전 scope의 order/PII를 절대 남기지 않는다.
+  const readScopeRef = useRef<string | null>(null);
 
   const readDetail = useCallback(
     async (token: string) => {
@@ -98,12 +102,15 @@ export default function OrderDetailPage({ params }: { params: Promise<{ orderId:
         if (!isCurrent()) return;
         if (!response.ok) {
           const failure = toDriverOrderReadError(response.status);
-          // 후속 refresh 실패는 기존 order를 지우지 않고 stale로 유지한다.
-          if (hasOrderRef.current) {
+          // AUTH_ERROR·NOT_FOUND는 authority loss/absence이므로 이전 order를 즉시 제거한다.
+          // FETCH_ERROR만 일시적 refresh 실패로 이전 내용을 stale로 유지할 수 있다.
+          if (shouldPreserveDriverOrderOnReadError(failure.kind, hasOrderRef.current)) {
             setReadError({ kind: failure.kind, message: failure.message });
           } else {
+            hasOrderRef.current = false;
             setOrder(null);
             setReadError({ kind: failure.kind, message: failure.message });
+            setReadbackWarning(null);
           }
         } else {
           const payload = (await response.json()) as Order;
@@ -111,6 +118,8 @@ export default function OrderDetailPage({ params }: { params: Promise<{ orderId:
           hasOrderRef.current = true;
           setOrder(payload);
           setReadError(null);
+          // fresh authoritative read는 이전 readback 불확실성을 해소한다.
+          setReadbackWarning(null);
         }
       } catch (cause: unknown) {
         if (!isCurrent() || (cause instanceof DOMException && cause.name === 'AbortError')) return;
@@ -130,19 +139,46 @@ export default function OrderDetailPage({ params }: { params: Promise<{ orderId:
     const token = session?.user.accessToken;
     if (!token) {
       // usable token 없음을 not-found/empty로 표시하지 않는다.
+      // token 상실 역시 authority loss이므로 이전 scope 잔여물을 모두 제거한다.
       readSeqRef.current += 1;
+      readScopeRef.current = `${orderId}::__no_token__`;
       setOrder(null);
       hasOrderRef.current = false;
       setReadError({ kind: 'AUTH_ERROR', message: '로그인 정보를 다시 확인해 주세요.' });
+      setReadbackWarning(null);
       setReadLoading(false);
       setReadRefreshing(false);
       return;
+    }
+    const nextScope = `${orderId}::${token}`;
+    if (readScopeRef.current !== nextScope) {
+      // orderId 또는 auth scope 변경: 이전 주문·PII·readError/readback을 새 scope에 남기지 않는다.
+      // 진행 중이던 이전 scope read는 seq 무효화로 덮어쓰기를 막는다.
+      readSeqRef.current += 1;
+      readScopeRef.current = nextScope;
+      hasOrderRef.current = false;
+      setOrder(null);
+      setReadError(null);
+      setReadbackWarning(null);
+      setReadLoading(true);
+      setReadRefreshing(false);
     }
     void readDetail(token);
   }, [orderId, session?.user.accessToken, readKey, readDetail]);
 
   async function updateStatus(status: string) {
     if (!order || !session) return;
+    // fail-closed: stale read confidence에서는 위험 command를 실행하지 않는다.
+    // AUTH/NOT_FOUND는 원칙적으로 order가 제거된 상태이며, FETCH stale·readback 미확인도 차단한다.
+    if (
+      !isDriverOrderCommandAllowed({
+        hasOrder: order !== null,
+        readErrorKind: readError?.kind ?? null,
+        hasReadbackWarning: readbackWarning !== null,
+      })
+    ) {
+      return;
+    }
     const token = session.user.accessToken;
     setLoading(true);
     setReadbackWarning(null);
@@ -166,8 +202,22 @@ export default function OrderDetailPage({ params }: { params: Promise<{ orderId:
         hasOrderRef.current = true;
         setOrder(fresh);
         setReadError(null);
+        setReadbackWarning(null);
       } catch (readbackCause: unknown) {
-        if (isTerminal) {
+        // readback 단계의 AUTH_ERROR·NOT_FOUND 역시 authority loss이므로 이전 order를 남기지 않는다.
+        const readbackKind = (readbackCause as { kind?: unknown } | null)?.kind;
+        if (readbackKind === 'AUTH_ERROR' || readbackKind === 'NOT_FOUND') {
+          const message =
+            readbackCause instanceof Error ? readbackCause.message : '주문을 찾을 수 없습니다';
+          hasOrderRef.current = false;
+          setOrder(null);
+          setReadError({
+            kind: readbackKind as DriverOrderReadErrorKind,
+            message,
+          });
+          setReadbackWarning(null);
+          if (!isTerminal) return;
+        } else if (isTerminal) {
           // terminal은 board가 fresh fetch하므로 navigation 계약을 유지한다.
         } else {
           const message =
@@ -244,6 +294,13 @@ export default function OrderDetailPage({ params }: { params: Promise<{ orderId:
     order.schemaVersion === 2 && Boolean(order.roundId) && order.deliveryMethod === 'direct';
   const paymentPresentation = getRedeliveryPaymentPresentation(order.redeliveryPayment);
   const deliveryStartAllowed = isDeliveryStartAllowed(order.redeliveryPayment);
+  // stale FETCH_ERROR 또는 readback 미확인 상태의 order는 최신 authoritative state가 아니다.
+  // 위험 command 진입(상태 변경·사진 촬영·보류)은 fail-closed로 비활성화한다.
+  const commandsAllowed = isDriverOrderCommandAllowed({
+    hasOrder: true,
+    readErrorKind: readError?.kind ?? null,
+    hasReadbackWarning: readbackWarning !== null,
+  });
   const preparedAtStr = order.preparedAt
     ? new Date(order.preparedAt).toLocaleTimeString('ko-KR', {
         hour: '2-digit',
@@ -467,6 +524,7 @@ export default function OrderDetailPage({ params }: { params: Promise<{ orderId:
               radius="xl"
               color="brand"
               loading={loading}
+              disabled={!commandsAllowed}
               onClick={() => updateStatus('DELIVERING')}
             >
               배송 재개
@@ -486,6 +544,7 @@ export default function OrderDetailPage({ params }: { params: Promise<{ orderId:
                   radius="xl"
                   color="brand"
                   loading={loading}
+                  disabled={!commandsAllowed}
                   onClick={() => updateStatus('DELIVERING')}
                 >
                   수거 완료 / 배송 시작
@@ -502,6 +561,7 @@ export default function OrderDetailPage({ params }: { params: Promise<{ orderId:
                 radius="xl"
                 color="brand"
                 loading={loading}
+                disabled={!commandsAllowed}
                 onClick={() =>
                   router.push(`/board/${orderId}/photo/round-direct?storeId=${order.storeId}`)
                 }
@@ -515,7 +575,7 @@ export default function OrderDetailPage({ params }: { params: Promise<{ orderId:
               radius="xl"
               color="red"
               variant="outline"
-              disabled={loading}
+              disabled={loading || !commandsAllowed}
               onClick={() => setHoldOpened(true)}
             >
               배송 보류
@@ -531,6 +591,7 @@ export default function OrderDetailPage({ params }: { params: Promise<{ orderId:
               radius="xl"
               color="brand"
               loading={loading}
+              disabled={!commandsAllowed}
               onClick={() => updateStatus('DELIVERING')}
             >
               수거 완료 / 배송 시작
@@ -547,6 +608,7 @@ export default function OrderDetailPage({ params }: { params: Promise<{ orderId:
             radius="xl"
             color="brand"
             loading={loading}
+            disabled={!commandsAllowed}
             onClick={() => updateStatus('DELIVERED')}
           >
             배송 완료
@@ -559,6 +621,7 @@ export default function OrderDetailPage({ params }: { params: Promise<{ orderId:
             radius="xl"
             color="blue"
             loading={loading}
+            disabled={!commandsAllowed}
             onClick={() => router.push(`/board/${orderId}/photo?storeId=${order.storeId}`)}
           >
             거점 도착

--- a/apps/driver/src/app/board/_lib/driver-order-detail-auth-scope.test.mjs
+++ b/apps/driver/src/app/board/_lib/driver-order-detail-auth-scope.test.mjs
@@ -1,0 +1,189 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+import {
+  isDriverOrderCommandAllowed,
+  shouldPreserveDriverOrderOnReadError,
+} from './driver-order-detail.ts';
+
+const detailSource = await readFile(
+  new URL('../[orderId]/page.tsx', import.meta.url),
+  'utf8',
+);
+const helperSource = await readFile(new URL('./driver-order-detail.ts', import.meta.url), 'utf8');
+
+// 1. initial success: fresh read가 order를 확정한다.
+test('fresh authoritative read는 order를 확정하고 error·readback을 해소한다', () => {
+  assert.match(detailSource, /hasOrderRef\.current = true/);
+  assert.match(detailSource, /setOrder\(payload\)/);
+  assert.match(detailSource, /setReadError\(null\)/);
+  assert.match(detailSource, /setReadbackWarning\(null\)/);
+});
+
+// 2. initial 401/403 → protected data 없음 (pure 정책).
+test('initial 401/403은 이전 order 없이 AUTH_ERROR이며 order를 보존하지 않는다', () => {
+  assert.equal(shouldPreserveDriverOrderOnReadError('AUTH_ERROR', false), false);
+  assert.equal(shouldPreserveDriverOrderOnReadError('AUTH_ERROR', true), false);
+  assert.equal(
+    isDriverOrderCommandAllowed({
+      hasOrder: false,
+      readErrorKind: 'AUTH_ERROR',
+      hasReadbackWarning: false,
+    }),
+    false,
+  );
+});
+
+// 2b. initial 401/403 → protected data 없음 (render 계약).
+test('AUTH_ERROR 초기 실패는 주문 없음 분기로 끝나고 PII·CTA를 렌더하지 않는다', () => {
+  assert.match(detailSource, /if \(!order\)/);
+  assert.match(detailSource, /로그인 정보를 다시 확인해 주세요/);
+  const guardAt = detailSource.indexOf('if (!order)');
+  for (const pii of ['order.address', 'order.buyerPhone', 'order.sellerPhone']) {
+    assert.ok(
+      detailSource.indexOf(pii) > guardAt,
+      `${pii}는 !order 가드 이후에만 렌더되어야 한다`,
+    );
+  }
+  for (const cta of ['배송 재개', '수거 완료 / 배송 시작', '배송 완료', '거점 도착', '배송 보류']) {
+    assert.ok(
+      detailSource.indexOf(cta) > guardAt,
+      `${cta}는 !order 가드 이후에만 렌더되어야 한다`,
+    );
+  }
+});
+
+// 3. success → refresh 401/403 → 이전 order 제거.
+test('refresh 401/403은 authority loss로 이전 order를 즉시 제거한다', () => {
+  assert.match(detailSource, /shouldPreserveDriverOrderOnReadError\(failure\.kind/);
+  assert.match(detailSource, /hasOrderRef\.current = false/);
+  assert.match(detailSource, /setOrder\(null\)/);
+  // 이전의 무조건 stale 유지 흐름은 남아 있지 않다.
+  assert.doesNotMatch(detailSource, /후속 refresh 실패는 기존 order를 지우지 않고/);
+  assert.equal(shouldPreserveDriverOrderOnReadError('AUTH_ERROR', true), false);
+});
+
+// 4. success → 404 → 이전 order 제거.
+test('refresh 404는 authoritative absence로 이전 order를 유지하지 않는다', () => {
+  assert.equal(shouldPreserveDriverOrderOnReadError('NOT_FOUND', true), false);
+  assert.equal(shouldPreserveDriverOrderOnReadError('NOT_FOUND', false), false);
+  assert.equal(
+    isDriverOrderCommandAllowed({
+      hasOrder: true,
+      readErrorKind: 'NOT_FOUND',
+      hasReadbackWarning: false,
+    }),
+    false,
+  );
+});
+
+// 5. success → network/5xx → stale 표시 정책.
+test('FETCH_ERROR만 stale 유지가 허용되고 이전 정보 표시·retry를 제공한다', () => {
+  assert.equal(shouldPreserveDriverOrderOnReadError('FETCH_ERROR', true), true);
+  assert.equal(shouldPreserveDriverOrderOnReadError('FETCH_ERROR', false), false);
+  assert.match(detailSource, /이전 정보 표시 중/);
+  assert.match(detailSource, /다시 확인/);
+  assert.match(detailSource, /readError\.kind === 'FETCH_ERROR'/);
+});
+
+// 6. AUTH_ERROR에서 CTA 없음.
+test('AUTH_ERROR에서는 order가 제거되어 CTA가 계산·실행되지 않는다', () => {
+  assert.match(detailSource, /if \(!order\)/);
+  assert.match(detailSource, /isDriverOrderCommandAllowed\(\{/);
+  assert.equal(
+    isDriverOrderCommandAllowed({
+      hasOrder: false,
+      readErrorKind: 'AUTH_ERROR',
+      hasReadbackWarning: false,
+    }),
+    false,
+  );
+  assert.equal(
+    isDriverOrderCommandAllowed({
+      hasOrder: true,
+      readErrorKind: 'AUTH_ERROR',
+      hasReadbackWarning: false,
+    }),
+    false,
+  );
+});
+
+// 7. stale FETCH_ERROR에서 위험 command 정책 검증.
+test('stale FETCH_ERROR·readback 미확인 상태에서는 command가 fail-closed된다', () => {
+  assert.equal(
+    isDriverOrderCommandAllowed({
+      hasOrder: true,
+      readErrorKind: 'FETCH_ERROR',
+      hasReadbackWarning: false,
+    }),
+    false,
+  );
+  assert.equal(
+    isDriverOrderCommandAllowed({
+      hasOrder: true,
+      readErrorKind: null,
+      hasReadbackWarning: true,
+    }),
+    false,
+  );
+  assert.equal(
+    isDriverOrderCommandAllowed({
+      hasOrder: true,
+      readErrorKind: null,
+      hasReadbackWarning: false,
+    }),
+    true,
+  );
+  assert.match(detailSource, /const commandsAllowed = isDriverOrderCommandAllowed/);
+  assert.match(detailSource, /disabled=\{!commandsAllowed\}/);
+  assert.match(detailSource, /disabled=\{loading \|\| !commandsAllowed\}/);
+});
+
+// 8. retry → success.
+test('FETCH 실패는 retry 키로 재조회하고 fresh 성공으로 수렴한다', () => {
+  assert.match(detailSource, /다시 시도/);
+  assert.match(detailSource, /다시 확인/);
+  assert.match(detailSource, /setReadKey\(\(key\)\s*=>\s*key\s*\+\s*1\)/);
+  assert.match(detailSource, /readKey, readDetail\]/);
+  assert.match(detailSource, /setOrder\(payload\)/);
+});
+
+// 9. orderId scope change → 이전 order/PII leak 없음.
+test('orderId·auth scope 변경은 이전 주문·PII·read 상태를 새 scope에 남기지 않는다', () => {
+  assert.match(detailSource, /readScopeRef/);
+  assert.match(detailSource, /orderId\}::\$\{token\}/);
+  assert.match(detailSource, /readScopeRef\.current !== nextScope/);
+  assert.match(detailSource, /setReadbackWarning\(null\)/);
+  // scope 경로에서 order·ref·error가 함께 초기화된다.
+  const scopeAt = detailSource.indexOf('readScopeRef.current !== nextScope');
+  const scopeBlock = detailSource.slice(scopeAt, scopeAt + 800);
+  assert.match(scopeBlock, /hasOrderRef\.current = false/);
+  assert.match(scopeBlock, /setOrder\(null\)/);
+  assert.match(scopeBlock, /setReadError\(null\)/);
+  assert.match(scopeBlock, /setReadLoading\(true\)/);
+  // token 상실도 같은 무효화 경로를 탄다.
+  assert.match(detailSource, /__no_token__/);
+  assert.match(helperSource, /AUTH_ERROR/);
+});
+
+// 10. 기존 redelivery payment gate 회귀 없음.
+test('redelivery payment gate 계약이 그대로 유지된다', () => {
+  assert.match(detailSource, /isDeliveryStartAllowed\(order\.redeliveryPayment\)/);
+  assert.match(detailSource, /deliveryStartAllowed \?/);
+  assert.match(detailSource, /getRedeliveryPaymentPresentation\(order\.redeliveryPayment\)/);
+  assert.match(detailSource, /disabled/);
+  assert.doesNotMatch(detailSource, /canPay/);
+  assert.doesNotMatch(detailSource, /orderCharges/);
+});
+
+// 11. 기존 command ACK/readback semantics 회귀 없음.
+test('command ACK 후 authoritative GET 수렴·readback 분리 계약이 유지된다', () => {
+  assert.match(detailSource, /isDriverOrderStatusAck\(result,\s*orderId,\s*status\)/);
+  assert.match(detailSource, /setOrder\(fresh\)/);
+  assert.match(detailSource, /readbackWarning/);
+  assert.match(detailSource, /처리는 완료되었지만 최신 상태를 확인하지 못했습니다/);
+  assert.match(detailSource, /상태 다시 확인/);
+  assert.match(detailSource, /readDetail\(token\)/);
+  assert.doesNotMatch(detailSource, /setTimeout\(updateStatus/);
+  assert.doesNotMatch(detailSource, /setInterval/);
+});

--- a/apps/driver/src/app/board/_lib/driver-order-detail.ts
+++ b/apps/driver/src/app/board/_lib/driver-order-detail.ts
@@ -54,6 +54,41 @@ export function toDriverOrderNetworkError(
 }
 
 /**
+ * authoritative GET 실패 때 이전 order를 화면에 유지해도 되는가.
+ *
+ * - AUTH_ERROR(401·403): authority loss이므로 절대 유지하지 않는다.
+ * - NOT_FOUND(404): authoritative absence이므로 절대 유지하지 않는다.
+ * - FETCH_ERROR(network/5xx 등): 일시적 refresh 실패만 이전 내용을 stale로 유지할 수 있다.
+ */
+export function shouldPreserveDriverOrderOnReadError(
+  kind: DriverOrderReadErrorKind,
+  hasOrder: boolean,
+): boolean {
+  if (!hasOrder) return false;
+  return kind === 'FETCH_ERROR';
+}
+
+/**
+ * 현재 read confidence에서 status 변경 계열 command를 노출·실행해도 되는가.
+ *
+ * - order 없음 → 불가
+ * - readError 존재(AUTH/NOT_FOUND/FETCH 모두) → 불가
+ *   (AUTH/NOT_FOUND는 원칙적으로 order가 이미 제거된 상태이며, 이중 fail-closed다)
+ * - readbackWarning 존재(처리 완료 후 최신 상태 미확인) → 불가
+ * - fresh order + error 없음 + warning 없음 → 가능
+ */
+export function isDriverOrderCommandAllowed(args: {
+  hasOrder: boolean;
+  readErrorKind: DriverOrderReadErrorKind | null;
+  hasReadbackWarning: boolean;
+}): boolean {
+  if (!args.hasOrder) return false;
+  if (args.hasReadbackWarning) return false;
+  if (args.readErrorKind !== null) return false;
+  return true;
+}
+
+/**
  * command semantic ACK: 서버가 반환한 orderId와 status가
  * 요청한 값과 정확히 일치해야 성공이다.
  */


### PR DESCRIPTION
SOURCE_TASK: DRIVER-ORDER-DETAIL-AUTH-SCOPE-RECOVERY-01 (COMPLETE) / Publication task DRIVER-ORDER-DETAIL-AUTH-SCOPE-RECOVERY-PUBLICATION-01, PUBLICATION_ONLY, no new feature or remediation beyond owned semantic change.

source baseline: 57ebcce7801072520276cdee8a47cd98249f00e0
candidate SHA: f36a4f3192b511ce08c132466c45f86bee15749e (local main commit, ref-only transport, no direct main push)
live remote main at framing: bc7b011dee7cf0c54e9e2c99a7469d587a740d0d; verified live remote main still bc7b011 before push (unrelated movement only).

owned files:
- apps/driver/src/app/board/[orderId]/page.tsx
- apps/driver/src/app/board/_lib/driver-order-detail.ts
- apps/driver/src/app/board/_lib/driver-order-detail-auth-scope.test.mjs
Note: intended path is _lib/...; verified lib/... without underscore does NOT exist, no duplicate/ambiguity, no BLOCK.

root cause:
Detail read failure preserved previous order whenever hasOrderRef was true, including AUTH_ERROR/NOT_FOUND and across orderId/auth-token scope changes. Stale protected order/PII could leak into another driver/order scope and initial failure could look READY.

contract:
- same auth/scope refresh FETCH_ERROR only may preserve stale order with retry UI
- AUTH_ERROR (401/403 incl. token loss) and NOT_FOUND (404) always clear previous order, readbackWarning, and set explicit error
- orderId/auth-token scope change clears order/PII/readError/readback, invalidates in-flight reads via seq, reloads fresh
- initial read failure never leaves stale READY; commands fail-closed via isDriverOrderCommandAllowed when any readError/readbackWarning present
- existing driver order-detail read-error taxonomy, ACK/readback convergence, and redelivery-payment gate preserved

focused tests (61 pass, 0 fail):
- node --test apps/driver/src/app/board/_lib/driver-order-detail.test.mjs apps/driver/src/app/board/_lib/driver-order-detail-auth-scope.test.mjs apps/driver/src/app/board/board-contract.test.mjs
- new auth/scope: 12 tests (initial AUTH, refresh AUTH/NOT_FOUND clear, FETCH stale only, fail-closed commands, scope-change PII clear, redelivery/ACK regression)
- existing detail: 7 tests; board-contract: 42 tests incl. direct-impact detail/readback scope
- No production/provider mutation: PortOne actual call NOT_RUN, ALIGO actual send NOT_RUN, Production Firebase mutation NOT_RUN, Production deployment NOT_RUN

foreign dirty excluded:
- Candidate commit diff --name-only is owned-only (verified via git diff HEAD~1 HEAD and git diff --cached --name-only before commit). No seller/board-client/map or other publication files staged or committed. Working tree after commit clean for foreign paths.

no force push: normal push only (git push origin HEAD:refs/heads/driver-order-detail-auth-scope-recovery-publication, new remote branch fast-forward from bc7b011 ancestor). No reset/restore/stash/clean/checkout/switch/worktree/rebase/cherry-pick/pull/force-push/direct-main-push.
publication branch never checked out: shared checkout remained main throughout (git branch --show-current == main); publication ref transported ref-only; local publication ref held by pre-existing temp worktree left untouched.