### PR TITLE
test(driver): fix Firebase binding env lifecycle

### DIFF
--- a/apps/driver/src/lib/firebase.binding.test.ts
+++ b/apps/driver/src/lib/firebase.binding.test.ts
@@ -82,30 +82,20 @@ const remoteEnvironment = {
   NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN: 'green-e4fe3.firebaseapp.com',
 };
 
-const savedEnvironment = new Map<string, string | undefined>();
-
 function setEnvironment(values: Record<string, string>): void {
   for (const key of ENVIRONMENT_KEYS) {
-    process.env[key] = values[key] ?? '';
+    vi.stubEnv(key, values[key] ?? '');
   }
 }
 
 beforeEach(() => {
-  for (const key of ENVIRONMENT_KEYS) {
-    savedEnvironment.set(key, process.env[key]);
-  }
   firebaseMocks.apps.length = 0;
   vi.clearAllMocks();
   vi.resetModules();
 });
 
 afterEach(() => {
-  for (const key of ENVIRONMENT_KEYS) {
-    const value = savedEnvironment.get(key);
-    if (value === undefined) delete process.env[key];
-    else process.env[key] = value;
-  }
-  savedEnvironment.clear();
+  vi.unstubAllEnvs();
 });
 
 describe('Driver Firebase local binding (FE-PILOT-DRIVER-FIREBASE-BINDING-PROOF-01, driver-only)', () => {


### PR DESCRIPTION
Root cause: manual process.env mutation directly assigned readonly NODE_ENV, causing TS2540.

Fix: switched to Vitest-native vi.stubEnv / vi.unstubAllEnvs lifecycle.

Proof:
- Driver Firebase binding 6/6 PASS
- Driver typecheck 0 errors
- Biome clean
- git diff --check clean