### PR TITLE
fix(api): isolate unit Jest from developer dotenv via repository-owned env contract

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -85,6 +85,7 @@
       "**/*.(t|j)s"
     ],
     "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "setupFiles": ["<rootDir>/unit-test-setup.ts"]
   }
 }

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -9,7 +9,7 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { AuthModule } from './auth/auth.module';
 import { AuditModule } from './common/audit/audit.module';
-import { shouldEnableScheduledJobs, validateRuntimeConfig } from './config/runtime-config';
+import { shouldEnableScheduledJobs, validateRuntimeConfig, isApiUnitTestEnv } from './config/runtime-config';
 import { DriverModule } from './driver/driver.module';
 import { FirestoreModule } from './firestore/firestore.module';
 import { HubsModule } from './hubs/hubs.module';
@@ -24,7 +24,11 @@ import { SettlementsModule } from './settlements/settlements.module';
 import { StoresModule } from './stores/stores.module';
 import { VarietiesModule } from './varieties/varieties.module';
 
-const configModule = ConfigModule.forRoot({ isGlobal: true, validate: validateRuntimeConfig });
+const configModule = ConfigModule.forRoot({
+  isGlobal: true,
+  validate: validateRuntimeConfig,
+  ignoreEnvFile: isApiUnitTestEnv(process.env),
+});
 const scheduleModule = shouldEnableScheduledJobs(process.env)
   ? ScheduleModule.forRoot()
   : undefined;

--- a/apps/api/src/config/runtime-config.ts
+++ b/apps/api/src/config/runtime-config.ts
@@ -57,6 +57,10 @@ export function isLocalRuntime(values: RuntimeConfigValues): boolean {
   return readString(values, 'GREENHUB_LOCAL_RUNTIME') === 'true';
 }
 
+export function isApiUnitTestEnv(values: RuntimeConfigValues = process.env): boolean {
+  return readString(values, 'GREENHUB_API_UNIT_TEST') === 'true';
+}
+
 export function shouldEnableScheduledJobs(values: RuntimeConfigValues = process.env): boolean {
   return readString(values, 'GREENHUB_SCHEDULES_ENABLED') !== 'false';
 }

--- a/apps/api/src/unit-test-setup.ts
+++ b/apps/api/src/unit-test-setup.ts
@@ -1,0 +1,26 @@
+// Repository-owned API unit-test env contract.
+//
+// Loaded via unit Jest `setupFiles`, before any test module (including
+// AppModule) is imported. Guarantees unit results are independent of the
+// developer's `apps/api/.env` and host shell authority.
+//
+// Contract:
+// - Sets an explicit unit-only marker (`GREENHUB_API_UNIT_TEST=true`).
+//   `AppModule` enables `ConfigModule.ignoreEnvFile` only for this marker,
+//   so E2E / development / production env-file semantics are unchanged.
+// - Pins a deterministic non-production Firebase identity.
+// - Removes host authority that could make the runtime look like production
+//   or load real credentials into unit tests.
+// - Never reads or prints secrets.
+process.env.GREENHUB_API_UNIT_TEST = 'true';
+process.env.NODE_ENV = 'test';
+process.env.FIREBASE_PROJECT_ID = 'greenhub-api-unit-test';
+process.env.FIREBASE_STORAGE_BUCKET = 'greenhub-api-unit-test.appspot.com';
+
+delete process.env.RAILWAY_ENVIRONMENT_NAME;
+delete process.env.VERCEL_ENV;
+delete process.env.GREENHUB_LOCAL_RUNTIME;
+delete process.env.FIRESTORE_EMULATOR_HOST;
+delete process.env.FIREBASE_AUTH_EMULATOR_HOST;
+delete process.env.FIREBASE_SERVICE_ACCOUNT_JSON;
+delete process.env.GOOGLE_APPLICATION_CREDENTIALS;


### PR DESCRIPTION
## Purpose (single purpose only) API unit test가 개발자 로컬 apps/api/.env 또는 production-valued shell/runtime authority를 읽어 테스트 결과가 머신별로 달라지는 문제를 제거한다. ## Owned paths (exact candidate 657a9e6e) - apps/api/src/config/runtime-config.ts: isApiUnitTestEnv() 추가 (GREENHUB_API_UNIT_TEST=true marker 판정) - apps/api/src/app.module.ts: ConfigModule ignoreEnvFile=isApiUnitTestEnv(process.env) — unit test에서만 local .env loading 차단 - apps/api/package.json: unit Jest에만 setupFiles [<rootDir>/unit-test-setup.ts] 추가 - apps/api/src/unit-test-setup.ts (new): unit-only env contract ## Unit-only marker - GREENHUB_API_UNIT_TEST=true (unit setup에서만 설정, production/runtime 코드에서 설정하지 않음) ## Deterministic Firebase test identity (unit setup) - FIREBASE_PROJECT_ID=greenhub-api-unit-test - FIREBASE_STORAGE_BUCKET=greenhub-api-unit-test.appspot.com - NODE_ENV=test ## Production authority sanitization (unit setup에서 delete) - RAILWAY_ENVIRONMENT_NAME, VERCEL_ENV, GREENHUB_LOCAL_RUNTIME, FIRESTORE_EMULATOR_HOST, FIREBASE_AUTH_EMULATOR_HOST, FIREBASE_SERVICE_ACCOUNT_JSON, GOOGLE_APPLICATION_CREDENTIALS - secrets를 읽거나 출력하지 않음 ## ConfigModule ignoreEnvFile boundary - unit marker일 때만 ignoreEnvFile=true - E2E/development/production의 env-file semantics 변경 없음 ## E2E config non-regression - apps/api/test/jest-e2e.json: setupFiles 없음 (변경 없음) - unit Jest(package.json jest.setupFiles)만 적용 ## Proof (prior task API-TEST-ENV-ISOLATION-REMEDIATION-01, COMPLETE_VERIFIED_PUBLICATION_DEFERRED; live movement는 docs-only이므로 proof 재사용) - targeted AppModule/runtime: 4 suites / 28 tests PASS - production-valued temporary apps/api/.env 존재: targeted 28/28 PASS - 동일 .env 상태 full API unit: 63 suites / 700 tests PASS - apps/api/.env 없음 full API unit: 63 suites / 700 tests PASS - hostile shell production authority: relevant AppModule specs PASS - runtime config fail-closed regression: PASS - pnpm --filter api build: PASS - PRE_PR admission (live e765d8e4 vs candidate 657a9e6e): PUBLICATION_ALLOWED ## Transport - exact SHA 657a9e6ea13c5fc8d3e40796afb273d4e4c3fc2d -> tmp/api-test-env-isolation-publication (worktree-checkout-free push, no rewrite) - merge-base(live, candidate)=2d646aab; live-side delta는 docs/specs/api/orders.md 등 unrelated only