### PR TITLE
fix(driver): guard detail command authority continuations

### DIFF
--- a/apps/driver/src/app/board/[orderId]/driver-detail-command-safety.test.mjs
+++ b/apps/driver/src/app/board/[orderId]/driver-detail-command-safety.test.mjs
@@ -114,11 +114,22 @@ test('D. HoldModal은 open 뒤 authority 이동 시 stale payload를 dispatch하
   assert.match(effectBlock, /onClose\(\)/);
 });
 
-// E. 403/409 → 자동 재전송 0회 → 상태 재확인 UX.
-test('E. 403/409는 자동 재전송 없이 authoritative read로 수렴한다', () => {
-  // detail: 403/409 분기가 readDetail 수렴 + return이며 PATCH를 추가 호출하지 않는다.
-  const branchAt = detailSource.indexOf('res.status === 403 || res.status === 409');
-  assert.ok(branchAt !== -1, '403/409 분기가 있어야 한다');
+// E. 409 → 자동 재전송 0회 → 상태 재확인 UX. detail 401/403은 authority loss로 분리된다.
+test('E. 409는 자동 재전송 없이 authoritative read로 수렴한다', () => {
+  // detail: 401/403 auth-loss 분기가 먼저 clear + AUTH_ERROR + return이며 PATCH를 추가 호출하지 않는다.
+  const authAt = detailSource.indexOf('isDriverOrderCommandAuthLoss(res.status)');
+  assert.ok(authAt !== -1, 'detail 401/403 auth-loss 분기가 있어야 한다');
+  const authBlock = detailSource.slice(authAt, authAt + 600);
+  assert.match(authBlock, /hasOrderRef\.current = false/);
+  assert.match(authBlock, /setOrder\(null\)/);
+  assert.match(authBlock, /kind: 'AUTH_ERROR'/);
+  assert.match(authBlock, /return;/);
+  assert.doesNotMatch(authBlock, /method: 'PATCH'/);
+  // detail: 403 단독 convergence는 남지 않고 409만 수렴한다.
+  assert.doesNotMatch(detailSource, /res\.status === 403 \|\| res\.status === 409/);
+  // detail: 409 분기가 readDetail 수렴 + return이며 PATCH를 추가 호출하지 않는다.
+  const branchAt = detailSource.indexOf('res.status === 409');
+  assert.ok(branchAt !== -1, '409 분기가 있어야 한다');
   const branchBlock = detailSource.slice(branchAt, branchAt + 700);
   assert.match(branchBlock, new RegExp(CONVERGENCE_MESSAGE.replace(/\./g, '\\.')));
   assert.match(branchBlock, /await readDetail\(token\)/);

--- a/apps/driver/src/app/board/[orderId]/page.tsx
+++ b/apps/driver/src/app/board/[orderId]/page.tsx
@@ -19,8 +19,11 @@ import { useSession } from 'next-auth/react';
 import { use, useCallback, useEffect, useRef, useState } from 'react';
 import { apiFetch } from '@/lib/api';
 import {
+  buildDriverOrderDetailScope,
   type DriverOrderReadErrorKind,
   isDriverOrderCommandAllowed,
+  isDriverOrderCommandAuthLoss,
+  isDriverOrderCommandContinuationCurrent,
   isDriverOrderStatusAck,
   shouldPreserveDriverOrderOnReadError,
   toDriverOrderNetworkError,
@@ -66,7 +69,7 @@ const METHOD_LABEL: Record<string, string> = {
 
 export default function OrderDetailPage({ params }: { params: Promise<{ orderId: string }> }) {
   const { orderId } = use(params);
-  const { data: session } = useSession();
+  const { data: session, status: sessionStatus } = useSession();
   const router = useRouter();
   const [order, setOrder] = useState<Order | null>(null);
   const [loading, setLoading] = useState(false);
@@ -81,9 +84,20 @@ export default function OrderDetailPage({ params }: { params: Promise<{ orderId:
   const [readbackWarning, setReadbackWarning] = useState<string | null>(null);
   const [readKey, setReadKey] = useState(0);
   const readSeqRef = useRef(0);
+  const commandSeqRef = useRef(0);
   const hasOrderRef = useRef(false);
-  // orderId·auth token scope가 바뀌면 이전 scope의 order/PII를 절대 남기지 않는다.
+  // detail scope: order identity + user id + role + access token.
+  // orderId·auth scope가 바뀌면 이전 scope의 order/PII를 절대 남기지 않는다.
   const readScopeRef = useRef<string | null>(null);
+  // render 중 동기 갱신되는 live scope: command continuation이 effect 실행 전
+  // 전환도 감지할 수 있도록 현재 principal을 항상 반영한다.
+  const liveScopeRef = useRef<string | null>(null);
+  liveScopeRef.current = buildDriverOrderDetailScope({
+    orderId,
+    userId: session?.user.id,
+    role: session?.user.role,
+    token: session?.user.accessToken,
+  });
   // C1: status command dispatch의 실제 authority. loading UI state와 분리된 ref 기반
   // in-flight guard이며, React state의 비동기 반영만으로는 막을 수 없는 동일 frame
   // double-click/double-submit에서도 두 번째 PATCH dispatch를 차단한다.
@@ -143,9 +157,20 @@ export default function OrderDetailPage({ params }: { params: Promise<{ orderId:
     const token = session?.user.accessToken;
     if (!token) {
       // usable token 없음을 not-found/empty로 표시하지 않는다.
-      // token 상실 역시 authority loss이므로 이전 scope 잔여물을 모두 제거한다.
+      // token 상실·session loading 역시 authority loss이므로 이전 scope 잔여물을 모두 제거한다.
+      // 이전 scope에서 시작된 command continuation도 scope/sequence 무효화로 차단한다.
       readSeqRef.current += 1;
-      readScopeRef.current = `${orderId}::__no_token__`;
+      commandSeqRef.current += 1;
+      inFlightRef.current = false;
+      // stale command loading은 새 scope 소유자가 직접 해제한다: stale finally는
+      // 새 scope를 덮지 않도록 guard되므로 여기서 해제하지 않으면 leaking된다.
+      setLoading(false);
+      readScopeRef.current = buildDriverOrderDetailScope({
+        orderId,
+        userId: session?.user.id,
+        role: session?.user.role,
+        token,
+      });
       setOrder(null);
       hasOrderRef.current = false;
       setReadError({ kind: 'AUTH_ERROR', message: '로그인 정보를 다시 확인해 주세요.' });
@@ -154,11 +179,21 @@ export default function OrderDetailPage({ params }: { params: Promise<{ orderId:
       setReadRefreshing(false);
       return;
     }
-    const nextScope = `${orderId}::${token}`;
+    const nextScope = buildDriverOrderDetailScope({
+      orderId,
+      userId: session?.user.id,
+      role: session?.user.role,
+      token,
+    });
     if (readScopeRef.current !== nextScope) {
-      // orderId 또는 auth scope 변경: 이전 주문·PII·readError/readback을 새 scope에 남기지 않는다.
-      // 진행 중이던 이전 scope read는 seq 무효화로 덮어쓰기를 막는다.
+      // orderId 또는 user/role/token scope 변경: 이전 주문·PII·readError/readback을
+      // 새 scope에 남기지 않는다. 진행 중이던 이전 scope read는 seq 무효화로,
+      // 이전 scope command는 command sequence 무효화로 덮어쓰기를 막는다.
       readSeqRef.current += 1;
+      commandSeqRef.current += 1;
+      inFlightRef.current = false;
+      // orderId·user/role/token 전환도 새 scope가 command loading을 소유하고 해제한다.
+      setLoading(false);
       readScopeRef.current = nextScope;
       hasOrderRef.current = false;
       setOrder(null);
@@ -168,7 +203,15 @@ export default function OrderDetailPage({ params }: { params: Promise<{ orderId:
       setReadRefreshing(false);
     }
     void readDetail(token);
-  }, [orderId, session?.user.accessToken, readKey, readDetail]);
+  }, [
+    orderId,
+    session?.user.id,
+    session?.user.role,
+    session?.user.accessToken,
+    sessionStatus,
+    readKey,
+    readDetail,
+  ]);
 
   async function updateStatus(status: string) {
     // C1: dispatch 직전에 ref를 선점한다. 이미 진행 중인 command가 있으면
@@ -187,6 +230,23 @@ export default function OrderDetailPage({ params }: { params: Promise<{ orderId:
       return;
     }
     const token = session.user.accessToken;
+    commandSeqRef.current += 1;
+    const cmdSeq = commandSeqRef.current;
+    const cmdScope = buildDriverOrderDetailScope({
+      orderId,
+      userId: session.user.id,
+      role: session.user.role,
+      token,
+    });
+    const cmdOrderId = orderId;
+    const isCommandCurrent = () =>
+      cmdOrderId === liveScopeRef.current?.split('::')[0] &&
+      isDriverOrderCommandContinuationCurrent({
+        snapshotSeq: cmdSeq,
+        snapshotScope: cmdScope,
+        currentSeq: commandSeqRef.current,
+        currentScope: liveScopeRef.current,
+      });
     inFlightRef.current = true;
     setLoading(true);
     setReadbackWarning(null);
@@ -196,11 +256,24 @@ export default function OrderDetailPage({ params }: { params: Promise<{ orderId:
         token,
         { method: 'PATCH', body: JSON.stringify({ status }) },
       );
+      if (!isCommandCurrent()) return;
       if (!res.ok) {
-        // 403 duplicate-sequential / 409 race-loser: 서버 authority가 이미 상태를
-        // 이동시켰다는 의미다. 같은 command를 자동 재전송하지 않고
-        // authoritative GET으로 수렴한다.
-        if (res.status === 403 || res.status === 409) {
+        // Command 401/403 = authority loss. 이전 protected order/PII/command
+        // authority를 즉시 clear하고 AUTH_ERROR로 수렴한다. generic 오류만 띄우고
+        // 이전 order를 유지하는 흐름을 남기지 않는다.
+        if (isDriverOrderCommandAuthLoss(res.status)) {
+          hasOrderRef.current = false;
+          setOrder(null);
+          setReadError({
+            kind: 'AUTH_ERROR',
+            message: '로그인 정보를 다시 확인해 주세요.',
+          });
+          setReadbackWarning(null);
+          return;
+        }
+        // 409 race-loser: 서버 authority가 이미 상태를 이동시켰다는 의미다.
+        // 같은 command를 자동 재전송하지 않고 authoritative GET으로 수렴한다.
+        if (res.status === 409) {
           notifications.show({
             color: 'yellow',
             message: '이미 상태가 변경되었을 수 있습니다. 최신 상태를 다시 확인합니다.',
@@ -211,6 +284,7 @@ export default function OrderDetailPage({ params }: { params: Promise<{ orderId:
         throw new Error('상태 전환 실패');
       }
       const result = (await res.json()) as { orderId?: unknown; status?: unknown };
+      if (!isCommandCurrent()) return;
       if (!isDriverOrderStatusAck(result, orderId, status)) {
         throw new Error('상태 전환 응답 불일치');
       }
@@ -218,13 +292,16 @@ export default function OrderDetailPage({ params }: { params: Promise<{ orderId:
       // ACK 성공 직후 local 합성 없이 authoritative GET으로 수렴한다. 자동 resend는 하지 않는다.
       try {
         const reread = await apiFetch(`/driver/orders/${encodeURIComponent(orderId)}`, token);
+        if (!isCommandCurrent()) return;
         if (!reread.ok) throw toDriverOrderReadError(reread.status);
         const fresh = (await reread.json()) as Order;
+        if (!isCommandCurrent()) return;
         hasOrderRef.current = true;
         setOrder(fresh);
         setReadError(null);
         setReadbackWarning(null);
       } catch (readbackCause: unknown) {
+        if (!isCommandCurrent()) return;
         // readback 단계의 AUTH_ERROR·NOT_FOUND 역시 authority loss이므로 이전 order를 남기지 않는다.
         const readbackKind = (readbackCause as { kind?: unknown } | null)?.kind;
         if (readbackKind === 'AUTH_ERROR' || readbackKind === 'NOT_FOUND') {
@@ -250,13 +327,18 @@ export default function OrderDetailPage({ params }: { params: Promise<{ orderId:
         }
       }
       if (isTerminal) {
+        if (!isCommandCurrent()) return;
         router.replace('/board?tab=preparing');
       }
     } catch {
+      if (!isCommandCurrent()) return;
       notifications.show({ color: 'red', message: '오류가 발생했습니다. 다시 시도해주세요.' });
     } finally {
-      // 모든 종료 경로에서 in-flight를 해제한다. 403/409 convergence return,
-      // readback 분기 return, throw 모두 여기를 거친다.
+      // 모든 종료 경로에서 in-flight를 해제한다. 401/403 authority-clear return,
+      // 409 convergence return, readback 분기 return, throw 모두 여기를 거친다.
+      // 이전 command의 finally가 새 scope의 command/loading 상태를 덮지 않도록
+      // 동일 generation + 동일 scope일 때만 해제한다.
+      if (!isCommandCurrent()) return;
       inFlightRef.current = false;
       setLoading(false);
     }

--- a/apps/driver/src/app/board/_lib/driver-order-detail-auth-scope.test.mjs
+++ b/apps/driver/src/app/board/_lib/driver-order-detail-auth-scope.test.mjs
@@ -2,7 +2,10 @@ import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 import test from 'node:test';
 import {
+  buildDriverOrderDetailScope,
   isDriverOrderCommandAllowed,
+  isDriverOrderCommandAuthLoss,
+  isDriverOrderCommandContinuationCurrent,
   shouldPreserveDriverOrderOnReadError,
 } from './driver-order-detail.ts';
 
@@ -144,14 +147,18 @@ test('FETCH 실패는 retry 키로 재조회하고 fresh 성공으로 수렴한�
   assert.match(detailSource, /다시 시도/);
   assert.match(detailSource, /다시 확인/);
   assert.match(detailSource, /setReadKey\(\(key\)\s*=>\s*key\s*\+\s*1\)/);
-  assert.match(detailSource, /readKey, readDetail\]/);
+  assert.match(detailSource, /readKey,/);
+  assert.match(detailSource, /readDetail,/);
   assert.match(detailSource, /setOrder\(payload\)/);
 });
 
 // 9. orderId scope change → 이전 order/PII leak 없음.
 test('orderId·auth scope 변경은 이전 주문·PII·read 상태를 새 scope에 남기지 않는다', () => {
   assert.match(detailSource, /readScopeRef/);
-  assert.match(detailSource, /orderId\}::\$\{token\}/);
+  assert.match(detailSource, /buildDriverOrderDetailScope\(\{/);
+  assert.match(detailSource, /userId: session\?\.user\.id/);
+  assert.match(detailSource, /role: session\?\.user\.role/);
+  assert.match(detailSource, /token: session\?\.user\.accessToken/);
   assert.match(detailSource, /readScopeRef\.current !== nextScope/);
   assert.match(detailSource, /setReadbackWarning\(null\)/);
   // scope 경로에서 order·ref·error가 함께 초기화된다.
@@ -161,9 +168,42 @@ test('orderId·auth scope 변경은 이전 주문·PII·read 상태를 새 scope
   assert.match(scopeBlock, /setOrder\(null\)/);
   assert.match(scopeBlock, /setReadError\(null\)/);
   assert.match(scopeBlock, /setReadLoading\(true\)/);
+  // command sequence도 함께 무효화된다.
+  assert.match(scopeBlock, /commandSeqRef\.current \+= 1/);
+  // 새 scope가 command loading을 직접 해제한다: stale finally는 guard되므로
+  // 여기서 해제하지 않으면 이전 command의 loading이 새 scope에 남는다.
+  assert.match(scopeBlock, /setLoading\(false\)/);
   // token 상실도 같은 무효화 경로를 탄다.
-  assert.match(detailSource, /__no_token__/);
+  assert.match(detailSource, /if \(!token\)/);
+  const noTokenAt = detailSource.indexOf('if (!token)');
+  const noTokenBlock = detailSource.slice(noTokenAt, noTokenAt + 900);
+  assert.match(noTokenBlock, /commandSeqRef\.current \+= 1/);
+  assert.match(noTokenBlock, /setLoading\(false\)/);
+  assert.match(helperSource, /__no_token__/);
+  assert.match(helperSource, /__no_user__/);
+  assert.match(helperSource, /__no_role__/);
   assert.match(helperSource, /AUTH_ERROR/);
+  // pure scope identity: orderId + user + role + token을 구분한다.
+  assert.equal(
+    buildDriverOrderDetailScope({ orderId: 'o1', userId: 'u1', role: 'driver', token: 't1' }),
+    buildDriverOrderDetailScope({ orderId: 'o1', userId: 'u1', role: 'driver', token: 't1' }),
+  );
+  assert.notEqual(
+    buildDriverOrderDetailScope({ orderId: 'o1', userId: 'u1', role: 'driver', token: 't1' }),
+    buildDriverOrderDetailScope({ orderId: 'o1', userId: 'u2', role: 'driver', token: 't1' }),
+  );
+  assert.notEqual(
+    buildDriverOrderDetailScope({ orderId: 'o1', userId: 'u1', role: 'driver', token: 't1' }),
+    buildDriverOrderDetailScope({ orderId: 'o1', userId: 'u1', role: 'admin', token: 't1' }),
+  );
+  assert.notEqual(
+    buildDriverOrderDetailScope({ orderId: 'o1', userId: 'u1', role: 'driver', token: 't1' }),
+    buildDriverOrderDetailScope({ orderId: 'o1', userId: 'u1', role: 'driver', token: 't2' }),
+  );
+  assert.notEqual(
+    buildDriverOrderDetailScope({ orderId: 'o1', userId: 'u1', role: 'driver', token: 't1' }),
+    buildDriverOrderDetailScope({ orderId: 'o2', userId: 'u1', role: 'driver', token: 't1' }),
+  );
 });
 
 // 10. 기존 redelivery payment gate 회귀 없음.
@@ -186,4 +226,166 @@ test('command ACK 후 authoritative GET 수렴·readback 분리 계약이 유지
   assert.match(detailSource, /readDetail\(token\)/);
   assert.doesNotMatch(detailSource, /setTimeout\(updateStatus/);
   assert.doesNotMatch(detailSource, /setInterval/);
+});
+
+// R1. fresh order → command PATCH 401 → order/PII clear → AUTH_REQUIRED → CTA 없음.
+test('R1. command PATCH 401은 authority loss로 이전 order를 즉시 제거한다', () => {
+  assert.equal(isDriverOrderCommandAuthLoss(401), true);
+  assert.match(detailSource, /isDriverOrderCommandAuthLoss\(res\.status\)/);
+  const authAt = detailSource.indexOf('isDriverOrderCommandAuthLoss(res.status)');
+  assert.ok(authAt !== -1, 'command 401/403 auth-loss 분기가 있어야 한다');
+  const authBlock = detailSource.slice(authAt, authAt + 600);
+  assert.match(authBlock, /hasOrderRef\.current = false/);
+  assert.match(authBlock, /setOrder\(null\)/);
+  assert.match(authBlock, /kind: 'AUTH_ERROR'/);
+  assert.match(authBlock, /setReadbackWarning\(null\)/);
+  // generic 오류만 띄우고 이전 order를 유지하는 흐름이 auth branch에 없음을 보장한다.
+  assert.doesNotMatch(authBlock, /오류가 발생했습니다/);
+});
+
+// R2. fresh order → command PATCH 403 → R1과 동일한 authority-loss branch.
+test('R2. command PATCH 403은 401과 동일한 authority-loss branch를 탄다', () => {
+  assert.equal(isDriverOrderCommandAuthLoss(403), true);
+  assert.equal(isDriverOrderCommandAuthLoss(409), false);
+  assert.equal(isDriverOrderCommandAuthLoss(500), false);
+  // 403은 별도 convergence가 아니라 401과 같은 auth-loss helper 분기를 탄다.
+  assert.match(detailSource, /isDriverOrderCommandAuthLoss\(res\.status\)/);
+  assert.match(helperSource, /status === 401 \|\| status === 403/);
+  // detail의 403 단독 convergence는 남지 않고 409만 수렴한다.
+  assert.match(detailSource, /if \(res\.status === 409\)/);
+  assert.doesNotMatch(detailSource, /res\.status === 403 \|\| res\.status === 409/);
+});
+
+// R3. A scope command → B user/token/role 전환 → A ACK/readback이 B에 반영되지 않음.
+test('R3. 이전 auth scope command continuation은 새 scope UI를 변경하지 않는다', () => {
+  assert.match(detailSource, /const commandSeqRef = useRef\(0\)/);
+  assert.match(detailSource, /const cmdSeq = commandSeqRef\.current/);
+  assert.match(detailSource, /const cmdScope = buildDriverOrderDetailScope/);
+  assert.match(detailSource, /liveScopeRef/);
+  assert.match(detailSource, /isDriverOrderCommandContinuationCurrent\(\{/);
+  assert.match(detailSource, /if \(!isCommandCurrent\(\)\) return;/);
+  // pure generation+scope binding: 동일할 때만 current다.
+  const scopeA = buildDriverOrderDetailScope({
+    orderId: 'o1',
+    userId: 'u1',
+    role: 'driver',
+    token: 't1',
+  });
+  const scopeB = buildDriverOrderDetailScope({
+    orderId: 'o1',
+    userId: 'u2',
+    role: 'driver',
+    token: 't2',
+  });
+  assert.equal(
+    isDriverOrderCommandContinuationCurrent({
+      snapshotSeq: 1,
+      snapshotScope: scopeA,
+      currentSeq: 1,
+      currentScope: scopeA,
+    }),
+    true,
+  );
+  assert.equal(
+    isDriverOrderCommandContinuationCurrent({
+      snapshotSeq: 1,
+      snapshotScope: scopeA,
+      currentSeq: 1,
+      currentScope: scopeB,
+    }),
+    false,
+  );
+  assert.equal(
+    isDriverOrderCommandContinuationCurrent({
+      snapshotSeq: 1,
+      snapshotScope: scopeA,
+      currentSeq: 2,
+      currentScope: scopeA,
+    }),
+    false,
+  );
+  // ACK/readback/notification이 모두 가드된다.
+  const cmdAt = detailSource.indexOf('const isCommandCurrent');
+  assert.ok(cmdAt !== -1);
+  const tail = detailSource.slice(cmdAt);
+  assert.match(tail, /setOrder\(fresh\)/);
+  assert.match(tail, /setReadbackWarning/);
+  assert.match(tail, /notifications\.show/);
+  assert.match(tail, /router\.replace/);
+  assert.match(tail, /await readDetail\(token\)/);
+});
+
+// R4. A orderId command → 다른 orderId 이동 → 덮어쓰기·navigation 금지.
+test('R4. 이전 orderId command 결과는 새 order detail을 덮거나 이동시키지 않는다', () => {
+  assert.match(detailSource, /const cmdOrderId = orderId/);
+  assert.match(detailSource, /cmdOrderId === liveScopeRef/);
+  // navigation은 scope/sequence 가드 뒤에만 있다.
+  const navAt = detailSource.indexOf("router.replace('/board?tab=preparing')");
+  assert.ok(navAt !== -1, 'terminal navigation이 있어야 한다');
+  const navWindow = detailSource.slice(Math.max(0, navAt - 300), navAt);
+  assert.match(navWindow, /isCommandCurrent/);
+  // orderId가 scope identity에 포함된다.
+  assert.match(helperSource, /orderId/);
+  assert.notEqual(
+    buildDriverOrderDetailScope({ orderId: 'o1', userId: 'u1', role: 'driver', token: 't1' }),
+    buildDriverOrderDetailScope({ orderId: 'o2', userId: 'u1', role: 'driver', token: 't1' }),
+  );
+});
+
+// R5. old command finally → 새 scope loading/command 상태를 해제하지 않음.
+test('R5. stale command finally는 새 scope의 loading·in-flight를 덮지 않는다', () => {
+  const finallyAt = detailSource.indexOf('} finally {');
+  assert.ok(finallyAt !== -1, 'finally가 있어야 한다');
+  const finallyBlock = detailSource.slice(finallyAt, finallyAt + 600);
+  assert.match(finallyBlock, /if \(!isCommandCurrent\(\)\) return;/);
+  assert.match(finallyBlock, /inFlightRef\.current = false/);
+  assert.match(finallyBlock, /setLoading\(false\)/);
+  const guardAt = finallyBlock.indexOf('if (!isCommandCurrent()) return;');
+  const releaseAt = finallyBlock.indexOf('inFlightRef.current = false');
+  assert.ok(guardAt !== -1 && guardAt < releaseAt, 'finally 해제는 가드 뒤에만 한다');
+});
+
+// R6. fresh same-scope 정상 command → semantic ACK → authoritative GET → fresh order.
+test('R6. 정상 command는 semantic ACK 후 authoritative GET으로 수렴한다', () => {
+  assert.match(detailSource, /isDriverOrderStatusAck\(result,\s*orderId,\s*status\)/);
+  assert.match(detailSource, /setOrder\(fresh\)/);
+  // detail PATCH는 상태 전환 1회뿐이며 자동 resend 타이머가 없다.
+  const patchCount = (detailSource.match(/method: 'PATCH'/g) ?? []).length;
+  assert.equal(patchCount, 1, 'detail PATCH는 상태 전환 1회뿐이다');
+  assert.doesNotMatch(detailSource, /setTimeout\(updateStatus/);
+  assert.doesNotMatch(detailSource, /setInterval/);
+});
+
+// R7. ACK 성공 → readback network/5xx 실패 → 자동 resend 없음·warning 유지·fail-closed.
+test('R7. readback 실패는 자동 재전송 없이 warning과 fail-closed를 유지한다', () => {
+  assert.match(detailSource, /처리는 완료되었지만 최신 상태를 확인하지 못했습니다/);
+  assert.match(detailSource, /setReadbackWarning\(message\)/);
+  assert.match(detailSource, /hasReadbackWarning: readbackWarning !== null/);
+  assert.equal(
+    isDriverOrderCommandAllowed({
+      hasOrder: true,
+      readErrorKind: null,
+      hasReadbackWarning: true,
+    }),
+    false,
+  );
+  const patchCount = (detailSource.match(/method: 'PATCH'/g) ?? []).length;
+  assert.equal(patchCount, 1, 'readback 실패가 PATCH 재전송을 만들지 않는다');
+});
+
+// R8. read refresh 401/403/404/FETCH_ERROR 기존 계약 회귀 없음.
+test('R8. detail read auth·absence·stale 계약이 그대로 유지된다', () => {
+  assert.equal(shouldPreserveDriverOrderOnReadError('AUTH_ERROR', true), false);
+  assert.equal(shouldPreserveDriverOrderOnReadError('NOT_FOUND', true), false);
+  assert.equal(shouldPreserveDriverOrderOnReadError('FETCH_ERROR', true), true);
+  assert.match(detailSource, /shouldPreserveDriverOrderOnReadError\(failure\.kind/);
+  assert.match(detailSource, /이전 정보 표시 중/);
+});
+
+// R9. redelivery payment gate 회귀 없음.
+test('R9. redelivery payment gate가 command 변경과 무관하게 유지된다', () => {
+  assert.match(detailSource, /isDeliveryStartAllowed\(order\.redeliveryPayment\)/);
+  assert.match(detailSource, /getRedeliveryPaymentPresentation\(order\.redeliveryPayment\)/);
+  assert.doesNotMatch(detailSource, /canPay/);
+  assert.doesNotMatch(detailSource, /orderCharges/);
 });

--- a/apps/driver/src/app/board/_lib/driver-order-detail.test.mjs
+++ b/apps/driver/src/app/board/_lib/driver-order-detail.test.mjs
@@ -1,8 +1,11 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
+  buildDriverOrderDetailScope,
   classifyDriverOrderReadError,
   DriverOrderReadError,
+  isDriverOrderCommandAuthLoss,
+  isDriverOrderCommandContinuationCurrent,
   isDriverOrderStatusAck,
   toDriverOrderNetworkError,
   toDriverOrderReadError,
@@ -51,6 +54,90 @@ test('semantic ACK: orderId 불일치는 false', () => {
 test('semantic ACK: status 불일치는 false', () => {
   assert.equal(
     isDriverOrderStatusAck({ orderId: 'o1', status: 'PREPARING' }, 'o1', 'DELIVERING'),
+    false,
+  );
+});
+
+test('detail scope는 orderId·user·role·token을 모두 구분한다', () => {
+  const base = { orderId: 'o1', userId: 'u1', role: 'driver', token: 't1' };
+  assert.equal(buildDriverOrderDetailScope(base), buildDriverOrderDetailScope(base));
+  assert.notEqual(
+    buildDriverOrderDetailScope(base),
+    buildDriverOrderDetailScope({ ...base, orderId: 'o2' }),
+  );
+  assert.notEqual(
+    buildDriverOrderDetailScope(base),
+    buildDriverOrderDetailScope({ ...base, userId: 'u2' }),
+  );
+  assert.notEqual(
+    buildDriverOrderDetailScope(base),
+    buildDriverOrderDetailScope({ ...base, role: 'admin' }),
+  );
+  assert.notEqual(
+    buildDriverOrderDetailScope(base),
+    buildDriverOrderDetailScope({ ...base, token: 't2' }),
+  );
+  assert.notEqual(
+    buildDriverOrderDetailScope(base),
+    buildDriverOrderDetailScope({ orderId: 'o1', userId: null, role: null, token: null }),
+  );
+});
+
+test('command 401·403만 authority loss다', () => {
+  assert.equal(isDriverOrderCommandAuthLoss(401), true);
+  assert.equal(isDriverOrderCommandAuthLoss(403), true);
+  for (const status of [404, 409, 422, 500]) {
+    assert.equal(isDriverOrderCommandAuthLoss(status), false);
+  }
+});
+
+test('command continuation은 동일 seq·scope일 때만 current다', () => {
+  const scope = buildDriverOrderDetailScope({
+    orderId: 'o1',
+    userId: 'u1',
+    role: 'driver',
+    token: 't1',
+  });
+  const other = buildDriverOrderDetailScope({
+    orderId: 'o1',
+    userId: 'u2',
+    role: 'driver',
+    token: 't2',
+  });
+  assert.equal(
+    isDriverOrderCommandContinuationCurrent({
+      snapshotSeq: 1,
+      snapshotScope: scope,
+      currentSeq: 1,
+      currentScope: scope,
+    }),
+    true,
+  );
+  assert.equal(
+    isDriverOrderCommandContinuationCurrent({
+      snapshotSeq: 1,
+      snapshotScope: scope,
+      currentSeq: 2,
+      currentScope: scope,
+    }),
+    false,
+  );
+  assert.equal(
+    isDriverOrderCommandContinuationCurrent({
+      snapshotSeq: 1,
+      snapshotScope: scope,
+      currentSeq: 1,
+      currentScope: other,
+    }),
+    false,
+  );
+  assert.equal(
+    isDriverOrderCommandContinuationCurrent({
+      snapshotSeq: 1,
+      snapshotScope: scope,
+      currentSeq: 1,
+      currentScope: null,
+    }),
     false,
   );
 });

--- a/apps/driver/src/app/board/_lib/driver-order-detail.ts
+++ b/apps/driver/src/app/board/_lib/driver-order-detail.ts
@@ -3,6 +3,9 @@
  *
  * Server authority를 유지하기 위한 최소 분류만 둔다.
  * - detail HTTP status classification (404 / 401·403 / 그 외·network)
+ * - detail scope identity (orderId + user identity + role + access token)
+ * - command 401·403 authority-loss classification
+ * - command scope/sequence continuation binding
  * - command semantic ACK matching (orderId + status)
  *
  * 어떤 Server mutation policy도 재정의하지 않으며,
@@ -98,4 +101,50 @@ export function isDriverOrderStatusAck(
   expectedStatus: string,
 ): boolean {
   return result.orderId === expectedOrderId && result.status === expectedStatus;
+}
+
+/**
+ * detail scope identity: order identity + current authenticated principal/scope.
+ *
+ * list shared owner의 user-id + role + access-token 의미를 detail 최소 형태로
+ * 확장한다. token 문자열 하나만을 principal 전체의 암묵적 owner로 사용하지
+ * 않는다. 빈 값은 명시적 sentinel로 정규화하여 scope 비교가 항상 문자열
+ * 동등성으로 동작하도록 한다.
+ */
+export function buildDriverOrderDetailScope(args: {
+  orderId: string;
+  userId?: string | null;
+  role?: string | null;
+  token?: string | null;
+}): string {
+  const userId = args.userId && args.userId.length > 0 ? args.userId : '__no_user__';
+  const role = args.role && args.role.length > 0 ? args.role : '__no_role__';
+  const token = args.token && args.token.length > 0 ? args.token : '__no_token__';
+  return `${args.orderId}::${userId}::${role}::${token}`;
+}
+
+/**
+ * command PATCH 자체의 401·403은 authority loss다.
+ * 409/422/5xx의 command recovery architecture를 재정의하지 않으며,
+ * 이 판정은 401·403만을 AUTH_ERROR branch로 보낸다.
+ */
+export function isDriverOrderCommandAuthLoss(status: number): boolean {
+  return status === 401 || status === 403;
+}
+
+/**
+ * command async continuation이 아직 동일 command generation + 동일 scope인지
+ * 판정한다. scope가 바뀌었거나 더 새로운 command가 시작됐으면 이전 ACK/
+ * readback/error/finally/navigation을 새 scope UI에 절대 반영하지 않는다.
+ * 이미 서버에 전달된 command 결과를 client가 취소됐다고 거짓 판정하지 않으며,
+ * 자동 resend도 하지 않는다. 호출자는 false일 때 state mutation·navigation·
+ * notification·reread를 모두 건너뛰어야 한다.
+ */
+export function isDriverOrderCommandContinuationCurrent(args: {
+  snapshotSeq: number;
+  snapshotScope: string | null;
+  currentSeq: number;
+  currentScope: string | null;
+}): boolean {
+  return args.snapshotSeq === args.currentSeq && args.snapshotScope === args.currentScope;
 }


### PR DESCRIPTION
Problem:
Driver order-detail async command continuation could mutate stale UI state after auth/user/role/token/order scope changed (authority race).

Changes:
- authority scope identity (orderId + user + role + token, sentinel-normalized)
- 401/403 command auth-loss handling (clear protected order/PII, converge to AUTH_ERROR, no resend)
- 409-only state convergence via authoritative readback (no combined 403/409 branch)
- command seq + scope continuation guard (ACK/readback/notification/navigation/finally/loading)
- stale finally protection; scope transitions own loading/in-flight release

Tests:
- node --test apps/driver/src/app/board/_lib/driver-order-detail.test.mjs apps/driver/src/app/board/_lib/driver-order-detail-auth-scope.test.mjs (31 pass)
- node apps/driver/src/app/board/[orderId]/driver-detail-command-safety.test.mjs (9 pass)
- Covers helper scope identity, auth loss 401/403, 409 convergence, R1-R9, stale ACK/readback/notification/navigation/finally suppression, normal continuation

Non-goals:
No API/auth architecture rewrite, no auto resend, no Driver-wide refactor.