### PR TITLE
fix(api): specialized pickup/review fresh expected-status race convergence

### DIFF
--- a/apps/api/src/orders/orders-lifecycle.service.ts
+++ b/apps/api/src/orders/orders-lifecycle.service.ts
@@ -599,21 +599,49 @@ export class OrdersLifecycleService {
     if (!snap.exists || snap.data()!['storeId'] !== storeId) {
       throw new NotFoundException();
     }
-    const order = snap.data()!;
-    if (order['userId'] !== userId) throw new ForbiddenException();
+    const staleOrder = snap.data()!;
+    if (staleOrder['userId'] !== userId) throw new ForbiddenException();
+    const entryStatus = staleOrder['status'] as string;
 
     const reviewableStatuses = ['DELIVERED', 'PICKED_UP'];
-    if (!reviewableStatuses.includes(order['status'])) {
-      throw new BadRequestException('DELIVERED 또는 PICKED_UP 상태에서만 리뷰 가능합니다.');
-    }
+    let alreadyReviewed = false;
+    let freshOrderForSettlement: Record<string, any> | null = null;
 
-    await this.firestore.doc(`orders/${orderId}`).update({
-      status: 'REVIEWED',
-      updatedAt: this.firestore.Timestamp.now(),
+    await this.firestore.runTransaction(async (tx) => {
+      const orderRef = this.firestore.doc(`orders/${orderId}`);
+      const latestSnap = await tx.get(orderRef);
+      if (!latestSnap.exists || latestSnap.data()?.['storeId'] !== storeId) {
+        throw new NotFoundException();
+      }
+      const latestOrder = latestSnap.data()!;
+      if (latestOrder['userId'] !== userId) throw new ForbiddenException();
+      const freshStatus = latestOrder['status'] as string;
+      if (freshStatus === 'REVIEWED') {
+        if (entryStatus !== 'REVIEWED') {
+          throw new ConflictException('주문 상태가 변경되었습니다.');
+        }
+        alreadyReviewed = true;
+        freshOrderForSettlement = { ...latestOrder, id: orderId };
+        return;
+      }
+      if (!reviewableStatuses.includes(freshStatus)) {
+        if (freshStatus !== entryStatus) {
+          throw new ConflictException('주문 상태가 변경되었습니다.');
+        }
+        throw new BadRequestException('DELIVERED 또는 PICKED_UP 상태에서만 리뷰 가능합니다.');
+      }
+      tx.update(orderRef, {
+        status: 'REVIEWED',
+        updatedAt: this.firestore.Timestamp.now(),
+      });
+      freshOrderForSettlement = { ...latestOrder, id: orderId };
     });
 
-    // 정산 자동 생성
-    await this.settlements.createSettlement(order, 'REVIEWED');
+    const settlementOrder = { ...(freshOrderForSettlement ?? staleOrder), id: orderId };
+    await this.settlements.createSettlement(settlementOrder, 'REVIEWED');
+    if (alreadyReviewed) {
+      throw new BadRequestException('DELIVERED 또는 PICKED_UP 상태에서만 리뷰 가능합니다.');
+    }
 
     return { orderId, status: 'REVIEWED' };
   }
@@ -623,22 +651,54 @@ export class OrdersLifecycleService {
     if (!snap.exists || snap.data()!['storeId'] !== storeId) {
       throw new NotFoundException();
     }
-    const order = snap.data()!;
-    if (order['userId'] !== userId) throw new ForbiddenException();
-    if (order['status'] !== 'HUB_ARRIVED') {
-      throw new BadRequestException('HUB_ARRIVED 상태에서만 픽업 확인 가능');
-    }
-    if (order['pickupCode'] !== pickupCode) {
-      throw new BadRequestException('픽업 코드가 올바르지 않습니다.');
-    }
+    const staleOrder = snap.data()!;
+    if (staleOrder['userId'] !== userId) throw new ForbiddenException();
+    const entryStatus = staleOrder['status'] as string;
 
-    await this.firestore.doc(`orders/${orderId}`).update({
-      status: 'PICKED_UP',
-      updatedAt: this.firestore.Timestamp.now(),
+    let alreadyPickedUp = false;
+    let freshOrderForSettlement: Record<string, any> | null = null;
+
+    await this.firestore.runTransaction(async (tx) => {
+      const orderRef = this.firestore.doc(`orders/${orderId}`);
+      const latestSnap = await tx.get(orderRef);
+      if (!latestSnap.exists || latestSnap.data()?.['storeId'] !== storeId) {
+        throw new NotFoundException();
+      }
+      const latestOrder = latestSnap.data()!;
+      if (latestOrder['userId'] !== userId) throw new ForbiddenException();
+      const freshStatus = latestOrder['status'] as string;
+      if (freshStatus === 'PICKED_UP') {
+        if (latestOrder['pickupCode'] !== pickupCode) {
+          throw new BadRequestException('픽업 코드가 올바르지 않습니다.');
+        }
+        if (entryStatus !== 'PICKED_UP') {
+          throw new ConflictException('주문 상태가 변경되었습니다.');
+        }
+        alreadyPickedUp = true;
+        freshOrderForSettlement = { ...latestOrder, id: orderId };
+        return;
+      }
+      if (freshStatus !== 'HUB_ARRIVED') {
+        if (freshStatus !== entryStatus) {
+          throw new ConflictException('주문 상태가 변경되었습니다.');
+        }
+        throw new BadRequestException('HUB_ARRIVED 상태에서만 픽업 확인 가능');
+      }
+      if (latestOrder['pickupCode'] !== pickupCode) {
+        throw new BadRequestException('픽업 코드가 올바르지 않습니다.');
+      }
+      tx.update(orderRef, {
+        status: 'PICKED_UP',
+        updatedAt: this.firestore.Timestamp.now(),
+      });
+      freshOrderForSettlement = { ...latestOrder, id: orderId };
     });
 
-    // 정산 자동 생성
-    await this.settlements.createSettlement(order, 'PICKED_UP');
+    const settlementOrder = { ...(freshOrderForSettlement ?? staleOrder), id: orderId };
+    await this.settlements.createSettlement(settlementOrder, 'PICKED_UP');
+    if (alreadyPickedUp) {
+      throw new BadRequestException('HUB_ARRIVED 상태에서만 픽업 확인 가능');
+    }
 
     return { orderId, status: 'PICKED_UP' };
   }
@@ -659,21 +719,57 @@ export class OrdersLifecycleService {
     if (!snap.exists || snap.data()!['storeId'] !== storeId) {
       throw new NotFoundException();
     }
-    const order = snap.data()!;
+    const staleOrder = snap.data()!;
+    const entryStatus = staleOrder['status'] as string;
 
-    if (order['status'] !== 'HUB_ARRIVED') {
-      throw new BadRequestException('HUB_ARRIVED 상태에서만 픽업 확인 가능');
-    }
-    if (order['pickupCode'] !== pickupCode) {
-      throw new BadRequestException('픽업 코드가 올바르지 않습니다.');
-    }
+    let alreadyPickedUp = false;
+    let freshOrderForSettlement: Record<string, any> | null = null;
 
-    await this.firestore.doc(`orders/${orderId}`).update({
-      status: 'PICKED_UP',
-      updatedAt: this.firestore.Timestamp.now(),
+    await this.firestore.runTransaction(async (tx) => {
+      const storeRef = this.firestore.doc(`stores/${storeId}`);
+      const latestStoreSnap = await tx.get(storeRef);
+      if (!latestStoreSnap.exists || latestStoreSnap.data()?.['ownerId'] !== requesterId) {
+        throw new ForbiddenException('해당 스토어에 대한 권한이 없습니다');
+      }
+      const orderRef = this.firestore.doc(`orders/${orderId}`);
+      const latestSnap = await tx.get(orderRef);
+      if (!latestSnap.exists || latestSnap.data()?.['storeId'] !== storeId) {
+        throw new NotFoundException();
+      }
+      const latestOrder = latestSnap.data()!;
+      const freshStatus = latestOrder['status'] as string;
+      if (freshStatus === 'PICKED_UP') {
+        if (latestOrder['pickupCode'] !== pickupCode) {
+          throw new BadRequestException('픽업 코드가 올바르지 않습니다.');
+        }
+        if (entryStatus !== 'PICKED_UP') {
+          throw new ConflictException('주문 상태가 변경되었습니다.');
+        }
+        alreadyPickedUp = true;
+        freshOrderForSettlement = { ...latestOrder, id: orderId };
+        return;
+      }
+      if (freshStatus !== 'HUB_ARRIVED') {
+        if (freshStatus !== entryStatus) {
+          throw new ConflictException('주문 상태가 변경되었습니다.');
+        }
+        throw new BadRequestException('HUB_ARRIVED 상태에서만 픽업 확인 가능');
+      }
+      if (latestOrder['pickupCode'] !== pickupCode) {
+        throw new BadRequestException('픽업 코드가 올바르지 않습니다.');
+      }
+      tx.update(orderRef, {
+        status: 'PICKED_UP',
+        updatedAt: this.firestore.Timestamp.now(),
+      });
+      freshOrderForSettlement = { ...latestOrder, id: orderId };
     });
 
-    await this.settlements.createSettlement(order, 'PICKED_UP');
+    const settlementOrder = { ...(freshOrderForSettlement ?? staleOrder), id: orderId };
+    await this.settlements.createSettlement(settlementOrder, 'PICKED_UP');
+    if (alreadyPickedUp) {
+      throw new BadRequestException('HUB_ARRIVED 상태에서만 픽업 확인 가능');
+    }
 
     return { orderId, status: 'PICKED_UP' };
   }

--- a/apps/api/src/orders/specialized-command-race-convergence.spec.ts
+++ b/apps/api/src/orders/specialized-command-race-convergence.spec.ts
@@ -1,0 +1,528 @@
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+} from '@nestjs/common';
+import { OrdersLifecycleService } from './orders-lifecycle.service';
+import { RoundOrderLifecycleService } from './round-order-lifecycle.service';
+import { SettlementsService } from '../settlements/settlements.service';
+
+type TestRecord = Record<string, unknown>;
+type TransactionCallback = (transaction: TestTransaction) => Promise<unknown>;
+type TransactionWrite = {
+  kind: 'set' | 'update';
+  path: string;
+  data: TestRecord;
+};
+type TestSnapshot = {
+  exists: boolean;
+  data: () => TestRecord | undefined;
+  ref: TestDocumentReference;
+};
+type TestDocumentReference = {
+  path: string;
+  get: () => Promise<TestSnapshot>;
+  update: (data: TestRecord) => Promise<void>;
+};
+type TestTransaction = {
+  get: (reference: TestDocumentReference) => Promise<TestSnapshot>;
+  set: (reference: TestDocumentReference, data: TestRecord) => void;
+  update: (reference: TestDocumentReference, data: TestRecord) => void;
+};
+
+const FIXED_NOW = new Date('2026-08-27T00:00:00.000Z');
+
+function copyRecord(record: TestRecord): TestRecord {
+  return { ...record };
+}
+
+function applyPatch(target: TestRecord, patch: TestRecord): TestRecord {
+  const next = { ...target };
+  for (const [key, value] of Object.entries(patch)) {
+    next[key] = value;
+  }
+  return next;
+}
+
+class FakeFirestore {
+  private readonly documents = new Map<string, { data: TestRecord; version: number }>();
+  private readonly references = new Map<string, TestDocumentReference>();
+  private beforeTransactionAttempt?: () => Promise<void> | void;
+
+  readonly transactionSets: string[] = [];
+  readonly transactionUpdates: Array<{ path: string; data: TestRecord }> = [];
+  readonly directUpdates: string[] = [];
+  readonly Timestamp = {
+    now: jest.fn(() => new Date(FIXED_NOW)),
+    fromDate: jest.fn((date: Date) => date),
+  };
+  readonly FieldValue = {
+    increment: jest.fn((amount: number) => ({ __increment: amount })),
+  };
+  readonly doc = jest.fn((path: string) => this.getReference(path));
+  readonly collection = jest.fn(() => ({
+    where: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    get: jest.fn(async () => ({ empty: true, docs: [] })),
+  }));
+  readonly runTransaction = jest.fn((callback: TransactionCallback): Promise<unknown> =>
+    this.executeTransaction(callback),
+  );
+
+  seed(path: string, data: TestRecord) {
+    this.documents.set(path, { data: copyRecord(data), version: 0 });
+  }
+
+  updateOutsideTransaction(path: string, data: TestRecord) {
+    this.writeUpdate(path, data, false);
+  }
+
+  setBeforeTransactionAttempt(hook: (() => Promise<void> | void) | undefined) {
+    this.beforeTransactionAttempt = hook;
+  }
+
+  getData(path: string): TestRecord | undefined {
+    const document = this.documents.get(path);
+    return document ? copyRecord(document.data) : undefined;
+  }
+
+  listData(prefix: string): TestRecord[] {
+    return [...this.documents.entries()]
+      .filter(([path]) => path.startsWith(prefix))
+      .map(([, document]) => copyRecord(document.data));
+  }
+
+  orderTransactionUpdates(path: string) {
+    return this.transactionUpdates.filter((write) => write.path === path);
+  }
+
+  private getReference(path: string): TestDocumentReference {
+    const existing = this.references.get(path);
+    if (existing) return existing;
+    const reference: TestDocumentReference = {
+      path,
+      get: () => Promise.resolve(this.readSnapshot(path, reference)),
+      update: (data) => Promise.resolve().then(() => this.writeUpdate(path, data, false)),
+    };
+    this.references.set(path, reference);
+    return reference;
+  }
+
+  private readSnapshot(path: string, reference = this.getReference(path)): TestSnapshot {
+    const document = this.documents.get(path);
+    const data = document ? copyRecord(document.data) : undefined;
+    return {
+      exists: document !== undefined,
+      data: () => data,
+      ref: reference,
+    };
+  }
+
+  private async executeTransaction(callback: TransactionCallback): Promise<unknown> {
+    for (let attempt = 0; attempt < 10; attempt += 1) {
+      if (this.beforeTransactionAttempt) {
+        const hook = this.beforeTransactionAttempt;
+        this.beforeTransactionAttempt = undefined;
+        await hook();
+      }
+
+      const readVersions = new Map<string, number>();
+      const writes: TransactionWrite[] = [];
+      const transaction: TestTransaction = {
+        get: (reference) => {
+          const document = this.documents.get(reference.path);
+          readVersions.set(reference.path, document?.version ?? 0);
+          const data = document ? copyRecord(document.data) : undefined;
+          return Promise.resolve({
+            exists: document !== undefined,
+            data: () => data,
+            ref: reference,
+          });
+        },
+        set: (reference, data) => {
+          writes.push({ kind: 'set', path: reference.path, data: copyRecord(data) });
+        },
+        update: (reference, data) => {
+          writes.push({ kind: 'update', path: reference.path, data: copyRecord(data) });
+        },
+      };
+
+      const result = await callback(transaction);
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      const conflicted = [...readVersions.entries()].some(
+        ([path, version]) => (this.documents.get(path)?.version ?? 0) !== version,
+      );
+      if (conflicted) continue;
+
+      for (const write of writes) {
+        if (write.kind === 'set') {
+          const previous = this.documents.get(write.path);
+          this.documents.set(write.path, {
+            data: copyRecord(write.data),
+            version: (previous?.version ?? 0) + 1,
+          });
+          this.transactionSets.push(write.path);
+          continue;
+        }
+        this.writeUpdate(write.path, write.data, true);
+      }
+      return result;
+    }
+    throw new Error('transaction retry limit exceeded');
+  }
+
+  private writeUpdate(path: string, data: TestRecord, fromTransaction: boolean) {
+    const document = this.documents.get(path);
+    if (!document) throw new Error(`missing document: ${path}`);
+    const nextData = applyPatch(document.data, data);
+    this.documents.set(path, { data: nextData, version: document.version + 1 });
+    if (fromTransaction) this.transactionUpdates.push({ path, data: copyRecord(data) });
+    else this.directUpdates.push(path);
+  }
+}
+
+function makeContext(options: {
+  order?: TestRecord;
+  store?: TestRecord;
+} = {}) {
+  const firestore = new FakeFirestore();
+  firestore.seed('stores/store-1', { id: 'store-1', ownerId: 'seller-1', ...(options.store ?? {}) });
+  firestore.seed('orders/order-1', {
+    id: 'order-1',
+    storeId: 'store-1',
+    userId: 'consumer-1',
+    status: 'HUB_ARRIVED',
+    pickupCode: '123456',
+    totalAmount: 50000,
+    ...(options.order ?? {}),
+  });
+  const configService = {
+    get: jest.fn((key: string) => {
+      if (key === 'PLATFORM_FEE_RATE') return '0.05';
+      if (key === 'SETTLEMENT_CONFIRM_DELAY_DAYS') return '1';
+      return undefined;
+    }),
+  };
+  const settlements = new SettlementsService(firestore as never, configService as never);
+  const notifications = {
+    sendToUser: jest.fn().mockResolvedValue(undefined),
+    sendToGroupParticipants: jest.fn().mockResolvedValue(undefined),
+  };
+  const payments = {
+    processRefundByOrderId: jest.fn().mockResolvedValue(undefined),
+    refundOrderChargesByOrderId: jest.fn().mockResolvedValue(undefined),
+  };
+  const capacity = {
+    releaseReservation: jest.fn().mockResolvedValue(undefined),
+    releaseReservationInTransaction: jest.fn().mockResolvedValue(undefined),
+  };
+  const roundLifecycle = new RoundOrderLifecycleService(
+    firestore as never,
+    payments as never,
+    settlements as never,
+    capacity as never,
+  );
+  const lifecycle = new OrdersLifecycleService(
+    firestore as never,
+    notifications as never,
+    payments as never,
+    settlements as never,
+    capacity as never,
+    roundLifecycle,
+  );
+  return { firestore, lifecycle, settlements };
+}
+
+describe('specialized command race convergence (review/confirm/hub-confirm)', () => {
+  it('A. reviewOrder normal success: DELIVERED → REVIEWED + settlement 1', async () => {
+    const context = makeContext({ order: { status: 'DELIVERED' } });
+
+    await expect(
+      context.lifecycle.reviewOrder('store-1', 'order-1', 'consumer-1'),
+    ).resolves.toEqual({ orderId: 'order-1', status: 'REVIEWED' });
+
+    expect(context.firestore.getData('orders/order-1')).toMatchObject({ status: 'REVIEWED' });
+    expect(context.firestore.orderTransactionUpdates('orders/order-1')).toHaveLength(1);
+    expect(context.firestore.directUpdates.filter((path) => path === 'orders/order-1')).toHaveLength(
+      0,
+    );
+    expect(context.firestore.listData('settlements/')).toHaveLength(1);
+    expect(context.firestore.getData('settlements/order-1')).toMatchObject({
+      orderId: 'order-1',
+      status: 'pending',
+      completedStatus: 'REVIEWED',
+    });
+  });
+
+  it('B. reviewOrder unauthorized consumer: 403 + side-effect 0', async () => {
+    const context = makeContext({ order: { status: 'DELIVERED' } });
+
+    await expect(
+      context.lifecycle.reviewOrder('store-1', 'order-1', 'consumer-other'),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+
+    expect(context.firestore.getData('orders/order-1')).toMatchObject({ status: 'DELIVERED' });
+    expect(context.firestore.orderTransactionUpdates('orders/order-1')).toHaveLength(0);
+    expect(context.firestore.listData('settlements/')).toHaveLength(0);
+  });
+
+  it('C. reviewOrder stale-state race: loser 409 + stale overwrite 없음', async () => {
+    const context = makeContext({ order: { status: 'DELIVERED' } });
+    context.firestore.setBeforeTransactionAttempt(() => {
+      context.firestore.updateOutsideTransaction('orders/order-1', { status: 'REVIEWED' });
+    });
+
+    await expect(
+      context.lifecycle.reviewOrder('store-1', 'order-1', 'consumer-1'),
+    ).rejects.toBeInstanceOf(ConflictException);
+
+    expect(context.firestore.getData('orders/order-1')).toMatchObject({ status: 'REVIEWED' });
+    expect(context.firestore.orderTransactionUpdates('orders/order-1')).toHaveLength(0);
+    expect(context.firestore.listData('settlements/')).toHaveLength(0);
+  });
+
+  it('D. concurrent reviewOrder: winner 1 x 200 + loser 409 + settlement 1', async () => {
+    const context = makeContext({ order: { status: 'DELIVERED' } });
+
+    const results = await Promise.allSettled([
+      context.lifecycle.reviewOrder('store-1', 'order-1', 'consumer-1'),
+      context.lifecycle.reviewOrder('store-1', 'order-1', 'consumer-1'),
+    ]);
+    const fulfilled = results.filter((result) => result.status === 'fulfilled');
+    const rejected = results.filter((result) => result.status === 'rejected');
+
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+    expect((rejected[0] as PromiseRejectedResult).reason).toBeInstanceOf(ConflictException);
+    expect(context.firestore.getData('orders/order-1')).toMatchObject({ status: 'REVIEWED' });
+    expect(context.firestore.orderTransactionUpdates('orders/order-1')).toHaveLength(1);
+    expect(context.firestore.listData('settlements/')).toHaveLength(1);
+  });
+
+  it('E. reviewOrder transition-success + settlement-failure + retry convergence', async () => {
+    const context = makeContext({ order: { status: 'DELIVERED' } });
+    const spy = jest
+      .spyOn(context.settlements, 'createSettlement')
+      .mockRejectedValueOnce(new Error('settlement infra down'));
+
+    await expect(
+      context.lifecycle.reviewOrder('store-1', 'order-1', 'consumer-1'),
+    ).rejects.toThrow('settlement infra down');
+    expect(context.firestore.getData('orders/order-1')).toMatchObject({ status: 'REVIEWED' });
+    expect(context.firestore.listData('settlements/')).toHaveLength(0);
+    spy.mockRestore();
+
+    await expect(
+      context.lifecycle.reviewOrder('store-1', 'order-1', 'consumer-1'),
+    ).rejects.toBeInstanceOf(BadRequestException);
+    expect(context.firestore.getData('orders/order-1')).toMatchObject({ status: 'REVIEWED' });
+    expect(context.firestore.listData('settlements/')).toHaveLength(1);
+    expect(context.firestore.getData('settlements/order-1')).toMatchObject({
+      status: 'pending',
+      completedStatus: 'REVIEWED',
+    });
+  });
+
+  it('F. confirmPickup normal success: HUB_ARRIVED → PICKED_UP + settlement 1', async () => {
+    const context = makeContext();
+
+    await expect(
+      context.lifecycle.confirmPickup('store-1', 'order-1', 'consumer-1', '123456'),
+    ).resolves.toEqual({ orderId: 'order-1', status: 'PICKED_UP' });
+
+    expect(context.firestore.getData('orders/order-1')).toMatchObject({ status: 'PICKED_UP' });
+    expect(context.firestore.orderTransactionUpdates('orders/order-1')).toHaveLength(1);
+    expect(context.firestore.directUpdates.filter((path) => path === 'orders/order-1')).toHaveLength(
+      0,
+    );
+    expect(context.firestore.listData('settlements/')).toHaveLength(1);
+    expect(context.firestore.getData('settlements/order-1')).toMatchObject({
+      completedStatus: 'PICKED_UP',
+    });
+  });
+
+  it('G. confirmPickup wrong pickupCode: 400 + side-effect 0', async () => {
+    const context = makeContext();
+
+    await expect(
+      context.lifecycle.confirmPickup('store-1', 'order-1', 'consumer-1', '000000'),
+    ).rejects.toBeInstanceOf(BadRequestException);
+
+    expect(context.firestore.getData('orders/order-1')).toMatchObject({ status: 'HUB_ARRIVED' });
+    expect(context.firestore.orderTransactionUpdates('orders/order-1')).toHaveLength(0);
+    expect(context.firestore.listData('settlements/')).toHaveLength(0);
+  });
+
+  it('H. confirmPickup wrong consumer: 403 + side-effect 0', async () => {
+    const context = makeContext();
+
+    await expect(
+      context.lifecycle.confirmPickup('store-1', 'order-1', 'consumer-other', '123456'),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+
+    expect(context.firestore.getData('orders/order-1')).toMatchObject({ status: 'HUB_ARRIVED' });
+    expect(context.firestore.orderTransactionUpdates('orders/order-1')).toHaveLength(0);
+    expect(context.firestore.listData('settlements/')).toHaveLength(0);
+  });
+
+  it('I. confirmPickup stale HUB_ARRIVED race: loser 409', async () => {
+    const context = makeContext();
+    context.firestore.setBeforeTransactionAttempt(() => {
+      context.firestore.updateOutsideTransaction('orders/order-1', { status: 'PICKED_UP' });
+    });
+
+    await expect(
+      context.lifecycle.confirmPickup('store-1', 'order-1', 'consumer-1', '123456'),
+    ).rejects.toBeInstanceOf(ConflictException);
+
+    expect(context.firestore.getData('orders/order-1')).toMatchObject({ status: 'PICKED_UP' });
+    expect(context.firestore.orderTransactionUpdates('orders/order-1')).toHaveLength(0);
+    expect(context.firestore.listData('settlements/')).toHaveLength(0);
+  });
+
+  it('J. concurrent confirmPickup: winner 1 x 200 + loser 409 + settlement 1', async () => {
+    const context = makeContext();
+
+    const results = await Promise.allSettled([
+      context.lifecycle.confirmPickup('store-1', 'order-1', 'consumer-1', '123456'),
+      context.lifecycle.confirmPickup('store-1', 'order-1', 'consumer-1', '123456'),
+    ]);
+    const fulfilled = results.filter((result) => result.status === 'fulfilled');
+    const rejected = results.filter((result) => result.status === 'rejected');
+
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+    expect((rejected[0] as PromiseRejectedResult).reason).toBeInstanceOf(ConflictException);
+    expect(context.firestore.getData('orders/order-1')).toMatchObject({ status: 'PICKED_UP' });
+    expect(context.firestore.orderTransactionUpdates('orders/order-1')).toHaveLength(1);
+    expect(context.firestore.listData('settlements/')).toHaveLength(1);
+  });
+
+  it('K. hubConfirmPickup normal success: seller owner HUB_ARRIVED → PICKED_UP', async () => {
+    const context = makeContext();
+
+    await expect(
+      context.lifecycle.hubConfirmPickup('store-1', 'order-1', 'seller-1', '123456'),
+    ).resolves.toEqual({ orderId: 'order-1', status: 'PICKED_UP' });
+
+    expect(context.firestore.getData('orders/order-1')).toMatchObject({ status: 'PICKED_UP' });
+    expect(context.firestore.orderTransactionUpdates('orders/order-1')).toHaveLength(1);
+    expect(context.firestore.listData('settlements/')).toHaveLength(1);
+  });
+
+  it('L. hubConfirmPickup non-owner seller: 403 + side-effect 0', async () => {
+    const context = makeContext();
+
+    await expect(
+      context.lifecycle.hubConfirmPickup('store-1', 'order-1', 'seller-other', '123456'),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+
+    expect(context.firestore.getData('orders/order-1')).toMatchObject({ status: 'HUB_ARRIVED' });
+    expect(context.firestore.orderTransactionUpdates('orders/order-1')).toHaveLength(0);
+    expect(context.firestore.listData('settlements/')).toHaveLength(0);
+  });
+
+  it('M. hubConfirmPickup wrong pickupCode: 400 + side-effect 0', async () => {
+    const context = makeContext();
+
+    await expect(
+      context.lifecycle.hubConfirmPickup('store-1', 'order-1', 'seller-1', '000000'),
+    ).rejects.toBeInstanceOf(BadRequestException);
+
+    expect(context.firestore.getData('orders/order-1')).toMatchObject({ status: 'HUB_ARRIVED' });
+    expect(context.firestore.orderTransactionUpdates('orders/order-1')).toHaveLength(0);
+    expect(context.firestore.listData('settlements/')).toHaveLength(0);
+  });
+
+  it('N. hubConfirmPickup stale HUB_ARRIVED race: loser 409', async () => {
+    const context = makeContext();
+    context.firestore.setBeforeTransactionAttempt(() => {
+      context.firestore.updateOutsideTransaction('orders/order-1', { status: 'PICKED_UP' });
+    });
+
+    await expect(
+      context.lifecycle.hubConfirmPickup('store-1', 'order-1', 'seller-1', '123456'),
+    ).rejects.toBeInstanceOf(ConflictException);
+
+    expect(context.firestore.getData('orders/order-1')).toMatchObject({ status: 'PICKED_UP' });
+    expect(context.firestore.orderTransactionUpdates('orders/order-1')).toHaveLength(0);
+    expect(context.firestore.listData('settlements/')).toHaveLength(0);
+  });
+
+  it('O. confirmPickup vs hubConfirmPickup concurrent race: PICKED_UP 1회 + settlement 1', async () => {
+    const context = makeContext();
+
+    const results = await Promise.allSettled([
+      context.lifecycle.confirmPickup('store-1', 'order-1', 'consumer-1', '123456'),
+      context.lifecycle.hubConfirmPickup('store-1', 'order-1', 'seller-1', '123456'),
+    ]);
+    const fulfilled = results.filter((result) => result.status === 'fulfilled');
+    const rejected = results.filter((result) => result.status === 'rejected');
+
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+    expect((rejected[0] as PromiseRejectedResult).reason).toBeInstanceOf(ConflictException);
+    expect(context.firestore.getData('orders/order-1')).toMatchObject({ status: 'PICKED_UP' });
+    expect(context.firestore.orderTransactionUpdates('orders/order-1')).toHaveLength(1);
+    expect(context.firestore.listData('settlements/')).toHaveLength(1);
+  });
+
+  it('P. PICKED_UP sequential duplicate converges settlement once without overwrite', async () => {
+    const context = makeContext();
+
+    await expect(
+      context.lifecycle.confirmPickup('store-1', 'order-1', 'consumer-1', '123456'),
+    ).resolves.toEqual({ orderId: 'order-1', status: 'PICKED_UP' });
+    const first = context.firestore.getData('settlements/order-1');
+
+    await expect(
+      context.lifecycle.hubConfirmPickup('store-1', 'order-1', 'seller-1', '123456'),
+    ).rejects.toBeInstanceOf(BadRequestException);
+
+    expect(context.firestore.getData('orders/order-1')).toMatchObject({ status: 'PICKED_UP' });
+    expect(context.firestore.orderTransactionUpdates('orders/order-1')).toHaveLength(1);
+    expect(context.firestore.listData('settlements/')).toHaveLength(1);
+    expect(context.firestore.getData('settlements/order-1')).toEqual(first);
+  });
+
+  it('Q. pickup settlement post-effect failure retry converges', async () => {
+    const context = makeContext();
+    const spy = jest
+      .spyOn(context.settlements, 'createSettlement')
+      .mockRejectedValueOnce(new Error('settlement infra down'));
+
+    await expect(
+      context.lifecycle.confirmPickup('store-1', 'order-1', 'consumer-1', '123456'),
+    ).rejects.toThrow('settlement infra down');
+    expect(context.firestore.getData('orders/order-1')).toMatchObject({ status: 'PICKED_UP' });
+    expect(context.firestore.listData('settlements/')).toHaveLength(0);
+    spy.mockRestore();
+
+    await expect(
+      context.lifecycle.confirmPickup('store-1', 'order-1', 'consumer-1', '123456'),
+    ).rejects.toBeInstanceOf(BadRequestException);
+    expect(context.firestore.listData('settlements/')).toHaveLength(1);
+    expect(context.firestore.getData('settlements/order-1')).toMatchObject({
+      status: 'pending',
+      completedStatus: 'PICKED_UP',
+    });
+  });
+
+  it('S6. REVIEWED retry does not overwrite DELIVERED-stage settlement snapshot', async () => {
+    const context = makeContext({ order: { status: 'PICKED_UP' } });
+    await context.settlements.createSettlement(
+      { id: 'order-1', storeId: 'store-1', status: 'DELIVERED', totalAmount: 50000 },
+      'DELIVERED',
+    );
+    const first = context.firestore.getData('settlements/order-1');
+    expect(first).toMatchObject({ completedStatus: 'DELIVERED' });
+
+    await expect(
+      context.lifecycle.reviewOrder('store-1', 'order-1', 'consumer-1'),
+    ).resolves.toEqual({ orderId: 'order-1', status: 'REVIEWED' });
+
+    expect(context.firestore.listData('settlements/')).toHaveLength(1);
+    expect(context.firestore.getData('settlements/order-1')).toEqual(first);
+  });
+});

--- a/docs/specs/api/orders.md
+++ b/docs/specs/api/orders.md
@@ -204,6 +204,28 @@ admin force-refund 우회는 `ADMIN-FORCE-REFUND-CONSISTENCY`를 따른다.
 - group scheduler(`confirmGroupBuy`/`cancelGroupBuyLack`)는 active cancellation ownership을 transaction fresh 재확인으로 존중하고 broadcast에서 제외한다.
 - 증거: `apps/api/src/orders/orders-lifecycle.service.ts`, `apps/api/src/notifications/notifications.service.ts`, `apps/api/src/orders/legacy-consumer-cancel-convergence.spec.ts`(`8 tests`).
 
+### 8B. Specialized pickup/review commands — `IMPLEMENTATION COMPLETE`
+
+- 대상: `OrdersLifecycleService.reviewOrder`(`DELIVERED|PICKED_UP → REVIEWED`),
+  `confirmPickup`(`HUB_ARRIVED → PICKED_UP`, consumer ownership + `pickupCode`),
+  `hubConfirmPickup`(`HUB_ARRIVED → PICKED_UP`, seller store ownership + `pickupCode`).
+- stale read는 fast `404`/`403` + entry-status capture에만 사용하고, mutation 권한은
+  transaction 내부의 fresh snapshot으로 다시 검증한다
+  (`storeId`, consumer `userId`/seller store `ownerId`, fresh status, fresh `pickupCode`).
+- fresh expected-status compare-and-set로 stale overwrite를 차단한다.
+  `confirmPickup`과 `hubConfirmPickup`은 같은 `HUB_ARRIVED → PICKED_UP` CAS를 공유하므로
+  동시 경쟁에서도 `PICKED_UP` 전이는 정확히 한 번만 발생한다.
+- sequential duplicate(entry도 이미 target)는 settlement를 idempotent하게 수렴시킨 뒤
+  기존 `400 BadRequest` 계약을 유지한다. race loser(entry eligible + fresh 이동)는
+  order write 없이 `409 Conflict`로 종료하며 settlement를 호출하지 않는다(generic §12 loser convention).
+- transition commit 뒤 `createSettlement`가 실패하면 주문은 target에 남고 에러가 전파되며,
+  후속 retry(sequential duplicate 경로)가 settlement를 보완한다.
+- settlement는 기존 `SettlementsService.createSettlement`의 `settlements/{orderId}`
+  transactional idempotency를 재사용한다. 이미 존재하면 최초 snapshot을 보존하므로
+  `REVIEWED` retry가 `DELIVERED`/`PICKED_UP` 단계 snapshot을 다시 쓰지 않는다.
+- 증거: `apps/api/src/orders/orders-lifecycle.service.ts`,
+  `apps/api/src/orders/specialized-command-race-convergence.spec.ts`(`18 tests`).
+
 ## 9. 배송 사진
 
 회차 직배송 사진은 담당 기사가 서버 API로 비공개 Storage에 업로드하며 사진 연결 없이 직접배송 `DELIVERED` 완료를 허용하지 않는다. read URL은 주문 권한 검증 뒤 단기 signed URL로 발급한다.


### PR DESCRIPTION
TASK_ID: ORDER-SPECIALIZED-COMMAND-RACE-CONVERGENCE-01

Converges legacy specialized order commands (reviewOrder, confirmPickup, hubConfirmPickup) from stale-read/plain-write to fresh expected-status transaction + duplicate/race-safe settlement convergence.

Delta (owned paths only, based on live main f49e37f7):
- apps/api/src/orders/orders-lifecycle.service.ts — three commands revalidate storeId/userId|store-owner/status/pickupCode on the fresh transaction snapshot; stale/race loser 409, sequential duplicate converges settlement then keeps current 400 contract; winner commits then createSettlement (failure propagates, retry converges).
- apps/api/src/orders/specialized-command-race-convergence.spec.ts — 18 focused tests (normal/auth/stale-race/concurrent/cross-command/failure-retry/settlement-once/S6 snapshot preservation). PASS.
- docs/specs/api/orders.md — Section 8B IMPLEMENTATION COMPLETE + changelog row.

Reuses existing SettlementsService.createSettlement orderId transactional idempotency (no new lock/framework). No generic/round rewrite. Frontend error buckets unchanged (400/403/409 all map to rejected).

Verify: focused 18 PASS; related suites (order-mutation-authorization, orders-duplicate-contract, legacy-consumer-cancel-convergence, settlements-lifecycle, mvp-order-flow, driver-command-error-contract) PASS; git diff --check clean; API tsc owned diagnostics 0 (8 baseline errors in untouched orders-duplicate-contract.spec.ts).

Admission PRE_PR: PUBLICATION_ALLOWED (candidate d620e6c9 vs live f49e37f7). Live movement since handoff (6f114a94..f49e37f7) is driver error-code + publication-transport infra — UNRELATED_SEMANTIC.