### PR TITLE
fix(driver): guard stale and duplicate detail commands

### DIFF
--- a/apps/driver/src/app/board/[orderId]/_components/DeliveryHoldModal.tsx
+++ b/apps/driver/src/app/board/[orderId]/_components/DeliveryHoldModal.tsx
@@ -13,7 +13,7 @@ import {
   TextInput,
 } from '@mantine/core';
 import { useSession } from 'next-auth/react';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { apiFetch } from '@/lib/api';
 
 export type HoldReason =
@@ -43,19 +43,39 @@ interface DeliveryHoldModalProps {
   loading: boolean;
   orderId: string;
   storeId: string;
+  // modal open 이후 authority 이동을 감지하기 위한 최소 prop. version이 아닌
+  // 현재 order status만으로 hold command 허용 범위를 판정한다.
+  orderStatus: string;
   onClose: () => void;
   onLoading: (loading: boolean) => void;
   onSaved?: () => void;
+  // stale/403/409 수렴용 authoritative reread 트리거. 같은 hold command를
+  // 자동 재전송하지 않고 parent의 fresh GET으로 수렴한다.
+  onConvergence?: () => void;
 }
+
+// 배송 보류 command가 유효한 order authority 범위.
+export const HOLD_COMMAND_ALLOWED_STATUSES = ['PREPARING', 'DELIVERING'] as const;
+
+export function isHoldCommandAllowedStatus(status: string): boolean {
+  return (HOLD_COMMAND_ALLOWED_STATUSES as readonly string[]).includes(status);
+}
+
+// 403 duplicate-sequential / 409 race-loser / stale-submit 공통 수렴 메시지.
+// "실패했으니 다시 제출"이 아니라 상태 재확인을 안내한다.
+export const HOLD_STALE_CONVERGENCE_MESSAGE =
+  '이미 상태가 변경되었을 수 있습니다. 최신 상태를 다시 확인합니다.';
 
 export function DeliveryHoldModal({
   opened,
   loading,
   orderId,
   storeId,
+  orderStatus,
   onClose,
   onLoading,
   onSaved,
+  onConvergence,
 }: DeliveryHoldModalProps) {
   const { data: session } = useSession();
   const [reasonCode, setReasonCode] = useState<HoldReason>('WEATHER');
@@ -66,6 +86,30 @@ export function DeliveryHoldModal({
   const [nextDeliveryAt, setNextDeliveryAt] = useState('');
   const [error, setError] = useState('');
   const isWeather = reasonCode === 'WEATHER';
+  // C3: 부모 loading state와 무관한 로컬 submitting guard. 동일 frame
+  // double-submit에서도 두 번째 PATCH를 dispatch하지 않는다.
+  const submittingRef = useRef(false);
+
+  function resetHoldFormFields() {
+    setReasonCode('WEATHER');
+    setReasonMessage('');
+    setCustomerResponsible(false);
+    setRedeliveryFee('');
+    setNextContactAt('');
+    setNextDeliveryAt('');
+  }
+
+  // modal open 이후 order authority가 command 허용 범위를 벗어나면 stale form을
+  // 남기지 않는다. parent가 이미 fresh authority를 들고 있으므로 별도 reread 없이
+  // reset 후 닫는다. submit 경로의 stale 가드와 403/409 수렴이 실제 dispatch를 막는다.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: opened·orderStatus만의 의도적 stale 감시이며 onClose는 parent setter다
+  useEffect(() => {
+    if (opened && !isHoldCommandAllowedStatus(orderStatus)) {
+      resetHoldFormFields();
+      setError('');
+      onClose();
+    }
+  }, [opened, orderStatus]);
 
   function changeReason(value: string) {
     const next = value as HoldReason;
@@ -77,6 +121,17 @@ export function DeliveryHoldModal({
   }
 
   async function submit() {
+    // C3: 진행 중인 submit이 있으면 두 번째 PATCH를 dispatch하지 않는다.
+    if (submittingRef.current) return;
+    // modal open 이후 authority가 이동했다면 stale form을 그대로 submit하지 않는다.
+    // dispatch 0회, form reset, convergence reread 유도 후 닫는다.
+    if (!isHoldCommandAllowedStatus(orderStatus)) {
+      resetHoldFormFields();
+      setError(HOLD_STALE_CONVERGENCE_MESSAGE);
+      onConvergence?.();
+      onClose();
+      return;
+    }
     const message = reasonMessage.trim();
     const token = session?.user.accessToken;
     if (!message) {
@@ -102,23 +157,37 @@ export function DeliveryHoldModal({
     };
 
     setError('');
+    submittingRef.current = true;
     onLoading(true);
     try {
       const response = await apiFetch(`/stores/${storeId}/orders/${orderId}/delivery-hold`, token, {
         method: 'PATCH',
         body: JSON.stringify({ deliveryHold }),
       });
-      if (!response.ok) throw new Error('배송 보류 저장 실패');
+      if (!response.ok) {
+        // 403 duplicate-sequential / 409 race-loser: 같은 hold command를 자동
+        // 재전송하지 않고 convergence path로 보낸다. 일반적인 재제출 메시지를 쓰지 않는다.
+        if (response.status === 403 || response.status === 409) {
+          resetHoldFormFields();
+          setError(HOLD_STALE_CONVERGENCE_MESSAGE);
+          onConvergence?.();
+          return;
+        }
+        throw new Error('배송 보류 저장 실패');
+      }
       const result = (await response.json()) as { orderId?: unknown; status?: unknown };
       if (result.orderId !== orderId || result.status !== 'DELIVERY_HELD') {
         throw new Error('배송 보류 응답 불일치');
       }
+      resetHoldFormFields();
+      setError('');
       onClose();
       // Order 합성 없이 parent가 authoritative GET으로 수렴한다.
       onSaved?.();
     } catch {
       setError('배송 보류를 저장하지 못했습니다. 주문 상태를 확인하고 다시 시도해주세요.');
     } finally {
+      submittingRef.current = false;
       onLoading(false);
     }
   }
@@ -173,7 +242,7 @@ export function DeliveryHoldModal({
           <Button variant="default" onClick={onClose} disabled={loading}>
             취소
           </Button>
-          <Button color="red" onClick={submit} loading={loading}>
+          <Button color="red" onClick={submit} loading={loading} disabled={loading}>
             배송 보류 저장
           </Button>
         </Group>

--- a/apps/driver/src/app/board/[orderId]/driver-detail-command-safety.test.mjs
+++ b/apps/driver/src/app/board/[orderId]/driver-detail-command-safety.test.mjs
@@ -1,0 +1,185 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+// DRIVER-DETAIL-COMMAND-INFLIGHT-STALE-GUARD-01 focused regression.
+// Driver 주문 상세 command의 UX 안전계약만 검증한다:
+// ref 기반 in-flight guard, CTA disabled normalization, HoldModal stale guard,
+// 403/409 convergence, readback uncertainty no-resend.
+// photo flow·server·FSM·board refresh 계약은 건드리지 않는다.
+const detailSource = await readFile(new URL('./page.tsx', import.meta.url), 'utf8');
+const holdModalSource = await readFile(
+  new URL('./_components/DeliveryHoldModal.tsx', import.meta.url),
+  'utf8',
+);
+
+const CONVERGENCE_MESSAGE = '이미 상태가 변경되었을 수 있습니다. 최신 상태를 다시 확인합니다.';
+
+// 수렴 메시지는 상수로 단일 정의되어 양 경로에서 공유된다.
+test('수렴 메시지는 단일 상수로 정의된다', () => {
+  assert.match(
+    holdModalSource,
+    /HOLD_STALE_CONVERGENCE_MESSAGE =\s*\n\s*'이미 상태가 변경되었을 수 있습니다\. 최신 상태를 다시 확인합니다\.'/,
+  );
+  assert.match(detailSource, new RegExp(CONVERGENCE_MESSAGE.replace(/\./g, '\\.')));
+});
+
+// A. 빠른 double-submit → PATCH 1회: ref 기반 in-flight guard가 dispatch authority다.
+test('A. updateStatus는 ref 기반 in-flight guard로 double-submit PATCH를 차단한다', () => {
+  assert.match(detailSource, /const inFlightRef = useRef\(false\)/);
+  const fnAt = detailSource.indexOf('async function updateStatus');
+  assert.ok(fnAt !== -1, 'updateStatus가 있어야 한다');
+  const guardAt = detailSource.indexOf('if (inFlightRef.current) return', fnAt);
+  const armAt = detailSource.indexOf('inFlightRef.current = true', fnAt);
+  const patchAt = detailSource.indexOf("method: 'PATCH'", fnAt);
+  const releaseAt = detailSource.indexOf('inFlightRef.current = false', fnAt);
+  assert.ok(guardAt !== -1 && armAt !== -1 && patchAt !== -1 && releaseAt !== -1);
+  // guard → arm → PATCH 순서: 동일 frame 두 번째 호출은 dispatch 전에 복귀한다.
+  assert.ok(guardAt < armAt, 'guard가 arm보다 먼저다');
+  assert.ok(armAt < patchAt, 'arm이 PATCH dispatch보다 먼저다');
+  // 해제는 finally에서만: 모든 종료 경로가 여기를 거친다.
+  const finallyAt = detailSource.indexOf('} finally {', fnAt);
+  assert.ok(finallyAt !== -1 && finallyAt < releaseAt, 'in-flight 해제는 finally에서 한다');
+  assert.match(detailSource, /모든 종료 경로에서 in-flight를 해제한다/);
+});
+
+// B. loading 중 CTA → disabled: 모든 status mutation CTA가 명시적으로 disabled다.
+test('B. PATCH dispatch CTA는 loading 중 명시적으로 disabled다', () => {
+  const buttons = detailSource.split('<Button');
+  const dispatchButtons = buttons.filter((chunk) => chunk.includes('updateStatus(') && chunk.includes('onClick'));
+  // 배송 재개·수거 완료/배송 시작·배송 완료 dispatch 버튼이 존재한다.
+  assert.ok(dispatchButtons.length >= 4, `dispatch 버튼이 4개 이상이어야 한다 (${dispatchButtons.length})`);
+  for (const chunk of dispatchButtons) {
+    assert.match(
+      chunk,
+      /disabled=\{loading \|\| !commandsAllowed\}/,
+      'dispatch CTA는 disabled={loading || !commandsAllowed}여야 한다',
+    );
+  }
+  // 사진 촬영 네비게이션(비-PATCH)은 기존 fail-closed disabled를 유지한다.
+  const navButtons = buttons.filter(
+    (chunk) => chunk.includes('/photo') && chunk.includes('router.push'),
+  );
+  assert.ok(navButtons.length >= 2, '사진 네비게이션 버튼이 유지되어야 한다');
+  for (const chunk of navButtons) {
+    assert.match(chunk, /disabled=\{!commandsAllowed\}/);
+  }
+});
+
+// C. HoldModal double-submit → PATCH 1회: 로컬 submittingRef guard.
+test('C. HoldModal은 submittingRef guard로 double-submit PATCH를 차단한다', () => {
+  assert.match(holdModalSource, /const submittingRef = useRef\(false\)/);
+  const fnAt = holdModalSource.indexOf('async function submit');
+  assert.ok(fnAt !== -1, 'submit이 있어야 한다');
+  const guardAt = holdModalSource.indexOf('if (submittingRef.current) return', fnAt);
+  const armAt = holdModalSource.indexOf('submittingRef.current = true', fnAt);
+  const patchAt = holdModalSource.indexOf("method: 'PATCH'", fnAt);
+  const releaseAt = holdModalSource.indexOf('submittingRef.current = false', fnAt);
+  assert.ok(guardAt !== -1 && armAt !== -1 && patchAt !== -1 && releaseAt !== -1);
+  assert.ok(guardAt < patchAt, 'guard가 PATCH dispatch보다 먼저다');
+  assert.ok(armAt < patchAt, 'arm이 PATCH dispatch보다 먼저다');
+  const finallyAt = holdModalSource.indexOf('} finally {', fnAt);
+  assert.ok(finallyAt !== -1 && finallyAt < releaseAt, 'submitting 해제는 finally에서 한다');
+  // 저장 버튼도 명시적으로 disabled다.
+  assert.match(holdModalSource, /배송 보류 저장/);
+  assert.match(holdModalSource, /onClick=\{submit\} loading=\{loading\} disabled=\{loading\}/);
+});
+
+// D. modal open 뒤 order status 변경 → stale payload dispatch 0회.
+test('D. HoldModal은 open 뒤 authority 이동 시 stale payload를 dispatch하지 않는다', () => {
+  // 최소 prop으로 현재 order status를 전달받는다.
+  assert.match(holdModalSource, /orderStatus: string/);
+  assert.match(detailSource, /orderStatus=\{order\.status\}/);
+  // 허용 범위는 PREPARING·DELIVERING뿐이다.
+  const allowedLiteral = holdModalSource.match(/HOLD_COMMAND_ALLOWED_STATUSES = \[([^\]]*)\]/);
+  assert.ok(allowedLiteral, '허용 상태 literal이 있어야 한다');
+  assert.match(allowedLiteral[1], /'PREPARING'/);
+  assert.match(allowedLiteral[1], /'DELIVERING'/);
+  assert.doesNotMatch(allowedLiteral[1], /DELIVERED|DELIVERY_HELD|HUB_ARRIVED/);
+  // submit 경로: stale 판정이 PATCH dispatch보다 먼저다.
+  const fnAt = holdModalSource.indexOf('async function submit');
+  const staleAt = holdModalSource.indexOf('isHoldCommandAllowedStatus(orderStatus)', fnAt);
+  const patchAt = holdModalSource.indexOf("method: 'PATCH'", fnAt);
+  assert.ok(staleAt !== -1 && staleAt < patchAt, 'stale guard가 dispatch보다 먼저다');
+  const staleBlock = holdModalSource.slice(staleAt, patchAt);
+  assert.match(staleBlock, /setError\(HOLD_STALE_CONVERGENCE_MESSAGE\)/);
+  assert.match(staleBlock, /onConvergence\?\.\(\)/);
+  assert.match(staleBlock, /onClose\(\)/);
+  // open 중 authority 이탈을 감시하는 effect: reset 후 닫는다.
+  assert.match(holdModalSource, /\[opened, orderStatus\]/);
+  const effectAt = holdModalSource.indexOf('[opened, orderStatus]');
+  const effectBlock = holdModalSource.slice(Math.max(0, effectAt - 600), effectAt);
+  assert.match(effectBlock, /isHoldCommandAllowedStatus\(orderStatus\)/);
+  assert.match(effectBlock, /resetHoldFormFields\(\)/);
+  assert.match(effectBlock, /onClose\(\)/);
+});
+
+// E. 403/409 → 자동 재전송 0회 → 상태 재확인 UX.
+test('E. 403/409는 자동 재전송 없이 authoritative read로 수렴한다', () => {
+  // detail: 403/409 분기가 readDetail 수렴 + return이며 PATCH를 추가 호출하지 않는다.
+  const branchAt = detailSource.indexOf('res.status === 403 || res.status === 409');
+  assert.ok(branchAt !== -1, '403/409 분기가 있어야 한다');
+  const branchBlock = detailSource.slice(branchAt, branchAt + 700);
+  assert.match(branchBlock, new RegExp(CONVERGENCE_MESSAGE.replace(/\./g, '\\.')));
+  assert.match(branchBlock, /await readDetail\(token\)/);
+  assert.match(branchBlock, /return;/);
+  assert.doesNotMatch(branchBlock, /method: 'PATCH'/);
+  // modal: 403/409 분기가 convergence reread 유도 + return이며 PATCH를 추가 호출하지 않는다.
+  const modalBranchAt = holdModalSource.indexOf('response.status === 403 || response.status === 409');
+  assert.ok(modalBranchAt !== -1, 'modal 403/409 분기가 있어야 한다');
+  const modalBranchBlock = holdModalSource.slice(modalBranchAt, modalBranchAt + 600);
+  assert.match(modalBranchBlock, /setError\(HOLD_STALE_CONVERGENCE_MESSAGE\)/);
+  assert.match(modalBranchBlock, /onConvergence\?\.\(\)/);
+  assert.match(modalBranchBlock, /return;/);
+  assert.doesNotMatch(modalBranchBlock, /method: 'PATCH'/);
+  // 일반적인 "실패했으니 다시 제출" 메시지로 처리하지 않는다.
+  assert.doesNotMatch(modalBranchBlock, /다시 시도/);
+  // 자동 재전송 타이머가 없다.
+  assert.doesNotMatch(detailSource, /setTimeout\(updateStatus/);
+  assert.doesNotMatch(detailSource, /setInterval/);
+  assert.doesNotMatch(holdModalSource, /setTimeout\(submit/);
+  assert.doesNotMatch(holdModalSource, /setInterval/);
+  // parent는 modal 수렴 요청을 authoritative GET에 연결한다.
+  assert.match(detailSource, /onConvergence=\{/);
+});
+
+// F. ACK success + authoritative reread failure → PATCH 추가 호출 0회·warning·command disabled.
+test('F. readback 불확실성은 PATCH 재호출 없이 warning과 fail-closed를 유지한다', () => {
+  // detail의 PATCH는 status 전환 1회뿐이다.
+  const patchCount = (detailSource.match(/method: 'PATCH'/g) ?? []).length;
+  assert.equal(patchCount, 1, 'detail PATCH는 상태 전환 1회뿐이다');
+  assert.match(detailSource, /readbackWarning/);
+  assert.match(detailSource, /처리는 완료되었지만 최신 상태를 확인하지 못했습니다/);
+  assert.match(detailSource, /상태 다시 확인/);
+  // readbackWarning 존재 시 command가 fail-closed된다.
+  assert.match(detailSource, /hasReadbackWarning: readbackWarning !== null/);
+  // 이전 order를 최신이라고 주장하지 않는다: local 합성 없이 fresh GET으로만 수렴.
+  assert.match(detailSource, /setOrder\(fresh\)/);
+  assert.doesNotMatch(detailSource, /setOrder\(\{\s*\.\.\.order/);
+});
+
+// G. terminal ACK + reread loss → 기존 board convergence 계약 유지.
+test('G. terminal ACK 뒤 readback loss에서도 board navigation 계약이 유지된다', () => {
+  assert.match(detailSource, /const isTerminal = status === 'DELIVERED' \|\| status === 'HUB_ARRIVED'/);
+  assert.match(detailSource, /terminal은 board가 fresh fetch하므로 navigation 계약을 유지한다/);
+  assert.match(detailSource, /router\.replace\('\/board\?tab=preparing'\)/);
+  // detail에 머물도록 바꾸지 않는다: terminal 분기에 return이 끼어들지 않는다.
+  const terminalAt = detailSource.indexOf('} else if (isTerminal) {');
+  assert.ok(terminalAt !== -1);
+  const terminalBlock = detailSource.slice(terminalAt, terminalAt + 200);
+  assert.doesNotMatch(terminalBlock, /return;/);
+});
+
+// 기존 안전계약 회귀 없음: commandsAllowed·ACK 검증·authoritative reread.
+test('기존 command 안전계약이 유지된다', () => {
+  assert.match(detailSource, /isDriverOrderCommandAllowed\(\{/);
+  assert.match(detailSource, /isDriverOrderStatusAck\(result,\s*orderId,\s*status\)/);
+  assert.match(detailSource, /\/driver\/orders\/\$\{encodeURIComponent\(orderId\)\}/);
+  assert.match(holdModalSource, /result\.status !== 'DELIVERY_HELD'/);
+  assert.match(holdModalSource, /onSaved\?\.\(\)/);
+  // 성공 후 form reset.
+  const successAt = holdModalSource.indexOf("result.status !== 'DELIVERY_HELD'");
+  const successBlock = holdModalSource.slice(successAt, successAt + 500);
+  assert.match(successBlock, /resetHoldFormFields\(\)/);
+  assert.match(successBlock, /onClose\(\)/);
+});

--- a/apps/driver/src/app/board/[orderId]/page.tsx
+++ b/apps/driver/src/app/board/[orderId]/page.tsx
@@ -84,6 +84,10 @@ export default function OrderDetailPage({ params }: { params: Promise<{ orderId:
   const hasOrderRef = useRef(false);
   // orderId·auth token scope가 바뀌면 이전 scope의 order/PII를 절대 남기지 않는다.
   const readScopeRef = useRef<string | null>(null);
+  // C1: status command dispatch의 실제 authority. loading UI state와 분리된 ref 기반
+  // in-flight guard이며, React state의 비동기 반영만으로는 막을 수 없는 동일 frame
+  // double-click/double-submit에서도 두 번째 PATCH dispatch를 차단한다.
+  const inFlightRef = useRef(false);
 
   const readDetail = useCallback(
     async (token: string) => {
@@ -167,6 +171,9 @@ export default function OrderDetailPage({ params }: { params: Promise<{ orderId:
   }, [orderId, session?.user.accessToken, readKey, readDetail]);
 
   async function updateStatus(status: string) {
+    // C1: dispatch 직전에 ref를 선점한다. 이미 진행 중인 command가 있으면
+    // 두 번째 PATCH를 dispatch하지 않고 즉시 복귀한다.
+    if (inFlightRef.current) return;
     if (!order || !session) return;
     // fail-closed: stale read confidence에서는 위험 command를 실행하지 않는다.
     // AUTH/NOT_FOUND는 원칙적으로 order가 제거된 상태이며, FETCH stale·readback 미확인도 차단한다.
@@ -180,6 +187,7 @@ export default function OrderDetailPage({ params }: { params: Promise<{ orderId:
       return;
     }
     const token = session.user.accessToken;
+    inFlightRef.current = true;
     setLoading(true);
     setReadbackWarning(null);
     try {
@@ -188,7 +196,20 @@ export default function OrderDetailPage({ params }: { params: Promise<{ orderId:
         token,
         { method: 'PATCH', body: JSON.stringify({ status }) },
       );
-      if (!res.ok) throw new Error('상태 전환 실패');
+      if (!res.ok) {
+        // 403 duplicate-sequential / 409 race-loser: 서버 authority가 이미 상태를
+        // 이동시켰다는 의미다. 같은 command를 자동 재전송하지 않고
+        // authoritative GET으로 수렴한다.
+        if (res.status === 403 || res.status === 409) {
+          notifications.show({
+            color: 'yellow',
+            message: '이미 상태가 변경되었을 수 있습니다. 최신 상태를 다시 확인합니다.',
+          });
+          await readDetail(token);
+          return;
+        }
+        throw new Error('상태 전환 실패');
+      }
       const result = (await res.json()) as { orderId?: unknown; status?: unknown };
       if (!isDriverOrderStatusAck(result, orderId, status)) {
         throw new Error('상태 전환 응답 불일치');
@@ -234,6 +255,9 @@ export default function OrderDetailPage({ params }: { params: Promise<{ orderId:
     } catch {
       notifications.show({ color: 'red', message: '오류가 발생했습니다. 다시 시도해주세요.' });
     } finally {
+      // 모든 종료 경로에서 in-flight를 해제한다. 403/409 convergence return,
+      // readback 분기 return, throw 모두 여기를 거친다.
+      inFlightRef.current = false;
       setLoading(false);
     }
   }
@@ -524,7 +548,7 @@ export default function OrderDetailPage({ params }: { params: Promise<{ orderId:
               radius="xl"
               color="brand"
               loading={loading}
-              disabled={!commandsAllowed}
+              disabled={loading || !commandsAllowed}
               onClick={() => updateStatus('DELIVERING')}
             >
               배송 재개
@@ -544,7 +568,7 @@ export default function OrderDetailPage({ params }: { params: Promise<{ orderId:
                   radius="xl"
                   color="brand"
                   loading={loading}
-                  disabled={!commandsAllowed}
+                  disabled={loading || !commandsAllowed}
                   onClick={() => updateStatus('DELIVERING')}
                 >
                   수거 완료 / 배송 시작
@@ -591,7 +615,7 @@ export default function OrderDetailPage({ params }: { params: Promise<{ orderId:
               radius="xl"
               color="brand"
               loading={loading}
-              disabled={!commandsAllowed}
+              disabled={loading || !commandsAllowed}
               onClick={() => updateStatus('DELIVERING')}
             >
               수거 완료 / 배송 시작
@@ -608,7 +632,7 @@ export default function OrderDetailPage({ params }: { params: Promise<{ orderId:
             radius="xl"
             color="brand"
             loading={loading}
-            disabled={!commandsAllowed}
+            disabled={loading || !commandsAllowed}
             onClick={() => updateStatus('DELIVERED')}
           >
             배송 완료
@@ -635,9 +659,14 @@ export default function OrderDetailPage({ params }: { params: Promise<{ orderId:
           loading={loading}
           orderId={orderId}
           storeId={order.storeId}
+          orderStatus={order.status}
           onClose={() => setHoldOpened(false)}
           onLoading={setLoading}
           onSaved={() => {
+            const token = session?.user.accessToken;
+            if (token) void readDetail(token);
+          }}
+          onConvergence={() => {
             const token = session?.user.accessToken;
             if (token) void readDetail(token);
           }}


### PR DESCRIPTION
Source Task: DRIVER-DETAIL-COMMAND-INFLIGHT-STALE-GUARD-01 Publication Task: DRIVER-DETAIL-COMMAND-INFLIGHT-STALE-GUARD-PUBLICATION-01 Base: 89f474ea1289771afd87e995adefcc2f10161f39 (live remote main at publication start) Owned files: - apps/driver/src/app/board/[orderId]/page.tsx - apps/driver/src/app/board/[orderId]/_components/DeliveryHoldModal.tsx - apps/driver/src/app/board/[orderId]/driver-detail-command-safety.test.mjs 핵심 계약: - in-flight PATCH single dispatch (inFlightRef/submittingRef, finally release) - stale authority fail-closed (HOLD_COMMAND_ALLOWED_STATUSES=PREPARING,DELIVERING) - 403/409 convergence without resend (single convergence message + authoritative GET) - authoritative reread (readDetail/onConvergence) - readback-loss safety (warning + fail-closed, no local synthesis) - Hold modal stale guard (PATCH 0, form reset, convergence, close) 명시적 제외: - c5322c38 photo ACK parity (photo-capture, photo-ack-parity test) - API duplicate/idempotency server work (orders-lifecycle.service.ts, orders-duplicate-contract.spec.ts) - Seller/Admin/Consumer foreign dirty Verification (publication workspace @89f474ea base): - focused driver-detail-command-safety 9/9 PASS - neighbor board-contract + driver-order-detail + auth-scope 70/70 PASS (handoff 61/61, no regression, expanded coverage from live baseline) - biome lint owned files clean - driver tsc --noEmit clean Next: DRIVER-COMMAND-RETRY-SAFETY-CONVERGENCE