### PR TITLE
fix(admin): preserve command outcome reconciliation

### DIFF
--- a/apps/seller/src/app/admin/drivers/_client.tsx
+++ b/apps/seller/src/app/admin/drivers/_client.tsx
@@ -1,9 +1,11 @@
 'use client';
 
 import { Box, Group, Title, UnstyledButton } from '@mantine/core';
+import { notifications } from '@mantine/notifications';
 import { useMemo, useState } from 'react';
 import { ConfirmModal } from '@/components/ConfirmModal';
 import { type DriverStatus, useAdminDrivers } from '@/hooks/useAdmin';
+import { describeAdminCommandOutcome } from '@/hooks/useAdmin';
 import { DriverList } from './_components/DriverList';
 import {
   ACTION_META,
@@ -23,14 +25,23 @@ export default function DriversClient() {
 
   const runPending = async () => {
     if (!pending) return;
+    const actionLabel =
+      pending.action === 'approve' ? '승인' : pending.action === 'suspend' ? '정지' : '정지 해제';
     setProcessingId(pending.userId);
     try {
-      if (pending.action === 'approve') {
-        await approve(pending.userId);
-      } else {
-        await toggleSuspend(pending.userId, pending.action === 'suspend');
-      }
+      const outcome =
+        pending.action === 'approve'
+          ? await approve(pending.userId)
+          : await toggleSuspend(pending.userId, pending.action === 'suspend');
       setPending(null);
+      if (outcome.kind === 'confirmed' && outcome.reconciled) return;
+      // rejected는 서버 reason 보존, unknown/stale은 재확인 우선 + blind retry 금지.
+      const presentation = describeAdminCommandOutcome(outcome, actionLabel);
+      notifications.show({
+        color: outcome.kind === 'rejected' ? 'red' : outcome.kind === 'unknown' ? 'orange' : 'yellow',
+        title: presentation.title,
+        message: presentation.message,
+      });
     } finally {
       setProcessingId(null);
     }

--- a/apps/seller/src/app/admin/orders/_client.tsx
+++ b/apps/seller/src/app/admin/orders/_client.tsx
@@ -4,6 +4,7 @@ import { Box, Group, Text, Title } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
 import { useState } from 'react';
 import { useAdminOrders } from '@/hooks/useAdmin';
+import { describeAdminCommandOutcome } from '@/hooks/useAdmin';
 import { OrdersFilters } from './_components/OrdersFilters';
 import { OrdersTable } from './_components/OrdersTable';
 
@@ -20,15 +21,16 @@ export default function AdminOrdersClient() {
     const reason = prompt('환불 사유를 입력하세요 (선택사항)');
     if (reason === null) return;
     setProcessingId(orderId);
-    const ok = await forceRefund(orderId, reason || undefined);
+    const outcome = await forceRefund(orderId, reason || undefined);
     setProcessingId(null);
-    if (!ok) {
-      notifications.show({
-        color: 'red',
-        title: '환불 처리 실패',
-        message: '주문 환불 처리 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.',
-      });
-    }
+    if (outcome.kind === 'confirmed' && outcome.reconciled) return;
+    // stale은 완료+재조회 copy를 사용한다. rejected는 서버 reason 보존, unknown은 재확인 우선.
+    const presentation = describeAdminCommandOutcome(outcome, '환불');
+    notifications.show({
+      color: outcome.kind === 'rejected' ? 'red' : outcome.kind === 'unknown' ? 'orange' : 'yellow',
+      title: presentation.title,
+      message: presentation.message,
+    });
   };
 
   return (

--- a/apps/seller/src/app/admin/settlements/_client.tsx
+++ b/apps/seller/src/app/admin/settlements/_client.tsx
@@ -5,6 +5,7 @@ import { notifications } from '@mantine/notifications';
 import { useState } from 'react';
 import { ConfirmModal } from '@/components/ConfirmModal';
 import { useAdminSettlements } from '@/hooks/useAdmin';
+import { describeAdminCommandOutcome } from '@/hooks/useAdmin';
 import { SettlementFilters } from './_components/SettlementFilters';
 import { SettlementTable } from './_components/SettlementTable';
 import { SummaryCards } from './_components/SummaryCards';
@@ -26,15 +27,16 @@ export default function AdminSettlementsClient() {
     if (!payTargetId) return;
     setProcessingId(payTargetId);
     try {
-      const ok = await markAsPaid(payTargetId);
+      const outcome = await markAsPaid(payTargetId);
       setPayTargetId(null);
-      if (!ok) {
-        notifications.show({
-          color: 'red',
-          title: '지급 처리 실패',
-          message: '정산 지급 처리 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.',
-        });
-      }
+      if (outcome.kind === 'confirmed' && outcome.reconciled) return;
+      // stale은 완료+재조회 copy를 사용한다. rejected는 서버 reason 보존, unknown은 재확인 우선.
+      const presentation = describeAdminCommandOutcome(outcome, '지급');
+      notifications.show({
+        color: outcome.kind === 'rejected' ? 'red' : outcome.kind === 'unknown' ? 'orange' : 'yellow',
+        title: presentation.title,
+        message: presentation.message,
+      });
     } finally {
       setProcessingId(null);
     }

--- a/apps/seller/src/app/admin/stores/_client.tsx
+++ b/apps/seller/src/app/admin/stores/_client.tsx
@@ -5,7 +5,7 @@ import { notifications } from '@mantine/notifications';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import type { AdminStore } from '@/hooks/useAdmin';
-import { useAdminStores } from '@/hooks/useAdmin';
+import { classifyAdminCommandError, describeAdminCommandOutcome, useAdminStores } from '@/hooks/useAdmin';
 import { StoresFilters } from './_components/StoresFilters';
 import { StoresTable } from './_components/StoresTable';
 import {
@@ -83,12 +83,28 @@ export default function AdminStoresClient() {
       return;
     }
     setSaving(true);
-    const ok = await setCommission(storeId, parsed.rate);
+    const outcome = await setCommission(storeId, parsed.rate);
     setSaving(false);
-    if (ok) {
+    if (outcome.kind === 'confirmed' && outcome.reconciled) {
       setEditId(null);
       setRateInput('');
+      return;
     }
+    if (outcome.kind === 'confirmed') {
+      // COMMAND CONFIRMED + RECONCILIATION FAILED — 실패로 되돌리지 않고 중복 실행을 유도하지 않는다.
+      setEditId(null);
+      setRateInput('');
+      const presentation = describeAdminCommandOutcome(outcome, '수수료율 변경');
+      notifications.show({ color: 'yellow', title: presentation.title, message: presentation.message });
+      return;
+    }
+    // rejected: 서버 reason 보존 + 편집 유지(수정 가능). unknown: 재확인 우선 + 편집 유지.
+    const presentation = describeAdminCommandOutcome(outcome, '수수료율 변경');
+    notifications.show({
+      color: outcome.kind === 'rejected' ? 'red' : 'orange',
+      title: presentation.title,
+      message: presentation.message,
+    });
   };
 
   const handleStartEdit = (store: AdminStore) => {
@@ -105,8 +121,22 @@ export default function AdminStoresClient() {
     const label = store.name || '(미설정)';
     if (!window.confirm(`${label} 판매자를 정리할까요? 주문·정산 기록은 보존됩니다.`)) return;
     try {
-      await archiveStore(store.id);
+      const reconciliation = await archiveStore(store.id);
+      if (!reconciliation.reconciled) {
+        // COMMAND CONFIRMED + RECONCILIATION FAILED — 실패로 표현하지 않고 중복 실행을 유도하지 않는다.
+        notifications.show({
+          color: 'yellow',
+          title: '정리 처리는 완료됐으나 목록 확인 실패',
+          message: `${reconciliation.readError ?? '목록 조회 실패'} 다시 조회해 최신 상태를 확인해 주세요. 같은 작업을 중복 실행하지 마세요.`,
+        });
+      }
     } catch (e) {
+      const classified = classifyAdminCommandError(e);
+      if (classified.kind === 'unknown') {
+        const presentation = describeAdminCommandOutcome(classified, '정리');
+        notifications.show({ color: 'orange', title: presentation.title, message: presentation.message });
+        return;
+      }
       // 기록 가드(400) 등 차단 사유를 서버 메시지 그대로 안내
       notifications.show({
         color: 'red',
@@ -118,8 +148,21 @@ export default function AdminStoresClient() {
 
   const handleRestore = async (store: AdminStore) => {
     try {
-      await restoreStore(store.id);
+      const reconciliation = await restoreStore(store.id);
+      if (!reconciliation.reconciled) {
+        notifications.show({
+          color: 'yellow',
+          title: '복구 처리는 완료됐으나 목록 확인 실패',
+          message: `${reconciliation.readError ?? '목록 조회 실패'} 다시 조회해 최신 상태를 확인해 주세요. 같은 작업을 중복 실행하지 마세요.`,
+        });
+      }
     } catch (e) {
+      const classified = classifyAdminCommandError(e);
+      if (classified.kind === 'unknown') {
+        const presentation = describeAdminCommandOutcome(classified, '복구');
+        notifications.show({ color: 'orange', title: presentation.title, message: presentation.message });
+        return;
+      }
       notifications.show({
         color: 'red',
         title: '복구할 수 없습니다',

--- a/apps/seller/src/app/admin/users/_client.tsx
+++ b/apps/seller/src/app/admin/users/_client.tsx
@@ -1,10 +1,11 @@
 'use client';
 
 import { Box, Button, Group, Paper, Stack, Text, Title } from '@mantine/core';
+import { notifications } from '@mantine/notifications';
 import { useState } from 'react';
 import { ConfirmModal } from '@/components/ConfirmModal';
 import type { AdminUser } from '@/hooks/useAdmin';
-import { useAdminUsers } from '@/hooks/useAdmin';
+import { describeAdminCommandOutcome, useAdminUsers } from '@/hooks/useAdmin';
 import { UsersTable } from './_components/UsersTable';
 
 interface PendingUserAction {
@@ -19,10 +20,19 @@ export default function AdminUsersClient() {
 
   const runPending = async () => {
     if (!pending) return;
+    const actionLabel = pending.currentlySuspended ? '정지 해제' : '정지';
     setProcessingId(pending.userId);
     try {
-      await toggleSuspend(pending.userId, !pending.currentlySuspended);
+      const outcome = await toggleSuspend(pending.userId, !pending.currentlySuspended);
       setPending(null);
+      if (outcome.kind === 'confirmed' && outcome.reconciled) return;
+      // rejected는 서버 reason 보존, unknown/stale은 재확인 우선 + blind retry 금지.
+      const presentation = describeAdminCommandOutcome(outcome, actionLabel);
+      notifications.show({
+        color: outcome.kind === 'rejected' ? 'red' : outcome.kind === 'unknown' ? 'orange' : 'yellow',
+        title: presentation.title,
+        message: presentation.message,
+      });
     } finally {
       setProcessingId(null);
     }

--- a/apps/seller/src/hooks/useAdmin.outcome.test.ts
+++ b/apps/seller/src/hooks/useAdmin.outcome.test.ts
@@ -1,0 +1,271 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import {
+  classifyAdminCommandError,
+  describeAdminCommandOutcome,
+  executeAdminCommand,
+  resolveConfirmedOutcome,
+} from './useAdmin.outcome';
+
+// Mock/local only — 실제 API 호출 없음. invoke/reload를 주입해 outcome 판정만 검증한다.
+
+function apiError(status: number, message: string) {
+  const error = new Error(message) as Error & { status: number };
+  error.name = 'ApiError';
+  error.status = status;
+  return error;
+}
+
+const useAdminSource = readFileSync(new URL('./useAdmin.ts', import.meta.url), 'utf8');
+const ordersClient = readFileSync(new URL('../app/admin/orders/_client.tsx', import.meta.url), 'utf8');
+const settlementsClient = readFileSync(
+  new URL('../app/admin/settlements/_client.tsx', import.meta.url),
+  'utf8',
+);
+const usersClient = readFileSync(new URL('../app/admin/users/_client.tsx', import.meta.url), 'utf8');
+const driversClient = readFileSync(
+  new URL('../app/admin/drivers/_client.tsx', import.meta.url),
+  'utf8',
+);
+const storesClient = readFileSync(
+  new URL('../app/admin/stores/_client.tsx', import.meta.url),
+  'utf8',
+);
+
+describe('1. 2xx command + reload success → confirmed/reconciled', () => {
+  it('invoke 성공 + readError null이면 reconciled true다', async () => {
+    const outcome = await executeAdminCommand({
+      invoke: async () => undefined,
+      reload: async () => null,
+    });
+    expect(outcome).toEqual({ kind: 'confirmed', reconciled: true });
+  });
+});
+
+describe('2. 2xx command + reload failure → confirmed/stale (실패로 붕괴 금지)', () => {
+  it('invoke 성공 + readError string이면 reconciled false + readError 보존이다', async () => {
+    const outcome = await executeAdminCommand({
+      invoke: async () => undefined,
+      reload: async () => '정산 목록 조회 중 오류 발생',
+    });
+    expect(outcome.kind).toBe('confirmed');
+    if (outcome.kind !== 'confirmed' || outcome.reconciled !== false) throw new Error('stale 기대');
+    expect(outcome.readError).toBe('정산 목록 조회 중 오류 발생');
+  });
+
+  it('stale은 rejected/unknown이 아니다', async () => {
+    const outcome = resolveConfirmedOutcome('주문 목록 조회 중 오류 발생');
+    expect(outcome.kind).toBe('confirmed');
+    expect(outcome).not.toMatchObject({ kind: 'rejected' });
+    expect(outcome).not.toMatchObject({ kind: 'unknown' });
+  });
+});
+
+describe('3. ApiError 4xx failure preserves server reason', () => {
+  it('400 reason/status를 그대로 전달한다', async () => {
+    const outcome = await executeAdminCommand({
+      invoke: async () => {
+        throw apiError(400, '기록이 있는 판매자는 정리할 수 없습니다');
+      },
+      reload: async () => null,
+    });
+    expect(outcome.kind).toBe('rejected');
+    if (outcome.kind !== 'rejected') throw new Error('rejected 기대');
+    expect(outcome.status).toBe(400);
+    expect(outcome.message).toContain('기록이 있는 판매자는 정리할 수 없습니다');
+  });
+
+  it('403/404도 rejected로 분류하고 reload를 호출하지 않는다', async () => {
+    let reloaded = false;
+    const outcome = await executeAdminCommand({
+      invoke: async () => {
+        throw apiError(403, '관리자 권한이 필요합니다');
+      },
+      reload: async () => {
+        reloaded = true;
+        return null;
+      },
+    });
+    expect(outcome.kind).toBe('rejected');
+    expect(reloaded).toBe(false);
+  });
+});
+
+describe('4. ApiError 5xx handling', () => {
+  it('500은 rejected가 아니라 unknown이다', async () => {
+    const outcome = await executeAdminCommand({
+      invoke: async () => {
+        throw apiError(500, '내부 서버 오류');
+      },
+      reload: async () => null,
+    });
+    expect(outcome.kind).toBe('unknown');
+  });
+
+  it('5xx unknown도 서버 reason을 버리지 않고 재확인 가이드를 함께 제공한다', () => {
+    const classified = classifyAdminCommandError(apiError(500, '내부 서버 오류'));
+    expect(classified.kind).toBe('unknown');
+    if (classified.kind !== 'unknown') throw new Error('unknown 기대');
+    expect(classified.message).toContain('내부 서버 오류');
+    expect(classified.message).toContain('다시 조회');
+  });
+});
+
+describe('5. transport/network unknown outcome', () => {
+  it('TypeError(fetch failed)는 unknown이다', async () => {
+    const outcome = await executeAdminCommand({
+      invoke: async () => {
+        throw new TypeError('fetch failed');
+      },
+      reload: async () => null,
+    });
+    expect(outcome.kind).toBe('unknown');
+  });
+
+  it('일반 Error도 unknown이며 상태를 단정하지 않는다', () => {
+    const classified = classifyAdminCommandError(new Error('network down'));
+    expect(classified.kind).toBe('unknown');
+  });
+});
+
+describe('6. unknown outcome does not advertise blind retry', () => {
+  it('unknown presentation은 command 재시도를 허용하지 않고 read retry를 요구한다', () => {
+    const presentation = describeAdminCommandOutcome(
+      { kind: 'unknown', message: 'x — 먼저 목록을 다시 조회해 상태를 확인하세요.' },
+      '환불',
+    );
+    expect(presentation.allowCommandRetry).toBe(false);
+    expect(presentation.needsReadRetry).toBe(true);
+  });
+
+  it('unknown copy는 재확인을 우선하고 즉시 재실행을 금지한다', () => {
+    const classified = classifyAdminCommandError(new TypeError('fetch failed'));
+    if (classified.kind !== 'unknown') throw new Error('unknown 기대');
+    const presentation = describeAdminCommandOutcome(classified, '지급');
+    expect(presentation.message).toContain('다시 조회');
+    expect(presentation.message).toContain('다시 실행하지 마세요');
+    expect(presentation.message).not.toContain('다시 시도');
+    expect(presentation.title).toContain('확인할 수 없습니다');
+  });
+});
+
+describe('7. force refund confirmed + reload failure does not become refund failed', () => {
+  it('stale presentation은 실패 copy로 붕괴하지 않는다', () => {
+    const presentation = describeAdminCommandOutcome(
+      { kind: 'confirmed', reconciled: false, readError: '주문 목록 조회 중 오류 발생' },
+      '환불',
+    );
+    expect(presentation.title).not.toBe('환불 처리 실패');
+    expect(presentation.message).not.toContain('환불 처리 실패');
+    expect(presentation.title).toContain('완료');
+    expect(presentation.message).toContain('다시 조회');
+    expect(presentation.message).toContain('중복 실행하지 마세요');
+    expect(presentation.allowCommandRetry).toBe(false);
+    expect(presentation.needsReadRetry).toBe(true);
+  });
+
+  it('orders _client는 stale을 실패 토스트로 표시하지 않는다', () => {
+    expect(ordersClient).toContain('describeAdminCommandOutcome(outcome,');
+    expect(ordersClient).not.toContain('환불 처리 실패');
+    expect(ordersClient).not.toContain('잠시 후 다시 시도해 주세요');
+  });
+});
+
+describe('8. settlement paid confirmed + reload failure same invariant', () => {
+  it('stale presentation은 실패 copy로 붕괴하지 않는다', () => {
+    const presentation = describeAdminCommandOutcome(
+      { kind: 'confirmed', reconciled: false, readError: '정산 목록 조회 중 오류 발생' },
+      '지급',
+    );
+    expect(presentation.title).not.toBe('지급 처리 실패');
+    expect(presentation.message).not.toContain('지급 처리 실패');
+    expect(presentation.title).toContain('완료');
+    expect(presentation.message).toContain('다시 조회');
+    expect(presentation.message).toContain('중복 실행하지 마세요');
+    expect(presentation.allowCommandRetry).toBe(false);
+  });
+
+  it('settlements _client는 stale을 실패 토스트로 표시하지 않는다', () => {
+    expect(settlementsClient).toContain('describeAdminCommandOutcome(outcome,');
+    expect(settlementsClient).not.toContain('지급 처리 실패');
+    expect(settlementsClient).not.toContain('잠시 후 다시 시도해 주세요');
+  });
+});
+
+describe('9. user/driver command consumers preserve reason', () => {
+  it('rejected presentation은 서버 reason을 그대로 전달한다', () => {
+    const rejected = { kind: 'rejected' as const, status: 400, message: '이미 정지된 계정입니다' };
+    expect(describeAdminCommandOutcome(rejected, '정지').message).toContain('이미 정지된 계정입니다');
+    const approveRejected = {
+      kind: 'rejected' as const,
+      status: 404,
+      message: '드라이버를 찾을 수 없습니다',
+    };
+    expect(describeAdminCommandOutcome(approveRejected, '승인').message).toContain(
+      '드라이버를 찾을 수 없습니다',
+    );
+  });
+
+  it('users _client는 outcome reason을 표시한다 (silent close 금지)', () => {
+    expect(usersClient).toContain('describeAdminCommandOutcome(outcome,');
+    expect(usersClient).toContain('notifications.show');
+    // 기존 ConfirmModal + reload 배선 유지
+    expect(usersClient).toContain('await toggleSuspend(pending.userId, !pending.currentlySuspended)');
+    expect(usersClient).toContain('onConfirm={runPending}');
+  });
+
+  it('drivers _client는 approve/suspend reason을 표시한다', () => {
+    expect(driversClient).toContain('describeAdminCommandOutcome(outcome,');
+    expect(driversClient).toContain('notifications.show');
+    expect(driversClient).toContain('approve(pending.userId)');
+    expect(driversClient).toContain('toggleSuspend(pending.userId');
+  });
+
+  it('stores commission도 서버 reason을 버리지 않는다', () => {
+    expect(storesClient).toContain('describeAdminCommandOutcome(outcome,');
+    const rejected = { kind: 'rejected' as const, status: 400, message: '수수료율 범위 오류' };
+    expect(describeAdminCommandOutcome(rejected, '수수료율 변경').message).toContain(
+      '수수료율 범위 오류',
+    );
+  });
+});
+
+describe('10. existing admin list error/reload behavior regression', () => {
+  it('useAdminList는 read failure를 error state에 남기고 readError를 반환한다', () => {
+    expect(useAdminSource).toContain('setError(readError)');
+    expect(useAdminSource).toContain('조회 중 오류 발생');
+    expect(useAdminSource).toContain('Promise<string | null>');
+    expect(useAdminSource).toContain('return readError');
+    expect(useAdminSource).toContain('return null');
+  });
+
+  it('reload 실패가 이전 items를 비우지 않는다 (stale 보존)', () => {
+    // catch 분기는 setItems를 호출하지 않고 error만 설정한다.
+    const loadBlock = useAdminSource.slice(
+      useAdminSource.indexOf('const load = useCallback'),
+      useAdminSource.indexOf('}, [token'),
+    );
+    expect(loadBlock).toContain('setItems(extract(data))');
+    expect(loadBlock).toContain('setError(readError)');
+    expect(loadBlock).not.toContain('setItems([])');
+  });
+
+  it('command 성공 뒤 reload를 호출하고 outcome 단일 소유자를 사용한다', () => {
+    expect(useAdminSource).toContain('executeAdminCommand');
+    expect(useAdminSource).toContain('runAdminCommand');
+    expect(useAdminSource).toContain('Promise<AdminCommandOutcome>');
+    // 구 boolean 축약이 남지 않는다 (banner save의 독립 boolean 계약은 범위 밖이므로 제외).
+    expect(useAdminSource).not.toContain('runAction');
+    expect(useAdminSource).not.toContain('성공 여부만 boolean으로 반환');
+  });
+
+  it('Banner/Invite 독립 error 계약을 깨뜨리지 않는다', () => {
+    expect(useAdminSource).toContain('useAdminBanner');
+    expect(useAdminSource).toContain('saveError');
+    expect(useAdminSource).toContain('useAdminInvite');
+    expect(useAdminSource).toContain('generateError');
+    // banner save / invite generate는 outcome 계약으로 흡수하지 않는다.
+    expect(useAdminSource).not.toContain("describeAdminCommandOutcome(outcome, '배너')");
+    expect(useAdminSource).not.toContain("describeAdminCommandOutcome(outcome, '초대')");
+  });
+});

--- a/apps/seller/src/hooks/useAdmin.outcome.ts
+++ b/apps/seller/src/hooks/useAdmin.outcome.ts
@@ -1,0 +1,165 @@
+/**
+ * Admin command outcome / reconciliation 순수 계약.
+ * `useAdmin.ts`의 single semantic owner가 공유하는 판정이며,
+ * vitest에서 `@/` alias 없이 직접 검증할 수 있도록 framework 의존성을 두지 않는다.
+ *
+ * Collapse 방지 원칙:
+ * - 서버 non-2xx 확정 거부는 reason/status를 보존한다 (ApiError message를 버리지 않음).
+ * - transport/network·5xx 불확정은 "실패했으니 다시 누르세요"로 축약하지 않고
+ *   상태 재확인을 우선하며 고위험 command 자동 재전송을 금지한다.
+ * - 2xx 확인 + authoritative reload 성공만 reconciled success다.
+ * - 2xx 확인 + reload 실패는 command 실패로 되돌리지 않고
+ *   "처리는 완료됐으나 최신 화면 확인 실패 + 수동 다시 조회 + 중복 실행 금지"로 표현한다.
+ * - reload 실패는 기존 list error state에도 남는다 (본 파일은 copy만 제공하고
+ *   실제 error state write는 `useAdminList.load`가 소유한다).
+ */
+
+export type AdminCommandOutcome =
+  | { kind: 'confirmed'; reconciled: true }
+  | { kind: 'confirmed'; reconciled: false; readError: string }
+  | { kind: 'rejected'; status: number | null; message: string }
+  | { kind: 'unknown'; message: string };
+
+export interface AdminCommandPresentation {
+  title: string;
+  message: string;
+  /** 같은 고위험 command를 바로 다시 실행하도록 유도해도 되는지. unknown/stale은 false. */
+  allowCommandRetry: boolean;
+  /** authoritative list 다시 조회가 필요한지. unknown/stale은 true. */
+  needsReadRetry: boolean;
+}
+
+export const ADMIN_COMMAND_MISSING_TOKEN_MESSAGE =
+  '인증 토큰이 없습니다. 다시 로그인해 주세요.';
+
+const UNKNOWN_GUIDANCE =
+  '요청이 서버에 전달됐는지 확인할 수 없습니다. 먼저 목록을 다시 조회해 상태를 확인하세요. 같은 작업을 바로 다시 실행하지 마세요.';
+
+const STALE_GUIDANCE = '다시 조회해 최신 상태를 확인해 주세요. 같은 작업을 중복 실행하지 마세요.';
+
+function isApiErrorLike(value: unknown): value is { status: number; message: string } {
+  if (typeof value !== 'object' || value === null) return false;
+  const record = value as Record<string, unknown>;
+  return typeof record.status === 'number' && typeof record.message === 'string';
+}
+
+function readApiStatus(value: unknown): number | null {
+  if (typeof value !== 'object' || value === null) return null;
+  const record = value as Record<string, unknown>;
+  return typeof record.status === 'number' ? record.status : null;
+}
+
+function readErrorMessage(value: unknown, fallback: string): string {
+  if (typeof value === 'object' && value !== null) {
+    const record = value as Record<string, unknown>;
+    if (typeof record.message === 'string' && record.message.trim().length > 0) {
+      return record.message;
+    }
+  }
+  if (value instanceof Error && value.message.trim().length > 0) return value.message;
+  return fallback;
+}
+
+/**
+ * command invoke 단계에서 던져진 에러를 확정 거부(rejected) / 불확정(unknown)으로 분류한다.
+ * - 4xx ApiError: 서버가 명확히 거부 — reason/status 보존.
+ * - 5xx ApiError: 적용 여부가 불확정 — 서버 reason을 버리지 않되 unknown으로 취급.
+ * - 그 외 transport/network/unknown: unknown으로 취급하고 재확인 우선 copy를 부여.
+ */
+export function classifyAdminCommandError(
+  error: unknown,
+): Extract<AdminCommandOutcome, { kind: 'rejected' } | { kind: 'unknown' }> {
+  if (isApiErrorLike(error)) {
+    const status = readApiStatus(error) ?? 0;
+    const serverMessage = readErrorMessage(error, `요청이 거부됐습니다 (${status})`);
+    if (status >= 500) {
+      return {
+        kind: 'unknown',
+        message: `${serverMessage} — ${UNKNOWN_GUIDANCE}`,
+      };
+    }
+    return { kind: 'rejected', status, message: serverMessage };
+  }
+  return { kind: 'unknown', message: UNKNOWN_GUIDANCE };
+}
+
+export function missingTokenOutcome(): Extract<AdminCommandOutcome, { kind: 'rejected' }> {
+  return { kind: 'rejected', status: null, message: ADMIN_COMMAND_MISSING_TOKEN_MESSAGE };
+}
+
+/**
+ * 2xx 확인 뒤 authoritative reload 결과를 outcome으로 결합한다.
+ * - readError null: COMMAND CONFIRMED + RECONCILED.
+ * - readError string: COMMAND CONFIRMED + RECONCILIATION FAILED.
+ *   command를 실패로 되돌리지 않으며 readError를 보존한다.
+ */
+export function resolveConfirmedOutcome(
+  readError: string | null,
+): Extract<AdminCommandOutcome, { kind: 'confirmed' }> {
+  if (readError === null) return { kind: 'confirmed', reconciled: true };
+  return { kind: 'confirmed', reconciled: false, readError };
+}
+
+/**
+ * mock/local focused regression용 오케스트레이션.
+ * 실제 fetch를 수행하지 않고 주입된 invoke/reload 결과만으로 outcome을 판정한다.
+ * `useAdmin.ts`의 runtime `runAdminCommand`와 동일한 순서를 공유한다:
+ * missingToken → invoke → classify → reload → resolve.
+ */
+export async function executeAdminCommand(options: {
+  invoke: () => Promise<void>;
+  reload: () => Promise<string | null>;
+  missingToken?: boolean;
+}): Promise<AdminCommandOutcome> {
+  if (options.missingToken) return missingTokenOutcome();
+  try {
+    await options.invoke();
+  } catch (error) {
+    return classifyAdminCommandError(error);
+  }
+  return resolveConfirmedOutcome(await options.reload());
+}
+
+/**
+ * outcome을 UI notification copy + 재시도 가드로 변환하는 단일 소유자.
+ * - rejected: 서버 reason 그대로 전달. command 재시도는 호출자가 의도적으로만 수행.
+ * - unknown: 상태 재확인 우선, 고위험 command 자동/즉시 재전송 금지.
+ * - confirmed+stale: "처리는 완료됐으나 확인 실패 + 수동 다시 조회 + 중복 금지".
+ *   절대 `${actionLabel} 처리 실패` copy로 붕괴하지 않는다.
+ * - confirmed+reconciled: 성공. 별도 경고 copy 없음.
+ */
+export function describeAdminCommandOutcome(
+  outcome: AdminCommandOutcome,
+  actionLabel: string,
+): AdminCommandPresentation {
+  if (outcome.kind === 'confirmed' && outcome.reconciled) {
+    return {
+      title: `${actionLabel} 처리 완료`,
+      message: `${actionLabel} 처리가 완료됐습니다.`,
+      allowCommandRetry: false,
+      needsReadRetry: false,
+    };
+  }
+  if (outcome.kind === 'confirmed') {
+    return {
+      title: `${actionLabel} 처리는 완료됐으나 목록 확인 실패`,
+      message: `${actionLabel} 처리는 완료됐으나 최신 목록 확인에 실패했습니다 (${outcome.readError}). ${STALE_GUIDANCE}`,
+      allowCommandRetry: false,
+      needsReadRetry: true,
+    };
+  }
+  if (outcome.kind === 'rejected') {
+    return {
+      title: `${actionLabel} 처리 실패`,
+      message: outcome.message,
+      allowCommandRetry: true,
+      needsReadRetry: false,
+    };
+  }
+  return {
+    title: `${actionLabel} 결과를 확인할 수 없습니다`,
+    message: outcome.message,
+    allowCommandRetry: false,
+    needsReadRetry: true,
+  };
+}

--- a/apps/seller/src/hooks/useAdmin.ts
+++ b/apps/seller/src/hooks/useAdmin.ts
@@ -4,6 +4,19 @@ import type { SettlementStatus, StoreStatus } from '@greenhub/shared';
 import { useSession } from 'next-auth/react';
 import { type DependencyList, useCallback, useEffect, useState } from 'react';
 import { apiJson } from '@/lib/api';
+import {
+  type AdminCommandOutcome,
+  executeAdminCommand,
+} from './useAdmin.outcome';
+
+export type { AdminCommandOutcome } from './useAdmin.outcome';
+export { classifyAdminCommandError, describeAdminCommandOutcome } from './useAdmin.outcome';
+
+/** archive/restore처럼 ApiError를 직접 전파하는 경로의 reconciliation 결과. */
+export interface AdminReconciliation {
+  reconciled: boolean;
+  readError: string | null;
+}
 
 // ── Types ────────────────────────────────────────────────────────
 
@@ -103,15 +116,18 @@ function useAdminList<T>(
   const [error, setError] = useState<string | null>(null);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: buildPath/extract/errLabel은 매 렌더 재생성되는 안정 클로저 — reload는 token·필터(deps) 변화로만 트리거한다
-  const load = useCallback(async () => {
-    if (!token) return;
+  const load = useCallback(async (): Promise<string | null> => {
+    if (!token) return '인증 토큰이 없습니다. 다시 로그인해 주세요.';
     setLoading(true);
     try {
       const data = await apiJson(buildPath(), token);
       setItems(extract(data));
       setError(null);
+      return null;
     } catch {
-      setError(`${errLabel} 조회 중 오류 발생`);
+      const readError = `${errLabel} 조회 중 오류 발생`;
+      setError(readError);
+      return readError;
     } finally {
       setLoading(false);
     }
@@ -124,19 +140,25 @@ function useAdminList<T>(
   return { items, loading, error, reload: load, token };
 }
 
-/** 관리자 액션(PATCH/POST/PUT) 실행 — 성공 여부만 boolean으로 반환. */
-async function runAction(
+/**
+ * 관리자 액션(PATCH/POST/PUT) 실행 — boolean 축약 없이 outcome으로 반환한다.
+ * - 2xx + reload 성공: confirmed/reconciled.
+ * - 2xx + reload 실패: confirmed/stale (command 실패로 되돌리지 않음, readError 보존).
+ * - 4xx ApiError: rejected (서버 reason/status 보존).
+ * - 5xx ApiError·transport: unknown (재확인 우선, blind retry 금지).
+ * reload 실패는 기존 list error state에도 남는다 (load가 소유).
+ */
+async function runAdminCommand(
   token: string | undefined,
   path: string,
   options: RequestInit,
-): Promise<boolean> {
-  if (!token) return false;
-  try {
-    await apiJson(path, token, options);
-    return true;
-  } catch {
-    return false;
-  }
+  reload: () => Promise<string | null>,
+): Promise<AdminCommandOutcome> {
+  return executeAdminCommand({
+    missingToken: !token,
+    invoke: () => apiJson(path, token as string, options).then(() => undefined),
+    reload,
+  });
 }
 
 function withQuery(base: string, params: Record<string, string | undefined>): string {
@@ -163,27 +185,35 @@ export function useAdminStores() {
     token,
   } = useAdminList<AdminStore>(() => '/admin/stores', pick<AdminStore>('stores'), '판매자 목록');
 
-  const setCommission = async (storeId: string, rate: number) => {
-    const ok = await runAction(token, `/admin/stores/${storeId}/commission`, {
-      method: 'PATCH',
-      body: JSON.stringify({ rate }),
-    });
-    if (ok) await reload();
-    return ok;
+  const setCommission = async (storeId: string, rate: number): Promise<AdminCommandOutcome> => {
+    return runAdminCommand(
+      token,
+      `/admin/stores/${storeId}/commission`,
+      {
+        method: 'PATCH',
+        body: JSON.stringify({ rate }),
+      },
+      reload,
+    );
   };
 
   // 치우기 — 기록 가드 차단(400) 사유를 UI에 그대로 안내해야 하므로
-  // runAction(에러 삼킴) 대신 apiJson을 직접 호출해 ApiError를 전파한다.
-  const archiveStore = async (storeId: string) => {
-    if (!token) return;
+  // outcome boolean 축약 대신 ApiError를 직접 전파한다.
+  // command 2xx 확인 뒤 reload 실패는 reconciliation으로 반환한다 (실패로 되돌리지 않음).
+  const archiveStore = async (storeId: string): Promise<AdminReconciliation> => {
+    if (!token) throw new Error('인증 토큰이 없습니다. 다시 로그인해 주세요.');
     await apiJson(`/admin/stores/${storeId}/archive`, token, { method: 'PATCH' });
-    await reload();
+    const readError = await reload();
+    if (readError === null) return { reconciled: true, readError: null };
+    return { reconciled: false, readError };
   };
 
-  const restoreStore = async (storeId: string) => {
-    if (!token) return;
+  const restoreStore = async (storeId: string): Promise<AdminReconciliation> => {
+    if (!token) throw new Error('인증 토큰이 없습니다. 다시 로그인해 주세요.');
     await apiJson(`/admin/stores/${storeId}/restore`, token, { method: 'PATCH' });
-    await reload();
+    const readError = await reload();
+    if (readError === null) return { reconciled: true, readError: null };
+    return { reconciled: false, readError };
   };
 
   return { stores, loading, error, reload, setCommission, archiveStore, restoreStore };
@@ -200,13 +230,19 @@ export function useAdminUsers() {
     token,
   } = useAdminList<AdminUser>(() => '/admin/users', pick<AdminUser>('users'), '사용자 목록');
 
-  const toggleSuspend = async (userId: string, suspended: boolean) => {
-    const ok = await runAction(token, `/admin/users/${userId}/status`, {
-      method: 'PATCH',
-      body: JSON.stringify({ suspended }),
-    });
-    if (ok) await reload();
-    return ok;
+  const toggleSuspend = async (
+    userId: string,
+    suspended: boolean,
+  ): Promise<AdminCommandOutcome> => {
+    return runAdminCommand(
+      token,
+      `/admin/users/${userId}/status`,
+      {
+        method: 'PATCH',
+        body: JSON.stringify({ suspended }),
+      },
+      reload,
+    );
   };
 
   return { users, loading, error, reload, toggleSuspend };
@@ -228,13 +264,16 @@ export function useAdminOrders(filters?: { storeId?: string; status?: string }) 
     [filters?.storeId, filters?.status],
   );
 
-  const forceRefund = async (orderId: string, reason?: string) => {
-    const ok = await runAction(token, `/admin/orders/${orderId}/refund`, {
-      method: 'POST',
-      body: JSON.stringify({ reason }),
-    });
-    if (ok) await reload();
-    return ok;
+  const forceRefund = async (orderId: string, reason?: string): Promise<AdminCommandOutcome> => {
+    return runAdminCommand(
+      token,
+      `/admin/orders/${orderId}/refund`,
+      {
+        method: 'POST',
+        body: JSON.stringify({ reason }),
+      },
+      reload,
+    );
   };
 
   return { orders, loading, error, reload, forceRefund };
@@ -261,12 +300,8 @@ export function useAdminSettlements(filters?: { storeId?: string; from?: string;
     [filters?.storeId, filters?.from, filters?.to],
   );
 
-  const markAsPaid = async (settlementId: string) => {
-    const ok = await runAction(token, `/admin/settlements/${settlementId}/pay`, {
-      method: 'PATCH',
-    });
-    if (ok) await reload();
-    return ok;
+  const markAsPaid = async (settlementId: string): Promise<AdminCommandOutcome> => {
+    return runAdminCommand(token, `/admin/settlements/${settlementId}/pay`, { method: 'PATCH' }, reload);
   };
 
   return { settlements, loading, error, reload, markAsPaid };
@@ -287,19 +322,23 @@ export function useAdminDrivers() {
     '드라이버 목록',
   );
 
-  const approve = async (userId: string) => {
-    const ok = await runAction(token, `/admin/drivers/${userId}/approve`, { method: 'PATCH' });
-    if (ok) await reload();
-    return ok;
+  const approve = async (userId: string): Promise<AdminCommandOutcome> => {
+    return runAdminCommand(token, `/admin/drivers/${userId}/approve`, { method: 'PATCH' }, reload);
   };
 
-  const toggleSuspend = async (userId: string, suspended: boolean) => {
-    const ok = await runAction(token, `/admin/drivers/${userId}/suspend`, {
-      method: 'PATCH',
-      body: JSON.stringify({ suspended }),
-    });
-    if (ok) await reload();
-    return ok;
+  const toggleSuspend = async (
+    userId: string,
+    suspended: boolean,
+  ): Promise<AdminCommandOutcome> => {
+    return runAdminCommand(
+      token,
+      `/admin/drivers/${userId}/suspend`,
+      {
+        method: 'PATCH',
+        body: JSON.stringify({ suspended }),
+      },
+      reload,
+    );
   };
 
   return { drivers, loading, error, reload, approve, toggleSuspend };


### PR DESCRIPTION
Problem: Admin command boolean collapse가 server rejection, unknown outcome, command-success/read-failure를 구분하지 못해 duplicate high-risk command 실행을 유도할 수 있었음. Fix: single AdminCommandOutcome owner + explicit reconciliation contract + UI retry guard. Evidence: - focused 23 tests PASS (src/hooks/useAdmin.outcome.test.ts) - seller full suite 28 files / 299 tests PASS (live 56c1b9e0 base + owned 8 paths only) - tsc --noEmit PASS - biome lint 8 owned files PASS Out of scope: - Banner boolean contract - Seller dashboard recovery - Driver/Consumer/API foreign changes Base: 56c1b9e0e5779530be1ff342a09e8120171e1548 Transport ref only; shared checkout untouched.