### PR TITLE
feat(git): semantic dedup admission gate for publication

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@
 
 - `main`에는 문서-only 변경을 포함해 직접 commit/push하지 않는다.
 - 모든 변경은 목적별 branch에서 만들고 PR을 통해 `main`으로 통합한다.
+- publication branch/PR 생성 직전과 merge 권한 행사 직전에 반드시 live `main`을 다시 조회하고 `scripts/git/publication-admission.mjs` admission gate로 owned effective delta를 재평가한다. delta가 0이면 새 PR·merge·CI·deploy 없이 `COMPLETE_ALREADY_PUBLISHED` / `SUPERSEDED_ALREADY_PUBLISHED`로 종료한다.
 - `main` 통합 자체를 production 배포 승인으로 해석하지 않는다.
 - production 배포는 현재 출시 PLAN의 별도 승인 게이트와 실제 release SHA 확인 뒤에만 수행한다.
 - exact-SHA 배포 또는 promotion 절차가 불명확하면 임의 production 배포보다 중단을 우선한다.

--- a/scripts/git/publication-admission.mjs
+++ b/scripts/git/publication-admission.mjs
@@ -1,0 +1,255 @@
+// Canonical owner: AGENTS.md section 2 (branch+PR principle for protected `main`).
+// This module is the executable admission gate for that principle — it does not
+// create a parallel publication SSOT.
+//
+// Purpose (root cause: PR #119 merged the driver legacy-hub photo semantic delta,
+// then PR #122 merged the same semantic delta as a zero-diff no-op merge, which
+// still triggered CI/deployments):
+//   the same semantic publication may start in parallel; once one of them lands
+//   on live `main`, the others must terminate as ALREADY_PUBLISHED / SUPERSEDED
+//   BEFORE the PR / CI / merge / deploy steps — never as a zero-diff merge.
+//
+// Admission points (both mandatory, both re-read live `main`):
+//   PRE_PR   — immediately before creating the temporary publication branch/PR.
+//   PRE_MERGE — immediately before exercising merge authority on an open PR.
+//
+// Method (repository-agnostic):
+//   Compare the candidate's EFFECTIVE OWNED DELTA against live `main` using exact
+//   per-path blob equality (`git ls-tree <ref> -- <path>`). Ancestry
+//   (candidate SHA is/isn't an ancestor of `main`) is NEVER used alone, because
+//   the same semantic content can exist under a different SHA after
+//   transport/rebase/merge. Only `ownedPaths` are compared, so unrelated `main`
+//   movement never invalidates a publication by itself.
+//
+// Automation authority is limited to exact owned-path diff, tree/blob equality,
+// and a caller-supplied deterministic proof flag. Generic semantic equivalence
+// is never inferred: when the semantic-owner paths moved on live `main` in a way
+// exact comparison cannot resolve, the gate fails closed with
+// SEMANTIC_OWNER_REVIEW_REQUIRED and the candidate must not auto-merge.
+//
+// Read-only contract:
+//   This gate only runs read-only git commands (`ls-tree`, `rev-parse`,
+//   `status --porcelain`). It never runs reset/restore/stash/clean/checkout,
+//   never touches foreign dirty state, and never recreates a publication branch.
+//   Unrelated movement is absorbed with canonical transport maintenance
+//   (merge live `main` into the publication branch), not by rebuilding source work.
+
+import { execFileSync } from 'node:child_process';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export const PRE_PR_PHASE = 'PRE_PR';
+export const PRE_MERGE_PHASE = 'PRE_MERGE';
+
+export const PUBLICATION_ALLOWED = 'PUBLICATION_ALLOWED';
+export const COMPLETE_ALREADY_PUBLISHED = 'COMPLETE_ALREADY_PUBLISHED';
+export const SUPERSEDED_ALREADY_PUBLISHED = 'SUPERSEDED_ALREADY_PUBLISHED';
+export const SEMANTIC_OWNER_REVIEW_REQUIRED = 'SEMANTIC_OWNER_REVIEW_REQUIRED';
+
+/**
+ * Pure admission decision over exact owned-path blob maps.
+ *
+ * @param {object} args
+ * @param {string[]} args.ownedPaths paths owned by this publication (repo-relative, non-empty).
+ * @param {Record<string, string|null>} args.candidateBlobs exact blob hash per owned path at the
+ *   candidate ref (`null` = path absent). Different SHAs with identical blobs count as identical.
+ * @param {Record<string, string|null>} args.liveMainBlobs exact blob hash per owned path at live `main`.
+ * @param {'PRE_PR'|'PRE_MERGE'} [args.phase='PRE_PR'] admission point being exercised.
+ * @param {boolean} [args.semanticOwnerReviewRequired=false] deterministic caller proof that the
+ *   semantic-owner paths moved on live `main` in a way exact comparison cannot resolve.
+ *   When true the gate fails closed regardless of the computed delta.
+ */
+export function evaluatePublicationAdmission({
+  ownedPaths,
+  candidateBlobs,
+  liveMainBlobs,
+  phase = PRE_PR_PHASE,
+  semanticOwnerReviewRequired = false,
+}) {
+  if (!Array.isArray(ownedPaths) || ownedPaths.length === 0) {
+    return {
+      status: SEMANTIC_OWNER_REVIEW_REQUIRED,
+      phase,
+      remainingDelta: [],
+      reason:
+        'ownedPaths is empty: no owned semantic delta can be proven, so automatic admission is refused.',
+    };
+  }
+  if (phase !== PRE_PR_PHASE && phase !== PRE_MERGE_PHASE) {
+    throw new Error(`unknown admission phase: ${String(phase)}`);
+  }
+  for (const path of ownedPaths) {
+    if (!(path in Object(candidateBlobs)) || !(path in Object(liveMainBlobs))) {
+      return {
+        status: SEMANTIC_OWNER_REVIEW_REQUIRED,
+        phase,
+        remainingDelta: [...ownedPaths],
+        reason:
+          `blob proof is missing for owned path "${path}": ` +
+          'automatic admission is refused until exact comparison is possible.',
+      };
+    }
+  }
+  if (semanticOwnerReviewRequired === true) {
+    return {
+      status: SEMANTIC_OWNER_REVIEW_REQUIRED,
+      phase,
+      remainingDelta: ownedPaths.filter((path) => candidateBlobs[path] !== liveMainBlobs[path]),
+      reason:
+        'semantic-owner paths moved on live main in a way exact blob comparison cannot resolve; ' +
+        'human/Agent semantic review is required and automatic merge is forbidden.',
+    };
+  }
+  const remainingDelta = ownedPaths.filter((path) => candidateBlobs[path] !== liveMainBlobs[path]);
+  if (remainingDelta.length === 0) {
+    if (phase === PRE_MERGE_PHASE) {
+      return {
+        status: SUPERSEDED_ALREADY_PUBLISHED,
+        phase,
+        remainingDelta,
+        reason:
+          'open publication PR has zero effective owned delta against live main: ' +
+          'do not merge; close the PR and clean up only the temporary publication ref.',
+      };
+    }
+    return {
+      status: COMPLETE_ALREADY_PUBLISHED,
+      phase,
+      remainingDelta,
+      reason:
+        'owned semantic delta already exists on live main: ' +
+        'do not create a publication PR, CI run, or deployment.',
+    };
+  }
+  return {
+    status: PUBLICATION_ALLOWED,
+    phase,
+    remainingDelta,
+    reason:
+      'owned effective delta still exists on live main; proceed with publication. ' +
+      'Unrelated main movement is absorbed with canonical transport maintenance ' +
+      '(merge live main into the publication branch) instead of recreating source work.',
+  };
+}
+
+/**
+ * Read-only exact blob map for owned paths at a git ref.
+ * Missing path -> null. Never touches the worktree, index, or dirty state.
+ */
+export function readOwnedBlobs({ repositoryRoot, ref, ownedPaths }) {
+  const blobs = {};
+  for (const path of ownedPaths) {
+    let stdout = '';
+    try {
+      stdout = execFileSync('git', ['ls-tree', ref, '--', path], {
+        cwd: repositoryRoot,
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+    } catch {
+      blobs[path] = null;
+      continue;
+    }
+    const line = stdout.split('\n').find((entry) => entry.length > 0);
+    if (!line) {
+      blobs[path] = null;
+      continue;
+    }
+    // Format: "<mode> <type> <blob>\t<path>"
+    const blob = line.split(/\s+/)[2]?.split('\t')[0] ?? '';
+    blobs[path] = blob.length > 0 ? blob : null;
+  }
+  return blobs;
+}
+
+/** Resolve a ref to its exact SHA (read-only proof of which live `main` was checked). */
+export function resolveRef({ repositoryRoot, ref }) {
+  return execFileSync('git', ['rev-parse', ref], {
+    cwd: repositoryRoot,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim();
+}
+
+function decideAtPhase({
+  repositoryRoot,
+  liveMainRef,
+  candidateRef,
+  ownedPaths,
+  phase,
+  semanticOwnerReviewRequired = false,
+}) {
+  const liveMainSha = resolveRef({ repositoryRoot, ref: liveMainRef });
+  const candidateSha = resolveRef({ repositoryRoot, ref: candidateRef });
+  const liveMainBlobs = readOwnedBlobs({ repositoryRoot, ref: liveMainSha, ownedPaths });
+  const candidateBlobs = readOwnedBlobs({ repositoryRoot, ref: candidateSha, ownedPaths });
+  const decision = evaluatePublicationAdmission({
+    ownedPaths,
+    candidateBlobs,
+    liveMainBlobs,
+    phase,
+    semanticOwnerReviewRequired,
+  });
+  return { ...decision, liveMainSha, candidateSha };
+}
+
+/**
+ * PRE_PR admission: call immediately before creating the publication branch/PR,
+ * with liveMainRef freshly re-read (fetch first; START_HEAD is provenance only).
+ */
+export function decidePrePublication(args) {
+  return decideAtPhase({ ...args, phase: PRE_PR_PHASE });
+}
+
+/**
+ * PRE_MERGE admission: call immediately before exercising merge authority on an
+ * open publication PR, with liveMainRef freshly re-read. `candidateRef` is the
+ * PR head (the effective state that would be merged).
+ */
+export function decidePreMerge(args) {
+  return decideAtPhase({ ...args, phase: PRE_MERGE_PHASE });
+}
+
+const EXIT_CODE_BY_STATUS = {
+  [PUBLICATION_ALLOWED]: 0,
+  [COMPLETE_ALREADY_PUBLISHED]: 2,
+  [SUPERSEDED_ALREADY_PUBLISHED]: 3,
+  [SEMANTIC_OWNER_REVIEW_REQUIRED]: 4,
+};
+
+// Minimal CLI for human/Agent publication flows. Read-only; see module contract above.
+const invokedAsMainScript =
+  process.argv[1] != null && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (invokedAsMainScript) {
+  const argv = process.argv.slice(2);
+  const getOption = (name) => {
+    const index = argv.indexOf(name);
+    return index >= 0 && index + 1 < argv.length ? argv[index + 1] : null;
+  };
+  const phase = getOption('--phase') ?? PRE_PR_PHASE;
+  const liveMainRef = getOption('--live-main');
+  const candidateRef = getOption('--candidate');
+  const repositoryRoot = getOption('--repo') ?? process.cwd();
+  const owned = argv.includes('--owned')
+    ? argv.slice(argv.indexOf('--owned') + 1).filter((entry) => !entry.startsWith('--'))
+    : [];
+  const semanticOwnerReviewRequired = argv.includes('--owner-review-required');
+  if (!liveMainRef || !candidateRef || owned.length === 0) {
+    console.error(
+      'usage: node scripts/git/publication-admission.mjs --phase PRE_PR|PRE_MERGE ' +
+        '--live-main <ref> --candidate <ref> --owned <path...> [--repo <dir>] [--owner-review-required]',
+    );
+    process.exit(1);
+  }
+  try {
+    const decision =
+      phase === PRE_MERGE_PHASE
+        ? decidePreMerge({ repositoryRoot, liveMainRef, candidateRef, ownedPaths: owned, semanticOwnerReviewRequired })
+        : decidePrePublication({ repositoryRoot, liveMainRef, candidateRef, ownedPaths: owned, semanticOwnerReviewRequired });
+    console.log(JSON.stringify(decision, null, 2));
+    process.exit(EXIT_CODE_BY_STATUS[decision.status] ?? 1);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}

--- a/scripts/git/publication-admission.spec.mjs
+++ b/scripts/git/publication-admission.spec.mjs
@@ -1,0 +1,259 @@
+// Regression proof for scripts/git/publication-admission.mjs.
+// Covers task CASE A..F using temp local git repositories only.
+// No GitHub PR, CI run, Vercel deployment, or real-repository mutation is made.
+
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import test from 'node:test';
+
+import {
+  COMPLETE_ALREADY_PUBLISHED,
+  PUBLICATION_ALLOWED,
+  SEMANTIC_OWNER_REVIEW_REQUIRED,
+  SUPERSEDED_ALREADY_PUBLISHED,
+  decidePreMerge,
+  decidePrePublication,
+  evaluatePublicationAdmission,
+} from './publication-admission.mjs';
+
+const OWNED = 'apps/driver/photo-capture.tsx';
+const UNRELATED = 'apps/consumer/unrelated.txt';
+const OWNED_V1 = 'photo-ack-v1\n';
+
+function git(cwd, args) {
+  return execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
+}
+
+function initRepo() {
+  const directory = mkdtempSync(join(tmpdir(), 'greenhub-pub-admission-'));
+  git(directory, ['init']);
+  git(directory, ['config', 'user.email', 'admission-test@local']);
+  git(directory, ['config', 'user.name', 'admission-test']);
+  git(directory, ['config', 'commit.gpgsign', 'false']);
+  return directory;
+}
+
+function commitFile(directory, relativePath, content, message) {
+  const absolute = join(directory, relativePath);
+  mkdirSync(dirname(absolute), { recursive: true });
+  writeFileSync(absolute, content);
+  git(directory, ['add', '--', relativePath]);
+  git(directory, ['commit', '-m', message]);
+  return git(directory, ['rev-parse', 'HEAD']);
+}
+
+function removeRepo(directory) {
+  rmSync(directory, { recursive: true, force: true });
+}
+
+/** Builds the PR #119/#122 shape: A merges the owned delta, B carries the same blobs under another SHA. */
+function buildParallelPublicationRepo() {
+  const directory = initRepo();
+  try {
+    const base = commitFile(directory, OWNED, 'photo-ack-v0\n', 'base');
+    commitFile(directory, UNRELATED, 'u0\n', 'base unrelated');
+    const baseSha = git(directory, ['rev-parse', 'HEAD']);
+    void base;
+    git(directory, ['checkout', '-b', 'live']);
+    const liveBase = git(directory, ['rev-parse', 'HEAD']);
+
+    git(directory, ['checkout', '-b', 'candA', 'live']);
+    const candASha = commitFile(directory, OWNED, OWNED_V1, 'candidate A owned delta');
+    git(directory, ['checkout', 'live']);
+    git(directory, ['merge', '--no-ff', 'candA', '-m', 'merge candidate A']);
+    const liveMerged = git(directory, ['rev-parse', 'HEAD']);
+
+    git(directory, ['checkout', '-b', 'candB', liveBase]);
+    const candBSha = commitFile(directory, OWNED, OWNED_V1, 'candidate B same semantic delta');
+    return { directory, liveBase, liveMerged, candASha, candBSha };
+  } catch (error) {
+    removeRepo(directory);
+    throw error;
+  }
+}
+
+test('CASE A: candidate delta absent from live main -> PUBLICATION_ALLOWED', () => {
+  const built = buildParallelPublicationRepo();
+  try {
+    const decision = decidePrePublication({
+      repositoryRoot: built.directory,
+      liveMainRef: built.liveBase,
+      candidateRef: built.candASha,
+      ownedPaths: [OWNED],
+    });
+    assert.equal(decision.status, PUBLICATION_ALLOWED);
+    assert.deepEqual(decision.remainingDelta, [OWNED]);
+  } finally {
+    removeRepo(built.directory);
+  }
+});
+
+test('CASE B: different exact SHA but identical owned blobs -> COMPLETE_ALREADY_PUBLISHED', () => {
+  const built = buildParallelPublicationRepo();
+  try {
+    assert.notEqual(built.candASha, built.candBSha);
+    const decision = decidePrePublication({
+      repositoryRoot: built.directory,
+      liveMainRef: built.liveMerged,
+      candidateRef: built.candBSha,
+      ownedPaths: [OWNED],
+    });
+    assert.equal(decision.status, COMPLETE_ALREADY_PUBLISHED);
+    assert.deepEqual(decision.remainingDelta, []);
+  } finally {
+    removeRepo(built.directory);
+  }
+});
+
+test('CASE C: delta existed at PR framing, gone after rival merge -> SUPERSEDED_ALREADY_PUBLISHED', () => {
+  const built = buildParallelPublicationRepo();
+  try {
+    const atFraming = decidePreMerge({
+      repositoryRoot: built.directory,
+      liveMainRef: built.liveBase,
+      candidateRef: built.candBSha,
+      ownedPaths: [OWNED],
+    });
+    assert.equal(atFraming.status, PUBLICATION_ALLOWED);
+
+    const atMerge = decidePreMerge({
+      repositoryRoot: built.directory,
+      liveMainRef: built.liveMerged,
+      candidateRef: built.candBSha,
+      ownedPaths: [OWNED],
+    });
+    assert.equal(atMerge.status, SUPERSEDED_ALREADY_PUBLISHED);
+    assert.deepEqual(atMerge.remainingDelta, []);
+  } finally {
+    removeRepo(built.directory);
+  }
+});
+
+test('CASE D: live main moved unrelated files only -> publication remains valid', () => {
+  const directory = initRepo();
+  try {
+    commitFile(directory, OWNED, 'photo-ack-v0\n', 'base');
+    commitFile(directory, UNRELATED, 'u0\n', 'base unrelated');
+    git(directory, ['checkout', '-b', 'live']);
+    git(directory, ['checkout', '-b', 'cand']);
+    const candidate = commitFile(directory, OWNED, OWNED_V1, 'candidate owned delta');
+    git(directory, ['checkout', 'live']);
+    git(directory, ['merge', '--no-ff', 'cand', '-m', 'unrelated transport']);
+    const liveUnrelated = commitFile(directory, UNRELATED, 'u1-unrelated-only\n', 'unrelated movement');
+    git(directory, ['checkout', '-b', 'cand2', 'live~1']);
+    const candidate2 = commitFile(directory, OWNED, 'photo-ack-v2\n', 'candidate owned delta v2');
+    const decision = decidePrePublication({
+      repositoryRoot: directory,
+      liveMainRef: liveUnrelated,
+      candidateRef: candidate2,
+      ownedPaths: [OWNED],
+    });
+    assert.equal(decision.status, PUBLICATION_ALLOWED);
+    assert.deepEqual(decision.remainingDelta, [OWNED]);
+    void candidate;
+  } finally {
+    removeRepo(directory);
+  }
+});
+
+test('CASE E: semantic-owner movement beyond exact proof -> SEMANTIC_OWNER_REVIEW_REQUIRED (fail closed)', () => {
+  const purePrePr = evaluatePublicationAdmission({
+    ownedPaths: [OWNED],
+    candidateBlobs: { [OWNED]: 'blob-candidate' },
+    liveMainBlobs: { [OWNED]: 'blob-live-diverged' },
+    phase: 'PRE_PR',
+    semanticOwnerReviewRequired: true,
+  });
+  assert.equal(purePrePr.status, SEMANTIC_OWNER_REVIEW_REQUIRED);
+
+  const purePreMerge = evaluatePublicationAdmission({
+    ownedPaths: [OWNED],
+    candidateBlobs: { [OWNED]: 'blob-candidate' },
+    liveMainBlobs: { [OWNED]: 'blob-candidate' },
+    phase: 'PRE_MERGE',
+    semanticOwnerReviewRequired: true,
+  });
+  assert.equal(purePreMerge.status, SEMANTIC_OWNER_REVIEW_REQUIRED);
+
+  const built = buildParallelPublicationRepo();
+  try {
+    const decision = decidePrePublication({
+      repositoryRoot: built.directory,
+      liveMainRef: built.liveBase,
+      candidateRef: built.candASha,
+      ownedPaths: [OWNED],
+      semanticOwnerReviewRequired: true,
+    });
+    assert.equal(decision.status, SEMANTIC_OWNER_REVIEW_REQUIRED);
+  } finally {
+    removeRepo(built.directory);
+  }
+});
+
+test('CASE F: foreign dirty on unrelated path is untouched and admission stays decidable', () => {
+  const built = buildParallelPublicationRepo();
+  try {
+    git(built.directory, ['checkout', 'live']);
+    const foreignAbsolute = join(built.directory, 'foreign-unrelated-dirty.txt');
+    writeFileSync(foreignAbsolute, 'foreign dirty must be preserved\n');
+    const statusBefore = execFileSync('git', ['status', '--porcelain=v1'], {
+      cwd: built.directory,
+      encoding: 'utf8',
+    });
+    assert.match(statusBefore, /foreign-unrelated-dirty\.txt/);
+
+    const decision = decidePrePublication({
+      repositoryRoot: built.directory,
+      liveMainRef: built.liveBase,
+      candidateRef: built.candASha,
+      ownedPaths: [OWNED],
+    });
+    assert.equal(decision.status, PUBLICATION_ALLOWED);
+
+    const statusAfter = execFileSync('git', ['status', '--porcelain=v1'], {
+      cwd: built.directory,
+      encoding: 'utf8',
+    });
+    assert.equal(statusAfter, statusBefore);
+  } finally {
+    removeRepo(built.directory);
+  }
+});
+
+test('phase contract: PRE_PR zero delta completes, PRE_MERGE zero delta supersedes, proofs are required', () => {
+  const blobs = { [OWNED]: 'same-blob' };
+  const prePr = evaluatePublicationAdmission({
+    ownedPaths: [OWNED],
+    candidateBlobs: { ...blobs },
+    liveMainBlobs: { ...blobs },
+    phase: 'PRE_PR',
+  });
+  assert.equal(prePr.status, COMPLETE_ALREADY_PUBLISHED);
+
+  const preMerge = evaluatePublicationAdmission({
+    ownedPaths: [OWNED],
+    candidateBlobs: { ...blobs },
+    liveMainBlobs: { ...blobs },
+    phase: 'PRE_MERGE',
+  });
+  assert.equal(preMerge.status, SUPERSEDED_ALREADY_PUBLISHED);
+
+  const missingProof = evaluatePublicationAdmission({
+    ownedPaths: [OWNED],
+    candidateBlobs: {},
+    liveMainBlobs: { ...blobs },
+    phase: 'PRE_PR',
+  });
+  assert.equal(missingProof.status, SEMANTIC_OWNER_REVIEW_REQUIRED);
+
+  const emptyOwned = evaluatePublicationAdmission({
+    ownedPaths: [],
+    candidateBlobs: {},
+    liveMainBlobs: {},
+    phase: 'PRE_PR',
+  });
+  assert.equal(emptyOwned.status, SEMANTIC_OWNER_REVIEW_REQUIRED);
+});


### PR DESCRIPTION
Implements the GIT-PUBLICATION-SEMANTIC-DEDUP-ADMISSION-01 admission contract: PRE_PR and PRE_MERGE re-evaluation of the owned effective delta against live main via exact blob equality, with COMPLETE_ALREADY_PUBLISHED / SUPERSEDED_ALREADY_PUBLISHED terminal closure and SEMANTIC_OWNER_REVIEW_REQUIRED fail-closed. Regression proof: node --test scripts/git/publication-admission.spec.mjs (CASE A-F, temp local repos only, no GitHub/Vercel side effects).