### PR TITLE
fix(consumer): preserve sale rounds across refresh failures

### DIFF
--- a/apps/consumer/src/app/category/page.tsx
+++ b/apps/consumer/src/app/category/page.tsx
@@ -187,6 +187,9 @@ function RoundDirectCategory({
   pastRounds,
   loading,
   error,
+  isRefreshing,
+  isStale,
+  status,
   refetch,
 }: ReturnType<typeof useSaleRounds> & { products: Product[] }) {
   if (loading) {
@@ -202,12 +205,17 @@ function RoundDirectCategory({
     );
   }
 
-  if (error) {
+  if (status === 'error') {
     return (
       <Stack align="center" py={48} gap="sm" role="alert">
         <Text size="sm" c="var(--color-text-secondary)">
           판매 회차를 불러오지 못했습니다.
         </Text>
+        {error && (
+          <Text size="sm" c="var(--color-text-disabled)">
+            {error}
+          </Text>
+        )}
         <Button variant="light" onClick={refetch}>
           다시 시도
         </Button>
@@ -234,6 +242,34 @@ function RoundDirectCategory({
 
   return (
     <Stack gap="xl">
+      {isRefreshing && (
+        <Text size="sm" c="var(--color-text-secondary)" ta="center" aria-live="polite">
+          최신 회차 정보를 확인하는 중...
+        </Text>
+      )}
+      {isStale && (
+        <Box
+          p="sm"
+          role="alert"
+          style={{
+            background: 'var(--color-primary-surface)',
+            borderRadius: 'var(--radius)',
+            border: 'var(--border)',
+          }}
+        >
+          <Text size="sm" c="var(--color-text-secondary)">
+            최신 회차 정보를 불러오지 못했습니다. 이전 결과를 표시합니다.
+          </Text>
+          {error && (
+            <Text size="sm" c="var(--color-text-disabled)" mt={4}>
+              {error}
+            </Text>
+          )}
+          <Button variant="light" size="xs" mt="xs" onClick={refetch}>
+            다시 시도
+          </Button>
+        </Box>
+      )}
       <Box component="section" aria-labelledby="current-category-round">
         <Title
           id="current-category-round"

--- a/apps/consumer/src/app/checkout/page.tsx
+++ b/apps/consumer/src/app/checkout/page.tsx
@@ -8,7 +8,7 @@ import type {
   Product,
   SaleType,
 } from '@greenhub/shared';
-import { Container, Text } from '@mantine/core';
+import { Box, Button, Container, Text } from '@mantine/core';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Script from 'next/script';
 import { useSession } from 'next-auth/react';
@@ -418,19 +418,55 @@ function RoundCartCheckoutContent({ cartItems }: { cartItems: RoundCartItem[] })
   const scheduleError =
     saleRounds.status === 'error'
       ? saleRounds.error
-      : (saleRounds.status === 'success' || saleRounds.status === 'empty') && !schedule
-        ? '상품·가격·회차 정보가 변경되어 결제할 수 없습니다. 장바구니에서 변경 내용을 다시 확인해 주세요.'
-        : null;
+      : saleRounds.status === 'stale'
+        ? `최신 회차 정보를 불러오지 못했습니다. 이전 결과로는 결제할 수 없습니다. 다시 시도 후 결제해 주세요.${saleRounds.error ? ` (${saleRounds.error})` : ''}`
+        : (saleRounds.status === 'success' ||
+              saleRounds.status === 'empty' ||
+              saleRounds.status === 'refreshing') &&
+            !schedule
+          ? '상품·가격·회차 정보가 변경되어 결제할 수 없습니다. 장바구니에서 변경 내용을 다시 확인해 주세요.'
+          : null;
   const canPay =
     !isLoading &&
     !!schedule &&
+    !saleRounds.isStale &&
     !!address.address &&
     !!address.zipCode &&
     PHONE_PATTERN.test(deliveryPhone.trim()) &&
     !!session;
 
   return (
-    <CheckoutForm
+    <>
+      {saleRounds.isRefreshing && (
+        <Container size="sm" px="md" pt="sm">
+          <Text size="sm" c="dimmed" ta="center" aria-live="polite">
+            최신 회차 정보를 확인하는 중...
+          </Text>
+        </Container>
+      )}
+      {saleRounds.isStale && (
+        <Container size="sm" px="md" pt="sm">
+          <Box
+            p="sm"
+            role="alert"
+            style={{
+              border: '1px solid var(--color-border)',
+              borderRadius: 'var(--radius)',
+            }}
+          >
+            <Text size="sm">최신 회차 정보를 불러오지 못했습니다. 이전 결과로는 결제할 수 없습니다.</Text>
+            {saleRounds.error && (
+              <Text size="sm" c="dimmed" mt={4}>
+                {saleRounds.error}
+              </Text>
+            )}
+            <Button variant="light" size="xs" mt="xs" onClick={saleRounds.refetch}>
+              다시 시도
+            </Button>
+          </Box>
+        </Container>
+      )}
+      <CheckoutForm
       items={cartItems}
       totalAmount={totalAmount}
       address={address}
@@ -444,6 +480,7 @@ function RoundCartCheckoutContent({ cartItems }: { cartItems: RoundCartItem[] })
       error={scheduleError ?? error}
       onPay={requestPayment}
     />
+    </>
   );
 }
 

--- a/apps/consumer/src/app/products/[id]/page.tsx
+++ b/apps/consumer/src/app/products/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import type { Product, SaleRoundItem, SalesMode, Variety } from '@greenhub/shared';
 import { normalizeSalesMode } from '@greenhub/shared';
-import { Box, Container, Skeleton, Stack, Text } from '@mantine/core';
+import { Box, Button, Container, Skeleton, Stack, Text } from '@mantine/core';
 import { doc, getDoc } from 'firebase/firestore';
 import { notFound } from 'next/navigation';
 import { use, useEffect, useState } from 'react';
@@ -287,11 +287,29 @@ function RoundDirectProductDetail({
   }
   if (saleRounds.status === 'error') {
     return (
-      <DetailStateFrame
-        label="판매 회차 조회 실패"
-        message="판매 회차를 불러오지 못했습니다. 잠시 후 다시 시도해 주세요."
-        alert
-      />
+      <Container size="sm" p={0}>
+        <ProductTopBar />
+        <Stack
+          px="md"
+          pt="calc(76px + env(safe-area-inset-top))"
+          gap="sm"
+          role="alert"
+          aria-label="판매 회차 조회 실패"
+          align="center"
+        >
+          <Text ta="center" py={12} c="var(--color-text-secondary)" size="sm">
+            판매 회차를 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.
+          </Text>
+          {saleRounds.error && (
+            <Text ta="center" c="var(--color-text-disabled)" size="sm">
+              {saleRounds.error}
+            </Text>
+          )}
+          <Button variant="light" size="xs" onClick={saleRounds.refetch}>
+            다시 시도
+          </Button>
+        </Stack>
+      </Container>
     );
   }
 
@@ -302,12 +320,87 @@ function RoundDirectProductDetail({
     saleRounds.pastRounds,
   );
   if (!roundProduct) {
+    if (saleRounds.isStale) {
+      return (
+        <Container size="sm" p={0}>
+          <ProductTopBar />
+          <Stack
+            px="md"
+            pt="calc(76px + env(safe-area-inset-top))"
+            gap="sm"
+            role="alert"
+            aria-label="판매 회차 확인 실패"
+            align="center"
+          >
+            <Text ta="center" c="var(--color-text-secondary)" size="sm">
+              최신 회차 정보를 불러오지 못했습니다. 이전 결과를 표시합니다.
+            </Text>
+            {saleRounds.error && (
+              <Text ta="center" c="var(--color-text-disabled)" size="sm">
+                {saleRounds.error}
+              </Text>
+            )}
+            <Button variant="light" size="xs" onClick={saleRounds.refetch}>
+              다시 시도
+            </Button>
+            <Text ta="center" py={12} c="var(--color-text-secondary)" size="sm">
+              이 상품에 연결된 공개 판매 회차를 찾을 수 없습니다.
+            </Text>
+          </Stack>
+        </Container>
+      );
+    }
     return (
       <DetailStateFrame
         label="판매 회차 상품 확인 실패"
         message="이 상품에 연결된 공개 판매 회차를 찾을 수 없습니다."
         alert
       />
+    );
+  }
+
+  if (saleRounds.isStale) {
+    return (
+      <>
+        <Container size="sm" px="md" pt="calc(52px + env(safe-area-inset-top))">
+          <Box
+            p="sm"
+            mt="sm"
+            role="alert"
+            style={{
+              background: 'var(--color-primary-surface)',
+              borderRadius: 'var(--radius)',
+              border: 'var(--border)',
+            }}
+          >
+            <Text size="sm" c="var(--color-text-secondary)">
+              최신 회차 정보를 불러오지 못했습니다. 이전 결과를 표시합니다.
+            </Text>
+            {saleRounds.error && (
+              <Text size="sm" c="var(--color-text-disabled)" mt={4}>
+                {saleRounds.error}
+              </Text>
+            )}
+            <Button variant="light" size="xs" mt="xs" onClick={saleRounds.refetch}>
+              다시 시도
+            </Button>
+          </Box>
+        </Container>
+        <ProductDetailContent product={product} variety={variety} roundProduct={roundProduct} />
+      </>
+    );
+  }
+
+  if (saleRounds.isRefreshing) {
+    return (
+      <>
+        <Container size="sm" px="md" pt="calc(52px + env(safe-area-inset-top))">
+          <Text size="sm" c="var(--color-text-secondary)" ta="center" aria-live="polite">
+            최신 회차 정보를 확인하는 중...
+          </Text>
+        </Container>
+        <ProductDetailContent product={product} variety={variety} roundProduct={roundProduct} />
+      </>
     );
   }
 

--- a/apps/consumer/src/components/HomeProductList.tsx
+++ b/apps/consumer/src/components/HomeProductList.tsx
@@ -190,6 +190,9 @@ function RoundDirectHome({
   loading,
   error,
   isEmpty,
+  isRefreshing,
+  isStale,
+  status,
   refetch,
 }: ReturnType<typeof useSaleRounds>) {
   if (loading) {
@@ -205,12 +208,17 @@ function RoundDirectHome({
     );
   }
 
-  if (error) {
+  if (status === 'error') {
     return (
       <Stack align="center" py={48} gap="sm" role="alert">
         <Text size="sm" c="var(--color-text-secondary)">
           판매 회차를 불러오지 못했습니다.
         </Text>
+        {error && (
+          <Text size="sm" c="var(--color-text-disabled)">
+            {error}
+          </Text>
+        )}
         <Button variant="light" onClick={refetch}>
           다시 시도
         </Button>
@@ -220,6 +228,34 @@ function RoundDirectHome({
 
   return (
     <Stack gap="xl">
+      {isRefreshing && (
+        <Text size="sm" c="var(--color-text-secondary)" ta="center" aria-live="polite">
+          최신 회차 정보를 확인하는 중...
+        </Text>
+      )}
+      {isStale && (
+        <Box
+          p="sm"
+          role="alert"
+          style={{
+            background: 'var(--color-primary-surface)',
+            borderRadius: 'var(--radius)',
+            border: 'var(--border)',
+          }}
+        >
+          <Text size="sm" c="var(--color-text-secondary)">
+            최신 회차 정보를 불러오지 못했습니다. 이전 결과를 표시합니다.
+          </Text>
+          {error && (
+            <Text size="sm" c="var(--color-text-disabled)" mt={4}>
+              {error}
+            </Text>
+          )}
+          <Button variant="light" size="xs" mt="xs" onClick={refetch}>
+            다시 시도
+          </Button>
+        </Box>
+      )}
       <Box component="section" aria-labelledby="current-round-title">
         <Stack gap={6} mb="md">
           <Title

--- a/apps/consumer/src/hooks/useSaleRounds.test.mjs
+++ b/apps/consumer/src/hooks/useSaleRounds.test.mjs
@@ -6,9 +6,9 @@ import ts from 'typescript';
 const source = await readFile(new URL('./useSaleRounds.ts', import.meta.url), 'utf8');
 const testableSource = `${source.replace(
   "import { getApiBaseUrl } from '@/lib/api-base-url';",
-  "const getApiBaseUrl = () => 'http://localhost:3000';",
+  "const getApiBaseUrl = () => 'https://api.example.test';",
 )}
-export { createLoadingSaleRoundsState, fetchPublicSaleRoundsState };`;
+export { createLoadingSaleRoundsState, createEmptySaleRoundsState, createErrorSaleRoundsState, hasRecoverableSaleRoundsData, createRefreshingSaleRoundsState, createStaleSaleRoundsState, resolveSaleRoundsRefreshStart, resolveSaleRoundsRefreshResult, fetchPublicSaleRoundsState };`;
 const compiled = ts.transpileModule(testableSource, {
   compilerOptions: {
     module: ts.ModuleKind.CommonJS,
@@ -34,12 +34,24 @@ new Function('require', 'module', 'exports', compiled)(
   saleRoundsModule.exports,
 );
 
-const { createLoadingSaleRoundsState, fetchPublicSaleRoundsState } = saleRoundsModule.exports;
+const {
+  createLoadingSaleRoundsState,
+  hasRecoverableSaleRoundsData,
+  createStaleSaleRoundsState,
+  resolveSaleRoundsRefreshStart,
+  resolveSaleRoundsRefreshResult,
+  fetchPublicSaleRoundsState,
+} = saleRoundsModule.exports;
 
-function round(id, status, orderOpenAt) {
+const originalFetch = globalThis.fetch;
+test.after(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function round(id, status, orderOpenAt, storeId = 'store-1') {
   return {
     id,
-    storeId: 'store-1',
+    storeId,
     name: id,
     status,
     closeReason: null,
@@ -85,6 +97,137 @@ function jsonResponse(body, status = 200) {
   });
 }
 
+function successFetcherFor(rounds) {
+  return async (input) => {
+    const url = String(input);
+    if (url.endsWith('/public')) {
+      return jsonResponse({ items: rounds });
+    }
+    const id = url.split('/').at(-1);
+    const selected = rounds.find((item) => item.id === id);
+    return jsonResponse({ ...selected, items: [{ id: `${id}-item`, roundId: id }] });
+  };
+}
+
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function mountHook({ storeId = 'store-1', fetchImpl }) {
+  globalThis.fetch = fetchImpl;
+  let currentStoreId = storeId;
+  const hookModule = { exports: {} };
+  const stateSlots = [];
+  const refSlots = [];
+  const effectSlots = [];
+  let cursor = 0;
+  let renderScheduled = true;
+  let latest = null;
+
+  const scheduleRender = () => {
+    renderScheduled = true;
+  };
+
+  function useState(initial) {
+    const index = cursor++;
+    if (stateSlots[index] === undefined) stateSlots[index] = { value: initial };
+    const slot = stateSlots[index];
+    const setState = (next) => {
+      const value = typeof next === 'function' ? next(slot.value) : next;
+      if (Object.is(value, slot.value)) return;
+      slot.value = value;
+      scheduleRender();
+    };
+    return [slot.value, setState];
+  }
+
+  function useRef(initial) {
+    const index = cursor++;
+    if (refSlots[index] === undefined) refSlots[index] = { current: initial };
+    return refSlots[index];
+  }
+
+  function useCallback(fn) {
+    return fn;
+  }
+
+  function useEffect(create, deps) {
+    const index = cursor++;
+    if (effectSlots[index] === undefined) {
+      effectSlots[index] = { deps: undefined, cleanup: undefined, hasRun: false };
+    }
+    effectSlots[index].pendingCreate = create;
+    effectSlots[index].pendingDeps = deps;
+  }
+
+  const requireForTest = (specifier) => {
+    if (specifier === 'react') return { useCallback, useEffect, useRef, useState };
+    if (specifier === '@/lib/api-base-url') {
+      return { getApiBaseUrl: () => 'https://api.example.test' };
+    }
+    throw new Error(`예상하지 못한 회차 모듈 요청: ${specifier}`);
+  };
+  new Function('require', 'module', 'exports', compiled)(
+    requireForTest,
+    hookModule,
+    hookModule.exports,
+  );
+
+  function flushEffects() {
+    for (const slot of effectSlots) {
+      if (!slot || slot.pendingCreate === undefined) continue;
+      const prevDeps = slot.deps;
+      const nextDeps = slot.pendingDeps;
+      const changed =
+        !slot.hasRun ||
+        prevDeps === undefined ||
+        nextDeps === undefined ||
+        nextDeps.length !== prevDeps.length ||
+        nextDeps.some((dep, i) => !Object.is(dep, prevDeps[i]));
+      if (!changed) continue;
+      if (typeof slot.cleanup === 'function') {
+        const cleanup = slot.cleanup;
+        slot.cleanup = undefined;
+        cleanup();
+      }
+      slot.deps = nextDeps;
+      slot.hasRun = true;
+      const nextCleanup = slot.pendingCreate();
+      slot.cleanup = typeof nextCleanup === 'function' ? nextCleanup : undefined;
+    }
+  }
+
+  function render() {
+    cursor = 0;
+    renderScheduled = false;
+    // biome-ignore lint/correctness/useHookAtTopLevel: React를 모의한 훅 계약 단위 테스트다.
+    latest = hookModule.exports.useSaleRounds(currentStoreId);
+    flushEffects();
+  }
+
+  async function settle(passes = 25) {
+    for (let i = 0; i < passes; i += 1) {
+      if (renderScheduled) render();
+      await new Promise((resolve) => setImmediate(resolve));
+      if (renderScheduled) render();
+    }
+    if (renderScheduled) render();
+  }
+
+  const get = () => latest;
+  const setStoreId = (next) => {
+    currentStoreId = next;
+    scheduleRender();
+  };
+  return { get, settle, render, setStoreId };
+}
+
 test('초기 상태는 회차 데이터 없이 loading이다', () => {
   assert.deepEqual(createLoadingSaleRoundsState(), {
     rounds: [],
@@ -94,36 +237,12 @@ test('초기 상태는 회차 데이터 없이 loading이다', () => {
     loading: true,
     error: null,
     isEmpty: false,
+    isRefreshing: false,
+    isStale: false,
   });
 });
 
-test('공개 회차가 없으면 empty 상태를 제공한다', async () => {
-  const state = await fetchPublicSaleRoundsState('store-1', async () =>
-    jsonResponse({ items: [] }),
-  );
-
-  assert.equal(state.status, 'empty');
-  assert.equal(state.loading, false);
-  assert.equal(state.isEmpty, true);
-  assert.equal(state.error, null);
-  assert.deepEqual(state.rounds, []);
-  assert.equal(state.currentRound, null);
-  assert.deepEqual(state.pastRounds, []);
-});
-
-test('공개 API 실패는 데이터를 비우고 error 상태를 제공한다', async () => {
-  const state = await fetchPublicSaleRoundsState('store-1', async () =>
-    jsonResponse({ message: '일시적인 장애' }, 503),
-  );
-
-  assert.equal(state.status, 'error');
-  assert.equal(state.loading, false);
-  assert.equal(state.isEmpty, false);
-  assert.equal(state.error, '회차 조회 오류: 503');
-  assert.deepEqual(state.rounds, []);
-});
-
-test('목록과 상세를 조회해 현재 회차 하나와 최신순 지난 회차를 제공한다', async () => {
+test('1. initial success: 목록과 상세를 조회해 현재 회차와 최신순 지난 회차를 제공한다', async () => {
   const open = round('round-open', 'OPEN', '2026-07-13T00:00:00.000Z');
   const closed = round('round-closed', 'CLOSED', '2026-07-06T00:00:00.000Z');
   const completed = round('round-completed', 'COMPLETED', '2026-06-29T00:00:00.000Z');
@@ -144,6 +263,8 @@ test('목록과 상세를 조회해 현재 회차 하나와 최신순 지난 회
   assert.equal(state.loading, false);
   assert.equal(state.isEmpty, false);
   assert.equal(state.error, null);
+  assert.equal(state.isRefreshing, false);
+  assert.equal(state.isStale, false);
   assert.equal(state.currentRound?.id, 'round-open');
   assert.deepEqual(
     state.pastRounds.map((item) => item.id),
@@ -155,14 +276,65 @@ test('목록과 상세를 조회해 현재 회차 하나와 최신순 지난 회
   );
   assert.equal(state.currentRound?.items[0]?.id, 'round-open-item');
   assert.equal(requests.length, 4);
+  assert.ok(hasRecoverableSaleRoundsData(state));
+});
+
+test('2. authoritative empty: 공개 회차가 없으면 empty 상태를 제공한다', async () => {
+  const state = await fetchPublicSaleRoundsState('store-1', async () =>
+    jsonResponse({ items: [] }),
+  );
+
+  assert.equal(state.status, 'empty');
+  assert.equal(state.loading, false);
+  assert.equal(state.isEmpty, true);
+  assert.equal(state.error, null);
+  assert.equal(state.isRefreshing, false);
+  assert.equal(state.isStale, false);
+  assert.deepEqual(state.rounds, []);
+  assert.equal(state.currentRound, null);
+  assert.deepEqual(state.pastRounds, []);
+  assert.equal(hasRecoverableSaleRoundsData(state), false);
+});
+
+test('3. initial failure != empty: 공개 API 실패는 error를 제공하고 empty로 위장하지 않는다', async () => {
+  const state = await fetchPublicSaleRoundsState('store-1', async () =>
+    jsonResponse({ message: '일시적인 장애' }, 503),
+  );
+
+  assert.equal(state.status, 'error');
+  assert.equal(state.loading, false);
+  assert.equal(state.isEmpty, false);
+  assert.equal(state.isRefreshing, false);
+  assert.equal(state.isStale, false);
+  assert.equal(state.error, '회차 조회 오류: 503');
+  assert.deepEqual(state.rounds, []);
+  assert.equal(hasRecoverableSaleRoundsData(state), false);
+});
+
+test('malformed 응답은 정상 empty로 바꾸지 않고 error를 유지한다', async () => {
+  const malformedList = await fetchPublicSaleRoundsState('store-1', async () =>
+    jsonResponse({ items: 'not-an-array' }),
+  );
+  assert.equal(malformedList.status, 'error');
+  assert.equal(malformedList.isEmpty, false);
+  assert.match(malformedList.error ?? '', /형식/);
+
+  const open = round('round-open', 'OPEN', '2026-07-13T00:00:00.000Z');
+  const malformedDetail = await fetchPublicSaleRoundsState('store-1', async (input) => {
+    const url = String(input);
+    if (url.endsWith('/public')) return jsonResponse({ items: [open] });
+    return jsonResponse({ unexpected: true });
+  });
+  assert.equal(malformedDetail.status, 'error');
+  assert.equal(malformedDetail.isEmpty, false);
 });
 
 test('판매 중 회차가 없으면 현재 시각 이후 가장 가까운 예정 회차를 선택한다', async () => {
   const now = new Date('2026-07-18T03:00:00.000Z');
-  const stale = round('round-stale', 'SCHEDULED', '2026-07-17T15:00:00.000Z');
+  const pastScheduled = round('round-past', 'SCHEDULED', '2026-07-17T15:00:00.000Z');
   const nearest = round('round-nearest', 'SCHEDULED', '2026-07-19T15:00:00.000Z');
   const later = round('round-later', 'SCHEDULED', '2026-07-26T15:00:00.000Z');
-  const rounds = [later, stale, nearest];
+  const rounds = [later, pastScheduled, nearest];
 
   const state = await fetchPublicSaleRoundsState(
     'store-1',
@@ -180,4 +352,342 @@ test('판매 중 회차가 없으면 현재 시각 이후 가장 가까운 예�
 
   assert.equal(state.status, 'success');
   assert.equal(state.currentRound?.id, 'round-nearest');
+});
+
+test('4. success → refresh start는 이전 데이터를 유지하고 refreshing을 표현한다', async () => {
+  const open = round('round-open', 'OPEN', '2026-07-13T00:00:00.000Z');
+  const previous = await fetchPublicSaleRoundsState('store-1', successFetcherFor([open]));
+  assert.equal(previous.status, 'success');
+
+  const started = resolveSaleRoundsRefreshStart(previous);
+  assert.equal(started.status, 'refreshing');
+  assert.equal(started.isRefreshing, true);
+  assert.equal(started.isStale, false);
+  assert.equal(started.loading, false);
+  assert.equal(started.isEmpty, false);
+  assert.equal(started.error, null);
+  assert.deepEqual(
+    started.rounds.map((item) => item.id),
+    ['round-open'],
+  );
+  assert.equal(started.currentRound?.id, 'round-open');
+
+  const emptyPrevious = await fetchPublicSaleRoundsState('store-1', async () =>
+    jsonResponse({ items: [] }),
+  );
+  assert.deepEqual(resolveSaleRoundsRefreshStart(emptyPrevious), createLoadingSaleRoundsState());
+
+  const failurePrevious = await fetchPublicSaleRoundsState('store-1', async () =>
+    jsonResponse({}, 500),
+  );
+  assert.deepEqual(resolveSaleRoundsRefreshStart(failurePrevious), createLoadingSaleRoundsState());
+});
+
+test('5. success → refresh failure는 이전 결과를 보존하고 stale/error를 노출한다', async () => {
+  const open = round('round-open', 'OPEN', '2026-07-13T00:00:00.000Z');
+  const previous = await fetchPublicSaleRoundsState('store-1', successFetcherFor([open]));
+  const failed = await fetchPublicSaleRoundsState('store-1', async () =>
+    jsonResponse({}, 503),
+  );
+  assert.equal(failed.status, 'error');
+
+  const stale = resolveSaleRoundsRefreshResult(previous, failed);
+  assert.equal(stale.status, 'stale');
+  assert.equal(stale.isStale, true);
+  assert.equal(stale.isRefreshing, false);
+  assert.equal(stale.loading, false);
+  assert.equal(stale.isEmpty, false);
+  assert.notEqual(stale.error, null);
+  assert.deepEqual(
+    stale.rounds.map((item) => item.id),
+    ['round-open'],
+  );
+  assert.equal(stale.currentRound?.id, 'round-open');
+
+  const withoutPrevious = await fetchPublicSaleRoundsState('store-1', async () =>
+    jsonResponse({ items: [] }),
+  );
+  const initialFailure = resolveSaleRoundsRefreshResult(withoutPrevious, failed);
+  assert.equal(initialFailure.status, 'error');
+  assert.equal(initialFailure.isStale, false);
+  assert.deepEqual(initialFailure.rounds, []);
+});
+
+test('6. success → refresh success는 최신 결과로 교체하고 stale을 해제한다', async () => {
+  const open = round('round-open', 'OPEN', '2026-07-13T00:00:00.000Z');
+  const previous = await fetchPublicSaleRoundsState('store-1', successFetcherFor([open]));
+  const stale = createStaleSaleRoundsState(previous, new Error('회차 조회 오류: 503'));
+  assert.equal(stale.isStale, true);
+
+  const nextOpen = round('round-next', 'OPEN', '2026-07-20T00:00:00.000Z');
+  const next = await fetchPublicSaleRoundsState('store-1', successFetcherFor([nextOpen]));
+  const replaced = resolveSaleRoundsRefreshResult(stale, next);
+  assert.equal(replaced.status, 'success');
+  assert.equal(replaced.isStale, false);
+  assert.equal(replaced.isRefreshing, false);
+  assert.equal(replaced.error, null);
+  assert.deepEqual(
+    replaced.rounds.map((item) => item.id),
+    ['round-next'],
+  );
+});
+
+test('7. success → refresh authoritative empty는 이전 데이터를 제거한다', async () => {
+  const open = round('round-open', 'OPEN', '2026-07-13T00:00:00.000Z');
+  const previous = await fetchPublicSaleRoundsState('store-1', successFetcherFor([open]));
+  const emptied = await fetchPublicSaleRoundsState('store-1', async () =>
+    jsonResponse({ items: [] }),
+  );
+  const resolved = resolveSaleRoundsRefreshResult(previous, emptied);
+  assert.equal(resolved.status, 'empty');
+  assert.equal(resolved.isEmpty, true);
+  assert.equal(resolved.isStale, false);
+  assert.deepEqual(resolved.rounds, []);
+  assert.equal(resolved.currentRound, null);
+});
+
+test('hook: success → refetch 시작은 데이터를 유지하고 refreshing을 노출한다', async () => {
+  const open = round('round-open', 'OPEN', '2026-07-13T00:00:00.000Z');
+  const gate = deferred();
+  let listCalls = 0;
+  const harness = mountHook({
+    storeId: 'store-1',
+    fetchImpl: async (input) => {
+      const url = String(input);
+      if (!url.endsWith('/public')) {
+        return jsonResponse({ ...open, items: [{ id: 'round-open-item', roundId: 'round-open' }] });
+      }
+      listCalls += 1;
+      if (listCalls === 1) return jsonResponse({ items: [open] });
+      return gate.promise;
+    },
+  });
+  await harness.settle();
+  assert.equal(harness.get().status, 'success');
+  assert.deepEqual(
+    harness.get().rounds.map((item) => item.id),
+    ['round-open'],
+  );
+
+  harness.get().refetch();
+  await harness.settle(5);
+  assert.equal(harness.get().status, 'refreshing');
+  assert.equal(harness.get().isRefreshing, true);
+  assert.equal(harness.get().loading, false);
+  assert.deepEqual(
+    harness.get().rounds.map((item) => item.id),
+    ['round-open'],
+  );
+
+  gate.resolve(jsonResponse({ items: [] }));
+  await harness.settle();
+  assert.equal(harness.get().status, 'empty');
+  assert.deepEqual(harness.get().rounds, []);
+});
+
+test('hook: success → refresh failure는 stale 데이터를 유지하고 retry를 노출한다', async () => {
+  const open = round('round-open', 'OPEN', '2026-07-13T00:00:00.000Z');
+  let mode = 'success';
+  const harness = mountHook({
+    storeId: 'store-1',
+    fetchImpl: async (input) => {
+      if (mode === 'success') return successFetcherFor([open])(input);
+      return jsonResponse({}, 503);
+    },
+  });
+  await harness.settle();
+  assert.equal(harness.get().status, 'success');
+
+  mode = 'failure';
+  harness.get().refetch();
+  await harness.settle();
+
+  assert.equal(harness.get().status, 'stale');
+  assert.equal(harness.get().isStale, true);
+  assert.equal(harness.get().isEmpty, false);
+  assert.notEqual(harness.get().error, null);
+  assert.deepEqual(
+    harness.get().rounds.map((item) => item.id),
+    ['round-open'],
+  );
+  assert.equal(typeof harness.get().refetch, 'function');
+});
+
+test('hook: success → refresh success는 데이터를 교체한다', async () => {
+  const open = round('round-open', 'OPEN', '2026-07-13T00:00:00.000Z');
+  const next = round('round-next', 'OPEN', '2026-07-20T00:00:00.000Z');
+  let current = [open];
+  const harness = mountHook({
+    storeId: 'store-1',
+    fetchImpl: async (input) => successFetcherFor(current)(input),
+  });
+  await harness.settle();
+  assert.deepEqual(
+    harness.get().rounds.map((item) => item.id),
+    ['round-open'],
+  );
+
+  current = [next];
+  harness.get().refetch();
+  await harness.settle();
+
+  assert.equal(harness.get().status, 'success');
+  assert.equal(harness.get().isStale, false);
+  assert.equal(harness.get().error, null);
+  assert.deepEqual(
+    harness.get().rounds.map((item) => item.id),
+    ['round-next'],
+  );
+});
+
+test('8. hook: storeId scope 변경은 이전 store 회차를 stale로 유지하지 않는다', async () => {
+  const openA = round('round-a', 'OPEN', '2026-07-13T00:00:00.000Z', 'store-a');
+  const openB = round('round-b', 'OPEN', '2026-07-13T00:00:00.000Z', 'store-b');
+  const harness = mountHook({
+    storeId: 'store-a',
+    fetchImpl: async (input) => {
+      const url = String(input);
+      if (url.includes('/stores/store-a/')) return successFetcherFor([openA])(input);
+      if (url.includes('/stores/store-b/')) return successFetcherFor([openB])(input);
+      return jsonResponse({}, 404);
+    },
+  });
+  await harness.settle();
+  assert.deepEqual(
+    harness.get().rounds.map((item) => item.id),
+    ['round-a'],
+  );
+
+  harness.setStoreId('store-b');
+  await harness.settle();
+
+  assert.deepEqual(
+    harness.get().rounds.map((item) => item.id),
+    ['round-b'],
+  );
+  assert.equal(harness.get().status, 'success');
+  assert.equal(harness.get().isStale, false);
+});
+
+test('hook: scope 변경 후 실패는 이전 scope 데이터를 노출하지 않는다', async () => {
+  const openA = round('round-a', 'OPEN', '2026-07-13T00:00:00.000Z', 'store-a');
+  const harness = mountHook({
+    storeId: 'store-a',
+    fetchImpl: async (input) => {
+      const url = String(input);
+      if (url.includes('/stores/store-a/')) return successFetcherFor([openA])(input);
+      return jsonResponse({}, 500);
+    },
+  });
+  await harness.settle();
+  assert.deepEqual(
+    harness.get().rounds.map((item) => item.id),
+    ['round-a'],
+  );
+
+  harness.setStoreId('store-b');
+  await harness.settle();
+
+  assert.equal(harness.get().status, 'error');
+  assert.equal(harness.get().isStale, false);
+  assert.deepEqual(harness.get().rounds, []);
+  assert.notEqual(harness.get().error, null);
+});
+
+test('9. hook: 늦은 이전 요청은 새 scope/newer refresh를 덮지 않는다', async () => {
+  const openA = round('round-a', 'OPEN', '2026-07-13T00:00:00.000Z', 'store-a');
+  const openB = round('round-b', 'OPEN', '2026-07-13T00:00:00.000Z', 'store-b');
+  const first = deferred();
+  const second = deferred();
+  let listCalls = 0;
+  const harness = mountHook({
+    storeId: 'store-a',
+    fetchImpl: async (input) => {
+      const url = String(input);
+      if (url.endsWith('/public')) {
+        listCalls += 1;
+        if (listCalls === 1) return first.promise;
+        return second.promise;
+      }
+      const id = url.split('/').at(-1);
+      const selected = [openA, openB].find((item) => item.id === id);
+      return jsonResponse({ ...selected, items: [{ id: `${id}-item`, roundId: id }] });
+    },
+  });
+  await harness.settle(5);
+
+  harness.setStoreId('store-b');
+  await harness.settle(5);
+
+  second.resolve(jsonResponse({ items: [openB] }));
+  await harness.settle();
+  assert.deepEqual(
+    harness.get().rounds.map((item) => item.id),
+    ['round-b'],
+  );
+
+  first.resolve(jsonResponse({ items: [openA] }));
+  await harness.settle();
+
+  assert.deepEqual(
+    harness.get().rounds.map((item) => item.id),
+    ['round-b'],
+  );
+  assert.equal(harness.get().isStale, false);
+});
+
+test('hook: stale refetch 응답은 더 최신 refetch 결과를 덮지 않는다', async () => {
+  const openA = round('round-a', 'OPEN', '2026-07-13T00:00:00.000Z');
+  const openB = round('round-b', 'OPEN', '2026-07-20T00:00:00.000Z');
+  const first = deferred();
+  const second = deferred();
+  let n = 0;
+  const harness = mountHook({
+    storeId: 'store-1',
+    fetchImpl: async (input) => {
+      const url = String(input);
+      if (!url.endsWith('/public')) {
+        const id = url.split('/').at(-1);
+        const selected = [openA, openB].find((item) => item.id === id);
+        return jsonResponse({ ...selected, items: [{ id: `${id}-item`, roundId: id }] });
+      }
+      n += 1;
+      if (n === 1) return successFetcherFor([openA])(input);
+      if (n === 2) return first.promise;
+      return second.promise;
+    },
+  });
+  await harness.settle();
+  assert.deepEqual(
+    harness.get().rounds.map((item) => item.id),
+    ['round-a'],
+  );
+
+  harness.get().refetch();
+  await harness.settle(5);
+  harness.get().refetch();
+  await harness.settle(5);
+
+  second.resolve(jsonResponse({ items: [openB] }));
+  await harness.settle();
+  // detail fetch는 즉시 성공하므로 최종은 round-b가 된다.
+  // (상세 fetch가 목록 resolve 이후 실행되기 때문에 settle로 모두 확정한다.)
+  await harness.settle();
+
+  first.resolve(jsonResponse({ items: [openA] }));
+  await harness.settle();
+
+  assert.deepEqual(
+    harness.get().rounds.map((item) => item.id),
+    ['round-b'],
+  );
+});
+
+test('hook 소스는 request race 보호와 scope 격리를 유지한다', () => {
+  assert.match(source, /requestId/);
+  assert.match(source, /requestId\.current !== currentRequestId|requestId\.current === currentRequestId/);
+  assert.match(source, /scopeRef/);
+  assert.match(source, /hasRecoverableSaleRoundsData/);
+  assert.match(source, /createRefreshingSaleRoundsState/);
+  assert.match(source, /createStaleSaleRoundsState/);
 });

--- a/apps/consumer/src/hooks/useSaleRounds.ts
+++ b/apps/consumer/src/hooks/useSaleRounds.ts
@@ -7,7 +7,13 @@ import { getApiBaseUrl } from '@/lib/api-base-url';
 const API_URL = getApiBaseUrl();
 
 export type PublicSaleRound = SaleRound & { items: SaleRoundItem[] };
-export type SaleRoundsRequestStatus = 'loading' | 'error' | 'empty' | 'success';
+export type SaleRoundsRequestStatus =
+  | 'loading'
+  | 'error'
+  | 'empty'
+  | 'success'
+  | 'refreshing'
+  | 'stale';
 
 export interface SaleRoundsState {
   rounds: PublicSaleRound[];
@@ -17,6 +23,8 @@ export interface SaleRoundsState {
   loading: boolean;
   error: string | null;
   isEmpty: boolean;
+  isRefreshing: boolean;
+  isStale: boolean;
 }
 
 export interface UseSaleRoundsResult extends SaleRoundsState {
@@ -40,26 +48,32 @@ export function createLoadingSaleRoundsState(): SaleRoundsState {
     loading: true,
     error: null,
     isEmpty: false,
+    isRefreshing: false,
+    isStale: false,
   };
 }
 
-function createEmptySaleRoundsState(): SaleRoundsState {
+export function createEmptySaleRoundsState(): SaleRoundsState {
   return {
     ...emptyData(),
     status: 'empty',
     loading: false,
     error: null,
     isEmpty: true,
+    isRefreshing: false,
+    isStale: false,
   };
 }
 
-function createErrorSaleRoundsState(error: unknown): SaleRoundsState {
+export function createErrorSaleRoundsState(error: unknown): SaleRoundsState {
   return {
     ...emptyData(),
     status: 'error',
     loading: false,
     error: error instanceof Error ? error.message : '회차 조회에 실패했습니다.',
     isEmpty: false,
+    isRefreshing: false,
+    isStale: false,
   };
 }
 
@@ -101,7 +115,67 @@ function createSuccessSaleRoundsState(rounds: PublicSaleRound[], now: Date): Sal
     loading: false,
     error: null,
     isEmpty: false,
+    isRefreshing: false,
+    isStale: false,
   };
+}
+
+function readErrorMessage(error: unknown): string {
+  if (typeof error === 'string' && error.length > 0) return error;
+  if (error instanceof Error) return error.message;
+  return '회차 조회에 실패했습니다.';
+}
+
+export function hasRecoverableSaleRoundsData(state: SaleRoundsState): boolean {
+  return state.rounds.length > 0;
+}
+
+export function createRefreshingSaleRoundsState(previous: SaleRoundsState): SaleRoundsState {
+  return {
+    rounds: previous.rounds,
+    currentRound: previous.currentRound,
+    pastRounds: previous.pastRounds,
+    status: 'refreshing',
+    loading: false,
+    error: null,
+    isEmpty: false,
+    isRefreshing: true,
+    isStale: false,
+  };
+}
+
+export function createStaleSaleRoundsState(
+  previous: SaleRoundsState,
+  error: unknown,
+): SaleRoundsState {
+  return {
+    rounds: previous.rounds,
+    currentRound: previous.currentRound,
+    pastRounds: previous.pastRounds,
+    status: 'stale',
+    loading: false,
+    error: readErrorMessage(error),
+    isEmpty: false,
+    isRefreshing: false,
+    isStale: true,
+  };
+}
+
+export function resolveSaleRoundsRefreshStart(previous: SaleRoundsState): SaleRoundsState {
+  if (hasRecoverableSaleRoundsData(previous)) {
+    return createRefreshingSaleRoundsState(previous);
+  }
+  return createLoadingSaleRoundsState();
+}
+
+export function resolveSaleRoundsRefreshResult(
+  previous: SaleRoundsState,
+  next: SaleRoundsState,
+): SaleRoundsState {
+  if (next.status === 'error' && hasRecoverableSaleRoundsData(previous)) {
+    return createStaleSaleRoundsState(previous, next.error);
+  }
+  return next;
 }
 
 function readRoundSummaries(payload: unknown): SaleRound[] {
@@ -164,29 +238,64 @@ export async function fetchPublicSaleRoundsState(
 export function useSaleRounds(storeId: string | null): UseSaleRoundsResult {
   const [state, setState] = useState<SaleRoundsState>(createLoadingSaleRoundsState);
   const requestId = useRef(0);
+  const scopeRef = useRef<string | null>(storeId);
+  const stateRef = useRef(state);
+  stateRef.current = state;
 
-  const loadRounds = useCallback(async () => {
+  useEffect(() => {
+    const target = storeId;
+    scopeRef.current = target;
     const currentRequestId = ++requestId.current;
-    if (!storeId) {
+    if (!target) {
+      setState(createEmptySaleRoundsState());
+      return () => {
+        requestId.current += 1;
+      };
+    }
+
+    // Scope 진입은 이전 scope 잔재를 무효화한다: 빈 loading으로 리셋한다.
+    setState(createLoadingSaleRoundsState());
+    void (async () => {
+      const nextState = await fetchPublicSaleRoundsState(target);
+      if (requestId.current === currentRequestId && scopeRef.current === target) {
+        setState(nextState);
+      }
+    })();
+    return () => {
+      requestId.current += 1;
+    };
+  }, [storeId]);
+
+  const refetch = useCallback(() => {
+    const target = storeId;
+    if (!target) {
+      scopeRef.current = target;
+      ++requestId.current;
       setState(createEmptySaleRoundsState());
       return;
     }
 
-    setState(createLoadingSaleRoundsState());
-    const nextState = await fetchPublicSaleRoundsState(storeId);
-    if (requestId.current === currentRequestId) setState(nextState);
+    // 동일 scope refresh는 이전 성공 데이터를 보존한다.
+    // scope가 바뀌는 동안의 호출은 loading으로 리셋해 이전 store 노출을 막는다.
+    const snapshot = stateRef.current;
+    const canRecover =
+      scopeRef.current === target && hasRecoverableSaleRoundsData(snapshot);
+    const currentRequestId = ++requestId.current;
+    setState(
+      canRecover
+        ? createRefreshingSaleRoundsState(snapshot)
+        : createLoadingSaleRoundsState(),
+    );
+    void (async () => {
+      const nextState = await fetchPublicSaleRoundsState(target);
+      if (requestId.current !== currentRequestId || scopeRef.current !== target) return;
+      if (nextState.status === 'error' && canRecover) {
+        setState(createStaleSaleRoundsState(snapshot, nextState.error));
+        return;
+      }
+      setState(nextState);
+    })();
   }, [storeId]);
-
-  useEffect(() => {
-    void loadRounds();
-    return () => {
-      requestId.current += 1;
-    };
-  }, [loadRounds]);
-
-  const refetch = useCallback(() => {
-    void loadRounds();
-  }, [loadRounds]);
 
   return { ...state, refetch };
 }


### PR DESCRIPTION
Root cause:
refetch start/failure가 기존 sale-round data를 비워 refresh failure를 empty/error로 collapse시키던 문제.

Behavior:
- same-scope refresh는 이전 rounds/currentRound/pastRounds를 유지하고 refreshing을 노출.
- refresh failure는 이전 데이터를 stale로 보존하고 error + retry 제공.
- authoritative empty는 이전 데이터를 제거하고 진짜 empty로 전환.
- store scope change는 이전 store 데이터를 stale로 재사용하지 않음 (loading 리셋).
- race: stale request가 더 최신 요청/scope를 overwrite하지 않음 (requestId + scopeRef).
- Home / Category: 초기 loading/error UX 유지, refreshing 중 기존 데이터 유지, stale 시 이전 결과 명시 + retry.
- Product detail: stale/refreshing을 fresh처럼 숨기지 않음, error retry 제공.
- Checkout: stale sale-round 상태에서는 payment 진행 차단, retry 제공, refreshing 표시.

Proof (source task semantic candidate, proof reused):
- useSaleRounds 18/18 PASS
- Category 5/5 PASS
- HomeProductList 4/4 PASS
- Product detail 6/6 PASS
- Checkout 8/8 PASS
- consumer tsc --noEmit PASS
- biome owned files new error NONE (HomeProductList skeleton noArrayIndexKey는 pre-existing)

Source task:
CONSUMER-SALE-ROUNDS-READ-RECOVERY-01 (provenance 3dd56ebe4b651387ec64ccbc271f4cfb4ba5e1a0)

Publication notes:
- Shared checkout은 main 유지, checkout/switch 없이 transport ref만 push.
- Candidate 9511f8fd (local main, parent c5322c38 driver photo local-ahead 포함)를 origin/main 949815db 위로 rebase한 transport 9caa59e6으로 PR. Transport diff는 owned 6개 파일만 포함하며 driver local-ahead(c5322c38)는 PR에 포함하지 않음.
- Owned paths: apps/consumer/src/hooks/useSaleRounds.ts, apps/consumer/src/hooks/useSaleRounds.test.mjs, apps/consumer/src/app/category/page.tsx, apps/consumer/src/components/HomeProductList.tsx, apps/consumer/src/app/products/[id]/page.tsx, apps/consumer/src/app/checkout/page.tsx

Acceptance:
- PR에는 owned source 외 foreign dirty 포함 없음.
