### PR TITLE
fix(driver): board/map list auth-collapse clear and user-token scope isolation

### DIFF
--- a/apps/driver/src/app/board/_client.tsx
+++ b/apps/driver/src/app/board/_client.tsx
@@ -7,6 +7,12 @@ import { useSession } from 'next-auth/react';
 import { useEffect, useRef, useState } from 'react';
 import OrderCard from '@/components/OrderCard';
 import { apiFetch } from '@/lib/api';
+import {
+  buildDriverListScope,
+  shouldPreserveDriverListOnReadError,
+  toDriverListReadError,
+  toDriverListReadErrorKind,
+} from '@/lib/driver-list-read';
 
 export default function BoardClient() {
   const searchParams = useSearchParams();
@@ -24,6 +30,9 @@ export default function BoardClient() {
   const [hasSuccessfulRead, setHasSuccessfulRead] = useState(false);
   const requestIdRef = useRef(0);
   const hasSuccessfulReadRef = useRef(false);
+  // user identity + role + access token scope가 바뀌면 이전 scope의
+  // protected rows를 새 fetch 완료 전에 동기적으로 제거한다.
+  const listScopeRef = useRef<string | null>(null);
 
   // focus 복귀·visibility 복귀 시 새 read를 수행한다. listener 누적 방지를 위해 cleanup한다.
   useEffect(() => {
@@ -48,6 +57,7 @@ export default function BoardClient() {
       // usable token 없음을 0건 성공으로 표시하지 않는다. 보호된 stale도 유지하지 않는다.
       // stale-empty가 auth 이후 initial failure로 오분류되지 않도록 성공 기록도 초기화한다.
       requestIdRef.current += 1;
+      listScopeRef.current = '__no_token__';
       hasSuccessfulReadRef.current = false;
       setHasSuccessfulRead(false);
       setPreparing([]);
@@ -57,6 +67,27 @@ export default function BoardClient() {
       setLoading(false);
       setRefreshing(false);
       return;
+    }
+
+    const nextScope = buildDriverListScope({
+      userId: session?.user.id,
+      role: session?.user.role,
+      token,
+    });
+    if (listScopeRef.current !== nextScope) {
+      // user/token scope 변경: 새 fetch 완료를 기다리지 않고 이전 scope의
+      // protected rows·성공 기록·error/freshness를 동기적으로 제거한다.
+      // 진행 중이던 이전 scope read는 sequence 무효화로 덮어쓰기를 막는다.
+      requestIdRef.current += 1;
+      listScopeRef.current = nextScope;
+      hasSuccessfulReadRef.current = false;
+      setHasSuccessfulRead(false);
+      setPreparing([]);
+      setDelivering([]);
+      setError(null);
+      setAuthRequired(false);
+      setLoading(true);
+      setRefreshing(false);
     }
 
     const controller = new AbortController();
@@ -77,7 +108,7 @@ export default function BoardClient() {
 
     apiFetch('/driver/orders', token, { signal: controller.signal })
       .then(async (response) => {
-        if (!response.ok) throw new Error(`driver orders request failed: ${response.status}`);
+        if (!response.ok) throw toDriverListReadError(response.status);
         const payload: unknown = await response.json();
         if (!Array.isArray(payload)) throw new Error('driver orders response is not a list');
         return payload as Order[];
@@ -96,7 +127,20 @@ export default function BoardClient() {
       })
       .catch((cause: unknown) => {
         if (!isCurrent() || (cause instanceof DOMException && cause.name === 'AbortError')) return;
-        if (hasSuccessfulReadRef.current) {
+        const kind = toDriverListReadErrorKind(cause);
+        if (kind === 'AUTH_ERROR') {
+          // authority loss(401·403): 이전 protected rows를 즉시 제거하고
+          // auth-required로 전환한다. 일반 retry loop가 권한 복구 없이
+          // stale data를 유지하지 않는다.
+          hasSuccessfulReadRef.current = false;
+          setHasSuccessfulRead(false);
+          setPreparing([]);
+          setDelivering([]);
+          setAuthRequired(true);
+          setError(null);
+          return;
+        }
+        if (shouldPreserveDriverListOnReadError(kind, hasSuccessfulReadRef.current)) {
           // refresh 실패는 마지막 정상 데이터를 지우지 않고 stale로 유지한다.
           setError('최신 주문을 불러오지 못했습니다. 기존 목록을 보여줍니다.');
         } else {
@@ -115,7 +159,7 @@ export default function BoardClient() {
       active = false;
       controller.abort();
     };
-  }, [session?.user.accessToken, sessionStatus, reloadKey]);
+  }, [session?.user.id, session?.user.role, session?.user.accessToken, sessionStatus, reloadKey]);
 
   const orders = tab === 'preparing' ? preparing : delivering;
   const today = new Date().toLocaleDateString('ko-KR', {

--- a/apps/driver/src/app/board/board-contract.test.mjs
+++ b/apps/driver/src/app/board/board-contract.test.mjs
@@ -41,6 +41,15 @@ const holdModalSource = await readFile(
   new URL('./[orderId]/_components/DeliveryHoldModal.tsx', import.meta.url),
   'utf8',
 );
+const listReadSource = await readFile(new URL('../../lib/driver-list-read.ts', import.meta.url), 'utf8');
+import {
+  buildDriverListScope,
+  classifyDriverListReadStatus,
+  DriverListReadError,
+  shouldPreserveDriverListOnReadError,
+  toDriverListReadError,
+  toDriverListReadErrorKind,
+} from '../../lib/driver-list-read.ts';
 
 test('Driver Board는 Driver role API에서 세 상태를 조회한다', () => {
   assert.match(boardSource, /apiFetch\(\s*['"]\/driver\/orders['"]/);
@@ -446,10 +455,16 @@ test('5. success [orders] → refresh failure는 이전 목록 + warning을 유�
   assert.match(boardSource, /\(이전 목록 표시 중\)/);
   assert.match(boardSource, /orders\.map\(\(order\)/);
   // refresh 실패는 list를 지우지 않는다: stale 분기에는 setPreparing([])이 없다.
+  // 401·403 authority loss는 별도 분기로 먼저 clear되므로 stale 판정은 공유 helper를 거친다.
   const catchBlock = boardSource.slice(boardSource.indexOf('.catch('), boardSource.indexOf('.finally('));
-  const refreshStart = catchBlock.indexOf('if (hasSuccessfulReadRef.current)');
+  const authBranchAt = catchBlock.indexOf("kind === 'AUTH_ERROR'");
+  const refreshStart = catchBlock.indexOf(
+    'if (shouldPreserveDriverListOnReadError(kind, hasSuccessfulReadRef.current))',
+  );
   const elseMarker = catchBlock.indexOf('} else {', refreshStart);
+  assert.ok(authBranchAt !== -1, 'AUTH_ERROR 분기가 있어야 한다');
   assert.ok(refreshStart !== -1 && elseMarker !== -1, 'refresh/initial 분기가 있어야 한다');
+  assert.ok(authBranchAt < refreshStart, 'authority loss가 stale 유지보다 먼저다');
   const refreshBranch = catchBlock.slice(refreshStart, elseMarker);
   assert.doesNotMatch(refreshBranch, /setPreparing\(\[\]\)/);
   assert.doesNotMatch(refreshBranch, /setDelivering\(\[\]\)/);
@@ -539,4 +554,210 @@ test('10. focus/visibility revalidation 회귀 없음', () => {
   // background refresh는 loading과 분리된다.
   assert.match(boardSource, /setRefreshing\(true\)/);
   assert.match(boardSource, /최신 정보를 확인하는 중입니다/);
+});
+
+// DRIVER-LIST-AUTH-SCOPE-RECOVERY-02 focused regression.
+// Board와 Map은 같은 목록 read 의미를 공유한다. 분류·보존·scope 판정은
+// 공유 helper의 runtime 동작으로 고정하고, 두 화면의 배선은 source로 고정한다.
+
+// 목록 read 상태机的 최소 시뮬레이터. 컴포넌트의 분기 순서
+// (AUTH clear → helper preserve 판정 → initial clear, scope 변경 시 동기 clear)를
+// 그대로 미러하며 실제 helper 분류 함수를 사용한다.
+function createListSim() {
+  return { orders: [], hasSuccess: false, authRequired: false, error: null };
+}
+
+function applyListSuccess(sim, rows) {
+  sim.orders = rows;
+  sim.hasSuccess = true;
+  sim.authRequired = false;
+  sim.error = null;
+  return sim;
+}
+
+function applyListFailure(sim, { status = null, network = false } = {}) {
+  const kind = network ? 'FETCH_ERROR' : classifyDriverListReadStatus(status);
+  if (kind === 'AUTH_ERROR') {
+    sim.orders = [];
+    sim.hasSuccess = false;
+    sim.authRequired = true;
+    sim.error = null;
+    return sim;
+  }
+  if (shouldPreserveDriverListOnReadError(kind, sim.hasSuccess)) {
+    sim.error = 'stale';
+    return sim;
+  }
+  sim.orders = [];
+  sim.error = 'initial';
+  return sim;
+}
+
+function applyListScopeChange(sim, prevScope, nextScope) {
+  if (prevScope !== nextScope) {
+    // 새 fetch 완료를 기다리지 않는 동기 clear.
+    sim.orders = [];
+    sim.hasSuccess = false;
+    sim.authRequired = false;
+    sim.error = null;
+  }
+  return sim;
+}
+
+test('11. 목록 helper는 401·403만 AUTH_ERROR로 분류한다 (runtime)', () => {
+  assert.equal(classifyDriverListReadStatus(401), 'AUTH_ERROR');
+  assert.equal(classifyDriverListReadStatus(403), 'AUTH_ERROR');
+  assert.equal(classifyDriverListReadStatus(404), 'FETCH_ERROR');
+  assert.equal(classifyDriverListReadStatus(500), 'FETCH_ERROR');
+  assert.equal(classifyDriverListReadStatus(503), 'FETCH_ERROR');
+  assert.equal(toDriverListReadError(401).kind, 'AUTH_ERROR');
+  assert.equal(toDriverListReadError(403).kind, 'AUTH_ERROR');
+  assert.equal(toDriverListReadError(500).kind, 'FETCH_ERROR');
+  assert.ok(toDriverListReadError(401) instanceof DriverListReadError);
+  // typed error는 kind를 보존하고, 일반 실패·network는 transient로 취급한다.
+  assert.equal(toDriverListReadErrorKind(toDriverListReadError(403)), 'AUTH_ERROR');
+  assert.equal(toDriverListReadErrorKind(new Error('boom')), 'FETCH_ERROR');
+  assert.equal(toDriverListReadErrorKind(null), 'FETCH_ERROR');
+  // 공유 helper source도 같은 분류를 고정한다.
+  assert.match(listReadSource, /status === 401 \|\| status === 403/);
+});
+
+test('12. AUTH_ERROR는 성공 기록이 있어도 절대 stale 유지하지 않는다 (runtime)', () => {
+  assert.equal(shouldPreserveDriverListOnReadError('AUTH_ERROR', true), false);
+  assert.equal(shouldPreserveDriverListOnReadError('AUTH_ERROR', false), false);
+  assert.equal(shouldPreserveDriverListOnReadError('FETCH_ERROR', true), true);
+  assert.equal(shouldPreserveDriverListOnReadError('FETCH_ERROR', false), false);
+});
+
+test('13. 목록 scope는 user identity + role + access token이다 (runtime)', () => {
+  const scopeA = buildDriverListScope({ userId: 'user-a', role: 'driver', token: 'token-a' });
+  assert.equal(scopeA, buildDriverListScope({ userId: 'user-a', role: 'driver', token: 'token-a' }));
+  assert.notEqual(scopeA, buildDriverListScope({ userId: 'user-b', role: 'driver', token: 'token-a' }));
+  assert.notEqual(scopeA, buildDriverListScope({ userId: 'user-a', role: 'driver', token: 'token-b' }));
+  assert.notEqual(scopeA, buildDriverListScope({ userId: 'user-a', role: 'admin', token: 'token-a' }));
+  // user/role 누락 시에도 token이 scope에 남는다.
+  assert.match(buildDriverListScope({ token: 'token-a' }), /token-a/);
+});
+
+test('14. success → 401이면 Board protected rows를 즉시 clear하고 auth 상태로 전환한다', () => {
+  // 배선: generic Error 문자열이 아닌 typed 분류를 throw한다.
+  assert.match(boardSource, /throw toDriverListReadError\(response\.status\)/);
+  assert.doesNotMatch(boardSource, /request failed: \$\{response\.status\}/);
+  assert.match(boardSource, /toDriverListReadErrorKind\(cause\)/);
+  const catchBlock = boardSource.slice(boardSource.indexOf('.catch('), boardSource.indexOf('.finally('));
+  const authBranch = catchBlock.slice(
+    catchBlock.indexOf("kind === 'AUTH_ERROR'"),
+    catchBlock.indexOf('if (shouldPreserveDriverListOnReadError'),
+  );
+  assert.match(authBranch, /setPreparing\(\[\]\)/);
+  assert.match(authBranch, /setDelivering\(\[\]\)/);
+  assert.match(authBranch, /setHasSuccessfulRead\(false\)/);
+  assert.match(authBranch, /hasSuccessfulReadRef\.current = false/);
+  assert.match(authBranch, /setAuthRequired\(true\)/);
+  // runtime: stale이 남지 않고 auth-required로 전환된다.
+  const sim = applyListSuccess(createListSim(), [{ id: 'o1' }, { id: 'o2' }]);
+  applyListFailure(sim, { status: 401 });
+  assert.deepEqual(sim.orders, []);
+  assert.equal(sim.hasSuccess, false);
+  assert.equal(sim.authRequired, true);
+  assert.equal(sim.error, null);
+  assert.equal(
+    resolveBoardView({
+      loading: false,
+      authRequired: sim.authRequired,
+      error: sim.error,
+      hasSuccessfulRead: sim.hasSuccess,
+      refreshing: false,
+      ordersLength: sim.orders.length,
+    }),
+    'AUTH_REQUIRED',
+  );
+});
+
+test('15. success → 403도 401과 같은 authority loss 분기로 clear된다', () => {
+  // 403 전용 ad-hoc 분기가 따로 있지 않고 401과 같은 kind 분기를 탄다.
+  assert.doesNotMatch(boardSource, /status === 403[\s\S]{0,200}setPreparing\(\[\]\)/);
+  const sim = applyListSuccess(createListSim(), [{ id: 'o1' }]);
+  applyListFailure(sim, { status: 403 });
+  assert.deepEqual(sim.orders, []);
+  assert.equal(sim.hasSuccess, false);
+  assert.equal(sim.authRequired, true);
+});
+
+test('16. 같은 scope의 network/5xx 실패는 stale을 유지한다 (PR #110/#111 퇴행 없음)', () => {
+  const sim = applyListSuccess(createListSim(), [{ id: 'o1' }, { id: 'o2' }]);
+  applyListFailure(sim, { network: true });
+  assert.equal(sim.orders.length, 2);
+  assert.equal(sim.hasSuccess, true);
+  assert.equal(sim.authRequired, false);
+  assert.equal(sim.error, 'stale');
+  const failed5xx = applyListSuccess(createListSim(), [{ id: 'o1' }]);
+  applyListFailure(failed5xx, { status: 503 });
+  assert.equal(failed5xx.orders.length, 1);
+  assert.equal(failed5xx.hasSuccess, true);
+  // Board stale 분기는 이전 목록 렌더를 유지한다.
+  assert.match(boardSource, /\(이전 목록 표시 중\)/);
+  assert.match(boardSource, /orders\.map\(\(order\)/);
+});
+
+test('17. user/token A → B 전환은 새 fetch 완료 전에 A 데이터를 동기 clear한다', () => {
+  // 배선: scope ref + user/token/role deps로 전환을 감지한다.
+  assert.match(boardSource, /listScopeRef/);
+  assert.match(boardSource, /buildDriverListScope\(\{/);
+  assert.match(boardSource, /session\?\.user\.id/);
+  assert.match(boardSource, /session\?\.user\.role/);
+  assert.match(
+    boardSource,
+    /session\?\.user\.id,\s*session\?\.user\.role,\s*session\?\.user\.accessToken,\s*sessionStatus,\s*reloadKey\]/,
+  );
+  const scopeAt = boardSource.indexOf('listScopeRef.current !== nextScope');
+  assert.ok(scopeAt !== -1, 'scope 변경 분기가 있어야 한다');
+  const scopeBlock = boardSource.slice(scopeAt, scopeAt + 900);
+  assert.match(scopeBlock, /setPreparing\(\[\]\)/);
+  assert.match(scopeBlock, /setDelivering\(\[\]\)/);
+  assert.match(scopeBlock, /setHasSuccessfulRead\(false\)/);
+  assert.match(scopeBlock, /setError\(null\)/);
+  // token 상실도 같은 무효화 경로를 탄다.
+  assert.match(boardSource, /__no_token__/);
+  // runtime: A 성공 상태에서 B scope로 바뀌는 순간 A rows가 사라진다.
+  const scopeA = buildDriverListScope({ userId: 'user-a', role: 'driver', token: 'token-a' });
+  const scopeB = buildDriverListScope({ userId: 'user-b', role: 'driver', token: 'token-b' });
+  const sim = applyListSuccess(createListSim(), [{ id: 'a-order' }]);
+  applyListScopeChange(sim, scopeA, scopeB);
+  assert.deepEqual(sim.orders, []);
+  assert.equal(sim.hasSuccess, false);
+  assert.equal(sim.authRequired, false);
+});
+
+test('18. scope B read 실패는 A 데이터를 재노출하지 않는다', () => {
+  const scopeA = buildDriverListScope({ userId: 'user-a', role: 'driver', token: 'token-a' });
+  const scopeB = buildDriverListScope({ userId: 'user-b', role: 'driver', token: 'token-b' });
+  const sim = applyListSuccess(createListSim(), [{ id: 'a-order' }]);
+  applyListScopeChange(sim, scopeA, scopeB);
+  // B의 첫 read가 network 실패: initial failure이며 A rows는 돌아오지 않는다.
+  applyListFailure(sim, { network: true });
+  assert.deepEqual(sim.orders, []);
+  assert.equal(sim.hasSuccess, false);
+  assert.equal(sim.error, 'initial');
+  // B의 첫 read가 401: auth-required이며 A rows는 돌아오지 않는다.
+  const sim2 = applyListSuccess(createListSim(), [{ id: 'a-order' }]);
+  applyListScopeChange(sim2, scopeA, scopeB);
+  applyListFailure(sim2, { status: 401 });
+  assert.deepEqual(sim2.orders, []);
+  assert.equal(sim2.authRequired, true);
+});
+
+test('19. Board·Map은 같은 목록 read 소유자를 공유하고 ad-hoc 분기를 따로 두지 않는다', () => {
+  for (const source of [boardSource, mapSource]) {
+    assert.match(source, /from ['"]@\/lib\/driver-list-read['"]/);
+    assert.match(source, /buildDriverListScope\(\{/);
+    assert.match(source, /toDriverListReadError\(response\.status\)/);
+    assert.match(source, /toDriverListReadErrorKind\(cause\)/);
+    assert.match(source, /shouldPreserveDriverListOnReadError\(kind/);
+    assert.match(source, /listScopeRef\.current !== nextScope/);
+    assert.doesNotMatch(source, /request failed: \$\{response\.status\}/);
+  }
+  // session loading guard는 양쪽에 보존된다.
+  assert.match(boardSource, /if \(sessionStatus === 'loading'\) return;/);
+  assert.match(mapSource, /if \(sessionStatus === 'loading'\) return;/);
 });

--- a/apps/driver/src/app/map/map-read-recovery.test.mjs
+++ b/apps/driver/src/app/map/map-read-recovery.test.mjs
@@ -1,6 +1,11 @@
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 import test from 'node:test';
+import {
+  buildDriverListScope,
+  classifyDriverListReadStatus,
+  shouldPreserveDriverListOnReadError,
+} from '../../lib/driver-list-read.ts';
 
 const mapSource = await readFile(new URL('./page.tsx', import.meta.url), 'utf8');
 
@@ -77,9 +82,10 @@ test('Map initial fetch failure shows error with retry, not empty', () => {
   assert.match(mapSource, /배송 경로를 불러오지 못했습니다\. 잠시 후 다시 시도해주세요\./);
   assert.match(mapSource, /다시 시도/);
   // Initial failure clears to [] AND records an error (never a silent empty).
+  // 401·403 authority loss는 별도 분기로 먼저 clear되므로 stale 판정은 공유 helper를 거친다.
   assert.match(
     mapSource,
-    /hasSuccessfulReadRef\.current\) \{\s*\/\/ refresh 실패/s,
+    /shouldPreserveDriverListOnReadError\(kind, hasSuccessfulReadRef\.current\)\) \{\s*\/\/ refresh 실패/s,
   );
   assert.match(mapSource, /\} else \{\s*setOrders\(\[\]\);\s*setError\('배송 경로를 불러오지 못했습니다/s);
   // The old collapse (catch -> setOrders([]) with no setError) must be gone.
@@ -141,7 +147,9 @@ test('Map refresh failure keeps previous route as stale with retry', () => {
   assert.match(mapSource, /최신 경로를 불러오지 못했습니다\. 이전 경로를 보여줍니다\./);
   assert.match(mapSource, /\(이전 경로 표시 중\)/);
   // Stale branch must not clear the retained route.
-  const staleIfStart = mapSource.indexOf('if (hasSuccessfulReadRef.current) {');
+  const staleIfStart = mapSource.indexOf(
+    'if (shouldPreserveDriverListOnReadError(kind, hasSuccessfulReadRef.current)) {',
+  );
   const staleSetErrorPos = mapSource.indexOf("setError('최신 경로를 불러오지 못했습니다");
   const staleSetErrorEnd = mapSource.indexOf("');", staleSetErrorPos) + 3;
   const staleBranch = mapSource.slice(staleIfStart, staleSetErrorEnd);
@@ -232,4 +240,131 @@ test('nearestNeighbor keeps input order fallback for missing coordinates', () =>
   ];
   const ids = nearestNeighborReference(orders).map((o) => o.id);
   assert.deepEqual(ids, ['a', 'no-geo', 'b']);
+});
+
+// DRIVER-LIST-AUTH-SCOPE-RECOVERY-02 focused regression.
+// Board와 같은 공유 helper로 401·403 authority loss와 user/token scope를 고정한다.
+
+// Map 목록 상태의 최소 시뮬레이터. page.tsx 분기 순서
+// (AUTH clear → helper preserve 판정 → initial clear, scope 변경 시 동기 clear)를
+// 그대로 미러하며 실제 helper 분류 함수를 사용한다.
+function createMapSim() {
+  return { orders: [], hasSuccess: false, authRequired: false, error: null };
+}
+
+function applyMapSuccess(sim, rows) {
+  sim.orders = rows;
+  sim.hasSuccess = true;
+  sim.authRequired = false;
+  sim.error = null;
+  return sim;
+}
+
+function applyMapFailure(sim, { status = null, network = false } = {}) {
+  const kind = network ? 'FETCH_ERROR' : classifyDriverListReadStatus(status);
+  if (kind === 'AUTH_ERROR') {
+    sim.orders = [];
+    sim.hasSuccess = false;
+    sim.authRequired = true;
+    sim.error = null;
+    return sim;
+  }
+  if (shouldPreserveDriverListOnReadError(kind, sim.hasSuccess)) {
+    sim.error = 'stale';
+    return sim;
+  }
+  sim.orders = [];
+  sim.error = 'initial';
+  return sim;
+}
+
+// 12. success → 401/403이면 Map protected route를 즉시 clear하고 auth 상태로 전환한다.
+test('Map 401·403 authority loss clears protected route and shows auth state', () => {
+  // 배선: generic Error 문자열이 아닌 typed 분류를 throw한다.
+  assert.match(mapSource, /throw toDriverListReadError\(response\.status\)/);
+  assert.doesNotMatch(mapSource, /request failed: \$\{response\.status\}/);
+  assert.match(mapSource, /toDriverListReadErrorKind\(cause\)/);
+  const catchBlock = mapSource.slice(mapSource.indexOf('.catch('), mapSource.indexOf('.finally('));
+  const authAt = catchBlock.indexOf("kind === 'AUTH_ERROR'");
+  const preserveAt = catchBlock.indexOf('if (shouldPreserveDriverListOnReadError');
+  assert.ok(authAt !== -1 && preserveAt !== -1 && authAt < preserveAt);
+  const authBranch = catchBlock.slice(authAt, preserveAt);
+  assert.match(authBranch, /setOrders\(\[\]\)/);
+  assert.match(authBranch, /setHasSuccessfulRead\(false\)/);
+  assert.match(authBranch, /hasSuccessfulReadRef\.current = false/);
+  assert.match(authBranch, /setAuthRequired\(true\)/);
+  // runtime: 401과 403 모두 stale 없이 auth-required로 전환된다.
+  for (const status of [401, 403]) {
+    const sim = applyMapSuccess(createMapSim(), [{ id: 'r1' }, { id: 'r2' }]);
+    applyMapFailure(sim, { status });
+    assert.deepEqual(sim.orders, []);
+    assert.equal(sim.hasSuccess, false);
+    assert.equal(sim.authRequired, true);
+    assert.equal(sim.error, null);
+  }
+});
+
+// 13. 같은 scope의 network/5xx 실패는 이전 route를 stale로 유지한다.
+test('Map same-scope transient failure preserves stale route', () => {
+  const sim = applyMapSuccess(createMapSim(), [{ id: 'r1' }]);
+  applyMapFailure(sim, { network: true });
+  assert.equal(sim.orders.length, 1);
+  assert.equal(sim.hasSuccess, true);
+  assert.equal(sim.authRequired, false);
+  assert.equal(sim.error, 'stale');
+  const failed5xx = applyMapSuccess(createMapSim(), [{ id: 'r1' }]);
+  applyMapFailure(failed5xx, { status: 500 });
+  assert.equal(failed5xx.orders.length, 1);
+  assert.equal(failed5xx.hasSuccess, true);
+});
+
+// 14. user/token A → B 전환은 새 fetch 완료 전에 A route를 동기 clear한다.
+test('Map user/token scope change synchronously clears previous route', () => {
+  assert.match(mapSource, /listScopeRef/);
+  assert.match(mapSource, /buildDriverListScope\(\{/);
+  assert.match(
+    mapSource,
+    /session\?\.user\.id,\s*session\?\.user\.role,\s*session\?\.user\.accessToken,\s*sessionStatus,\s*reloadKey\]/,
+  );
+  const scopeAt = mapSource.indexOf('listScopeRef.current !== nextScope');
+  assert.ok(scopeAt !== -1, 'scope 변경 분기가 있어야 한다');
+  const scopeBlock = mapSource.slice(scopeAt, scopeAt + 900);
+  assert.match(scopeBlock, /setOrders\(\[\]\)/);
+  assert.match(scopeBlock, /setHasSuccessfulRead\(false\)/);
+  assert.match(scopeBlock, /setError\(null\)/);
+  assert.match(mapSource, /__no_token__/);
+  // runtime: A 성공 상태에서 B scope로 바뀌는 순간 A route가 사라진다.
+  const scopeA = buildDriverListScope({ userId: 'user-a', role: 'driver', token: 'token-a' });
+  const scopeB = buildDriverListScope({ userId: 'user-b', role: 'driver', token: 'token-b' });
+  assert.notEqual(scopeA, scopeB);
+  const sim = applyMapSuccess(createMapSim(), [{ id: 'a-route' }]);
+  if (scopeA !== scopeB) {
+    sim.orders = [];
+    sim.hasSuccess = false;
+    sim.authRequired = false;
+    sim.error = null;
+  }
+  assert.deepEqual(sim.orders, []);
+  assert.equal(sim.hasSuccess, false);
+  // B의 첫 read 실패는 A route를 재노출하지 않는다.
+  applyMapFailure(sim, { network: true });
+  assert.deepEqual(sim.orders, []);
+  assert.equal(sim.hasSuccess, false);
+});
+
+// 15. AUTH 상태에서는 navigation이 노출되지 않고 stale fail-close가 유지된다.
+test('Map auth-loss exposes no navigation and stale fail-close is preserved', () => {
+  // AUTH 분기는 orders를 비우므로 active/stale navigation 가드가 모두 실패한다.
+  const catchBlock = mapSource.slice(mapSource.indexOf('.catch('), mapSource.indexOf('.finally('));
+  const authAt = catchBlock.indexOf("kind === 'AUTH_ERROR'");
+  const authBranch = catchBlock.slice(authAt, catchBlock.indexOf('if (shouldPreserveDriverListOnReadError'));
+  assert.match(authBranch, /setOrders\(\[\]\)/);
+  assert.doesNotMatch(authBranch, /buildKakaoNaviUrl/);
+  // fresh navigation 가드와 stale fail-closed 렌더는 그대로 유지된다.
+  assert.match(
+    mapSource,
+    /sorted\.length > 0 && !loading && !authRequired && !error && hasSuccessfulRead/,
+  );
+  assert.match(mapSource, /sorted\.length > 0 && error && hasSuccessfulRead/);
+  assert.match(mapSource, /disabled/);
 });

--- a/apps/driver/src/app/map/page.tsx
+++ b/apps/driver/src/app/map/page.tsx
@@ -3,6 +3,12 @@
 import { useEffect, useRef, useState } from 'react';
 import { useSession } from 'next-auth/react';
 import { apiFetch } from '@/lib/api';
+import {
+  buildDriverListScope,
+  shouldPreserveDriverListOnReadError,
+  toDriverListReadError,
+  toDriverListReadErrorKind,
+} from '@/lib/driver-list-read';
 import { Box, Stack, Text, Title, Badge, Button } from '@mantine/core';
 
 type Order = {
@@ -59,6 +65,9 @@ export default function MapPage() {
   const [hasSuccessfulRead, setHasSuccessfulRead] = useState(false);
   const requestIdRef = useRef(0);
   const hasSuccessfulReadRef = useRef(false);
+  // user identity + role + access token scope가 바뀌면 이전 scope의
+  // protected route를 새 fetch 완료 전에 동기적으로 제거한다.
+  const listScopeRef = useRef<string | null>(null);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: reloadKey is an intentional manual-refresh trigger for the error-state retry button
   useEffect(() => {
@@ -69,6 +78,7 @@ export default function MapPage() {
       // usable token 없음을 0건 성공으로 표시하지 않는다. 보호된 stale도 유지하지 않는다.
       // 다음 인증된 조회가 initial loading으로 시작하도록 성공 기억도 초기화한다.
       requestIdRef.current += 1;
+      listScopeRef.current = '__no_token__';
       hasSuccessfulReadRef.current = false;
       setOrders([]);
       setHasSuccessfulRead(false);
@@ -77,6 +87,26 @@ export default function MapPage() {
       setLoading(false);
       setRefreshing(false);
       return;
+    }
+
+    const nextScope = buildDriverListScope({
+      userId: session?.user.id,
+      role: session?.user.role,
+      token,
+    });
+    if (listScopeRef.current !== nextScope) {
+      // user/token scope 변경: 새 fetch 완료를 기다리지 않고 이전 scope의
+      // protected route·성공 기록·error/freshness를 동기적으로 제거한다.
+      // 진행 중이던 이전 scope read는 sequence 무효화로 덮어쓰기를 막는다.
+      requestIdRef.current += 1;
+      listScopeRef.current = nextScope;
+      hasSuccessfulReadRef.current = false;
+      setOrders([]);
+      setHasSuccessfulRead(false);
+      setError(null);
+      setAuthRequired(false);
+      setLoading(true);
+      setRefreshing(false);
     }
 
     const controller = new AbortController();
@@ -98,7 +128,7 @@ export default function MapPage() {
     apiFetch('/driver/orders', token, { signal: controller.signal })
       .then(async (response) => {
         if (!response.ok) {
-          throw new Error(`driver map orders request failed: ${response.status}`);
+          throw toDriverListReadError(response.status);
         }
         const payload: unknown = await response.json();
         if (!Array.isArray(payload)) throw new Error('driver map orders response is not a list');
@@ -117,7 +147,18 @@ export default function MapPage() {
       })
       .catch((cause: unknown) => {
         if (!isCurrent() || (cause instanceof DOMException && cause.name === 'AbortError')) return;
-        if (hasSuccessfulReadRef.current) {
+        const kind = toDriverListReadErrorKind(cause);
+        if (kind === 'AUTH_ERROR') {
+          // authority loss(401·403): 이전 protected route를 즉시 제거하고
+          // auth-required로 전환한다. stale route 유지·stale navigation을 허용하지 않는다.
+          hasSuccessfulReadRef.current = false;
+          setOrders([]);
+          setHasSuccessfulRead(false);
+          setAuthRequired(true);
+          setError(null);
+          return;
+        }
+        if (shouldPreserveDriverListOnReadError(kind, hasSuccessfulReadRef.current)) {
           // refresh 실패는 마지막 정상 route를 지우지 않고 stale로 유지한다.
           // stale route를 최신 경로로 오인시키지 않도록 navigation은 fail-closed한다.
           setError('최신 경로를 불러오지 못했습니다. 이전 경로를 보여줍니다.');
@@ -136,7 +177,7 @@ export default function MapPage() {
       active = false;
       controller.abort();
     };
-  }, [session?.user.accessToken, sessionStatus, reloadKey]);
+  }, [session?.user.id, session?.user.role, session?.user.accessToken, sessionStatus, reloadKey]);
 
   const sorted = nearestNeighbor(orders);
 

--- a/apps/driver/src/lib/driver-list-read.ts
+++ b/apps/driver/src/lib/driver-list-read.ts
@@ -1,0 +1,96 @@
+/**
+ * Driver list (Board/Map) read pure contract helper.
+ *
+ * Board(`board/_client.tsx`)와 Map(`map/page.tsx`)이 같은 목록 read
+ * semantics를 공유하기 위한 최소 소유자다. Detail helper
+ * (`board/_lib/driver-order-detail.ts`)를 건드리지 않고 목록 범위에만 적용한다.
+ *
+ * - 목록 GET의 HTTP status 분류 (401·403 / 그 외·network)
+ * - user identity + role + access token scope identity
+ * - 실패 때 이전 protected rows를 유지해도 되는지에 대한 단일 판정
+ *
+ * Server mutation policy를 재정의하지 않으며 raw Firestore read나
+ * payment 의미 재조합을 도입하지 않는다.
+ */
+
+export type DriverListReadErrorKind = 'AUTH_ERROR' | 'FETCH_ERROR';
+
+export class DriverListReadError extends Error {
+  readonly kind: DriverListReadErrorKind;
+  readonly status: number | null;
+
+  constructor(kind: DriverListReadErrorKind, status: number | null, message: string) {
+    super(message);
+    this.name = 'DriverListReadError';
+    this.kind = kind;
+    this.status = status;
+  }
+}
+
+/**
+ * 목록 GET의 HTTP status를 두 의미로 분류한다.
+ * 401·403은 authority loss이며 그 외 HTTP 실패는 transient fetch 실패다.
+ * 목록 GET에 authoritative absence(404) 계약은 없으므로 404는 FETCH_ERROR로 둔다.
+ */
+export function classifyDriverListReadStatus(status: number): DriverListReadErrorKind {
+  if (status === 401 || status === 403) return 'AUTH_ERROR';
+  return 'FETCH_ERROR';
+}
+
+export function toDriverListReadError(
+  status: number,
+  fallbackMessage = '주문을 불러오지 못했습니다',
+): DriverListReadError {
+  const kind = classifyDriverListReadStatus(status);
+  if (kind === 'AUTH_ERROR') {
+    return new DriverListReadError(kind, status, '로그인이 필요합니다. 세션을 다시 확인해 주세요.');
+  }
+  return new DriverListReadError(kind, status, fallbackMessage);
+}
+
+export function toDriverListNetworkError(
+  fallbackMessage = '주문을 불러오지 못했습니다',
+): DriverListReadError {
+  return new DriverListReadError('FETCH_ERROR', null, fallbackMessage);
+}
+
+/**
+ * catch 진입의 unknown 원인을 목록 read 의미로 정규화한다.
+ * typed AUTH/ FETCH error는 kind를 보존하고, 그 외(network·abort 외·malformed)는
+ * transient FETCH_ERROR로 취급한다.
+ */
+export function toDriverListReadErrorKind(cause: unknown): DriverListReadErrorKind {
+  if (cause instanceof DriverListReadError) return cause.kind;
+  return 'FETCH_ERROR';
+}
+
+/**
+ * 목록 GET 실패 때 이전 protected rows를 화면에 유지해도 되는가.
+ *
+ * - AUTH_ERROR(401·403): authority loss이므로 절대 유지하지 않는다.
+ * - FETCH_ERROR(network/5xx·malformed 등): 같은 scope에서 이미 성공한 read가
+ *   있을 때만 이전 내용을 stale로 유지할 수 있다.
+ */
+export function shouldPreserveDriverListOnReadError(
+  kind: DriverListReadErrorKind,
+  hasSuccessfulRead: boolean,
+): boolean {
+  if (!hasSuccessfulRead) return false;
+  return kind === 'FETCH_ERROR';
+}
+
+/**
+ * 목록 read의 최소 scope identity: user identity + role + access token.
+ * role은 driver app의 scope authority(proxy gate)라 포함한다.
+ * token이 회전해도 같은 user의 이전 scope 잔여물이 새 scope에 남지 않도록
+ * token 원문을 포함한다.
+ */
+export function buildDriverListScope(args: {
+  userId?: string | null;
+  role?: string | null;
+  token: string;
+}): string {
+  const userId = args.userId && args.userId.length > 0 ? args.userId : '__no_user__';
+  const role = args.role && args.role.length > 0 ? args.role : '__no_role__';
+  return `${userId}::${role}::${args.token}`;
+}


### PR DESCRIPTION
TASK: DRIVER-LIST-AUTH-SCOPE-RECOVERY-02

Root cause (single change for F01+F02): Board and Map threw a generic Error on non-OK list GET, so 401/403 fell into the same stale-preserve path as network/5xx (F01), and neither screen tracked user/token scope, so A->B transitions kept rendering A rows until the next fetch resolved (F02).

Contract (shared owner apps/driver/src/lib/driver-list-read.ts, Board/Map wired to it):
- 401/403: immediate protected-rows clear, success-authority reset, auth-required state; generic retry loop never retains stale data.
- Same-scope network/5xx: stale preserve kept (no PR #110/#111 regression).
- Scope identity user-id + role + access-token: synchronous clear of rows/success/error on change, before next fetch; B failure never re-exposes A.
- Session-loading guards preserved; Map stale navigation stays fail-closed.
- Detail/Photo helpers untouched.

Verify:
- node --test apps/driver/src/app/board/board-contract.test.mjs (51 pass)
- node --test apps/driver/src/app/map/map-read-recovery.test.mjs (20 pass)
- detail auth-scope/detail unit tests unchanged pass; driver tsc --noEmit clean; deployment-safety guard OK.