### PR TITLE
fix(seller): recover dashboard settlement summary reads

### DIFF
--- a/apps/seller/src/app/_components/StatusCards.tsx
+++ b/apps/seller/src/app/_components/StatusCards.tsx
@@ -8,6 +8,11 @@ import { Fragment } from 'react';
 import type { OrderGroup } from '@/app/orders/_constants';
 import type { Summary } from '@/app/settlements/_constants';
 import { DashboardCard } from '@/components/DashboardCard';
+import type { DashboardSummaryData } from '@/hooks/useDashboardSummary.recovery';
+import {
+  resolveDashboardSummaryAmountText,
+  resolveDashboardSummaryView,
+} from '@/hooks/useDashboardSummary.recovery';
 
 // ─── 주문 처리 현황 카드 ──────────────────────────────────────────
 
@@ -81,17 +86,85 @@ export function OrderStatusCard({ groupCounts }: { groupCounts: Record<OrderGrou
 }
 
 // ─── 정산 현황 카드 ──────────────────────────────────────────────
+// 정산 조회 실패를 정상 0원으로 표시하지 않는다.
+// 첫 실패는 "—" + 오류 + retry, stale은 이전 금액 + 갱신 실패 표시.
 
 export function SettlementCard({
   summary,
   loading,
   error,
+  hasLoaded,
+  onRetry,
 }: {
   summary: Summary | null;
   loading: boolean;
   error: string | null;
+  hasLoaded?: boolean;
+  onRetry?: () => void;
 }) {
-  const amount = summary?.totalNetAmount ?? 0;
+  const effectiveHasLoaded = hasLoaded ?? (summary !== null);
+  const view = resolveDashboardSummaryView({
+    hasLoaded: effectiveHasLoaded,
+    loading,
+    error,
+  });
+  const amountText = resolveDashboardSummaryAmountText({
+    summary: summary as unknown as DashboardSummaryData | null,
+    view,
+  });
+
+  if (view === 'LOADING') {
+    return (
+      <DashboardCard title="정산 현황" moreHref="/settlements">
+        <Text style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-text-disabled)' }}>
+          불러오는 중…
+        </Text>
+      </DashboardCard>
+    );
+  }
+
+  if (view === 'READ_FAILED') {
+    return (
+      <DashboardCard title="정산 현황" moreHref="/settlements">
+        <Stack gap="xs">
+          <Group justify="space-between">
+            <Text style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-text-secondary)' }}>
+              오늘 정산 예정
+            </Text>
+            <Text
+              style={{
+                fontSize: 'var(--font-size-md)',
+                fontWeight: 'var(--fw-bold)',
+                color: 'var(--color-text-disabled)',
+              }}
+            >
+              —
+            </Text>
+          </Group>
+          <Text
+            role="alert"
+            style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-text-disabled)' }}
+          >
+            {error ?? '정산 정보를 불러오지 못했습니다.'}
+          </Text>
+          {onRetry && (
+            <Button
+              size="xs"
+              variant="light"
+              color="red"
+              leftSection={<RefreshCcw size={14} />}
+              onClick={onRetry}
+              style={{ alignSelf: 'flex-start' }}
+            >
+              다시 조회
+            </Button>
+          )}
+        </Stack>
+      </DashboardCard>
+    );
+  }
+
+  const isStale = view === 'STALE';
   return (
     <DashboardCard title="정산 현황" moreHref="/settlements">
       <Group justify="space-between">
@@ -102,12 +175,34 @@ export function SettlementCard({
           style={{
             fontSize: 'var(--font-size-md)',
             fontWeight: 'var(--fw-bold)',
-            color: error ? 'var(--color-text-disabled)' : 'var(--color-primary)',
+            color: 'var(--color-primary)',
           }}
         >
-          {loading ? '불러오는 중…' : error ? '—' : `${amount.toLocaleString('ko-KR')}원`}
+          {amountText}
         </Text>
       </Group>
+      {isStale && (
+        <Stack gap="xs" mt="xs">
+          <Text
+            role="alert"
+            style={{ fontSize: 'var(--font-size-sm)', color: 'var(--color-text-disabled)' }}
+          >
+            최신 정보를 확인하지 못했습니다. 이전 정보입니다.
+          </Text>
+          {onRetry && (
+            <Button
+              size="xs"
+              variant="light"
+              color="yellow"
+              leftSection={<RefreshCcw size={14} />}
+              onClick={onRetry}
+              style={{ alignSelf: 'flex-start' }}
+            >
+              다시 조회
+            </Button>
+          )}
+        </Stack>
+      )}
     </DashboardCard>
   );
 }

--- a/apps/seller/src/app/page.tsx
+++ b/apps/seller/src/app/page.tsx
@@ -29,7 +29,13 @@ export default function Home() {
     retry: retryProducts,
     hasLoaded: productsHasLoaded,
   } = useStoreProducts(storeId);
-  const { summary, loading: summaryLoading, error: summaryError } = useDashboardSummary();
+  const {
+    summary,
+    loading: summaryLoading,
+    error: summaryError,
+    hasLoaded: summaryHasLoaded,
+    retry: retrySummary,
+  } = useDashboardSummary();
   const productsTrustworthy = areStoreProductCountsTrustworthy({
     hasLoaded: productsHasLoaded,
     loading: productsLoading,
@@ -71,7 +77,13 @@ export default function Home() {
             productsTrustworthy={productsTrustworthy}
           />
           <OrderStatusCard groupCounts={groupCounts} />
-          <SettlementCard summary={summary} loading={summaryLoading} error={summaryError} />
+          <SettlementCard
+            summary={summary}
+            loading={summaryLoading}
+            error={summaryError}
+            hasLoaded={summaryHasLoaded}
+            onRetry={retrySummary}
+          />
           <ProductStatusCard
             products={products}
             loading={productsLoading}

--- a/apps/seller/src/hooks/useDashboardSummary.recovery.test.ts
+++ b/apps/seller/src/hooks/useDashboardSummary.recovery.test.ts
@@ -1,0 +1,266 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildDashboardSummaryPath,
+  DASHBOARD_SUMMARY_AUTH_ERROR,
+  DASHBOARD_SUMMARY_INVALID_RESPONSE_ERROR,
+  formatDashboardSummaryAmount,
+  isDashboardSummaryBackgroundRefresh,
+  isDashboardSummaryStale,
+  isValidDashboardSummaryPayload,
+  nextDashboardSummaryRetryKey,
+  parseDashboardSummaryPayload,
+  resolveDashboardSummaryAfterFailure,
+  resolveDashboardSummaryAmountText,
+  resolveDashboardSummaryAuthState,
+  resolveDashboardSummaryView,
+  shouldIgnoreDashboardSummaryResponse,
+  shouldInvalidateDashboardSummaryScope,
+  type DashboardSummaryData,
+} from './useDashboardSummary.recovery';
+
+function validSummary(overrides: Partial<DashboardSummaryData> = {}): DashboardSummaryData {
+  return {
+    date: '2026-09-10',
+    count: 2,
+    totalAmount: 30000,
+    totalPlatformFee: 3000,
+    totalNetAmount: 27000,
+    byStatus: { pending: 1, confirmed: 1, paid: 0, cancelled: 0 },
+    ...overrides,
+  };
+}
+
+describe('Dashboard settlement summary — no auth scope does not hang', () => {
+  it('세션 transient은 recoverable loading으로 유지한다', () => {
+    expect(resolveDashboardSummaryAuthState('loading', null, null)).toBe('loading');
+    expect(resolveDashboardSummaryAuthState('loading', 'store-1', 'token-1')).toBe('loading');
+  });
+
+  it('확정된 prerequisite 부재는 missing으로 닫고 무한 loading에 남기지 않는다', () => {
+    expect(resolveDashboardSummaryAuthState('unauthenticated', null, null)).toBe('missing');
+    expect(resolveDashboardSummaryAuthState('authenticated', null, 'token-1')).toBe('missing');
+    expect(resolveDashboardSummaryAuthState('authenticated', 'store-1', null)).toBe('missing');
+    expect(resolveDashboardSummaryAuthState('authenticated', 'store-1', '')).toBe('missing');
+    expect(resolveDashboardSummaryAuthState('unauthenticated', null, null)).not.toBe('loading');
+  });
+
+  it('인증된 store+token 조합만 network fetch 가능하다', () => {
+    expect(resolveDashboardSummaryAuthState('authenticated', 'store-1', 'token-1')).toBe('ready');
+  });
+
+  it('인증 오류는 빈 결과로 확정하지 않고 명시적 메시지로 닫는다', () => {
+    expect(DASHBOARD_SUMMARY_AUTH_ERROR).toBe('셀러 스토어 인증 정보를 확인할 수 없습니다.');
+    expect(
+      resolveDashboardSummaryView({ hasLoaded: false, loading: false, error: DASHBOARD_SUMMARY_AUTH_ERROR }),
+    ).toBe('READ_FAILED');
+  });
+});
+
+describe('Dashboard settlement summary — successful 0원 summary', () => {
+  it('0원은 유효한 성공 값으로 파싱된다', () => {
+    const payload = validSummary({
+      count: 0,
+      totalAmount: 0,
+      totalPlatformFee: 0,
+      totalNetAmount: 0,
+      byStatus: { pending: 0, confirmed: 0, paid: 0, cancelled: 0 },
+    });
+    expect(isValidDashboardSummaryPayload(payload)).toBe(true);
+    expect(parseDashboardSummaryPayload(payload).totalNetAmount).toBe(0);
+  });
+
+  it('0원 성공은 READY이며 "0원"으로 표시한다', () => {
+    const summary = validSummary({ totalNetAmount: 0, count: 0 });
+    const view = resolveDashboardSummaryView({ hasLoaded: true, loading: false, error: null });
+    expect(view).toBe('READY');
+    expect(resolveDashboardSummaryAmountText({ summary, view })).toBe('0원');
+    expect(formatDashboardSummaryAmount(0)).toBe('0원');
+  });
+});
+
+describe('Dashboard settlement summary — malformed response failure', () => {
+  it('null·배열·빈 객체를 0원 summary로 승격하지 않는다', () => {
+    expect(isValidDashboardSummaryPayload(null)).toBe(false);
+    expect(isValidDashboardSummaryPayload([])).toBe(false);
+    expect(isValidDashboardSummaryPayload({})).toBe(false);
+    expect(() => parseDashboardSummaryPayload(null)).toThrow(
+      DASHBOARD_SUMMARY_INVALID_RESPONSE_ERROR,
+    );
+    expect(() => parseDashboardSummaryPayload([])).toThrow(
+      DASHBOARD_SUMMARY_INVALID_RESPONSE_ERROR,
+    );
+  });
+
+  it('부분 필드·문자열 금액·NaN을 거부한다', () => {
+    const missingFee = validSummary();
+    // @ts-expect-error intentional malformed fixture
+    delete missingFee.totalPlatformFee;
+    expect(isValidDashboardSummaryPayload(missingFee)).toBe(false);
+
+    expect(
+      isValidDashboardSummaryPayload(validSummary({ totalNetAmount: '27000' as never })),
+    ).toBe(false);
+    expect(isValidDashboardSummaryPayload(validSummary({ totalNetAmount: NaN }))).toBe(false);
+    expect(
+      isValidDashboardSummaryPayload(validSummary({ totalNetAmount: Number.POSITIVE_INFINITY })),
+    ).toBe(false);
+    expect(() =>
+      parseDashboardSummaryPayload(validSummary({ totalNetAmount: '27000' as never })),
+    ).toThrow(DASHBOARD_SUMMARY_INVALID_RESPONSE_ERROR);
+  });
+
+  it('byStatus 누락·날짜 형식 오류를 거부한다', () => {
+    const noByStatus = { ...validSummary() } as Record<string, unknown>;
+    delete noByStatus.byStatus;
+    expect(isValidDashboardSummaryPayload(noByStatus)).toBe(false);
+
+    const badStatus = validSummary({ byStatus: { pending: 1, confirmed: 0, paid: 0 } as never });
+    expect(isValidDashboardSummaryPayload(badStatus)).toBe(false);
+
+    expect(isValidDashboardSummaryPayload(validSummary({ date: '2026/09/10' }))).toBe(false);
+    expect(isValidDashboardSummaryPayload(validSummary({ date: '' }))).toBe(false);
+  });
+});
+
+describe('Dashboard settlement summary — initial failure', () => {
+  it('첫 실패는 READ_FAILED이며 empty·0원이 아니다', () => {
+    const view = resolveDashboardSummaryView({
+      hasLoaded: false,
+      loading: false,
+      error: '정산 정보를 불러오지 못했습니다.',
+    });
+    expect(view).toBe('READ_FAILED');
+    expect(view).not.toBe('READY');
+    expect(resolveDashboardSummaryAmountText({ summary: null, view })).toBe('—');
+  });
+
+  it('첫 실패는 합성 0원 summary를 만들지 않는다', () => {
+    expect(resolveDashboardSummaryAfterFailure(null)).toBeNull();
+  });
+});
+
+describe('Dashboard settlement summary — success to retry start preserves summary', () => {
+  it('이전 성공이 있으면 background 갱신으로 취급한다', () => {
+    expect(isDashboardSummaryBackgroundRefresh(true)).toBe(true);
+    expect(isDashboardSummaryBackgroundRefresh(false)).toBe(false);
+  });
+
+  it('retry 시작(loading) 중에도 이전 금액 표시를 LOADING으로 되돌리지 않는다', () => {
+    const prev = validSummary({ totalNetAmount: 27000 });
+    const view = resolveDashboardSummaryView({ hasLoaded: true, loading: true, error: null });
+    expect(view).toBe('READY');
+    expect(resolveDashboardSummaryAmountText({ summary: prev, view })).toBe('27,000원');
+  });
+
+  it('실패 시 이전 summary 참조를 보존한다', () => {
+    const prev = validSummary({ totalNetAmount: 27000 });
+    expect(resolveDashboardSummaryAfterFailure(prev)).toBe(prev);
+  });
+});
+
+describe('Dashboard settlement summary — success to retry failure is stale', () => {
+  it('이전 성공 뒤 재조회 실패는 STALE이며 이전 금액을 유지한다', () => {
+    const prev = validSummary({ totalNetAmount: 27000 });
+    const view = resolveDashboardSummaryView({
+      hasLoaded: true,
+      loading: false,
+      error: '정산 정보를 불러오지 못했습니다.',
+    });
+    expect(view).toBe('STALE');
+    expect(isDashboardSummaryStale('정산 정보를 불러오지 못했습니다.', true)).toBe(true);
+    expect(resolveDashboardSummaryAmountText({ summary: prev, view })).toBe('27,000원');
+    expect(resolveDashboardSummaryAmountText({ summary: prev, view })).not.toBe('—');
+  });
+
+  it('stale은 최신 확정값이 아니다', () => {
+    expect(isDashboardSummaryStale(null, true)).toBe(false);
+    expect(isDashboardSummaryStale('boom', false)).toBe(false);
+  });
+});
+
+describe('Dashboard settlement summary — retry success clears stale', () => {
+  it('재조회 성공은 error를 해제하고 최신 summary로 교체한다', () => {
+    const next = validSummary({ totalNetAmount: 35000 });
+    const view = resolveDashboardSummaryView({ hasLoaded: true, loading: false, error: null });
+    expect(view).toBe('READY');
+    expect(isDashboardSummaryStale(null, true)).toBe(false);
+    expect(resolveDashboardSummaryAmountText({ summary: next, view })).toBe('35,000원');
+  });
+});
+
+describe('Dashboard settlement summary — store scope change invalidates', () => {
+  it('scope 변경(A→B, A→null, null→A)은 이전 summary를 무효화한다', () => {
+    expect(shouldInvalidateDashboardSummaryScope('store-a', 'store-b')).toBe(true);
+    expect(shouldInvalidateDashboardSummaryScope('store-a', null)).toBe(true);
+    expect(shouldInvalidateDashboardSummaryScope(null, 'store-a')).toBe(true);
+  });
+
+  it('동일 scope는 무효화하지 않는다', () => {
+    expect(shouldInvalidateDashboardSummaryScope('store-a', 'store-a')).toBe(false);
+    expect(shouldInvalidateDashboardSummaryScope(null, null)).toBe(false);
+  });
+
+  it('scope 미확정·미로드 상태는 READY로 승격하지 않는다', () => {
+    expect(resolveDashboardSummaryView({ hasLoaded: false, loading: true, error: null })).toBe(
+      'LOADING',
+    );
+    expect(resolveDashboardSummaryView({ hasLoaded: false, loading: false, error: null })).toBe(
+      'LOADING',
+    );
+  });
+});
+
+describe('Dashboard settlement summary — request race suppression', () => {
+  it('취소·stale 응답을 무시하고 최신 응답만 허용한다', () => {
+    expect(shouldIgnoreDashboardSummaryResponse(false, 2, 2)).toBe(true);
+    expect(shouldIgnoreDashboardSummaryResponse(true, 2, 1)).toBe(true);
+    expect(shouldIgnoreDashboardSummaryResponse(true, 1, 2)).toBe(true);
+    expect(shouldIgnoreDashboardSummaryResponse(true, 2, 2)).toBe(false);
+  });
+
+  it('중복 retry가 guard를 깨지 않는다', () => {
+    const current = 5;
+    expect(shouldIgnoreDashboardSummaryResponse(true, current, 3)).toBe(true);
+    expect(shouldIgnoreDashboardSummaryResponse(true, current, 4)).toBe(true);
+    expect(shouldIgnoreDashboardSummaryResponse(true, current, 5)).toBe(false);
+  });
+
+  it('retry 키는 단조 증가하고 동일한 network 경로를 재사용한다', () => {
+    expect(nextDashboardSummaryRetryKey(0)).toBe(1);
+    expect(nextDashboardSummaryRetryKey(1)).toBe(2);
+    expect(buildDashboardSummaryPath('store-1', '2026-09-10')).toBe(
+      '/stores/store-1/settlements/summary?date=2026-09-10',
+    );
+    expect(buildDashboardSummaryPath('store id/한글', '2026-09-10')).toBe(
+      `/stores/${encodeURIComponent('store id/한글')}/settlements/summary?date=2026-09-10`,
+    );
+  });
+});
+
+describe('SettlementCard does not turn failure into 0원', () => {
+  it('초기 실패는 "—"이며 "0원"이 아니다', () => {
+    const view = resolveDashboardSummaryView({
+      hasLoaded: false,
+      loading: false,
+      error: '정산 정보를 불러오지 못했습니다.',
+    });
+    expect(resolveDashboardSummaryAmountText({ summary: null, view })).toBe('—');
+    expect(resolveDashboardSummaryAmountText({ summary: null, view })).not.toBe('0원');
+    expect(resolveDashboardSummaryAmountText({ summary: null, view })).not.toContain('0');
+  });
+
+  it('stale은 이전 금액을 유지하고 실패를 0원으로 바꾸지 않는다', () => {
+    const prev = validSummary({ totalNetAmount: 5000 });
+    const text = resolveDashboardSummaryAmountText({ summary: prev, view: 'STALE' });
+    expect(text).toBe('5,000원');
+    expect(text).not.toBe('—');
+    expect(text).not.toBe('0원');
+  });
+
+  it('로딩 중에는 금액을 단정하지 않는다', () => {
+    expect(resolveDashboardSummaryAmountText({ summary: null, view: 'LOADING' })).toBe(
+      '불러오는 중…',
+    );
+    expect(resolveDashboardSummaryAmountText({ summary: null, view: 'LOADING' })).not.toBe('0원');
+  });
+});

--- a/apps/seller/src/hooks/useDashboardSummary.recovery.ts
+++ b/apps/seller/src/hooks/useDashboardSummary.recovery.ts
@@ -1,0 +1,200 @@
+/**
+ * Seller 홈 정산 summary read recovery 순수 계약.
+ * `useDashboardSummary.ts`의 runtime effect와 동일한 판정을 공유하되,
+ * vitest에서 `@/` alias 없이 직접 검증할 수 있도록 framework 의존성을 두지 않는다.
+ *
+ * 상품/주문 recovery와 같은 의미 계약을 사용하되 전체 공통 abstraction은 만들지 않는다.
+ * Settlement 전용 최소 계약만 둔다.
+ *
+ * Collapse 방지 원칙:
+ * - 성공한 summary만 금액을 표시한다. 0원은 유효한 성공 값이다.
+ * - summary가 한 번도 성공하지 않은 첫 실패는 0원·empty로 표시하지 않고
+ *   명시적 오류 + retry로 닫는다.
+ * - 이전 성공 뒤 재조회 실패는 이전 금액을 지우지 않고 stale로 보존한다.
+ * - scope(storeId) 변경 시 이전 store summary를 새 scope 값처럼 노출하지 않는다.
+ * - 잘못된 응답 객체를 0원 summary로 렌더하지 않는다.
+ */
+
+export const DASHBOARD_SUMMARY_AUTH_ERROR = '셀러 스토어 인증 정보를 확인할 수 없습니다.';
+export const DASHBOARD_SUMMARY_READ_ERROR = '정산 정보를 불러오지 못했습니다.';
+export const DASHBOARD_SUMMARY_INVALID_RESPONSE_ERROR = '정산 응답 형식이 올바르지 않습니다.';
+
+export type DashboardSummaryScopeId = string | null | undefined;
+
+export type DashboardSummaryAuthState = 'loading' | 'missing' | 'ready';
+
+export type DashboardSummaryView = 'LOADING' | 'READ_FAILED' | 'STALE' | 'READY';
+
+export interface DashboardSummaryByStatus {
+  pending: number;
+  confirmed: number;
+  paid: number;
+  cancelled: number;
+}
+
+export interface DashboardSummaryData {
+  date: string;
+  count: number;
+  totalAmount: number;
+  totalPlatformFee: number;
+  totalNetAmount: number;
+  byStatus: DashboardSummaryByStatus;
+}
+
+/**
+ * Seller 정산 summary의 인증 전제를 판정한다.
+ * - `loading`: 세션 transient — 무한 loading이 아니라 recoverable loading으로 유지한다.
+ * - `missing`: 확정된 prerequisite 부재(unauthenticated/store·token 없음) — 빈 결과로
+ *   확정하지 않고 인증 오류로 닫는다. 호출부는 loading을 false로 닫아야 한다.
+ * - `ready`: network fetch 가능.
+ * `useOrders`의 동일 분기와 메시지를 공유한다.
+ */
+export function resolveDashboardSummaryAuthState(
+  sessionStatus: string,
+  storeId: DashboardSummaryScopeId,
+  token: string | null | undefined,
+): DashboardSummaryAuthState {
+  if (sessionStatus === 'loading') return 'loading';
+  if (!storeId || !token) return 'missing';
+  return 'ready';
+}
+
+/** scope가 바뀌면 이전 scope summary를 무효화해야 한다 (A→B, A→null, null→A 포함). */
+export function shouldInvalidateDashboardSummaryScope(
+  prevStoreId: DashboardSummaryScopeId,
+  nextStoreId: DashboardSummaryScopeId,
+): boolean {
+  return (prevStoreId ?? null) !== (nextStoreId ?? null);
+}
+
+/** 이전 성공 summary가 있으면 initial loading으로 되돌리지 않고 background 갱신으로 취급한다. */
+export function isDashboardSummaryBackgroundRefresh(hasLoaded: boolean): boolean {
+  return hasLoaded;
+}
+
+/** race guard: 취소됐거나 최신 요청이 아니면 응답을 무시한다. */
+export function shouldIgnoreDashboardSummaryResponse(
+  active: boolean,
+  currentRequestId: number,
+  responseRequestId: number,
+): boolean {
+  return !active || currentRequestId !== responseRequestId;
+}
+
+/** network refetch 경로. manual retry가 동일한 경로를 사용한다. */
+export function buildDashboardSummaryPath(storeId: string, date: string): string {
+  return `/stores/${encodeURIComponent(storeId)}/settlements/summary?date=${encodeURIComponent(date)}`;
+}
+
+/** retry 키. retry 호출마다 단조 증가하며 effect deps로 사용된다. */
+export function nextDashboardSummaryRetryKey(current: number): number {
+  return current + 1;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isDateKey(value: unknown): value is string {
+  return typeof value === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(value);
+}
+
+function isCount(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0;
+}
+
+function isMoney(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0;
+}
+
+/**
+ * Summary 실제 계약의 최소 runtime validation.
+ * API `getSummary` 반환 `{ date, count, totalAmount, totalPlatformFee, totalNetAmount, byStatus }`만
+ * 인정한다. 0원은 유효하므로 falsy로 거부하지 않는다.
+ */
+export function isValidDashboardSummaryPayload(payload: unknown): payload is DashboardSummaryData {
+  if (!isRecord(payload)) return false;
+  if (!isDateKey(payload.date)) return false;
+  if (!isCount(payload.count)) return false;
+  if (!isMoney(payload.totalAmount)) return false;
+  if (!isMoney(payload.totalPlatformFee)) return false;
+  if (!isMoney(payload.totalNetAmount)) return false;
+  const byStatus = payload.byStatus;
+  if (!isRecord(byStatus)) return false;
+  if (!isCount(byStatus.pending)) return false;
+  if (!isCount(byStatus.confirmed)) return false;
+  if (!isCount(byStatus.paid)) return false;
+  if (!isCount(byStatus.cancelled)) return false;
+  return true;
+}
+
+/**
+ * fetch 응답을 검증된 summary로 변환한다.
+ * 잘못된 객체·배열·부분 필드·문자열 금액·NaN/Infinity·음수·날짜 형식 오류는
+ * 0원 summary로 승격하지 않고 throw한다.
+ */
+export function parseDashboardSummaryPayload(payload: unknown): DashboardSummaryData {
+  if (!isValidDashboardSummaryPayload(payload)) {
+    throw new Error(DASHBOARD_SUMMARY_INVALID_RESPONSE_ERROR);
+  }
+  return payload;
+}
+
+/**
+ * 정산 summary 읽기 상태를 단일 view로 판정한다.
+ * 우선순위: 첫 조회 실패(READ_FAILED) > stale(STALE) > 초기 로딩(LOADING) > 성공(READY).
+ * - READ_FAILED: 성공 이력 없음 + error — "—" + 명시적 오류 + retry. 0원으로 표시 금지.
+ * - STALE: 이전 성공 + 최신 확인 실패 — 이전 금액 유지 + stale 명시 + retry.
+ * - LOADING: 성공 이력 없음 + 요청 중.
+ * - READY: 마지막 성공 — 0원도 유효한 성공 값이다.
+ */
+export function resolveDashboardSummaryView(input: {
+  hasLoaded: boolean;
+  loading: boolean;
+  error: string | null;
+}): DashboardSummaryView {
+  const { hasLoaded, loading, error } = input;
+  if (error && !hasLoaded) return 'READ_FAILED';
+  if (error && hasLoaded) return 'STALE';
+  if (!hasLoaded && loading) return 'LOADING';
+  if (!hasLoaded) return 'LOADING';
+  return 'READY';
+}
+
+/** stale은 "이전 성공 summary + 현재 error"일 때만 true다. 최신 확정값처럼 쓰지 않는다. */
+export function isDashboardSummaryStale(error: string | null, hasLoaded: boolean): boolean {
+  return error !== null && hasLoaded;
+}
+
+/**
+ * 실패 시 summary 판정: 이전 summary를 그대로 보존한다.
+ * 첫 실패(prev null)도 `0원 summary`를 만들어내지 않는다.
+ */
+export function resolveDashboardSummaryAfterFailure(
+  prevSummary: DashboardSummaryData | null,
+): DashboardSummaryData | null {
+  return prevSummary;
+}
+
+/** 성공 금액 포맷. view 판정과 분리되어 실패를 0원으로 바꾸지 않는다. */
+export function formatDashboardSummaryAmount(totalNetAmount: number): string {
+  return `${totalNetAmount.toLocaleString('ko-KR')}원`;
+}
+
+/**
+ * SettlementCard 금액 영역 표시 텍스트.
+ * - READY/STALE + summary 있음: 실제 금액(0원 포함).
+ * - LOADING: 불러오는 중.
+ * - READ_FAILED 그 외: "—". 실패를 금액으로 바꾸지 않는다.
+ */
+export function resolveDashboardSummaryAmountText(input: {
+  summary: DashboardSummaryData | null;
+  view: DashboardSummaryView;
+}): string {
+  const { summary, view } = input;
+  if ((view === 'READY' || view === 'STALE') && summary) {
+    return formatDashboardSummaryAmount(summary.totalNetAmount);
+  }
+  if (view === 'LOADING') return '불러오는 중…';
+  return '—';
+}

--- a/apps/seller/src/hooks/useDashboardSummary.ts
+++ b/apps/seller/src/hooks/useDashboardSummary.ts
@@ -1,54 +1,168 @@
 'use client';
 
 import { useSession } from 'next-auth/react';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { todayKST } from '@greenhub/shared';
 import type { Summary } from '@/app/settlements/_constants';
 import { apiJson } from '@/lib/api';
+import {
+  buildDashboardSummaryPath,
+  DASHBOARD_SUMMARY_AUTH_ERROR,
+  DASHBOARD_SUMMARY_INVALID_RESPONSE_ERROR,
+  DASHBOARD_SUMMARY_READ_ERROR,
+  isDashboardSummaryBackgroundRefresh,
+  isDashboardSummaryStale,
+  parseDashboardSummaryPayload,
+  resolveDashboardSummaryAuthState,
+  shouldIgnoreDashboardSummaryResponse,
+} from './useDashboardSummary.recovery';
+
+export {
+  buildDashboardSummaryPath,
+  DASHBOARD_SUMMARY_AUTH_ERROR,
+  DASHBOARD_SUMMARY_INVALID_RESPONSE_ERROR,
+  DASHBOARD_SUMMARY_READ_ERROR,
+  isDashboardSummaryBackgroundRefresh,
+  isDashboardSummaryStale,
+  isValidDashboardSummaryPayload,
+  nextDashboardSummaryRetryKey,
+  parseDashboardSummaryPayload,
+  resolveDashboardSummaryAmountText,
+  resolveDashboardSummaryAuthState,
+  resolveDashboardSummaryView,
+  shouldIgnoreDashboardSummaryResponse,
+  shouldInvalidateDashboardSummaryScope,
+} from './useDashboardSummary.recovery';
+export type {
+  DashboardSummaryAuthState,
+  DashboardSummaryData,
+  DashboardSummaryView,
+} from './useDashboardSummary.recovery';
 
 interface UseDashboardSummaryResult {
   summary: Summary | null;
   loading: boolean;
   error: string | null;
+  /** 현재 scope에서 검증된 summary를 1회 이상 수신했는지. 0원 성공도 true. */
+  hasLoaded: boolean;
+  /** 이전 성공 summary + 최신 확인 실패. 최신 확정값이 아니다. */
+  isStale: boolean;
+  /** 같은 scope를 다시 조회한다. 이전 성공 summary를 지우지 않는다. */
+  retry: () => void;
 }
 
 /**
- * 홈 대시보드 전용 — 오늘자 정산 summary 1회 fetch.
- * `apiJson` 사용(#CL-32 — raw fetch 금지). 날짜는 정산 페이지와 동일 기준.
+ * 홈 대시보드 전용 — 오늘자 정산 summary fetch + read recovery.
+ * `apiJson` 사용(#CL-32 — raw fetch 금지). 날짜는 정산 페이지와 동일하게 `todayKST()` 기준.
+ *
+ * 계약:
+ * - 첫 성공 전 실패는 0원·empty로 표시하지 않고 error + retry로 닫는다.
+ * - 이전 성공 뒤 재조회 실패는 이전 금액을 stale로 보존한다.
+ * - scope(storeId) 변경 시 이전 store summary를 새 scope 값처럼 노출하지 않는다.
+ * - 늦은 이전 요청이 새로운 scope/retry 결과를 덮지 않는다.
+ * - 잘못된 응답 객체를 0원 summary로 렌더하지 않는다.
  */
 export function useDashboardSummary(): UseDashboardSummaryResult {
-  const { data: session } = useSession();
+  const { data: session, status: sessionStatus } = useSession();
   const storeId = session?.user.storeId;
   const token = session?.user.accessToken;
+  const normalizedStoreId = storeId ?? null;
 
   const [summary, setSummary] = useState<Summary | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [hasLoaded, setHasLoaded] = useState(false);
+  const [retryKey, setRetryKey] = useState(0);
+  const [scope, setScope] = useState<string | null>(normalizedStoreId);
+  const scopeRef = useRef<string | null>(normalizedStoreId);
+  const requestIdRef = useRef(0);
+  const hasLoadedRef = useRef(false);
+
+  // Scope 변경(A→B, A→null, null→A)이면 이전 store summary를
+  // 새 scope의 authoritative data처럼 노출하지 않도록 렌더 단계에서 무효화한다.
+  if (scope !== normalizedStoreId) {
+    scopeRef.current = normalizedStoreId;
+    hasLoadedRef.current = false;
+    requestIdRef.current += 1;
+    setScope(normalizedStoreId);
+    setSummary(null);
+    setError(null);
+    setHasLoaded(false);
+    setLoading(true);
+  }
+
+  const retry = useCallback(() => {
+    setRetryKey((key) => key + 1);
+  }, []);
+
+  const today = todayKST();
 
   useEffect(() => {
-    if (!storeId || !token) return;
-    let cancelled = false;
-    const today = todayKST();
+    void retryKey;
+    void today;
+    const authState = resolveDashboardSummaryAuthState(sessionStatus, storeId, token);
+    if (authState === 'loading') {
+      if (!isDashboardSummaryBackgroundRefresh(hasLoadedRef.current)) {
+        setLoading(true);
+      }
+      return;
+    }
+    if (authState === 'missing') {
+      requestIdRef.current += 1;
+      hasLoadedRef.current = false;
+      scopeRef.current = normalizedStoreId;
+      setSummary(null);
+      setHasLoaded(false);
+      setError(DASHBOARD_SUMMARY_AUTH_ERROR);
+      setLoading(false);
+      return;
+    }
 
+    const requestStoreId = storeId as string;
+    const requestToken = token as string;
+    scopeRef.current = requestStoreId;
+    // 같은 scope retry는 이전 summary를 유지한 채 background 갱신한다.
     setLoading(true);
     setError(null);
-    apiJson<Summary>(`/stores/${storeId}/settlements/summary?date=${today}`, token)
-      .then((data) => {
-        if (!cancelled) setSummary(data);
+    const myId = requestIdRef.current + 1;
+    requestIdRef.current = myId;
+    const requestDate = todayKST();
+    const path = buildDashboardSummaryPath(requestStoreId, requestDate);
+    let active = true;
+
+    apiJson<unknown>(path, requestToken)
+      .then((payload) => {
+        if (shouldIgnoreDashboardSummaryResponse(active, requestIdRef.current, myId)) return;
+        if (scopeRef.current !== requestStoreId) return;
+        const parsed = parseDashboardSummaryPayload(payload);
+        hasLoadedRef.current = true;
+        setSummary(parsed as unknown as Summary);
+        setHasLoaded(true);
+        setError(null);
       })
       .catch((e) => {
-        if (!cancelled) {
-          setError(e instanceof Error ? e.message : '정산 정보를 불러오지 못했습니다');
+        if (shouldIgnoreDashboardSummaryResponse(active, requestIdRef.current, myId)) return;
+        if (scopeRef.current !== requestStoreId) return;
+        // 이전 성공 summary가 있으면 유지하고 오류만 기록한다 (stale).
+        // 첫 실패는 summary null을 유지해 0원으로 승격하지 않는다.
+        if (e instanceof Error && e.message === DASHBOARD_SUMMARY_INVALID_RESPONSE_ERROR) {
+          setError(e.message);
+        } else {
+          setError(e instanceof Error ? e.message : DASHBOARD_SUMMARY_READ_ERROR);
         }
       })
       .finally(() => {
-        if (!cancelled) setLoading(false);
+        if (shouldIgnoreDashboardSummaryResponse(active, requestIdRef.current, myId)) return;
+        if (scopeRef.current !== requestStoreId) return;
+        setLoading(false);
       });
 
     return () => {
-      cancelled = true;
+      active = false;
     };
-  }, [storeId, token]);
+  }, [sessionStatus, storeId, token, retryKey, today, normalizedStoreId]);
 
-  return { summary, loading, error };
+  const isStale = isDashboardSummaryStale(error, hasLoaded);
+
+  return { summary, loading, error, hasLoaded, isStale, retry };
 }


### PR DESCRIPTION
Seller Dashboard Settlement Summary read-recovery publication.

- initial dashboard settlement read failure no longer renders fake 0원 (READ_FAILED with — + retry)
- zero-valued successful summary remains valid 0원 (READY)
- retry supports previous-data STALE state (preserves previous amount)
- scope changes invalidate prior store summary (A→B, A→null, null→A)
- malformed API payloads fail closed (throw, never 0원 synthesis)
- request races are suppressed (stale/late responses ignored)
- no settlement API/schema change
- todayKST basis unchanged

Validation:
- recovery focused tests: 26 / 26 PASS (src/hooks/useDashboardSummary.recovery.test.ts)
- Seller npx tsc --noEmit: PASS
- Biome lint on 5 owned files: PASS
- Related 60-test regression from source task preserved (not rerun here: working tree contains active foreign mutations in useOrders/useAdmin/admin clients that would invalidate rerun)

Owned files (5):
- apps/seller/src/hooks/useDashboardSummary.ts
- apps/seller/src/app/_components/StatusCards.tsx
- apps/seller/src/app/page.tsx
- apps/seller/src/hooks/useDashboardSummary.recovery.ts
- apps/seller/src/hooks/useDashboardSummary.recovery.test.ts

No foreign dirty included. Shared checkout remains on main; publication branch is transport-only.