### PR TITLE
fix(driver): converge detail commands to stable error-code recovery

### DIFF
--- a/apps/driver/src/app/board/[orderId]/_components/DeliveryHoldModal.tsx
+++ b/apps/driver/src/app/board/[orderId]/_components/DeliveryHoldModal.tsx
@@ -15,6 +15,10 @@ import {
 import { useSession } from 'next-auth/react';
 import { useEffect, useRef, useState } from 'react';
 import { apiFetch } from '@/lib/api';
+import {
+  classifyDriverOrderCommandError,
+  readDriverOrderCommandErrorCodeFromResponse,
+} from '../../_lib/driver-order-detail';
 
 export type HoldReason =
   | 'WEATHER'
@@ -56,6 +60,13 @@ interface DeliveryHoldModalProps {
   // parent는 fresh GET 성공 전에는 warning으로 위험 command를 fail-closed하고,
   // modal은 닫혀 immediate same-hold resubmit을 차단한다. 자동 resend 없음.
   onUncertainConvergence?: () => void;
+  // authority-loss 수렴용 parent clear 트리거. 401 또는 403 + AUTHORITY_DENIED는
+  // modal 내부 표시로 끝나지 않고 parent가 protected order/PII를 즉시 제거하고
+  // AUTH_ERROR로 전환하며 modal을 reset/close한다. 자동 resend 없음.
+  onAuthorityLoss?: () => void;
+  // absence/hiding 수렴용 parent clear 트리거. DRIVER_ORDER_NOT_FOUND code를
+  // 직접 받으면 이전 protected order를 신뢰하지 않고 NOT_FOUND 의미로 수렴한다.
+  onNotFound?: () => void;
 }
 
 // 배송 보류 command가 유효한 order authority 범위.
@@ -89,6 +100,8 @@ export function DeliveryHoldModal({
   onSaved,
   onConvergence,
   onUncertainConvergence,
+  onAuthorityLoss,
+  onNotFound,
 }: DeliveryHoldModalProps) {
   const { data: session } = useSession();
   const [reasonCode, setReasonCode] = useState<HoldReason>('WEATHER');
@@ -178,16 +191,52 @@ export function DeliveryHoldModal({
         body: JSON.stringify({ deliveryHold }),
       });
       if (!response.ok) {
-        // 403 duplicate-sequential / 409 race-loser: 같은 hold command를 자동
-        // 재전송하지 않고 convergence path로 보낸다. 일반적인 재제출 메시지를 쓰지 않는다.
-        if (response.status === 403 || response.status === 409) {
+        // 401은 envelope code와 무관하게 authority loss다. modal 내부 표시로
+        // 끝나지 않고 parent clear + AUTH_ERROR + modal reset/close로 수렴한다.
+        if (response.status === 401) {
+          resetHoldFormFields();
+          setError('로그인 정보를 다시 확인해 주세요.');
+          onAuthorityLoss?.();
+          onClose();
+          return;
+        }
+        // error-code aware hold recovery: envelope code를 안전하게 읽는다.
+        // body 파싱 실패는 null이며 그 자체가 same-hold resend를 유도하지 않는다.
+        const errorCode = await readDriverOrderCommandErrorCodeFromResponse(response);
+        const recovery = classifyDriverOrderCommandError({
+          status: response.status,
+          code: errorCode,
+        });
+        // 403 + AUTHORITY_DENIED (및 unknown/missing-code 403 fail-closed):
+        // stale/state convergence로 오분류하지 않고 authority-loss 경로로 보낸다.
+        // parent가 protected data를 즉시 제거하므로 modal 내부 표시에 그치지 않는다.
+        if (recovery === 'AUTHORITY_LOSS') {
+          resetHoldFormFields();
+          setError('로그인 정보를 다시 확인해 주세요.');
+          onAuthorityLoss?.();
+          onClose();
+          return;
+        }
+        // 403/409 + STATE_CONFLICT: authority loss로 오분류하지 않는다.
+        // 같은 hold를 자동 재전송하지 않고 convergence path로 보낸다.
+        if (recovery === 'STATE_CONFLICT') {
           resetHoldFormFields();
           setError(HOLD_STALE_CONVERGENCE_MESSAGE);
           onConvergence?.();
           return;
         }
-        // F/G: 403/409 이외 4xx·5xx ACK-uncertain. 같은 HOLD를 자동 재전송하지 않고
-        // modal을 닫아 immediate resubmit을 차단한 뒤 parent authoritative GET으로 수렴한다.
+        // DRIVER_ORDER_NOT_FOUND: authoritative absence/hiding. 이전 protected
+        // order를 신뢰하지 않고 NOT_FOUND 의미로 수렴한다. 자동 resend 없음.
+        if (recovery === 'NOT_FOUND') {
+          resetHoldFormFields();
+          setError('주문을 찾을 수 없습니다.');
+          onNotFound?.();
+          onClose();
+          return;
+        }
+        // F/G: 403/409 STATE·AUTHORITY·NOT_FOUND 이외 4xx·5xx ACK-uncertain.
+        // 같은 HOLD를 자동 재전송하지 않고 modal을 닫아 immediate resubmit을
+        // 차단한 뒤 parent authoritative GET으로 수렴한다.
         resetHoldFormFields();
         setError(HOLD_UNCERTAIN_CONVERGENCE_MESSAGE);
         onUncertainConvergence?.();

--- a/apps/driver/src/app/board/[orderId]/driver-detail-command-safety.test.mjs
+++ b/apps/driver/src/app/board/[orderId]/driver-detail-command-safety.test.mjs
@@ -2,7 +2,9 @@ import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 import test from 'node:test';
 import {
+  classifyDriverOrderCommandError,
   isDriverOrderCommandAllowed,
+  readDriverOrderErrorCode,
   shouldPreserveDriverOrderOnReadError,
 } from '../_lib/driver-order-detail.ts';
 
@@ -118,30 +120,56 @@ test('D. HoldModal은 open 뒤 authority 이동 시 stale payload를 dispatch하
   assert.match(effectBlock, /onClose\(\)/);
 });
 
-// E. 409 → 자동 재전송 0회 → 상태 재확인 UX. detail 401/403은 authority loss로 분리된다.
-test('E. 409는 자동 재전송 없이 authoritative read로 수렴한다', () => {
-  // detail: 401/403 auth-loss 분기가 먼저 clear + AUTH_ERROR + return이며 PATCH를 추가 호출하지 않는다.
-  const authAt = detailSource.indexOf('isDriverOrderCommandAuthLoss(res.status)');
-  assert.ok(authAt !== -1, 'detail 401/403 auth-loss 분기가 있어야 한다');
-  const authBlock = detailSource.slice(authAt, authAt + 600);
-  assert.match(authBlock, /hasOrderRef\.current = false/);
-  assert.match(authBlock, /setOrder\(null\)/);
-  assert.match(authBlock, /kind: 'AUTH_ERROR'/);
-  assert.match(authBlock, /return;/);
-  assert.doesNotMatch(authBlock, /method: 'PATCH'/);
-  // detail: 403 단독 convergence는 남지 않고 409만 수렴한다.
-  assert.doesNotMatch(detailSource, /res\.status === 403 \|\| res\.status === 409/);
-  // detail: 409 분기가 readDetail 수렴 + return이며 PATCH를 추가 호출하지 않는다.
-  const branchAt = detailSource.indexOf('res.status === 409');
-  assert.ok(branchAt !== -1, '409 분기가 있어야 한다');
+// E. error-code aware convergence: 401/AUTHORITY → auth-loss, STATE → GET 수렴, 자동 재전송 0회.
+test('E. error-code aware command는 authority/state를 구분해 수렴하며 자동 재전송하지 않는다', () => {
+  // pure: 401 → AUTHORITY_LOSS, 403 AUTHORITY → AUTHORITY_LOSS, 403 STATE → STATE_CONFLICT.
+  assert.equal(classifyDriverOrderCommandError({ status: 401, code: null }), 'AUTHORITY_LOSS');
+  assert.equal(
+    classifyDriverOrderCommandError({ status: 403, code: 'DRIVER_ORDER_AUTHORITY_DENIED' }),
+    'AUTHORITY_LOSS',
+  );
+  assert.equal(
+    classifyDriverOrderCommandError({ status: 403, code: 'DRIVER_ORDER_STATE_CONFLICT' }),
+    'STATE_CONFLICT',
+  );
+  assert.equal(
+    classifyDriverOrderCommandError({ status: 409, code: 'DRIVER_ORDER_STATE_CONFLICT' }),
+    'STATE_CONFLICT',
+  );
+  assert.equal(classifyDriverOrderCommandError({ status: 403, code: null }), 'AUTHORITY_LOSS');
+  // detail: 401 분기가 먼저 clear + AUTH_ERROR + return이며 PATCH를 추가 호출하지 않는다.
+  const auth401At = detailSource.indexOf('if (res.status === 401)');
+  assert.ok(auth401At !== -1, 'detail 401 auth-loss 분기가 있어야 한다');
+  const auth401Block = detailSource.slice(auth401At, auth401At + 600);
+  assert.match(auth401Block, /hasOrderRef\.current = false/);
+  assert.match(auth401Block, /setOrder\(null\)/);
+  assert.match(auth401Block, /kind: 'AUTH_ERROR'/);
+  assert.match(auth401Block, /return;/);
+  assert.doesNotMatch(auth401Block, /method: 'PATCH'/);
+  // detail: error-code aware classifier로 AUTHORITY_LOSS/STATE_CONFLICT/NOT_FOUND를 구분한다.
+  assert.match(detailSource, /readDriverOrderCommandErrorCodeFromResponse\(res\)/);
+  assert.match(detailSource, /classifyDriverOrderCommandError\(\{/);
+  assert.match(detailSource, /recovery === 'AUTHORITY_LOSS'/);
+  assert.match(detailSource, /recovery === 'STATE_CONFLICT'/);
+  assert.match(detailSource, /recovery === 'NOT_FOUND'/);
+  // detail: STATE_CONFLICT 분기가 readDetail 수렴 + return이며 PATCH를 추가 호출하지 않는다.
+  const branchAt = detailSource.indexOf("recovery === 'STATE_CONFLICT'");
+  assert.ok(branchAt !== -1, 'STATE_CONFLICT 분기가 있어야 한다');
   const branchBlock = detailSource.slice(branchAt, branchAt + 700);
   assert.match(branchBlock, new RegExp(CONVERGENCE_MESSAGE.replace(/\./g, '\\.')));
   assert.match(branchBlock, /await readDetail\(token\)/);
   assert.match(branchBlock, /return;/);
   assert.doesNotMatch(branchBlock, /method: 'PATCH'/);
-  // modal: 403/409 분기가 convergence reread 유도 + return이며 PATCH를 추가 호출하지 않는다.
-  const modalBranchAt = holdModalSource.indexOf('response.status === 403 || response.status === 409');
-  assert.ok(modalBranchAt !== -1, 'modal 403/409 분기가 있어야 한다');
+  // 구 status-only 직접 분기는 남지 않는다.
+  assert.doesNotMatch(detailSource, /isDriverOrderCommandAuthLoss\(res\.status\)/);
+  assert.doesNotMatch(detailSource, /if \(res\.status === 409\)/);
+  // modal: AUTHORITY_LOSS는 stale convergence로 오분류하지 않고 authority 경로로 보낸다.
+  assert.match(holdModalSource, /recovery === 'AUTHORITY_LOSS'/);
+  assert.match(holdModalSource, /onAuthorityLoss\?\.\(\)/);
+  // modal: STATE_CONFLICT는 authority loss로 오분류하지 않고 stale convergence로 보낸다.
+  assert.match(holdModalSource, /recovery === 'STATE_CONFLICT'/);
+  const modalBranchAt = holdModalSource.indexOf("recovery === 'STATE_CONFLICT'");
+  assert.ok(modalBranchAt !== -1, 'modal STATE_CONFLICT 분기가 있어야 한다');
   const modalBranchBlock = holdModalSource.slice(modalBranchAt, modalBranchAt + 600);
   assert.match(modalBranchBlock, /setError\(HOLD_STALE_CONVERGENCE_MESSAGE\)/);
   assert.match(modalBranchBlock, /onConvergence\?\.\(\)/);
@@ -156,6 +184,9 @@ test('E. 409는 자동 재전송 없이 authoritative read로 수렴한다', () 
   assert.doesNotMatch(holdModalSource, /setInterval/);
   // parent는 modal 수렴 요청을 authoritative GET에 연결한다.
   assert.match(detailSource, /onConvergence=\{/);
+  // parent는 modal authority-loss를 order clear + AUTH_ERROR + close로 수렴한다.
+  assert.match(detailSource, /onAuthorityLoss=\{/);
+  assert.match(holdModalSource, /onAuthorityLoss\?:/);
 });
 
 // F. ACK success + authoritative reread failure → PATCH 추가 호출 0회·warning·command disabled.
@@ -219,7 +250,7 @@ test('H1. STATUS uncertain constants exist without resend copy', () => {
 test('H2. STATUS F/G other 4xx-5xx converges with GET and no resend', () => {
   const fnAt = detailSource.indexOf('async function updateStatus');
   assert.ok(fnAt !== -1);
-  const fgMarker = detailSource.indexOf('403/409', fnAt);
+  const fgMarker = detailSource.indexOf('F/G:', fnAt);
   assert.ok(fgMarker !== -1);
   const fgBlock = detailSource.slice(fgMarker, fgMarker + 900);
   assert.match(fgBlock, /STATUS_UNCERTAIN_CONVERGENCE_MESSAGE/);
@@ -304,7 +335,7 @@ test('H7. HOLD uncertain constants exist without resend copy', () => {
 test('H8. HOLD F/G other 4xx-5xx converges to parent GET and closes modal', () => {
   const fnAt = holdModalSource.indexOf('async function submit');
   assert.ok(fnAt !== -1);
-  const fgMarker = holdModalSource.indexOf('403/409', fnAt);
+  const fgMarker = holdModalSource.indexOf('F/G:', fnAt);
   assert.ok(fgMarker !== -1);
   const after = holdModalSource.slice(fgMarker, fgMarker + 1400);
   assert.match(after, /setError\(HOLD_UNCERTAIN_CONVERGENCE_MESSAGE\)/);
@@ -361,7 +392,7 @@ test('H11. HOLD parent uncertain sets warning before GET and blocks resubmit', (
   );
   assert.match(detailSource, /disabled=\{loading \|\| !commandsAllowed\}/);
   assert.match(detailSource, /readDetail\(token\)/);
-  assert.match(holdModalSource, /response\.status === 403 \|\| response\.status === 409/);
+  assert.match(holdModalSource, /classifyDriverOrderCommandError\(\{/);
   assert.match(holdModalSource, /onSaved\?\.\(\)/);
 });
 
@@ -393,4 +424,56 @@ test('H12. uncertain warning blocks risk commands at runtime', () => {
   assert.equal(shouldPreserveDriverOrderOnReadError('FETCH_ERROR', true), true);
   assert.equal(shouldPreserveDriverOrderOnReadError('AUTH_ERROR', true), false);
   assert.equal(shouldPreserveDriverOrderOnReadError('NOT_FOUND', true), false);
+});
+
+// 8. DeliveryHoldModal authority 403 → stale-conflict 분기로 오분류하지 않음.
+test('8. HoldModal authority 403은 stale 분기로 오분류하지 않는다', () => {
+  assert.equal(
+    classifyDriverOrderCommandError({ status: 403, code: 'DRIVER_ORDER_AUTHORITY_DENIED' }),
+    'AUTHORITY_LOSS',
+  );
+  const authAt = holdModalSource.indexOf("recovery === 'AUTHORITY_LOSS'");
+  assert.ok(authAt !== -1, 'modal AUTHORITY_LOSS 분기가 있어야 한다');
+  const authBlock = holdModalSource.slice(authAt, authAt + 350);
+  assert.match(authBlock, /onAuthorityLoss\?\.\(\)/);
+  assert.match(authBlock, /onClose\(\)/);
+  assert.doesNotMatch(authBlock, /onConvergence\?\.\(\)/);
+  // parent는 authority-loss를 order clear + AUTH_ERROR + close로 수렴한다.
+  const parentAt = detailSource.indexOf('onAuthorityLoss={');
+  assert.ok(parentAt !== -1, 'parent onAuthorityLoss가 있어야 한다');
+  const parentBlock = detailSource.slice(parentAt, parentAt + 800);
+  assert.match(parentBlock, /hasOrderRef\.current = false/);
+  assert.match(parentBlock, /setOrder\(null\)/);
+  assert.match(parentBlock, /kind: 'AUTH_ERROR'/);
+  assert.match(parentBlock, /setHoldOpened\(false\)/);
+});
+
+// 9. DeliveryHoldModal state-conflict 403 → authority loss로 오분류하지 않음.
+test('9. HoldModal state-conflict 403은 authority loss로 오분류하지 않는다', () => {
+  assert.equal(
+    classifyDriverOrderCommandError({ status: 403, code: 'DRIVER_ORDER_STATE_CONFLICT' }),
+    'STATE_CONFLICT',
+  );
+  const stateAt = holdModalSource.indexOf("recovery === 'STATE_CONFLICT'");
+  assert.ok(stateAt !== -1);
+  const stateBlock = holdModalSource.slice(stateAt, stateAt + 600);
+  assert.match(stateBlock, /HOLD_STALE_CONVERGENCE_MESSAGE/);
+  assert.match(stateBlock, /onConvergence\?\.\(\)/);
+  assert.doesNotMatch(stateBlock, /onAuthorityLoss/);
+  assert.doesNotMatch(stateBlock, /로그인 정보를 다시 확인해 주세요/);
+});
+
+// 10. 기존 409 race convergence 유지 (409 STATE → GET, resend 없음).
+test('10. 기존 409 race convergence가 유지된다', () => {
+  assert.equal(
+    classifyDriverOrderCommandError({ status: 409, code: 'DRIVER_ORDER_STATE_CONFLICT' }),
+    'STATE_CONFLICT',
+  );
+  assert.equal(readDriverOrderErrorCode({ code: 'DRIVER_ORDER_ALREADY_APPLIED' }), null);
+  const patchCount = (detailSource.match(/method: 'PATCH'/g) ?? []).length;
+  assert.equal(patchCount, 1, 'detail PATCH는 상태 전환 1회뿐이다');
+  const holdPatchCount = (holdModalSource.match(/method: 'PATCH'/g) ?? []).length;
+  assert.equal(holdPatchCount, 1, 'hold PATCH는 1회뿐이다');
+  assert.doesNotMatch(detailSource, /setTimeout\(updateStatus/);
+  assert.doesNotMatch(holdModalSource, /setTimeout\(submit/);
 });

--- a/apps/driver/src/app/board/[orderId]/page.tsx
+++ b/apps/driver/src/app/board/[orderId]/page.tsx
@@ -20,11 +20,12 @@ import { use, useCallback, useEffect, useRef, useState } from 'react';
 import { apiFetch } from '@/lib/api';
 import {
   buildDriverOrderDetailScope,
+  classifyDriverOrderCommandError,
   type DriverOrderReadErrorKind,
   isDriverOrderCommandAllowed,
-  isDriverOrderCommandAuthLoss,
   isDriverOrderCommandContinuationCurrent,
   isDriverOrderStatusAck,
+  readDriverOrderCommandErrorCodeFromResponse,
   shouldPreserveDriverOrderOnReadError,
   toDriverOrderNetworkError,
   toDriverOrderReadError,
@@ -268,10 +269,9 @@ export default function OrderDetailPage({ params }: { params: Promise<{ orderId:
       );
       if (!isCommandCurrent()) return;
       if (!res.ok) {
-        // Command 401/403 = authority loss. 이전 protected order/PII/command
-        // authority를 즉시 clear하고 AUTH_ERROR로 수렴한다. generic 오류만 띄우고
-        // 이전 order를 유지하는 흐름을 남기지 않는다.
-        if (isDriverOrderCommandAuthLoss(res.status)) {
+        // 401은 envelope code와 무관하게 authority loss다. body 파싱 없이 즉시
+        // protected order/PII/command authority를 clear하고 AUTH_ERROR로 수렴한다.
+        if (res.status === 401) {
           hasOrderRef.current = false;
           setOrder(null);
           setReadError({
@@ -281,9 +281,29 @@ export default function OrderDetailPage({ params }: { params: Promise<{ orderId:
           setReadbackWarning(null);
           return;
         }
-        // 409 race-loser: 서버 authority가 이미 상태를 이동시켰다는 의미다.
-        // 같은 command를 자동 재전송하지 않고 authoritative GET으로 수렴한다.
-        if (res.status === 409) {
+        // error-code aware command recovery: envelope code를 안전하게 읽는다.
+        // body 파싱 실패는 null이며 그 자체가 same-command resend를 유도하지 않는다.
+        const errorCode = await readDriverOrderCommandErrorCodeFromResponse(res);
+        if (!isCommandCurrent()) return;
+        const recovery = classifyDriverOrderCommandError({
+          status: res.status,
+          code: errorCode,
+        });
+        // 403 AUTHORITY + unknown/missing-code 403 fail-closed authority loss.
+        // 이전 protected order/PII를 유지하는 흐름을 남기지 않는다.
+        if (recovery === 'AUTHORITY_LOSS') {
+          hasOrderRef.current = false;
+          setOrder(null);
+          setReadError({
+            kind: 'AUTH_ERROR',
+            message: '로그인 정보를 다시 확인해 주세요.',
+          });
+          setReadbackWarning(null);
+          return;
+        }
+        // 403/409 + STATE_CONFLICT: 로그인 상실이 아니다. 같은 command를 자동
+        // 재전송하지 않고 authoritative GET으로 수렴한다 (기존 409 race convergence 재사용).
+        if (recovery === 'STATE_CONFLICT') {
           notifications.show({
             color: 'yellow',
             message: '이미 상태가 변경되었을 수 있습니다. 최신 상태를 다시 확인합니다.',
@@ -291,9 +311,21 @@ export default function OrderDetailPage({ params }: { params: Promise<{ orderId:
           await readDetail(token);
           return;
         }
-        // F/G: 403/409 이외 4xx·5xx ACK-uncertain. 같은 PATCH를 자동 재전송하지 않고
-        // UNCERTAIN을 보존한 채 authoritative GET으로 수렴한다.
-        // fresh GET 성공이 warning을 해소하기 전에는 fail-closed로 위험 command를 차단한다.
+        // DRIVER_ORDER_NOT_FOUND: authoritative absence/hiding. 이전 protected
+        // order를 신뢰하지 않고 NOT_FOUND 의미로 수렴한다. 자동 resend 없음.
+        if (recovery === 'NOT_FOUND') {
+          hasOrderRef.current = false;
+          setOrder(null);
+          setReadError({
+            kind: 'NOT_FOUND',
+            message: '주문을 찾을 수 없습니다',
+          });
+          setReadbackWarning(null);
+          return;
+        }
+        // F/G: 403/409 STATE·AUTHORITY·NOT_FOUND 이외 4xx·5xx ACK-uncertain.
+        // 같은 PATCH를 자동 재전송하지 않고 UNCERTAIN을 보존한 채 authoritative
+        // GET으로 수렴한다. fresh GET 성공이 warning을 해소하기 전에는 fail-closed다.
         notifications.show({
           color: 'yellow',
           message: STATUS_UNCERTAIN_CONVERGENCE_MESSAGE,
@@ -805,6 +837,31 @@ export default function OrderDetailPage({ params }: { params: Promise<{ orderId:
             setReadbackWarning(HOLD_UNCERTAIN_READBACK_WARNING);
             const token = session?.user.accessToken;
             if (token) void readDetail(token);
+          }}
+          onAuthorityLoss={() => {
+            // HOLD 401 / 403 + AUTHORITY_DENIED: modal 내부 표시에 그치지 않고
+            // parent가 protected order/PII를 즉시 제거하고 AUTH_ERROR로 수렴하며
+            // modal을 reset/close한다. 같은 hold 자동 resend 금지.
+            hasOrderRef.current = false;
+            setOrder(null);
+            setReadError({
+              kind: 'AUTH_ERROR',
+              message: '로그인 정보를 다시 확인해 주세요.',
+            });
+            setReadbackWarning(null);
+            setHoldOpened(false);
+          }}
+          onNotFound={() => {
+            // HOLD DRIVER_ORDER_NOT_FOUND: authoritative absence/hiding.
+            // 이전 protected order를 신뢰하지 않고 NOT_FOUND 의미로 수렴한다.
+            hasOrderRef.current = false;
+            setOrder(null);
+            setReadError({
+              kind: 'NOT_FOUND',
+              message: '주문을 찾을 수 없습니다',
+            });
+            setReadbackWarning(null);
+            setHoldOpened(false);
           }}
         />
       )}

--- a/apps/driver/src/app/board/_lib/driver-order-detail-auth-scope.test.mjs
+++ b/apps/driver/src/app/board/_lib/driver-order-detail-auth-scope.test.mjs
@@ -3,9 +3,10 @@ import { readFile } from 'node:fs/promises';
 import test from 'node:test';
 import {
   buildDriverOrderDetailScope,
+  classifyDriverOrderCommandError,
   isDriverOrderCommandAllowed,
-  isDriverOrderCommandAuthLoss,
   isDriverOrderCommandContinuationCurrent,
+  readDriverOrderErrorCode,
   shouldPreserveDriverOrderOnReadError,
 } from './driver-order-detail.ts';
 
@@ -229,11 +230,12 @@ test('command ACK 후 authoritative GET 수렴·readback 분리 계약이 유지
 });
 
 // R1. fresh order → command PATCH 401 → order/PII clear → AUTH_REQUIRED → CTA 없음.
+// 401은 envelope code와 무관하게 authority loss다.
 test('R1. command PATCH 401은 authority loss로 이전 order를 즉시 제거한다', () => {
-  assert.equal(isDriverOrderCommandAuthLoss(401), true);
-  assert.match(detailSource, /isDriverOrderCommandAuthLoss\(res\.status\)/);
-  const authAt = detailSource.indexOf('isDriverOrderCommandAuthLoss(res.status)');
-  assert.ok(authAt !== -1, 'command 401/403 auth-loss 분기가 있어야 한다');
+  assert.equal(classifyDriverOrderCommandError({ status: 401, code: null }), 'AUTHORITY_LOSS');
+  assert.match(detailSource, /if \(res\.status === 401\)/);
+  const authAt = detailSource.indexOf('if (res.status === 401)');
+  assert.ok(authAt !== -1, 'command 401 auth-loss 분기가 있어야 한다');
   const authBlock = detailSource.slice(authAt, authAt + 600);
   assert.match(authBlock, /hasOrderRef\.current = false/);
   assert.match(authBlock, /setOrder\(null\)/);
@@ -243,17 +245,33 @@ test('R1. command PATCH 401은 authority loss로 이전 order를 즉시 제거�
   assert.doesNotMatch(authBlock, /오류가 발생했습니다/);
 });
 
-// R2. fresh order → command PATCH 403 → R1과 동일한 authority-loss branch.
-test('R2. command PATCH 403은 401과 동일한 authority-loss branch를 탄다', () => {
-  assert.equal(isDriverOrderCommandAuthLoss(403), true);
-  assert.equal(isDriverOrderCommandAuthLoss(409), false);
-  assert.equal(isDriverOrderCommandAuthLoss(500), false);
-  // 403은 별도 convergence가 아니라 401과 같은 auth-loss helper 분기를 탄다.
-  assert.match(detailSource, /isDriverOrderCommandAuthLoss\(res\.status\)/);
-  assert.match(helperSource, /status === 401 \|\| status === 403/);
-  // detail의 403 단독 convergence는 남지 않고 409만 수렴한다.
-  assert.match(detailSource, /if \(res\.status === 409\)/);
-  assert.doesNotMatch(detailSource, /res\.status === 403 \|\| res\.status === 409/);
+// R2. fresh order → command PATCH 403는 error-code로 AUTHORITY/STATE를 구분한다.
+// 403 + AUTHORITY_DENIED/unknown → AUTHORITY_LOSS, 403 + STATE_CONFLICT → STATE_CONFLICT.
+test('R2. command PATCH 403은 error-code로 authority/state를 구분한다', () => {
+  assert.equal(
+    classifyDriverOrderCommandError({ status: 403, code: 'DRIVER_ORDER_AUTHORITY_DENIED' }),
+    'AUTHORITY_LOSS',
+  );
+  assert.equal(
+    classifyDriverOrderCommandError({ status: 403, code: 'DRIVER_ORDER_STATE_CONFLICT' }),
+    'STATE_CONFLICT',
+  );
+  assert.equal(classifyDriverOrderCommandError({ status: 403, code: null }), 'AUTHORITY_LOSS');
+  assert.equal(readDriverOrderErrorCode({ code: 'DRIVER_ORDER_ALREADY_APPLIED' }), null);
+  // detail은 status-only helper 분기가 아니라 error-code aware classifier를 사용한다.
+  assert.match(detailSource, /classifyDriverOrderCommandError\(\{/);
+  assert.match(detailSource, /readDriverOrderCommandErrorCodeFromResponse\(res\)/);
+  assert.match(detailSource, /recovery === 'AUTHORITY_LOSS'/);
+  assert.match(detailSource, /recovery === 'STATE_CONFLICT'/);
+  assert.match(detailSource, /recovery === 'NOT_FOUND'/);
+  // 403 STATE를 AUTH_ERROR로 오분류하지 않는다: STATE 분기는 GET 수렴이다.
+  const stateAt = detailSource.indexOf("recovery === 'STATE_CONFLICT'");
+  assert.ok(stateAt !== -1, 'STATE_CONFLICT 분기가 있어야 한다');
+  const stateBlock = detailSource.slice(stateAt, stateAt + 600);
+  assert.match(stateBlock, /await readDetail\(token\)/);
+  assert.doesNotMatch(stateBlock, /kind: 'AUTH_ERROR'/);
+  // 구 status-only 403 auth-loss 직접 분기는 남지 않는다.
+  assert.doesNotMatch(detailSource, /isDriverOrderCommandAuthLoss\(res\.status\)/);
 });
 
 // R3. A scope command → B user/token/role 전환 → A ACK/readback이 B에 반영되지 않음.

--- a/apps/driver/src/app/board/_lib/driver-order-detail.test.mjs
+++ b/apps/driver/src/app/board/_lib/driver-order-detail.test.mjs
@@ -1,12 +1,16 @@
 import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
 import test from 'node:test';
 import {
   buildDriverOrderDetailScope,
+  classifyDriverOrderCommandError,
   classifyDriverOrderReadError,
   DriverOrderReadError,
   isDriverOrderCommandAuthLoss,
   isDriverOrderCommandContinuationCurrent,
   isDriverOrderStatusAck,
+  readDriverOrderCommandErrorCodeFromResponse,
+  readDriverOrderErrorCode,
   toDriverOrderNetworkError,
   toDriverOrderReadError,
 } from './driver-order-detail.ts';
@@ -83,7 +87,7 @@ test('detail scope는 orderId·user·role·token을 모두 구분한다', () => 
   );
 });
 
-test('command 401·403만 authority loss다', () => {
+test('command 401·403만 authority loss다 (legacy fail-closed fallback)', () => {
   assert.equal(isDriverOrderCommandAuthLoss(401), true);
   assert.equal(isDriverOrderCommandAuthLoss(403), true);
   for (const status of [404, 409, 422, 500]) {
@@ -140,4 +144,160 @@ test('command continuation은 동일 seq·scope일 때만 current다', () => {
     }),
     false,
   );
+});
+
+// DRIVER-DETAIL-COMMAND-ERROR-CODE-CLIENT-CONVERGENCE-01 pure contract.
+// status + stable error-code → client recovery classification.
+
+// 1. 401 → AUTHORITY_LOSS (code 무관).
+test('1. 401은 code와 무관하게 AUTHORITY_LOSS다', () => {
+  assert.equal(classifyDriverOrderCommandError({ status: 401, code: null }), 'AUTHORITY_LOSS');
+  assert.equal(
+    classifyDriverOrderCommandError({ status: 401, code: 'DRIVER_ORDER_STATE_CONFLICT' }),
+    'AUTHORITY_LOSS',
+  );
+  assert.equal(
+    classifyDriverOrderCommandError({ status: 401, code: 'DRIVER_ORDER_AUTHORITY_DENIED' }),
+    'AUTHORITY_LOSS',
+  );
+  assert.equal(
+    classifyDriverOrderCommandError({ status: 401, code: 'DRIVER_ORDER_NOT_FOUND' }),
+    'AUTHORITY_LOSS',
+  );
+});
+
+// 2. 403 + AUTHORITY_DENIED → AUTHORITY_LOSS.
+test('2. 403 + DRIVER_ORDER_AUTHORITY_DENIED는 AUTHORITY_LOSS다', () => {
+  assert.equal(
+    classifyDriverOrderCommandError({ status: 403, code: 'DRIVER_ORDER_AUTHORITY_DENIED' }),
+    'AUTHORITY_LOSS',
+  );
+});
+
+// 3. 403 + STATE_CONFLICT → STATE_CONFLICT (auth-loss 아님).
+test('3. 403 + DRIVER_ORDER_STATE_CONFLICT는 STATE_CONFLICT이며 auth-loss가 아니다', () => {
+  assert.equal(
+    classifyDriverOrderCommandError({ status: 403, code: 'DRIVER_ORDER_STATE_CONFLICT' }),
+    'STATE_CONFLICT',
+  );
+  assert.notEqual(
+    classifyDriverOrderCommandError({ status: 403, code: 'DRIVER_ORDER_STATE_CONFLICT' }),
+    'AUTHORITY_LOSS',
+  );
+});
+
+// 4. 409 + STATE_CONFLICT → STATE_CONFLICT.
+test('4. 409 + DRIVER_ORDER_STATE_CONFLICT는 STATE_CONFLICT다', () => {
+  assert.equal(
+    classifyDriverOrderCommandError({ status: 409, code: 'DRIVER_ORDER_STATE_CONFLICT' }),
+    'STATE_CONFLICT',
+  );
+});
+
+// 5. 404 + NOT_FOUND → NOT_FOUND.
+test('5. 404 + DRIVER_ORDER_NOT_FOUND는 NOT_FOUND다', () => {
+  assert.equal(
+    classifyDriverOrderCommandError({ status: 404, code: 'DRIVER_ORDER_NOT_FOUND' }),
+    'NOT_FOUND',
+  );
+});
+
+// 6. unknown/missing-code 403 → fail-closed AUTHORITY_LOSS.
+test('6. code 없는 unknown 403은 fail-closed AUTHORITY_LOSS다', () => {
+  assert.equal(classifyDriverOrderCommandError({ status: 403, code: null }), 'AUTHORITY_LOSS');
+  assert.equal(
+    classifyDriverOrderCommandError({ status: 403, code: undefined }),
+    'AUTHORITY_LOSS',
+  );
+  assert.equal(classifyDriverOrderCommandError({ status: 403, code: 'SOME_UNKNOWN' }), 'AUTHORITY_LOSS');
+  assert.equal(classifyDriverOrderCommandError({ status: 403, code: '' }), 'AUTHORITY_LOSS');
+});
+
+// 7. malformed error body → crash 없음, null, 자동 resend 없음 (분류는 fail-closed).
+test('7. malformed error body는 null이며 crash 없이 fail-closed 분류한다', async () => {
+  assert.equal(readDriverOrderErrorCode(null), null);
+  assert.equal(readDriverOrderErrorCode(undefined), null);
+  assert.equal(readDriverOrderErrorCode('FORBIDDEN'), null);
+  assert.equal(readDriverOrderErrorCode(403), null);
+  assert.equal(readDriverOrderErrorCode({}), null);
+  assert.equal(readDriverOrderErrorCode({ code: null }), null);
+  assert.equal(readDriverOrderErrorCode({ code: 403 }), null);
+  assert.equal(readDriverOrderErrorCode({ code: 'UNKNOWN_CODE' }), null);
+  assert.equal(
+    readDriverOrderErrorCode({ code: 'DRIVER_ORDER_AUTHORITY_DENIED' }),
+    'DRIVER_ORDER_AUTHORITY_DENIED',
+  );
+  // Response json 파싱 실패도 throw 없이 null이다.
+  const malformed = { json: async () => { throw new SyntaxError('Unexpected end of JSON input'); } };
+  assert.equal(await readDriverOrderCommandErrorCodeFromResponse(malformed), null);
+  const emptyThrow = { json: async () => { throw new Error('empty body'); } };
+  assert.equal(
+    classifyDriverOrderCommandError({
+      status: 409,
+      code: await readDriverOrderCommandErrorCodeFromResponse(emptyThrow),
+    }),
+    'UNCERTAIN',
+  );
+  // 403 malformed는 authority protection을 낮추지 않는다.
+  assert.equal(
+    classifyDriverOrderCommandError({
+      status: 403,
+      code: await readDriverOrderCommandErrorCodeFromResponse(malformed),
+    }),
+    'AUTHORITY_LOSS',
+  );
+});
+
+// 404 body 미판독/코드 없음은 새로운 성공 의미를 추론하지 않는다 (UNCERTAIN).
+test('404 unknown 코드는 NOT_FOUND가 아니라 UNCERTAIN이다', () => {
+  assert.equal(classifyDriverOrderCommandError({ status: 404, code: null }), 'UNCERTAIN');
+  assert.equal(classifyDriverOrderCommandError({ status: 404, code: 'UNKNOWN' }), 'UNCERTAIN');
+});
+
+// 예상 밖 4xx/5xx + ratified 코드 없음은 UNCERTAIN이며 성공으로 추론하지 않는다.
+test('unknown 4xx/5xx는 UNCERTAIN이며 성공·resend를 유도하지 않는다', () => {
+  assert.equal(classifyDriverOrderCommandError({ status: 409, code: null }), 'UNCERTAIN');
+  assert.equal(classifyDriverOrderCommandError({ status: 500, code: null }), 'UNCERTAIN');
+  assert.equal(classifyDriverOrderCommandError({ status: 422, code: null }), 'UNCERTAIN');
+  assert.equal(classifyDriverOrderCommandError({ status: 400, code: null }), 'UNCERTAIN');
+});
+
+// 12. DRIVER_ORDER_ALREADY_APPLIED를 client에서 새로 생성·추론하지 않는다.
+test('12. DRIVER_ORDER_ALREADY_APPLIED는 인식하지 않으며 새 의미를 만들지 않는다', async () => {
+  assert.equal(readDriverOrderErrorCode({ code: 'DRIVER_ORDER_ALREADY_APPLIED' }), null);
+  assert.equal(
+    classifyDriverOrderCommandError({ status: 409, code: 'DRIVER_ORDER_ALREADY_APPLIED' }),
+    'UNCERTAIN',
+  );
+  assert.equal(
+    classifyDriverOrderCommandError({ status: 403, code: 'DRIVER_ORDER_ALREADY_APPLIED' }),
+    'AUTHORITY_LOSS',
+  );
+  const helperSource = await readFile(new URL('./driver-order-detail.ts', import.meta.url), 'utf8');
+  // 새로 정의하지 않는다: const 정의나 union 타입 추가로 만들지 않는다.
+  assert.doesNotMatch(helperSource, /export const \w*ALREADY_APPLIED/);
+  assert.doesNotMatch(helperSource, /\|\s*'DRIVER_ORDER_ALREADY_APPLIED'/);
+  assert.doesNotMatch(helperSource, /return\s*'DRIVER_ORDER_ALREADY_APPLIED'/);
+});
+
+// shared SSOT와 동일한 wire 문자열만 인식한다 (client UX 의미를 shared에 넣지 않음).
+test('shared stable code와 동일한 wire 문자열을 소비한다', async () => {
+  const helperSource = await readFile(new URL('./driver-order-detail.ts', import.meta.url), 'utf8');
+  assert.match(helperSource, /DRIVER_ORDER_AUTHORITY_DENIED/);
+  assert.match(helperSource, /DRIVER_ORDER_STATE_CONFLICT/);
+  assert.match(helperSource, /DRIVER_ORDER_NOT_FOUND/);
+  const sharedSource = await readFile(
+    new URL('../../../../../../packages/shared/src/driver-order-error.types.ts', import.meta.url),
+    'utf8',
+  );
+  for (const code of [
+    'DRIVER_ORDER_AUTHORITY_DENIED',
+    'DRIVER_ORDER_STATE_CONFLICT',
+    'DRIVER_ORDER_NOT_FOUND',
+  ]) {
+    assert.match(sharedSource, new RegExp(code));
+    assert.match(helperSource, new RegExp(code));
+  }
+  assert.doesNotMatch(sharedSource, /AUTHORITY_LOSS/);
+  assert.doesNotMatch(sharedSource, /STATE_CONFLICT.*recovery|recovery.*STATE_CONFLICT/);
 });

--- a/apps/driver/src/app/board/_lib/driver-order-detail.ts
+++ b/apps/driver/src/app/board/_lib/driver-order-detail.ts
@@ -4,7 +4,9 @@
  * Server authority를 유지하기 위한 최소 분류만 둔다.
  * - detail HTTP status classification (404 / 401·403 / 그 외·network)
  * - detail scope identity (orderId + user identity + role + access token)
- * - command 401·403 authority-loss classification
+ * - command 401·403 authority-loss classification (legacy fail-closed fallback)
+ * - command status + stable error-code recovery classification
+ *   (AUTHORITY_LOSS / STATE_CONFLICT / NOT_FOUND / UNCERTAIN)
  * - command scope/sequence continuation binding
  * - command semantic ACK matching (orderId + status)
  *
@@ -127,9 +129,112 @@ export function buildDriverOrderDetailScope(args: {
  * command PATCH 자체의 401·403은 authority loss다.
  * 409/422/5xx의 command recovery architecture를 재정의하지 않으며,
  * 이 판정은 401·403만을 AUTH_ERROR branch로 보낸다.
+ *
+ * @deprecated status-only fallback. 신규 command 경로는
+ * `classifyDriverOrderCommandError` (status + stable error code)를 사용한다.
+ * 403은 code가 STATE_CONFLICT이면 authority loss가 아니다. 본 함수는
+ * unknown/missing-code 403의 fail-closed fallback으로만 유지된다.
  */
 export function isDriverOrderCommandAuthLoss(status: number): boolean {
   return status === 401 || status === 403;
+}
+
+/**
+ * Driver command error-code convergence (client-local recovery meaning).
+ *
+ * Server/shared stable wire-code SSOT는
+ * `packages/shared/src/driver-order-error.types.ts`가 소유한다:
+ * - DRIVER_ORDER_AUTHORITY_DENIED
+ * - DRIVER_ORDER_STATE_CONFLICT
+ * - DRIVER_ORDER_NOT_FOUND
+ *
+ * 본 helper는 wire 문자열을 그대로 인식만 하며, shared에 client UX/recovery
+ * 의미를 추가하지 않는다. DRIVER_ORDER_ALREADY_APPLIED는 서버 Task에서
+ * DEFERRED_NOT_PROVABLE로 결정됐으므로 여기서 새로 정의·추론하지 않는다.
+ */
+export type DriverOrderCommandErrorCode =
+  | 'DRIVER_ORDER_AUTHORITY_DENIED'
+  | 'DRIVER_ORDER_STATE_CONFLICT'
+  | 'DRIVER_ORDER_NOT_FOUND';
+
+/**
+ * status + code → client recovery classification.
+ * - AUTHORITY_LOSS: protected order/PII 즉시 제거, AUTH_ERROR 수렴, resend 금지.
+ * - STATE_CONFLICT: 로그인 오류 아님, resend 금지, authoritative GET 수렴.
+ * - NOT_FOUND: authoritative absence/hiding, 이전 order 불신, resend 금지.
+ * - UNCERTAIN: 성공 추론 금지, resend 금지, 기존 ACK-uncertain/GET 수렴 유지.
+ */
+export type DriverOrderCommandRecovery =
+  | 'AUTHORITY_LOSS'
+  | 'STATE_CONFLICT'
+  | 'NOT_FOUND'
+  | 'UNCERTAIN';
+
+/**
+ * error envelope에서 stable code만 안전하게 읽는다.
+ * body parsing 실패·형식 불일치·ratified 외 문자열은 모두 null이다.
+ * null 때문에 same-command resend를 유도하지 않으며, 호출자는
+ * `classifyDriverOrderCommandError`의 fail-closed fallback을 사용한다.
+ * DRIVER_ORDER_ALREADY_APPLIED를 포함한 미정의 코드는 절대 인식하지 않는다.
+ */
+export function readDriverOrderErrorCode(body: unknown): DriverOrderCommandErrorCode | null {
+  if (typeof body !== 'object' || body === null) return null;
+  const code = (body as { code?: unknown }).code;
+  if (
+    code === 'DRIVER_ORDER_AUTHORITY_DENIED' ||
+    code === 'DRIVER_ORDER_STATE_CONFLICT' ||
+    code === 'DRIVER_ORDER_NOT_FOUND'
+  ) {
+    return code;
+  }
+  return null;
+}
+
+/**
+ * Response error envelope의 code를 안전하게 읽는다.
+ * body가 비었거나 malformed이거나 json 파싱이 실패해도 throw하지 않고
+ * null을 반환한다. null 자체가 resend를 유도하지 않는다.
+ */
+export async function readDriverOrderCommandErrorCodeFromResponse(
+  response: Pick<Response, 'json'>,
+): Promise<DriverOrderCommandErrorCode | null> {
+  try {
+    const body: unknown = await response.json();
+    return readDriverOrderErrorCode(body);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * status + code를 client recovery 의미로 분류한다.
+ * HTTP status만 보지 않으며, 가능한 경우 envelope code가 우선한다.
+ *
+ * - 401은 code와 무관하게 AUTHORITY_LOSS다.
+ * - DRIVER_ORDER_AUTHORITY_DENIED는 status와 무관하게 AUTHORITY_LOSS다.
+ * - DRIVER_ORDER_NOT_FOUND는 authoritative absence/hiding으로 NOT_FOUND다.
+ * - 403/409 + DRIVER_ORDER_STATE_CONFLICT는 STATE_CONFLICT다.
+ * - code 없는 unknown/missing 403은 기존 보안 경계를 낮추지 않도록
+ *   fail-closed AUTHORITY_LOSS로 유지한다.
+ * - 그 외 ratified 코드 없음·malformed·예상 밖 4xx/5xx는 UNCERTAIN이다.
+ *   (404 body 미판독/코드 없음도 UNCERTAIN이며 새로운 성공 의미를 추론하지 않는다)
+ */
+export function classifyDriverOrderCommandError(args: {
+  status: number;
+  code: DriverOrderCommandErrorCode | string | null | undefined;
+}): DriverOrderCommandRecovery {
+  const { status, code } = args;
+  if (status === 401) return 'AUTHORITY_LOSS';
+  if (code === 'DRIVER_ORDER_AUTHORITY_DENIED') return 'AUTHORITY_LOSS';
+  if (code === 'DRIVER_ORDER_NOT_FOUND') return 'NOT_FOUND';
+  if (
+    code === 'DRIVER_ORDER_STATE_CONFLICT' &&
+    (status === 403 || status === 409)
+  ) {
+    return 'STATE_CONFLICT';
+  }
+  if (status === 403) return 'AUTHORITY_LOSS';
+  return 'UNCERTAIN';
 }
 
 /**


### PR DESCRIPTION
CLIENT CONVERGENCE ONLY. No server/FSM/idempotency changes.

Consumes already-published stable codes (DRIVER_ORDER_AUTHORITY_DENIED, DRIVER_ORDER_STATE_CONFLICT, DRIVER_ORDER_NOT_FOUND) in Driver detail status command and DeliveryHoldModal via a single Driver-local pure helper (status+code to AUTHORITY_LOSS/STATE_CONFLICT/NOT_FOUND/UNCERTAIN).

- 401 always AUTHORITY_LOSS; 403 AUTHORITY or unknown-code 403 fail-closed AUTHORITY_LOSS with PII clear; 403/409 STATE goes to authoritative GET convergence, never auth-loss; NOT_FOUND discards prior order; malformed/unknown is UNCERTAIN with no resend.
- HoldModal authority-loss propagates to parent order clear + AUTH_ERROR + modal reset/close via minimal onAuthorityLoss/onNotFound callbacks.
- No automatic resend added (PATCH still 1 per command); double-submit, sequence, scope, stale, GET convergence, ACK, readback, navigation, hold stale guard, payment gate preserved.
- DRIVER_ORDER_ALREADY_APPLIED not defined or inferred.

Tests: driver-order-detail.test.mjs (21), driver-order-detail-auth-scope.test.mjs (21), driver-detail-command-safety.test.mjs (24) all PASS via node. Helper tsc clean. Biome shows only pre-existing finally/suppression findings.