### PR TITLE
fix(seller): isolate orders by store and auth scope

### DIFF
--- a/apps/seller/src/hooks/useOrders.recovery.ts
+++ b/apps/seller/src/hooks/useOrders.recovery.ts
@@ -45,6 +45,42 @@ export function buildSellerOrdersPath(storeId: string): string {
 }
 
 /**
+ * Seller 주문 read scope identity — 최소 `storeId + auth token`.
+ * 같은 store라도 token이 바뀌면 별도 scope이며, 이전 scope의
+ * orders/count/badge/hasData/error authority를 재사용하지 않는다.
+ * `\0` 구분자로 store·token 경계를 보존한다.
+ */
+export function buildSellerOrdersScopeKey(
+  storeId: string | null,
+  token: string | null | undefined,
+): string {
+  return `${storeId ?? ''}\u0000${token ?? ''}`;
+}
+
+/**
+ * Cross-scope reuse 판정: 이전 scope key와 다음 scope key가 다르면
+ * 이전 scope의 orders/count/badge/hasData/error를 즉시 무효화해야 한다.
+ * (A→B, A→missing, missing→A 포함. 동일 scope는 무효화하지 않는다.)
+ */
+export function shouldInvalidateSellerOrdersScope(
+  prevScopeKey: string | null,
+  nextScopeKey: string | null,
+): boolean {
+  return (prevScopeKey ?? null) !== (nextScopeKey ?? null);
+}
+
+/**
+ * Scope guard: 현재 scope와 응답 scope가 다르면 늦은 응답이라도
+ * 현재 scope state를 덮지 않는다. requestId guard와 함께 사용한다.
+ */
+export function shouldIgnoreSellerOrdersScopeResponse(
+  currentScopeKey: string,
+  responseScopeKey: string,
+): boolean {
+  return currentScopeKey !== responseScopeKey;
+}
+
+/**
  * 초기 결과 구분: 인증·network 오류와 빈 목록을 혼동하지 않는다.
  * - error + 데이터 없음 → error UI (EMPTY collapse 금지)
  * - error + stale 있음 → stale 유지 + 인라인 오류

--- a/apps/seller/src/hooks/useOrders.test.ts
+++ b/apps/seller/src/hooks/useOrders.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, it } from 'vitest';
 import {
   buildSellerOrdersPath,
+  buildSellerOrdersScopeKey,
   isSellerOrdersBackgroundRefresh,
   resolveSellerOrdersAuthState,
   resolveSellerOrdersInitialView,
   SELLER_ORDERS_AUTH_ERROR,
   shouldIgnoreSellerOrdersResponse,
+  shouldIgnoreSellerOrdersScopeResponse,
+  shouldInvalidateSellerOrdersScope,
 } from './useOrders.recovery';
 
 describe('Seller 주문 recovery — auth prerequisite', () => {
@@ -81,5 +84,164 @@ describe('Seller 주문 recovery — initial error vs empty / stale preservation
 
   it('정상 목록은 error 여부와 무관하게 list로 유지된다', () => {
     expect(resolveSellerOrdersInitialView(2, null)).toBe('list');
+  });
+});
+
+describe('Seller 주문 scope authority — storeId + token identity', () => {
+  it('scope key는 store와 token을 함께 식별한다', () => {
+    const a = buildSellerOrdersScopeKey('store-a', 'token-a');
+    const sameStoreSameToken = buildSellerOrdersScopeKey('store-a', 'token-a');
+    const storeB = buildSellerOrdersScopeKey('store-b', 'token-a');
+    const tokenB = buildSellerOrdersScopeKey('store-a', 'token-b');
+    expect(sameStoreSameToken).toBe(a);
+    expect(storeB).not.toBe(a);
+    expect(tokenB).not.toBe(a);
+    expect(storeB).not.toBe(tokenB);
+  });
+
+  it('store 경계가 보존된다 — 단순 결합 충돌이 scope를 속이지 않는다', () => {
+    // 'AB'+'C' 와 'A'+'BC' 는 다른 scope다.
+    expect(buildSellerOrdersScopeKey('AB', 'C')).not.toBe(buildSellerOrdersScopeKey('A', 'BC'));
+  });
+
+  it('A success → store B change → synchronous clear 판정', () => {
+    const prevScope = buildSellerOrdersScopeKey('store-a', 'token-a');
+    const nextScope = buildSellerOrdersScopeKey('store-b', 'token-a');
+    // hook 렌더 단계: scope가 바뀌면 이전 authority를 즉시 무효화한다.
+    expect(shouldInvalidateSellerOrdersScope(prevScope, nextScope)).toBe(true);
+    // 무효화 뒤: hasData reset → background가 아니라 initial loading이다.
+    const clearedHasData = false;
+    const clearedOrdersLength = 0;
+    const clearedError: string | null = null;
+    expect(isSellerOrdersBackgroundRefresh(clearedHasData)).toBe(false);
+    expect(clearedOrdersLength).toBe(0);
+    expect(clearedError).toBeNull();
+    // A rows/count/badge authority가 B에 노출되지 않는다.
+    expect(resolveSellerOrdersInitialView(clearedOrdersLength, clearedError)).toBe('empty');
+    expect(resolveSellerOrdersInitialView(clearedOrdersLength, clearedError)).not.toBe('list');
+  });
+
+  it('A success → token B change → synchronous clear 판정', () => {
+    const prevScope = buildSellerOrdersScopeKey('store-a', 'token-a');
+    const nextScope = buildSellerOrdersScopeKey('store-a', 'token-b');
+    expect(shouldInvalidateSellerOrdersScope(prevScope, nextScope)).toBe(true);
+    expect(isSellerOrdersBackgroundRefresh(false)).toBe(false);
+    expect(resolveSellerOrdersInitialView(0, null)).toBe('empty');
+  });
+
+  it('동일 scope는 무효화하지 않는다 — same-scope stale 계약의 전제', () => {
+    const scope = buildSellerOrdersScopeKey('store-a', 'token-a');
+    expect(shouldInvalidateSellerOrdersScope(scope, scope)).toBe(false);
+    // 동일 scope에서 기존 데이터가 있으면 background refreshing이다.
+    expect(isSellerOrdersBackgroundRefresh(true)).toBe(true);
+  });
+});
+
+describe('Seller 주문 scope 전환 — B loading 중 A rows/count 없음', () => {
+  it('B fetch loading은 A stale을 background로 표시하지 않는다', () => {
+    const prevScope = buildSellerOrdersScopeKey('store-a', 'token-a');
+    const nextScope = buildSellerOrdersScopeKey('store-b', 'token-a');
+    expect(shouldInvalidateSellerOrdersScope(prevScope, nextScope)).toBe(true);
+    // clear 뒤 hasData=false → loading=true, refreshing=false 경로다.
+    const hasDataAfterClear = false;
+    const isBackground = isSellerOrdersBackgroundRefresh(hasDataAfterClear);
+    expect(isBackground).toBe(false);
+    const loading = !isBackground;
+    const refreshing = isBackground;
+    expect(loading).toBe(true);
+    expect(refreshing).toBe(false);
+    // rows/count 없음: orders 0 + error null → empty, list가 아니다.
+    expect(resolveSellerOrdersInitialView(0, null)).toBe('empty');
+  });
+
+  it('이전 error/reset state를 B scope에 재사용하지 않는다', () => {
+    const prevScope = buildSellerOrdersScopeKey('store-a', 'token-a');
+    const nextScope = buildSellerOrdersScopeKey('store-b', 'token-a');
+    expect(shouldInvalidateSellerOrdersScope(prevScope, nextScope)).toBe(true);
+    // hook은 scope 전환 시 setError(null)로 이전 오류를 버린다.
+    const carriedError: string | null = null;
+    expect(carriedError).toBeNull();
+    expect(resolveSellerOrdersAuthState('authenticated', 'store-b', 'token-a')).toBe('ready');
+    expect(resolveSellerOrdersInitialView(0, carriedError)).toBe('empty');
+  });
+});
+
+describe('Seller 주문 scope 전환 — late response / B failure guard', () => {
+  it('A request가 늦게 완료되어도 requestId guard로 B를 덮지 않는다', () => {
+    // A myId=1 → B myId=2. 현재 최신은 2이므로 늦은 A(1)는 무시된다.
+    const currentRequestId = 2;
+    const lateAResponseId = 1;
+    const currentBResponseId = 2;
+    expect(shouldIgnoreSellerOrdersResponse(true, currentRequestId, lateAResponseId)).toBe(true);
+    expect(shouldIgnoreSellerOrdersResponse(true, currentRequestId, currentBResponseId)).toBe(
+      false,
+    );
+  });
+
+  it('A request가 늦게 완료되어도 scope guard로 B를 덮지 않는다', () => {
+    const scopeA = buildSellerOrdersScopeKey('store-a', 'token-a');
+    const scopeB = buildSellerOrdersScopeKey('store-b', 'token-a');
+    expect(shouldIgnoreSellerOrdersScopeResponse(scopeB, scopeA)).toBe(true);
+    expect(shouldIgnoreSellerOrdersScopeResponse(scopeB, scopeB)).toBe(false);
+  });
+
+  it('B failure 시 A stale fallback으로 복구하지 않는다', () => {
+    const scopeA = buildSellerOrdersScopeKey('store-a', 'token-a');
+    const scopeB = buildSellerOrdersScopeKey('store-b', 'token-a');
+    expect(shouldInvalidateSellerOrdersScope(scopeA, scopeB)).toBe(true);
+    // B 실패 직후: B scope 성공 이력이 없으므로 orders 0 + error → error view다.
+    // A의 이전 3건이 B의 stale처럼 list로 복구되면 실패다.
+    expect(resolveSellerOrdersInitialView(0, '주문 목록을 불러오지 못했습니다.')).toBe('error');
+    expect(resolveSellerOrdersInitialView(0, '주문 목록을 불러오지 못했습니다.')).not.toBe('list');
+  });
+
+  it('same-scope refresh failure에서는 기존 stale-preserve 계약을 유지한다', () => {
+    const scope = buildSellerOrdersScopeKey('store-a', 'token-a');
+    expect(shouldInvalidateSellerOrdersScope(scope, scope)).toBe(false);
+    // 같은 scope에서 이전 성공 3건 + 재조회 실패 → stale list를 유지한다.
+    expect(resolveSellerOrdersInitialView(3, '주문 목록을 불러오지 못했습니다.')).toBe('list');
+    expect(isSellerOrdersBackgroundRefresh(true)).toBe(true);
+  });
+});
+
+describe('Seller 주문 scope 전환 — missing store/token clear', () => {
+  it('store 또는 token이 없어지면 protected state를 clear한다', () => {
+    const scopeA = buildSellerOrdersScopeKey('store-a', 'token-a');
+    const missingStore = buildSellerOrdersScopeKey(null, 'token-a');
+    const missingToken = buildSellerOrdersScopeKey('store-a', null);
+    const missingBoth = buildSellerOrdersScopeKey(null, null);
+    expect(shouldInvalidateSellerOrdersScope(scopeA, missingStore)).toBe(true);
+    expect(shouldInvalidateSellerOrdersScope(scopeA, missingToken)).toBe(true);
+    expect(shouldInvalidateSellerOrdersScope(scopeA, missingBoth)).toBe(true);
+    expect(resolveSellerOrdersAuthState('authenticated', null, 'token-a')).toBe('missing');
+    expect(resolveSellerOrdersAuthState('authenticated', 'store-a', null)).toBe('missing');
+    expect(resolveSellerOrdersAuthState('authenticated', null, null)).toBe('missing');
+  });
+
+  it('missing은 이전 store의 order/count를 유지하지 않고 인증 오류로 닫는다', () => {
+    // hook missing 분기: orders [] + hasData false + AUTH_ERROR + loading false.
+    const clearedOrdersLength = 0;
+    const clearedHasData = false;
+    expect(clearedOrdersLength).toBe(0);
+    expect(clearedHasData).toBe(false);
+    expect(isSellerOrdersBackgroundRefresh(clearedHasData)).toBe(false);
+    expect(resolveSellerOrdersInitialView(clearedOrdersLength, SELLER_ORDERS_AUTH_ERROR)).toBe(
+      'error',
+    );
+    expect(resolveSellerOrdersInitialView(clearedOrdersLength, SELLER_ORDERS_AUTH_ERROR)).not.toBe(
+      'list',
+    );
+    expect(resolveSellerOrdersInitialView(clearedOrdersLength, SELLER_ORDERS_AUTH_ERROR)).not.toBe(
+      'empty',
+    );
+  });
+
+  it('genuine empty와 read failure 의미를 보존한다', () => {
+    // B scope 첫 성공이 빈 목록이면 error 없이 empty다.
+    expect(resolveSellerOrdersInitialView(0, null)).toBe('empty');
+    // B scope 첫 실패는 empty로 속이지 않고 error다.
+    expect(resolveSellerOrdersInitialView(0, '주문 목록을 불러오지 못했습니다.')).toBe('error');
+    expect(resolveSellerOrdersInitialView(0, null)).not.toBe('error');
+    expect(resolveSellerOrdersInitialView(0, '주문 목록을 불러오지 못했습니다.')).not.toBe('empty');
   });
 });

--- a/apps/seller/src/hooks/useOrders.ts
+++ b/apps/seller/src/hooks/useOrders.ts
@@ -7,18 +7,24 @@ import { type OrderGroup, STATUS_GROUP_MAP } from '@/app/orders/_constants';
 import { apiJson } from '@/lib/api';
 import {
   buildSellerOrdersPath,
+  buildSellerOrdersScopeKey,
   isSellerOrdersBackgroundRefresh,
   resolveSellerOrdersAuthState,
   SELLER_ORDERS_AUTH_ERROR,
   shouldIgnoreSellerOrdersResponse,
+  shouldIgnoreSellerOrdersScopeResponse,
+  shouldInvalidateSellerOrdersScope,
 } from './useOrders.recovery';
 
 export {
   buildSellerOrdersPath,
+  buildSellerOrdersScopeKey,
   isSellerOrdersBackgroundRefresh,
   resolveSellerOrdersAuthState,
   SELLER_ORDERS_AUTH_ERROR,
   shouldIgnoreSellerOrdersResponse,
+  shouldIgnoreSellerOrdersScopeResponse,
+  shouldInvalidateSellerOrdersScope,
 } from './useOrders.recovery';
 export type { SellerOrdersAuthState } from './useOrders.recovery';
 export { resolveSellerOrdersInitialView } from './useOrders.recovery';
@@ -35,13 +41,30 @@ interface UseOrdersResult {
 export function useOrders(storeId: string | null): UseOrdersResult {
   const { data: session, status: sessionStatus } = useSession();
   const token = session?.user.accessToken;
+  const scopeKey = buildSellerOrdersScopeKey(storeId, token);
   const [orders, setOrders] = useState<Order[]>([]);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [tick, setTick] = useState(0);
+  const [scope, setScope] = useState(scopeKey);
+  const scopeRef = useRef(scopeKey);
   const requestIdRef = useRef(0);
   const hasDataRef = useRef(false);
+
+  // Cross-scope reuse 금지: store/token이 바뀌면 이전 scope의
+  // orders/count/badge(hasData)/error authority를 렌더 단계에서 동기적으로 무효화한다.
+  // same-scope refresh는 hasData를 유지해 background refreshing + stale-preserve 계약을 보존한다.
+  if (shouldInvalidateSellerOrdersScope(scope, scopeKey)) {
+    scopeRef.current = scopeKey;
+    hasDataRef.current = false;
+    requestIdRef.current += 1;
+    setScope(scopeKey);
+    setOrders([]);
+    setError(null);
+    setLoading(true);
+    setRefreshing(false);
+  }
 
   const refresh = useCallback(() => {
     setTick((t) => t + 1);
@@ -49,6 +72,7 @@ export function useOrders(storeId: string | null): UseOrdersResult {
 
   useEffect(() => {
     void tick;
+    void scopeKey;
     const authState = resolveSellerOrdersAuthState(sessionStatus, storeId, token);
     if (authState === 'loading') {
       if (isSellerOrdersBackgroundRefresh(hasDataRef.current)) {
@@ -61,6 +85,7 @@ export function useOrders(storeId: string | null): UseOrdersResult {
     if (authState === 'missing') {
       requestIdRef.current += 1;
       hasDataRef.current = false;
+      scopeRef.current = scopeKey;
       setOrders([]);
       setError(SELLER_ORDERS_AUTH_ERROR);
       setLoading(false);
@@ -68,6 +93,8 @@ export function useOrders(storeId: string | null): UseOrdersResult {
       return;
     }
 
+    const requestScopeKey = scopeKey;
+    scopeRef.current = requestScopeKey;
     const isBackground = isSellerOrdersBackgroundRefresh(hasDataRef.current);
     if (isBackground) {
       setRefreshing(true);
@@ -81,17 +108,21 @@ export function useOrders(storeId: string | null): UseOrdersResult {
     apiJson<Order[]>(buildSellerOrdersPath(storeId as string), token as string)
       .then((payload) => {
         if (shouldIgnoreSellerOrdersResponse(active, requestIdRef.current, myId)) return;
+        if (shouldIgnoreSellerOrdersScopeResponse(scopeRef.current, requestScopeKey)) return;
         if (!Array.isArray(payload)) throw new Error('주문 목록 응답 형식이 올바르지 않습니다.');
         hasDataRef.current = true;
         setOrders(payload);
       })
       .catch((err: unknown) => {
         if (shouldIgnoreSellerOrdersResponse(active, requestIdRef.current, myId)) return;
-        // 이전 정상 목록이 있으면 유지하고 오류만 기록한다 (EMPTY collapse 방지).
+        if (shouldIgnoreSellerOrdersScopeResponse(scopeRef.current, requestScopeKey)) return;
+        // Same-scope 실패만 이전 정상 목록을 유지한다 (EMPTY collapse 방지).
+        // Cross-scope 실패는 이미 scope 전환 시 clear되었으므로 A stale을 복구하지 않는다.
         setError(err instanceof Error ? err.message : '주문 목록을 불러오지 못했습니다.');
       })
       .finally(() => {
         if (shouldIgnoreSellerOrdersResponse(active, requestIdRef.current, myId)) return;
+        if (shouldIgnoreSellerOrdersScopeResponse(scopeRef.current, requestScopeKey)) return;
         setLoading(false);
         setRefreshing(false);
       });
@@ -99,7 +130,7 @@ export function useOrders(storeId: string | null): UseOrdersResult {
     return () => {
       active = false;
     };
-  }, [token, sessionStatus, storeId, tick]);
+  }, [token, sessionStatus, storeId, scopeKey, tick]);
 
   useEffect(() => {
     const revalidate = () => {


### PR DESCRIPTION
source task: SELLER-ORDERS-STORE-SCOPE-02

Root cause:
- hasDataRef/success authority persisted across store/token scope changes, so a new scope B fetch could be misread as background refresh and keep showing previous scope A orders.
- Response authority depended only on requestId/active without verifying scope identity, leaving room for a late A response to affect new B state.

Changes (owned paths only):
- apps/seller/src/hooks/useOrders.ts
- apps/seller/src/hooks/useOrders.recovery.ts
- apps/seller/src/hooks/useOrders.test.ts

Contract:
- store/token scope invalidation: buildSellerOrdersScopeKey(storeId, token) forms seller-order scope identity; store or token change immediately invalidates prior scope data authority (render-phase clear of orders/groupCounts/hasData/error/loading).
- requestId + scope dual response guard: then/catch/finally check both requestId and scope identity, so stale-scope responses never mutate new scope state.
- same-scope stale refresh preservation: identical scope keeps background refresh and stale-data preservation behavior.
- missing-scope auth clearing: store/token missing clears prior list and converges to auth error contract instead of showing stale list.

Verification:
- focused tests: pnpm --filter seller exec vitest run src/hooks/useOrders.test.ts -> 26/26 PASS
- seller full tests: pnpm --filter seller exec vitest run -> 29 files / 339 tests PASS
- typecheck: pnpm --filter seller exec tsc --noEmit -> PASS

No unrelated files included.