### PR TITLE
converge(public-catalog): close anonymous Firestore direct-read boundary on API projections

### DIFF
--- a/apps/api/src/products/product-visibility.spec.ts
+++ b/apps/api/src/products/product-visibility.spec.ts
@@ -1,0 +1,107 @@
+import {
+  isPubliclyVisibleProduct,
+  toPublicGroupConfig,
+  toPublicGroupSummary,
+  toPublicProductDetail,
+  toPublicProductSummary,
+} from './product-visibility';
+
+describe('public visibility canonical predicate', () => {
+  it('isActive true + testOnly not true만 공개한다', () => {
+    expect(isPubliclyVisibleProduct({ isActive: true } as never)).toBe(true);
+    expect(isPubliclyVisibleProduct({ isActive: true, testOnly: false } as never)).toBe(true);
+    expect(isPubliclyVisibleProduct({ isActive: false } as never)).toBe(false);
+    expect(isPubliclyVisibleProduct({ isActive: true, testOnly: true } as never)).toBe(false);
+    expect(isPubliclyVisibleProduct({} as never)).toBe(false);
+    expect(isPubliclyVisibleProduct(null)).toBe(false);
+  });
+});
+
+describe('public product projection', () => {
+  const stored = {
+    id: 'p-1',
+    storeId: 's-1',
+    name: '공개 상품',
+    images: ['https://example.com/a.jpg', 'https://example.com/b.jpg'],
+    price: 10000,
+    category: 'cut_flower',
+    saleType: 'normal',
+    deliverySize: 'small',
+    isActive: true,
+    testOnly: false,
+    sellerNote: '내부 메모',
+    sellerOverride: true,
+    content: { headline: '제목', description: '설명', isEditedByUser: true },
+    varietyId: 'v-1',
+    selection: { colors: ['레드'] },
+    createdAt: '2026-09-01T00:00:00.000Z',
+    updatedAt: '2026-09-02T00:00:00.000Z',
+  };
+
+  it('detail에서 내부 필드를 제거한다', () => {
+    const detail = toPublicProductDetail(stored as never, null) as Record<string, unknown>;
+    expect(detail).not.toHaveProperty('sellerNote');
+    expect(detail).not.toHaveProperty('sellerOverride');
+    expect(detail).not.toHaveProperty('testOnly');
+    expect(detail['content']).toEqual({ headline: '제목', description: '설명' });
+    expect(detail['id']).toBe('p-1');
+    expect(detail['storeId']).toBe('s-1');
+    expect(detail['varietyId']).toBe('v-1');
+  });
+
+  it('summary는 allowlist만 반환하고 원문을 spread하지 않는다', () => {
+    const summary = toPublicProductSummary(stored as never, null) as Record<string, unknown>;
+    expect(Object.keys(summary).sort()).toEqual(
+      ['category', 'colors', 'id', 'images', 'isActive', 'name', 'price', 'saleType'].sort(),
+    );
+    expect(summary).not.toHaveProperty('sellerNote');
+    expect(summary).not.toHaveProperty('content');
+    expect(summary['images']).toEqual(['https://example.com/a.jpg']);
+  });
+
+  it('group summary/detail에서 isProcessed를 제거한다', () => {
+    const gc = {
+      productId: 'p-1',
+      minQuantity: 5,
+      targetQuantity: 10,
+      maxPerPerson: 2,
+      recruitDeadline: '2026-09-10T00:00:00.000Z',
+      currentQuantity: 3,
+      groupDeliveryDate: '2026-09-15T00:00:00.000Z',
+      groupDeliveryMethod: 'direct',
+      deliveryFeeDiscount: 0,
+      isProcessed: true,
+    };
+    const summary = toPublicGroupSummary(gc as never);
+    expect(summary).not.toHaveProperty('isProcessed');
+    expect(summary).toEqual({
+      currentQuantity: 3,
+      minQuantity: 5,
+      targetQuantity: 10,
+      recruitDeadline: '2026-09-10T00:00:00.000Z',
+    });
+
+    const config = toPublicGroupConfig(gc as never) as unknown as Record<string, unknown>;
+    expect(config).not.toHaveProperty('isProcessed');
+    expect(config['productId']).toBe('p-1');
+    expect(config['currentQuantity']).toBe(3);
+  });
+
+  it('Firestore Timestamp를 ISO로 정규화한다', () => {
+    const gc = {
+      productId: 'p-1',
+      minQuantity: 1,
+      targetQuantity: 2,
+      maxPerPerson: 1,
+      recruitDeadline: { toDate: () => new Date('2026-09-10T00:00:00.000Z') },
+      currentQuantity: 0,
+      groupDeliveryDate: { toDate: () => new Date('2026-09-15T00:00:00.000Z') },
+      groupDeliveryMethod: 'direct',
+      deliveryFeeDiscount: 0,
+      isProcessed: false,
+    };
+    const config = toPublicGroupConfig(gc as never) as unknown as Record<string, unknown>;
+    expect(config['recruitDeadline']).toBe('2026-09-10T00:00:00.000Z');
+    expect(config['groupDeliveryDate']).toBe('2026-09-15T00:00:00.000Z');
+  });
+});

--- a/apps/api/src/products/product-visibility.ts
+++ b/apps/api/src/products/product-visibility.ts
@@ -1,0 +1,190 @@
+/**
+ * Public catalog visibility — single semantic owner.
+ *
+ * Canonical public predicate (anonymous product APIs):
+ *   isActive === true AND testOnly !== true
+ *
+ * All anonymous product reads (GET /products, GET /products/:id,
+ * GET /stores/:storeId/products, GET /stores/:storeId/products/:productId)
+ * must enforce this predicate and return only the explicit public projection.
+ *
+ * Seller owner/internal reads use the separate owner path and are NOT
+ * filtered/projected here.
+ */
+
+export interface PublicContent {
+  headline: string;
+  description: string;
+}
+
+export interface PublicGroupSummary {
+  currentQuantity: number;
+  minQuantity: number;
+  targetQuantity: number;
+  recruitDeadline: string | null;
+}
+
+export interface PublicGroupConfig {
+  productId: string;
+  minQuantity: number;
+  targetQuantity: number;
+  maxPerPerson: number;
+  recruitDeadline: string | null;
+  currentQuantity: number;
+  groupDeliveryDate: string | null;
+  groupDeliveryMethod: 'direct' | 'parcel';
+  deliveryFeeDiscount: number;
+}
+
+export function isPubliclyVisibleProduct(
+  data: Record<string, unknown> | null | undefined,
+): boolean {
+  if (!data) return false;
+  return data['isActive'] === true && data['testOnly'] !== true;
+}
+
+export function toIsoOrNull(value: unknown): string | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value === 'string') return value;
+  if (value instanceof Date) return value.toISOString();
+  if (typeof (value as { toDate?: () => Date }).toDate === 'function') {
+    return (value as { toDate: () => Date }).toDate().toISOString();
+  }
+  if (typeof value === 'object' && value !== null && 'seconds' in value) {
+    const seconds = (value as { seconds: number }).seconds;
+    if (typeof seconds === 'number') return new Date(seconds * 1000).toISOString();
+  }
+  return null;
+}
+
+function toIsoOrOriginal(value: unknown): unknown {
+  if (value === null || value === undefined) return value;
+  if (typeof value === 'string') return value;
+  const iso = toIsoOrNull(value);
+  return iso ?? value;
+}
+
+export function toPublicGroupSummary(
+  gc: Record<string, unknown>,
+): PublicGroupSummary {
+  return {
+    currentQuantity: (gc['currentQuantity'] as number) ?? 0,
+    minQuantity: (gc['minQuantity'] as number) ?? 0,
+    targetQuantity: (gc['targetQuantity'] as number) ?? 0,
+    recruitDeadline: toIsoOrNull(gc['recruitDeadline']),
+  };
+}
+
+export function toPublicGroupConfig(
+  gc: Record<string, unknown>,
+): PublicGroupConfig {
+  return {
+    productId: String(gc['productId'] ?? ''),
+    minQuantity: (gc['minQuantity'] as number) ?? 0,
+    targetQuantity: (gc['targetQuantity'] as number) ?? 0,
+    maxPerPerson: (gc['maxPerPerson'] as number) ?? 0,
+    recruitDeadline: toIsoOrNull(gc['recruitDeadline']),
+    currentQuantity: (gc['currentQuantity'] as number) ?? 0,
+    groupDeliveryDate: toIsoOrNull(gc['groupDeliveryDate']),
+    groupDeliveryMethod: gc['groupDeliveryMethod'] === 'parcel' ? 'parcel' : 'direct',
+    deliveryFeeDiscount: (gc['deliveryFeeDiscount'] as number) ?? 0,
+  };
+}
+
+function readColors(p: Record<string, unknown>): unknown[] {
+  const selection = p['selection'] as Record<string, unknown> | undefined;
+  if (Array.isArray(selection?.['colors'])) return selection['colors'] as unknown[];
+  if (Array.isArray(p['colors'])) return p['colors'] as unknown[];
+  return [];
+}
+
+function toPublicContent(
+  content: unknown,
+): PublicContent | undefined {
+  if (!content || typeof content !== 'object') return undefined;
+  const c = content as Record<string, unknown>;
+  if (typeof c['headline'] !== 'string' || typeof c['description'] !== 'string') {
+    return undefined;
+  }
+  // Explicitly drop content.isEditedByUser (internal).
+  return { headline: c['headline'] as string, description: c['description'] as string };
+}
+
+/**
+ * Public list summary — allowlist only.
+ * Never spreads the stored document.
+ */
+export function toPublicProductSummary(
+  p: Record<string, unknown>,
+  groupConfig?: Record<string, unknown> | null,
+  opts: { includeStoreId?: boolean } = {},
+): Record<string, unknown> {
+  const summary: Record<string, unknown> = {
+    id: p['id'],
+    name: p['name'],
+    price: p['price'],
+    images: Array.isArray(p['images']) ? [(p['images'] as unknown[])[0]] : [],
+    category: p['category'],
+    colors: readColors(p),
+    saleType: p['saleType'],
+    isActive: p['isActive'],
+  };
+  if (opts.includeStoreId) summary['storeId'] = p['storeId'];
+  if (p['saleType'] === 'group' && groupConfig) {
+    summary['groupSummary'] = toPublicGroupSummary(groupConfig);
+  }
+  return summary;
+}
+
+/**
+ * Public detail — allowlist only.
+ * Drops: sellerNote, sellerOverride, content.isEditedByUser, testOnly,
+ * internal timestamps (raw), groupProductConfig.isProcessed.
+ */
+export function toPublicProductDetail(
+  p: Record<string, unknown>,
+  groupConfig?: Record<string, unknown> | null,
+): Record<string, unknown> {
+  const detail: Record<string, unknown> = {
+    id: p['id'],
+    storeId: p['storeId'],
+    name: p['name'],
+    images: Array.isArray(p['images']) ? p['images'] : [],
+    price: p['price'],
+    category: p['category'],
+    saleType: p['saleType'],
+    deliverySize: p['deliverySize'],
+    isActive: p['isActive'],
+    createdAt: toIsoOrOriginal(p['createdAt']),
+    updatedAt: toIsoOrOriginal(p['updatedAt']),
+  };
+  if (p['varietyId'] !== undefined) detail['varietyId'] = p['varietyId'];
+  if (p['selection'] !== undefined) detail['selection'] = p['selection'];
+  // Legacy compat fields (non-sensitive).
+  if (p['description'] !== undefined) detail['description'] = p['description'];
+  if (p['colors'] !== undefined) detail['colors'] = p['colors'];
+  const content = toPublicContent(p['content']);
+  if (content) detail['content'] = content;
+  if (groupConfig) {
+    detail['groupConfig'] = toPublicGroupConfig(groupConfig);
+  }
+  return detail;
+}
+
+/**
+ * Owner/internal detail — full fidelity for seller mutation/read flows.
+ * No visibility filtering, no public projection. Timestamp normalization
+ * for groupConfig dates only (matches historical behavior).
+ */
+export function toOwnerProductDetail(
+  p: Record<string, unknown>,
+  groupConfig?: Record<string, unknown> | null,
+): Record<string, unknown> {
+  if (!groupConfig) return { ...p };
+  const gc: Record<string, unknown> = { ...groupConfig };
+  const rd = gc['recruitDeadline'] as { toDate?: () => Date };
+  const gd = gc['groupDeliveryDate'] as { toDate?: () => Date };
+  if (typeof rd?.toDate === 'function') gc['recruitDeadline'] = rd.toDate().toISOString();
+  if (typeof gd?.toDate === 'function') gc['groupDeliveryDate'] = gd.toDate().toISOString();
+  return { ...p, groupConfig: gc };
+}

--- a/apps/api/src/products/products.controller.ts
+++ b/apps/api/src/products/products.controller.ts
@@ -32,6 +32,17 @@ export class ProductsController {
     return this.productsService.getProducts(storeId, query);
   }
 
+  @Get(':productId/owner')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('seller', 'admin')
+  getOwnerProduct(
+    @Param('storeId') storeId: string,
+    @Param('productId') productId: string,
+    @CurrentUser() user: JwtPayload,
+  ) {
+    return this.productsService.getOwnerProduct(storeId, productId, user.sub, user.role);
+  }
+
   @Get(':productId')
   getProduct(@Param('storeId') storeId: string, @Param('productId') productId: string) {
     return this.productsService.getProduct(storeId, productId);

--- a/apps/api/src/products/products.service.spec.ts
+++ b/apps/api/src/products/products.service.spec.ts
@@ -46,8 +46,22 @@ describe('공개 상품 API', () => {
     await expect(service.getPublicProduct(product.id)).rejects.toBeInstanceOf(NotFoundException);
   });
 
-  it('활성 공개 상품 상세는 그대로 반환한다', async () => {
-    const product = { id: 'public-001', isActive: true, saleType: 'normal', name: '공개 상품' };
+  it('활성 공개 상품 상세는 public projection으로 반환한다', async () => {
+    const product = {
+      id: 'public-001',
+      storeId: 'store-1',
+      isActive: true,
+      saleType: 'normal',
+      name: '공개 상품',
+      images: ['https://example.com/a.jpg'],
+      price: 10000,
+      category: 'cut_flower',
+      deliverySize: 'small',
+      sellerNote: '내부 메모',
+      sellerOverride: true,
+      testOnly: false,
+      content: { headline: '제목', description: '설명', isEditedByUser: true },
+    };
     const firestore = {
       doc: jest.fn().mockReturnValue({
         get: jest.fn().mockResolvedValue({ exists: true, data: () => product }),
@@ -55,7 +69,174 @@ describe('공개 상품 API', () => {
     };
     const service = new ProductsService(firestore as never);
 
-    await expect(service.getPublicProduct(product.id)).resolves.toEqual(product);
+    const detail = (await service.getPublicProduct(product.id)) as Record<string, unknown>;
+    expect(detail).not.toHaveProperty('sellerNote');
+    expect(detail).not.toHaveProperty('sellerOverride');
+    expect(detail).not.toHaveProperty('testOnly');
+    expect(detail['content']).toEqual({ headline: '제목', description: '설명' });
+    expect(detail['id']).toBe('public-001');
+  });
+
+  it('public group detail에서 isProcessed를 제거한다', async () => {
+    const product = {
+      id: 'group-001',
+      storeId: 'store-1',
+      isActive: true,
+      saleType: 'group',
+      name: '공구 상품',
+      images: [],
+      price: 5000,
+      category: 'cut_flower',
+      deliverySize: 'small',
+    };
+    const groupConfig = {
+      productId: 'group-001',
+      minQuantity: 5,
+      targetQuantity: 10,
+      maxPerPerson: 2,
+      recruitDeadline: '2026-09-10T00:00:00.000Z',
+      currentQuantity: 3,
+      groupDeliveryDate: '2026-09-15T00:00:00.000Z',
+      groupDeliveryMethod: 'direct',
+      deliveryFeeDiscount: 0,
+      isProcessed: true,
+    };
+    const firestore = {
+      doc: jest.fn((path: string) => ({
+        get: jest.fn().mockResolvedValue({
+          exists: true,
+          data: () => (path === 'products/group-001' ? product : groupConfig),
+        }),
+      })),
+    };
+    const service = new ProductsService(firestore as never);
+
+    const detail = (await service.getPublicProduct('group-001')) as Record<string, unknown>;
+    const gc = detail['groupConfig'] as Record<string, unknown>;
+    expect(gc).not.toHaveProperty('isProcessed');
+    expect(gc['currentQuantity']).toBe(3);
+  });
+});
+
+describe('store-scoped anonymous product API 우회 차단', () => {
+  function makeChainable(docs: Array<{ data: () => unknown }>) {
+    const get = jest.fn().mockResolvedValue({ docs });
+    const query: { where: jest.Mock; get: jest.Mock } = {
+      where: jest.fn(() => query),
+      get,
+    };
+    return query;
+  }
+
+  it('store 목록에서 inactive/testOnly를 제외하고 isActive=false 우회를 막는다', async () => {
+    const docs = [
+      { data: () => ({ id: 'public-001', storeId: 's-1', isActive: true, saleType: 'normal' }) },
+      { data: () => ({ id: 'inactive-001', storeId: 's-1', isActive: false, saleType: 'normal' }) },
+      {
+        data: () => ({
+          id: 'e2e-001',
+          storeId: 's-1',
+          isActive: true,
+          testOnly: true,
+          saleType: 'normal',
+        }),
+      },
+    ];
+    const query = makeChainable(docs);
+    const firestore = {
+      collection: jest.fn().mockReturnValue(query),
+      doc: jest.fn(),
+    };
+    const service = new ProductsService(firestore as never);
+
+    // isActive=false를 요청해도 공개 predicate를 우회하지 못한다.
+    const result = (await service.getProducts('s-1', { isActive: false } as never)) as {
+      items: Array<Record<string, unknown>>;
+    };
+    expect(query.where).toHaveBeenCalledWith('isActive', '==', true);
+    expect(result.items.map((item) => item['id'])).toEqual(['public-001']);
+  });
+
+  it.each([
+    ['비활성 상품', { id: 'p-1', storeId: 's-1', isActive: false, saleType: 'normal' }],
+    [
+      '시험용 상품',
+      { id: 'p-1', storeId: 's-1', isActive: true, testOnly: true, saleType: 'normal' },
+    ],
+  ])('store 상세에서 %s를 상품 없음으로 처리한다', async (_label, product) => {
+    const firestore = {
+      doc: jest.fn().mockReturnValue({
+        get: jest.fn().mockResolvedValue({ exists: true, data: () => product }),
+      }),
+    };
+    const service = new ProductsService(firestore as never);
+
+    await expect(service.getProduct('s-1', 'p-1')).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('store 상세가 다른 store 상품을 반환하지 않는다', async () => {
+    const product = { id: 'p-1', storeId: 'other-store', isActive: true, saleType: 'normal' };
+    const firestore = {
+      doc: jest.fn().mockReturnValue({
+        get: jest.fn().mockResolvedValue({ exists: true, data: () => product }),
+      }),
+    };
+    const service = new ProductsService(firestore as never);
+
+    await expect(service.getProduct('s-1', 'p-1')).rejects.toBeInstanceOf(NotFoundException);
+  });
+});
+
+describe('seller owner/internal read regression', () => {
+  it('owner 상세는 내부 필드를 보존한다', async () => {
+    const product = {
+      id: 'p-1',
+      storeId: 's-1',
+      isActive: false,
+      testOnly: true,
+      saleType: 'normal',
+      name: '비활성 시험 상품',
+      sellerNote: '내부 메모',
+      sellerOverride: true,
+      content: { headline: '제목', description: '설명', isEditedByUser: true },
+    };
+    const firestore = {
+      doc: jest.fn((path: string) => ({
+        get: jest.fn().mockResolvedValue({
+          exists: true,
+          data: () =>
+            path === 'stores/s-1' ? { ownerId: 'seller-1' } : product,
+        }),
+      })),
+    };
+    const service = new ProductsService(firestore as never);
+
+    const owner = (await service.getOwnerProduct('s-1', 'p-1', 'seller-1', 'seller')) as Record<
+      string,
+      unknown
+    >;
+    expect(owner['sellerNote']).toBe('내부 메모');
+    expect(owner['sellerOverride']).toBe(true);
+    expect(owner['content']).toEqual({
+      headline: '제목',
+      description: '설명',
+      isEditedByUser: true,
+    });
+  });
+
+  it('owner가 아닌 seller의 owner 조회를 거부한다', async () => {
+    const product = { id: 'p-1', storeId: 's-1', isActive: true, saleType: 'normal' };
+    const firestore = {
+      doc: jest.fn((path: string) => ({
+        get: jest.fn().mockResolvedValue({
+          exists: true,
+          data: () => (path === 'stores/s-1' ? { ownerId: 'seller-1' } : product),
+        }),
+      })),
+    };
+    const service = new ProductsService(firestore as never);
+
+    await expect(service.getOwnerProduct('s-1', 'p-1', 'seller-2', 'seller')).rejects.toThrow();
   });
 });
 

--- a/apps/api/src/products/products.service.ts
+++ b/apps/api/src/products/products.service.ts
@@ -6,16 +6,26 @@ import { CreateProductDto } from './dto/create-product.dto';
 import { ProductQueryDto } from './dto/product-query.dto';
 import { UpdateDeliveryConfigDto } from './dto/update-delivery-config.dto';
 import { UpdateProductDto } from './dto/update-product.dto';
+import {
+  isPubliclyVisibleProduct,
+  toOwnerProductDetail,
+  toPublicGroupSummary,
+  toPublicProductDetail,
+  toPublicProductSummary,
+} from './product-visibility';
 
 @Injectable()
 export class ProductsService {
   constructor(private readonly firestore: FirestoreService) {}
 
   async getProducts(storeId: string, query: ProductQueryDto) {
+    // Anonymous store-scoped list is PUBLIC: always enforce the canonical
+    // visibility predicate (isActive === true AND testOnly !== true).
+    // query.isActive is intentionally ignored here — inactive/testOnly must
+    // never leak through the store-scoped bypass.
     let ref = this.firestore.collection('products').where('storeId', '==', storeId);
 
-    const isActive = query.isActive !== false;
-    ref = ref.where('isActive', '==', isActive) as any;
+    ref = ref.where('isActive', '==', true) as any;
 
     if (query.category) {
       ref = ref.where('category', '==', query.category) as any;
@@ -25,7 +35,9 @@ export class ProductsService {
     }
 
     const snap = await ref.get();
-    let products = snap.docs.map((d) => d.data());
+    let products = snap.docs
+      .map((d) => d.data())
+      .filter((p) => isPubliclyVisibleProduct(p as Record<string, unknown>));
 
     // 색상 필터 — 신규(selection.colors) / 구버전(colors) 모두 지원
     if (query.colors) {
@@ -60,30 +72,17 @@ export class ProductsService {
     }
 
     // 스펙 응답: { items: ProductSummary[], total: number }
+    // Public summary is an explicit allowlist — never spread the stored doc.
     const items = products.map((p) => {
-      const summary: Record<string, unknown> = {
-        id: p['id'],
-        name: p['name'],
-        price: p['price'],
-        images: Array.isArray(p['images']) ? [p['images'][0]] : [],
-        category: p['category'],
-        colors: p['selection']?.['colors'] ?? p['colors'] ?? [],
-        saleType: p['saleType'],
-        isActive: p['isActive'],
-      };
-      if (p['saleType'] === 'group') {
-        const gc = groupConfigMap.get(p['id'] as string);
-        if (gc) {
-          summary['groupSummary'] = {
-            currentQuantity: gc['currentQuantity'],
-            minQuantity: gc['minQuantity'],
-            targetQuantity: gc['targetQuantity'],
-            recruitDeadline:
-              typeof (gc['recruitDeadline'] as { toDate?: () => Date })?.toDate === 'function'
-                ? (gc['recruitDeadline'] as { toDate: () => Date }).toDate().toISOString()
-                : gc['recruitDeadline'],
-          };
-        }
+      const gc = groupConfigMap.get(p['id'] as string);
+      const summary = toPublicProductSummary(
+        p as Record<string, unknown>,
+        (gc as Record<string, unknown> | undefined) ?? null,
+      );
+      // Backfill groupSummary for group products when the helper omitted it
+      // (kept for contract compat with the previous manual shape).
+      if (p['saleType'] === 'group' && gc && !summary['groupSummary']) {
+        summary['groupSummary'] = toPublicGroupSummary(gc as Record<string, unknown>);
       }
       return summary;
     });
@@ -96,7 +95,11 @@ export class ProductsService {
     if (!snap.exists || snap.data()!['storeId'] !== storeId) {
       throw new NotFoundException('상품을 찾을 수 없습니다.');
     }
-    const product = snap.data()!;
+    const product = snap.data()! as Record<string, unknown>;
+    // Anonymous store-scoped detail is PUBLIC: same canonical predicate.
+    if (!isPubliclyVisibleProduct(product)) {
+      throw new NotFoundException('상품을 찾을 수 없습니다.');
+    }
 
     let groupConfig: Record<string, unknown> | null = null;
     if (product['saleType'] === 'group') {
@@ -104,16 +107,32 @@ export class ProductsService {
       groupConfig = gc.exists ? (gc.data() as Record<string, unknown>) : null;
     }
 
-    // groupConfig가 있을 때만 포함 (스펙: optional 필드)
-    if (groupConfig) {
-      const gc: Record<string, unknown> = { ...groupConfig };
-      const rd = gc['recruitDeadline'] as { toDate?: () => Date };
-      const gd = gc['groupDeliveryDate'] as { toDate?: () => Date };
-      if (typeof rd?.toDate === 'function') gc['recruitDeadline'] = rd.toDate().toISOString();
-      if (typeof gd?.toDate === 'function') gc['groupDeliveryDate'] = gd.toDate().toISOString();
-      return { ...product, groupConfig: gc };
+    return toPublicProductDetail(product, groupConfig);
+  }
+
+  /**
+   * Owner/internal detail — seller mutation/read path.
+   * No visibility filtering, full fidelity (sellerNote/content.isEditedByUser/
+   * sellerOverride/testOnly preserved). Ownership is enforced.
+   */
+  async getOwnerProduct(storeId: string, productId: string, sellerId: string, role?: string) {
+    await this.assertSellerOwnsStore(storeId, sellerId, role);
+    return this.getOwnerProductInternal(storeId, productId);
+  }
+
+  private async getOwnerProductInternal(storeId: string, productId: string) {
+    const snap = await this.firestore.doc(`products/${productId}`).get();
+    if (!snap.exists || snap.data()!['storeId'] !== storeId) {
+      throw new NotFoundException('상품을 찾을 수 없습니다.');
     }
-    return { ...product };
+    const product = snap.data()! as Record<string, unknown>;
+
+    let groupConfig: Record<string, unknown> | null = null;
+    if (product['saleType'] === 'group') {
+      const gc = await this.firestore.doc(`groupProductConfig/${productId}`).get();
+      groupConfig = gc.exists ? (gc.data() as Record<string, unknown>) : null;
+    }
+    return toOwnerProductDetail(product, groupConfig);
   }
 
   async createProduct(storeId: string, sellerId: string, dto: CreateProductDto, role?: string) {
@@ -143,7 +162,7 @@ export class ProductsService {
       });
     }
 
-    return this.getProduct(storeId, productId);
+    return this.getOwnerProductInternal(storeId, productId);
   }
 
   async updateProduct(
@@ -173,7 +192,7 @@ export class ProductsService {
         .set({ productId, ...groupConfig }, { merge: true });
     }
 
-    return this.getProduct(storeId, productId);
+    return this.getOwnerProductInternal(storeId, productId);
   }
 
   async toggleProductActive(
@@ -289,7 +308,7 @@ export class ProductsService {
     const snap = await ref.get();
     let products = snap.docs
       .map((d: any) => d.data())
-      .filter((product: Record<string, unknown>) => product['testOnly'] !== true);
+      .filter((product: Record<string, unknown>) => isPubliclyVisibleProduct(product));
 
     if (query.colors) {
       const colorFilter = Array.isArray(query.colors)
@@ -321,30 +340,11 @@ export class ProductsService {
       gcSnap.docs.forEach((d: any) => groupConfigMap.set(d.data()['productId'], d.data()));
     }
 
-    const items = products.map((p: any) => {
-      const summary: Record<string, unknown> = {
-        id: p['id'],
-        storeId: p['storeId'],
-        name: p['name'],
-        price: p['price'],
-        images: Array.isArray(p['images']) ? [p['images'][0]] : [],
-        category: p['category'],
-        colors: p['selection']?.['colors'] ?? p['colors'] ?? [],
-        saleType: p['saleType'],
-        isActive: p['isActive'],
-      };
-      if (p['saleType'] === 'group') {
-        const gc = groupConfigMap.get(p['id'] as string);
-        if (gc)
-          summary['groupSummary'] = {
-            currentQuantity: gc['currentQuantity'],
-            minQuantity: gc['minQuantity'],
-            targetQuantity: gc['targetQuantity'],
-            recruitDeadline: gc['recruitDeadline'],
-          };
-      }
-      return summary;
-    });
+    const items = products.map((p: any) =>
+      toPublicProductSummary(p as Record<string, unknown>, groupConfigMap.get(p['id'] as string) ?? null, {
+        includeStoreId: true,
+      }),
+    );
 
     return { items, total: items.length };
   }
@@ -352,15 +352,16 @@ export class ProductsService {
   async getPublicProduct(productId: string) {
     const snap = await this.firestore.doc(`products/${productId}`).get();
     if (!snap.exists) throw new NotFoundException('상품을 찾을 수 없습니다.');
-    const product = snap.data()!;
-    if (product['isActive'] !== true || product['testOnly'] === true) {
+    const product = snap.data()! as Record<string, unknown>;
+    if (!isPubliclyVisibleProduct(product)) {
       throw new NotFoundException('상품을 찾을 수 없습니다.');
     }
     if (product['saleType'] === 'group') {
       const gc = await this.firestore.doc(`groupProductConfig/${productId}`).get();
-      if (gc.exists) return { ...product, groupConfig: gc.data() };
+      const groupConfig = gc.exists ? (gc.data() as Record<string, unknown>) : null;
+      return toPublicProductDetail(product, groupConfig);
     }
-    return { ...product };
+    return toPublicProductDetail(product, null);
   }
 
   private async assertSellerOwnsStore(storeId: string, sellerId: string, role?: string) {

--- a/apps/api/src/sale-rounds/sale-rounds.service.spec.ts
+++ b/apps/api/src/sale-rounds/sale-rounds.service.spec.ts
@@ -270,6 +270,71 @@ describe('SaleRoundsService', () => {
     });
   });
 
+  it('public detail에서 HIDDEN item을 제외한다', async () => {
+    const { service } = makeService(
+      {
+        'saleRoundItems/item-1': makeItem({ id: 'item-1', status: 'ACTIVE', displayOrder: 1 }),
+        'saleRoundItems/item-hidden': makeItem({
+          id: 'item-hidden',
+          status: 'HIDDEN',
+          displayOrder: 0,
+        }),
+      },
+      makeRound({ status: 'OPEN' }),
+    );
+
+    const round = await service.getPublicRound('store-1', 'round-1');
+    expect(round.items.map((item) => item.id)).toEqual(['item-1']);
+    expect(round.items.some((item) => item.status === 'HIDDEN')).toBe(false);
+  });
+
+  it.each(['ACTIVE', 'SOLD_OUT', 'CLOSED'])(
+    'public detail에서 %s item을 유지한다 (품절 표시 회귀 방지)',
+    async (status) => {
+      const { service } = makeService(
+        { 'saleRoundItems/item-1': makeItem({ status }) },
+        makeRound({ status: 'OPEN' }),
+      );
+
+      await expect(service.getPublicRound('store-1', 'round-1')).resolves.toMatchObject({
+        items: [{ id: 'item-1', status }],
+      });
+    },
+  );
+
+  it('public detail에서 item displayOrder를 보존한다', async () => {
+    const { service } = makeService(
+      {
+        'saleRoundItems/item-b': makeItem({ id: 'item-b', displayOrder: 1 }),
+        'saleRoundItems/item-a': makeItem({ id: 'item-a', displayOrder: 0 }),
+        'saleRoundItems/item-hidden': makeItem({
+          id: 'item-hidden',
+          displayOrder: 2,
+          status: 'HIDDEN',
+        }),
+      },
+      makeRound({ status: 'OPEN' }),
+    );
+
+    const round = await service.getPublicRound('store-1', 'round-1');
+    expect(round.items.map((item) => item.id)).toEqual(['item-a', 'item-b']);
+  });
+
+  it('seller 상세 조회에서는 HIDDEN item을 유지한다', async () => {
+    const { service } = makeService(
+      {
+        'saleRoundItems/item-1': makeItem({ id: 'item-1', status: 'ACTIVE' }),
+        'saleRoundItems/item-hidden': makeItem({ id: 'item-hidden', status: 'HIDDEN' }),
+      },
+      makeRound({ status: 'OPEN' }),
+    );
+
+    const round = await (service as any).getRound('store-1', 'round-1', 'seller-1', 'seller');
+    expect(round.items.map((item: { id: string }) => item.id).sort()).toEqual(
+      ['item-1', 'item-hidden'].sort(),
+    );
+  });
+
   it('public detail은 requested store와 parent round store가 다르면 refresh 전에 거부한다', async () => {
     const { service, firestore, collectionCalls } = makeService(
       { 'saleRoundItems/item-1': makeItem() },

--- a/apps/api/src/sale-rounds/sale-rounds.service.ts
+++ b/apps/api/src/sale-rounds/sale-rounds.service.ts
@@ -24,6 +24,25 @@ function isPublicSaleRoundStatus(status: unknown): status is (typeof PUBLIC_SALE
   return (PUBLIC_SALE_ROUND_STATUSES as readonly unknown[]).includes(status);
 }
 
+/**
+ * Public round-item visibility — single semantic owner.
+ * HIDDEN is never public. ACTIVE / SOLD_OUT / CLOSED preserve the existing
+ * contract (SOLD_OUT/CLOSED remain visible as sold-out/closed display;
+ * consumer treats only ACTIVE in an OPEN round as purchasable).
+ * Seller management reads must NOT use this predicate.
+ */
+export function isPubliclyVisibleRoundItem(
+  item: Pick<SaleRoundItem, 'status'> | Record<string, unknown> | null | undefined,
+): boolean {
+  if (!item) return false;
+  return (item as { status: unknown }).status !== 'HIDDEN';
+}
+
+function toPublicRoundItems(items: SaleRoundItem[]): SaleRoundItem[] {
+  // Preserve displayOrder sorting done by getRoundItems; filter only.
+  return items.filter((item) => isPubliclyVisibleRoundItem(item));
+}
+
 @Injectable()
 export class SaleRoundsService {
   constructor(
@@ -48,6 +67,8 @@ export class SaleRoundsService {
       .where('storeId', '==', storeId)
       .where('status', 'in', PUBLIC_SALE_ROUND_STATUSES)
       .get();
+    // List returns round summaries without items by design; item visibility
+    // is enforced in getPublicRound via toPublicRoundItems (same predicate).
     const rounds = await Promise.all(
       snap.docs.map(async (doc: any) => {
         const storedRound = doc.data() as Record<string, any>;
@@ -72,11 +93,19 @@ export class SaleRoundsService {
     const items = await this.getRoundItems(roundId, storeId);
     return { ...round, items };
   }
+  private async getPublicRoundWithItems(
+    storeId: string,
+    roundId: string,
+  ): Promise<RoundWithItems> {
+    const round = await this.refreshRoundStatus(storeId, roundId);
+    const items = await this.getRoundItems(roundId, storeId);
+    return { ...round, items: toPublicRoundItems(items) };
+  }
   async getPublicRound(storeId: string, roundId: string): Promise<RoundWithItems> {
     await this.assertPublicRoundStore(storeId);
     const storedRound = await this.getStoredRound(storeId, roundId);
     this.assertPublicRoundBoundary(storeId, storedRound);
-    const round = await this.getRoundWithItems(storeId, roundId);
+    const round = await this.getPublicRoundWithItems(storeId, roundId);
     this.assertPublicRoundBoundary(storeId, round);
     return round;
   }

--- a/apps/api/src/stores/stores.controller.ts
+++ b/apps/api/src/stores/stores.controller.ts
@@ -24,7 +24,6 @@ export class StoresController {
   getStore(@Param('storeId') storeId: string, @CurrentUser() user: JwtPayload) {
     return this.storesService.getStore(storeId, user.sub);
   }
-
   @Post()
   @HttpCode(HttpStatus.CREATED)
   createStore(@CurrentUser() user: JwtPayload, @Body() dto: UpdateStoreDto) {
@@ -39,5 +38,19 @@ export class StoresController {
     @Body() dto: UpdateStoreDto,
   ) {
     return this.storesService.updateStore(storeId, user.sub, dto);
+  }
+}
+
+/**
+ * Public store profile — no auth guard (OWNER_SCOPED owner API above is unchanged).
+ * Contract: GET /stores/:storeId/public-profile → { id, name, logoUrl, salesMode }.
+ */
+@Controller('stores')
+export class PublicStoresController {
+  constructor(private readonly storesService: StoresService) {}
+
+  @Get(':storeId/public-profile')
+  getPublicProfile(@Param('storeId') storeId: string) {
+    return this.storesService.getPublicProfile(storeId);
   }
 }

--- a/apps/api/src/stores/stores.module.ts
+++ b/apps/api/src/stores/stores.module.ts
@@ -1,9 +1,9 @@
 import { Module } from '@nestjs/common';
-import { StoresController } from './stores.controller';
+import { PublicStoresController, StoresController } from './stores.controller';
 import { StoresService } from './stores.service';
 
 @Module({
-  controllers: [StoresController],
+  controllers: [PublicStoresController, StoresController],
   providers: [StoresService],
   exports: [StoresService],
 })

--- a/apps/api/src/stores/stores.service.spec.ts
+++ b/apps/api/src/stores/stores.service.spec.ts
@@ -1,0 +1,99 @@
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { StoresService } from './stores.service';
+
+function makeService(storeData: Record<string, unknown> | null) {
+  const firestore = {
+    doc: jest.fn().mockReturnValue({
+      get: jest.fn().mockResolvedValue({
+        exists: storeData !== null,
+        data: () => storeData,
+      }),
+    }),
+    collection: jest.fn(),
+  };
+  return new StoresService(firestore as never);
+}
+
+describe('public store profile contract', () => {
+  it('allowlist 필드만 반환한다', async () => {
+    const service = makeService({
+      id: 's-1',
+      ownerId: 'seller-1',
+      name: '디어오키드',
+      ceoName: '홍길동',
+      phone: '010-1234-5678',
+      address: '경기도 이천시',
+      businessNumber: '123-45-67890',
+      logoUrl: 'https://example.com/logo.png',
+      status: 'active',
+      salesMode: 'round_direct',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-02T00:00:00.000Z',
+    });
+
+    const profile = (await service.getPublicProfile('s-1')) as Record<string, unknown>;
+    expect(Object.keys(profile).sort()).toEqual(['id', 'logoUrl', 'name', 'salesMode'].sort());
+    expect(profile).toEqual({
+      id: 's-1',
+      name: '디어오키드',
+      logoUrl: 'https://example.com/logo.png',
+      salesMode: 'round_direct',
+    });
+    expect(profile).not.toHaveProperty('ownerId');
+    expect(profile).not.toHaveProperty('ceoName');
+    expect(profile).not.toHaveProperty('phone');
+    expect(profile).not.toHaveProperty('address');
+    expect(profile).not.toHaveProperty('businessNumber');
+    expect(profile).not.toHaveProperty('status');
+    expect(profile).not.toHaveProperty('createdAt');
+    expect(profile).not.toHaveProperty('updatedAt');
+  });
+
+  it.each([['legacy'], [undefined], [null], ['unsupported']])(
+    'salesMode %s는 legacy로 정규화한다 (round_direct만 공개 직배송)',
+    async (salesMode) => {
+      const service = makeService({ id: 's-1', name: '상점', logoUrl: null, salesMode });
+      const profile = (await service.getPublicProfile('s-1')) as Record<string, unknown>;
+      if (salesMode === 'legacy' || salesMode == null) {
+        expect(profile['salesMode']).toBe('legacy');
+      } else {
+        // invalid 값은 legacy로 fail-closed한다.
+        expect(profile['salesMode']).toBe('legacy');
+      }
+    },
+  );
+
+  it('존재하지 않는 store는 404한다', async () => {
+    const service = makeService(null);
+    await expect(service.getPublicProfile('missing')).rejects.toBeInstanceOf(NotFoundException);
+  });
+});
+
+describe('owner store API regression', () => {
+  it('owner 조회는 기존 계약을 유지한다', async () => {
+    const service = makeService({
+      ownerId: 'seller-1',
+      name: '디어오키드',
+      ceoName: '홍길동',
+      phone: '010-1234-5678',
+      address: '경기도 이천시',
+      businessNumber: '123-45-67890',
+      logoUrl: null,
+    });
+
+    await expect(service.getStore('s-1', 'seller-1')).resolves.toMatchObject({
+      id: 's-1',
+      name: '디어오키드',
+    });
+  });
+
+  it('owner가 아닌 조회는 거부한다', async () => {
+    const service = makeService({ ownerId: 'seller-1', name: '상점' });
+    await expect(service.getStore('s-1', 'seller-2')).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
+  it('존재하지 않는 store는 404한다', async () => {
+    const service = makeService(null);
+    await expect(service.getStore('missing', 'seller-1')).rejects.toBeInstanceOf(NotFoundException);
+  });
+});

--- a/apps/api/src/stores/stores.service.ts
+++ b/apps/api/src/stores/stores.service.ts
@@ -4,6 +4,7 @@ import {
   ForbiddenException,
   ConflictException,
 } from '@nestjs/common';
+import { normalizeSalesMode } from '@greenhub/shared';
 import { v4 as uuidv4 } from 'uuid';
 import { FirestoreService } from '../firestore/firestore.service';
 import { UpdateStoreDto } from './dto/update-store.dto';
@@ -25,6 +26,26 @@ export class StoresService {
       address: data.address ?? '',
       businessNumber: data.businessNumber ?? null,
       logoUrl: data.logoUrl ?? null,
+    };
+  }
+
+  /**
+   * Public store profile — unauthenticated allowlist.
+   * Returns exactly { id, name, logoUrl, salesMode }. Never PII/owner/
+   * status/timestamps. Missing store → 404 (not empty profile).
+   */
+  async getPublicProfile(storeId: string) {
+    const snap = await this.firestore.doc(`stores/${storeId}`).get();
+    if (!snap.exists) throw new NotFoundException('스토어를 찾을 수 없습니다');
+    const data = snap.data()!;
+    const salesMode = normalizeSalesMode(
+      data.salesMode === 'round_direct' ? 'round_direct' : undefined,
+    );
+    return {
+      id: storeId,
+      name: data.name ?? '',
+      logoUrl: data.logoUrl ?? null,
+      salesMode,
     };
   }
 

--- a/apps/consumer/src/app/category/page.tsx
+++ b/apps/consumer/src/app/category/page.tsx
@@ -15,14 +15,13 @@ import {
   Title,
   UnstyledButton,
 } from '@mantine/core';
-import { doc, getDoc } from 'firebase/firestore';
 import Image from 'next/image';
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
 import ProductCard from '@/components/ProductCard';
 import { useProducts } from '@/hooks/useProducts';
 import { type PublicSaleRound, useSaleRounds } from '@/hooks/useSaleRounds';
-import { db } from '@/lib/firebase';
+import { fetchPublicStoreProfile } from '@/lib/public-store-profile';
 
 const TABS: { label: string; value: Category | undefined; saleType?: SaleType }[] = [
   { label: '전체', value: undefined },
@@ -85,13 +84,11 @@ function useStoreMode(storeId: string | null, discoveryPending: boolean): StoreM
     let active = true;
     setState({ storeId, salesMode: 'legacy', status: 'loading' });
 
-    void getDoc(doc(db, 'stores', storeId))
-      .then((snapshot) => {
+    void fetchPublicStoreProfile(storeId)
+      .then((profile) => {
         if (!active) return;
-        if (!snapshot.exists()) throw new Error('스토어를 찾을 수 없습니다.');
-
-        const value = snapshot.data()?.salesMode;
-        if (value !== undefined && value !== 'legacy' && value !== 'round_direct') {
+        const value = profile.salesMode;
+        if (value !== 'legacy' && value !== 'round_direct') {
           throw new Error('판매 방식 정보가 올바르지 않습니다.');
         }
         setState({ storeId, salesMode: normalizeSalesMode(value), status: 'ready' });

--- a/apps/consumer/src/app/groupbuy/page.tsx
+++ b/apps/consumer/src/app/groupbuy/page.tsx
@@ -3,13 +3,12 @@
 import type { Product, SalesMode } from '@greenhub/shared';
 import { getGroupBuyStatus, normalizeSalesMode } from '@greenhub/shared';
 import { Box, Button, Container, SimpleGrid, Skeleton, Stack, Text } from '@mantine/core';
-import { doc, getDoc } from 'firebase/firestore';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useEffect, useMemo, useState } from 'react';
 import ProductCard from '@/components/ProductCard';
 import { useProducts } from '@/hooks/useProducts';
-import { db } from '@/lib/firebase';
+import { fetchPublicStoreProfile } from '@/lib/public-store-profile';
 
 type StoreModeStatus = 'loading' | 'ready' | 'error';
 
@@ -44,13 +43,11 @@ function useStoreMode(storeId: string | null, productsLoading: boolean): StoreMo
     let active = true;
     setState({ salesMode: 'legacy', status: 'loading' });
 
-    void getDoc(doc(db, 'stores', storeId))
-      .then((snapshot) => {
+    void fetchPublicStoreProfile(storeId)
+      .then((profile) => {
         if (!active) return;
-        if (!snapshot.exists()) throw new Error('스토어를 찾을 수 없습니다.');
-
-        const value = snapshot.data()?.salesMode;
-        if (value !== undefined && value !== 'legacy' && value !== 'round_direct') {
+        const value = profile.salesMode;
+        if (value !== 'legacy' && value !== 'round_direct') {
           throw new Error('판매 방식 정보가 올바르지 않습니다.');
         }
         setState({ salesMode: normalizeSalesMode(value), status: 'ready' });

--- a/apps/consumer/src/app/products/[id]/page.tsx
+++ b/apps/consumer/src/app/products/[id]/page.tsx
@@ -3,14 +3,13 @@
 import type { Product, SaleRoundItem, SalesMode, Variety } from '@greenhub/shared';
 import { normalizeSalesMode } from '@greenhub/shared';
 import { Box, Button, Container, Skeleton, Stack, Text } from '@mantine/core';
-import { doc, getDoc } from 'firebase/firestore';
 import { notFound } from 'next/navigation';
 import { use, useEffect, useState } from 'react';
 import ProductTopBar from '@/components/ProductTopBar';
 import { type PublicSaleRound, useSaleRounds } from '@/hooks/useSaleRounds';
 import { captureAcquisition } from '@/lib/acquisition';
 import { getApiBaseUrl } from '@/lib/api-base-url';
-import { db } from '@/lib/firebase';
+import { fetchPublicStoreProfile } from '@/lib/public-store-profile';
 import ProductActions from './_components/ProductActions';
 import ProductImages from './_components/ProductImages';
 import ProductInfo from './_components/ProductInfo';
@@ -138,13 +137,11 @@ function useStoreMode(storeId: string | null): StoreModeState {
     let active = true;
     setStoreMode({ status: 'loading', storeId, salesMode: 'legacy' });
 
-    void getDoc(doc(db, 'stores', storeId))
-      .then((snapshot) => {
+    void fetchPublicStoreProfile(storeId)
+      .then((profile) => {
         if (!active) return;
-        if (!snapshot.exists()) throw new Error('스토어를 찾을 수 없습니다.');
-
-        const value = snapshot.data()?.salesMode;
-        if (value !== undefined && value !== 'legacy' && value !== 'round_direct') {
+        const value = profile.salesMode;
+        if (value !== 'legacy' && value !== 'round_direct') {
           throw new Error('판매 방식 정보가 올바르지 않습니다.');
         }
         setStoreMode({

--- a/apps/consumer/src/components/BottomNav.tsx
+++ b/apps/consumer/src/components/BottomNav.tsx
@@ -3,7 +3,6 @@
 import type { Product, SalesMode } from '@greenhub/shared';
 import { normalizeSalesMode } from '@greenhub/shared';
 import { Box, Stack, Text, UnstyledButton } from '@mantine/core';
-import { doc, getDoc } from 'firebase/firestore';
 import { Home, LayoutGrid, ShoppingCart, User, Users } from 'lucide-react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
@@ -11,7 +10,7 @@ import { useSession } from 'next-auth/react';
 import { useEffect, useMemo, useState } from 'react';
 import { useCart } from '@/hooks/useCart';
 import { useProducts } from '@/hooks/useProducts';
-import { db } from '@/lib/firebase';
+import { fetchPublicStoreProfile } from '@/lib/public-store-profile';
 
 const ROUND_DIRECT_TABS = [
   { href: '/', label: '홈', Icon: Home, showBadge: false },
@@ -63,13 +62,11 @@ function useStoreMode(storeId: string | null, productsLoading: boolean): StoreMo
     let active = true;
     setState({ salesMode: 'legacy', status: 'loading' });
 
-    void getDoc(doc(db, 'stores', storeId))
-      .then((snapshot) => {
+    void fetchPublicStoreProfile(storeId)
+      .then((profile) => {
         if (!active) return;
-        if (!snapshot.exists()) throw new Error('스토어를 찾을 수 없습니다.');
-
-        const value = snapshot.data()?.salesMode;
-        if (value !== undefined && value !== 'legacy' && value !== 'round_direct') {
+        const value = profile.salesMode;
+        if (value !== 'legacy' && value !== 'round_direct') {
           throw new Error('판매 방식 정보가 올바르지 않습니다.');
         }
         setState({ salesMode: normalizeSalesMode(value), status: 'ready' });

--- a/apps/consumer/src/components/HomeProductList.tsx
+++ b/apps/consumer/src/components/HomeProductList.tsx
@@ -13,7 +13,6 @@ import {
   Text,
   Title,
 } from '@mantine/core';
-import { doc, getDoc } from 'firebase/firestore';
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
 import { useEffect, useMemo, useState } from 'react';
@@ -23,7 +22,7 @@ import ResilientImage, { PRODUCT_IMAGE_FALLBACK } from '@/components/ResilientIm
 import { useProducts } from '@/hooks/useProducts';
 import { type PublicSaleRound, useSaleRounds } from '@/hooks/useSaleRounds';
 import { captureAcquisition } from '@/lib/acquisition';
-import { db } from '@/lib/firebase';
+import { fetchPublicStoreProfile } from '@/lib/public-store-profile';
 import { resolveHomeStoreId } from './home-store-selection';
 
 type StoreModeStatus = 'loading' | 'ready' | 'error';
@@ -63,13 +62,11 @@ function useStoreMode(storeId: string | null, productsLoading: boolean): StoreMo
     let active = true;
     setState({ storeId, salesMode: 'legacy', status: 'loading' });
 
-    void getDoc(doc(db, 'stores', storeId))
-      .then((snapshot) => {
+    void fetchPublicStoreProfile(storeId)
+      .then((profile) => {
         if (!active) return;
-        if (!snapshot.exists()) throw new Error('스토어를 찾을 수 없습니다.');
-
-        const value = snapshot.data()?.salesMode;
-        if (value !== undefined && value !== 'legacy' && value !== 'round_direct') {
+        const value = profile.salesMode;
+        if (value !== 'legacy' && value !== 'round_direct') {
           throw new Error('판매 방식 정보가 올바르지 않습니다.');
         }
         setState({

--- a/apps/consumer/src/hooks/useGroupProduct.ts
+++ b/apps/consumer/src/hooks/useGroupProduct.ts
@@ -1,8 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
-import { doc, onSnapshot } from 'firebase/firestore';
-import { db } from '@/lib/firebase';
+import { getApiBaseUrl } from '@/lib/api-base-url';
 import type { GroupProductConfig } from '@greenhub/shared';
 
 interface UseGroupProductResult {
@@ -10,12 +9,38 @@ interface UseGroupProductResult {
   loading: boolean;
   error: string | null;
   /**
-   * Firestore authoritative snapshot에서 문서가 실제로 없다고 확인된 상태.
+   * Public API authoritative 응답에서 문서가 실제로 없다고 확인된 상태.
    * read failure(error !== null)와 반드시 구분된다.
    */
   isMissing: boolean;
-  /** onSnapshot fatal error 이후 명시적 재구독. */
+  /** fatal error 이후 명시적 재조회. */
   retry: () => void;
+}
+
+const API_URL = getApiBaseUrl();
+// Public-safe polling: Firestore 원문 onSnapshot 대신 public product detail API를
+// 사용한다. Rules convergence 후 익명 원문 read가 차단돼도 동작한다.
+// 구매 가능성·currentQuantity freshness를 위해 mount/retry/scope 변경 시 즉시
+// 조회하고 10초 간격으로 갱신한다.
+const GROUP_CONFIG_POLL_INTERVAL_MS = 10_000;
+
+function toGroupConfig(productId: string, payload: unknown): GroupProductConfig | null {
+  if (typeof payload !== 'object' || payload === null) return null;
+  const record = payload as Record<string, unknown>;
+  const groupConfig = record['groupConfig'];
+  if (typeof groupConfig !== 'object' || groupConfig === null) return null;
+  const gc = groupConfig as Record<string, unknown>;
+  return {
+    productId,
+    minQuantity: Number(gc['minQuantity'] ?? 0),
+    targetQuantity: Number(gc['targetQuantity'] ?? 0),
+    maxPerPerson: Number(gc['maxPerPerson'] ?? 0),
+    recruitDeadline: String(gc['recruitDeadline'] ?? ''),
+    currentQuantity: Number(gc['currentQuantity'] ?? 0),
+    groupDeliveryDate: String(gc['groupDeliveryDate'] ?? ''),
+    groupDeliveryMethod: gc['groupDeliveryMethod'] === 'parcel' ? 'parcel' : 'direct',
+    deliveryFeeDiscount: Number(gc['deliveryFeeDiscount'] ?? 0),
+  } as GroupProductConfig;
 }
 
 export function useGroupProduct(productId: string | null): UseGroupProductResult {
@@ -27,9 +52,7 @@ export function useGroupProduct(productId: string | null): UseGroupProductResult
 
   const retry = useCallback(() => {
     if (!productId) return;
-    // 재구독 전 fail-closed 유지: loading으로 구매 판정 대기, 이전 error/missing 확정 해제.
-    // config는 effect 재구독 시 scope 기준으로 정리되며, 비동기 listener 실패 콜백은
-    // 기존 config를 지우지 않고 error만 세워 최신 read failure를 무시하지 않게 한다.
+    // 재조회 전 fail-closed 유지: loading으로 구매 판정 대기, 이전 error/missing 확정 해제.
     setError(null);
     setIsMissing(false);
     setLoading(true);
@@ -47,43 +70,65 @@ export function useGroupProduct(productId: string | null): UseGroupProductResult
       return;
     }
 
+    const targetProductId = productId;
+
     // scope 진입/변경/retry: 이전 scope 확정(config/error/missing)을 새 것처럼 보이지 않게 한다.
     setConfig(null);
     setError(null);
     setIsMissing(false);
     setLoading(true);
 
-    const ref = doc(db, 'groupProductConfig', productId);
-    const unsubscribe = onSnapshot(
-      ref,
-      (snap) => {
-        if (snap.exists()) {
-          const data = snap.data();
-          // Firestore Timestamp → ISO string 변환
-          if (data.recruitDeadline?.toDate)
-            data.recruitDeadline = data.recruitDeadline.toDate().toISOString();
-          if (data.groupDeliveryDate?.toDate)
-            data.groupDeliveryDate = data.groupDeliveryDate.toDate().toISOString();
-          setConfig(data as GroupProductConfig);
-          setIsMissing(false);
-        } else {
-          // authoritative missing: 실제로 문서가 없음 (read failure와 구분).
+    let cancelled = false;
+
+    async function fetchConfig() {
+      try {
+        const res = await fetch(
+          `${API_URL}/products/${encodeURIComponent(targetProductId)}`,
+        );
+        if (cancelled) return;
+        if (res.status === 404) {
+          // authoritative missing/invisible: 비활성·testOnly·삭제·groupConfig 없음과
+          // 구분 없이 구매 불가로 fail-closed한다.
           setConfig(null);
           setIsMissing(true);
+          setError(null);
+          setLoading(false);
+          return;
         }
-        setLoading(false);
+        if (!res.ok) throw new Error(`공동구매 조회 오류: ${res.status}`);
+        const payload: unknown = await res.json();
+        if (cancelled) return;
+        const next = toGroupConfig(targetProductId, payload);
+        if (!next) {
+          setConfig(null);
+          setIsMissing(true);
+          setError(null);
+          setLoading(false);
+          return;
+        }
+        setConfig(next);
+        setIsMissing(false);
         setError(null);
-      },
-      (err) => {
+        setLoading(false);
+      } catch (e: unknown) {
+        if (cancelled) return;
         // read failure: missing으로 위장하지 않는다. config는 표시용으로 유지될 수
         // 있으나 error가 최신 상태이므로 구매 판정은 fail-closed여야 한다.
-        setError(err.message);
+        setError(e instanceof Error ? e.message : '공동구매 조회 실패');
         setLoading(false);
         setIsMissing(false);
-      },
-    );
+      }
+    }
 
-    return unsubscribe;
+    void fetchConfig();
+    const intervalId = setInterval(() => {
+      void fetchConfig();
+    }, GROUP_CONFIG_POLL_INTERVAL_MS);
+
+    return () => {
+      cancelled = true;
+      clearInterval(intervalId);
+    };
   }, [productId, attempt]);
 
   return { config, loading, error, isMissing, retry };

--- a/apps/consumer/src/hooks/useProducts.ts
+++ b/apps/consumer/src/hooks/useProducts.ts
@@ -1,17 +1,16 @@
 'use client';
 
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { doc, getDoc } from 'firebase/firestore';
-import { db } from '@/lib/firebase';
 import type { Product, Category, ColorOption, SaleType, Variety } from '@greenhub/shared';
 import { getApiBaseUrl } from '@/lib/api-base-url';
+import {
+  PublicStoreProfileNotFoundError,
+  fetchPublicStoreProfile,
+} from '@/lib/public-store-profile';
 
 export interface StoreInfo {
   id: string;
   name: string;
-  ceoName: string;
-  phone: string;
-  address: string;
   logoUrl: string | null;
 }
 
@@ -84,7 +83,8 @@ export function useProducts(
 }
 
 /**
- * 단일 상품 조회
+ * 단일 상품 조회 — public Product API 사용.
+ * Firestore products 직접 읽기를 사용하지 않는다 (Rules convergence 후 익명 원문 read 차단).
  */
 export function useProduct(productId: string) {
   const [product, setProduct] = useState<Product | null>(null);
@@ -96,55 +96,101 @@ export function useProduct(productId: string) {
       setLoading(false);
       return;
     }
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    setProduct(null);
     async function fetchProduct() {
       try {
-        const snap = await getDoc(doc(db, 'products', productId));
-        if (snap.exists()) {
-          setProduct({ id: snap.id, ...snap.data() } as Product);
-        } else {
+        const res = await fetch(`${API_URL}/products/${encodeURIComponent(productId)}`);
+        if (cancelled) return;
+        if (res.status === 404) {
           setError('상품을 찾을 수 없습니다.');
+          setLoading(false);
+          return;
         }
+        if (!res.ok) throw new Error(`상품 조회 오류: ${res.status}`);
+        const data = (await res.json()) as Product;
+        if (cancelled) return;
+        setProduct(data);
+        setError(null);
+        setLoading(false);
       } catch (e: unknown) {
+        if (cancelled) return;
         setError(e instanceof Error ? e.message : '상품 조회 실패');
-      } finally {
         setLoading(false);
       }
     }
-    fetchProduct();
+    void fetchProduct();
+    return () => {
+      cancelled = true;
+    };
   }, [productId]);
 
   return { product, loading, error };
 }
 
 /**
- * 단일 스토어 정보 조회
+ * 단일 스토어 공개 프로필 조회 — public-profile API 사용.
+ * Firestore stores 직접 읽기를 사용하지 않는다.
+ * network failure(error)와 missing(isMissing)을 구분한다.
  */
 export function useStore(storeId: string | null) {
   const [store, setStore] = useState<StoreInfo | null>(null);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [isMissing, setIsMissing] = useState(false);
 
   useEffect(() => {
     if (!storeId) {
+      setStore(null);
+      setError(null);
+      setIsMissing(false);
       setLoading(false);
       return;
     }
     const sid = storeId;
+    let cancelled = false;
+    setStore(null);
+    setError(null);
+    setIsMissing(false);
+    setLoading(true);
     async function fetchStore() {
       try {
-        const snap = await getDoc(doc(db, 'stores', sid));
-        if (snap.exists()) {
-          setStore({ id: snap.id, ...snap.data() } as StoreInfo);
+        const profile = await fetchPublicStoreProfile(sid);
+        if (cancelled) return;
+        setStore({ id: profile.id, name: profile.name, logoUrl: profile.logoUrl });
+        setError(null);
+        setIsMissing(false);
+      } catch (e: unknown) {
+        if (cancelled) return;
+        if (e instanceof PublicStoreProfileNotFoundError) {
+          setStore(null);
+          setIsMissing(true);
+          setError(null);
+        } else {
+          // network failure는 missing으로 표현하지 않는다.
+          setStore(null);
+          setIsMissing(false);
+          setError(e instanceof Error ? e.message : '스토어 조회 실패');
         }
       } finally {
-        setLoading(false);
+        if (!cancelled) setLoading(false);
       }
     }
-    fetchStore();
+    void fetchStore();
+    return () => {
+      cancelled = true;
+    };
   }, [storeId]);
 
-  return { store, loading };
+  return { store, loading, error, isMissing };
 }
 
+/**
+ * 단일 품종 조회 — public Varieties API 사용.
+ * Firestore varieties 직접 읽기를 사용하지 않는다.
+ */
 export function useVariety(varietyId: string | null | undefined) {
   const [variety, setVariety] = useState<Variety | null>(null);
 
@@ -153,11 +199,22 @@ export function useVariety(varietyId: string | null | undefined) {
       setVariety(null);
       return;
     }
-    getDoc(doc(db, 'varieties', varietyId))
-      .then((snap) =>
-        snap.exists() ? setVariety({ id: snap.id, ...snap.data() } as Variety) : null,
-      )
+    let cancelled = false;
+    setVariety(null);
+    fetch(`${API_URL}/varieties/${encodeURIComponent(varietyId)}`)
+      .then((res) => {
+        if (cancelled) return null;
+        if (!res.ok) return null;
+        return res.json() as Promise<Variety>;
+      })
+      .then((data) => {
+        if (cancelled || !data) return;
+        setVariety(data);
+      })
       .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
   }, [varietyId]);
 
   return { variety };

--- a/apps/consumer/src/lib/public-store-profile.ts
+++ b/apps/consumer/src/lib/public-store-profile.ts
@@ -1,0 +1,42 @@
+'use client';
+
+import type { SalesMode, StorePublicProfile } from '@greenhub/shared';
+import { normalizeSalesMode } from '@greenhub/shared';
+import { getApiBaseUrl } from '@/lib/api-base-url';
+
+export type { StorePublicProfile };
+
+export class PublicStoreProfileNotFoundError extends Error {
+  constructor(storeId: string) {
+    super(`스토어를 찾을 수 없습니다: ${storeId}`);
+    this.name = 'PublicStoreProfileNotFoundError';
+  }
+}
+
+/**
+ * Public store profile API — single consumer-side owner for
+ * GET /stores/:storeId/public-profile.
+ * Returns exactly { id, name, logoUrl, salesMode }.
+ * 404 → PublicStoreProfileNotFoundError (missing, not network failure).
+ */
+export async function fetchPublicStoreProfile(
+  storeId: string,
+  signal?: AbortSignal,
+): Promise<StorePublicProfile> {
+  const res = await fetch(
+    `${getApiBaseUrl()}/stores/${encodeURIComponent(storeId)}/public-profile`,
+    { signal },
+  );
+  if (res.status === 404) throw new PublicStoreProfileNotFoundError(storeId);
+  if (!res.ok) throw new Error(`스토어 조회 오류: ${res.status}`);
+  const payload = (await res.json()) as Record<string, unknown>;
+  const salesModeValue = payload['salesMode'];
+  const salesMode: SalesMode =
+    salesModeValue === 'round_direct' ? 'round_direct' : normalizeSalesMode(undefined);
+  return {
+    id: String(payload['id'] ?? storeId),
+    name: String(payload['name'] ?? ''),
+    logoUrl: (payload['logoUrl'] as string | null) ?? null,
+    salesMode,
+  };
+}

--- a/apps/seller/src/app/products/[id]/edit/page.tsx
+++ b/apps/seller/src/app/products/[id]/edit/page.tsx
@@ -48,7 +48,7 @@ export default function EditProductPage() {
   useEffect(() => {
     if (!storeId || !token || !productId) return;
 
-    fetch(`${getApiBaseUrl()}/stores/${storeId}/products/${productId}`, {
+    fetch(`${getApiBaseUrl()}/stores/${storeId}/products/${productId}/owner`, {
       headers: { Authorization: `Bearer ${token}` },
     })
       .then(async (res) => {

--- a/firestore.rules
+++ b/firestore.rules
@@ -64,26 +64,33 @@ service cloud.firestore {
       allow write: if false;
     }
 
-    // products: 읽기 전체 허용 (공개 상품 데이터 — seller 실시간 리스너 + consumer 조회)
+    // products: anonymous raw document unrestricted read 제거 — 공개 카탈로그는
+    // Public Product API projection을 사용한다. 인증된 seller owner surface
+    // (store products listener / order-detail fallback)는 유지한다.
     match /products/{productId} {
-      allow read: if true;
+      allow read: if request.auth != null;
       allow write: if false;
     }
 
-    // stores: 단일 문서 get만 허용 (상품 상세 판매자 정보 노출용)
+    // stores: anonymous raw store get 제거 — 공개 프로필은
+    // GET /stores/:storeId/public-profile API를 사용한다.
     match /stores/{storeId} {
-      allow get: if true;
+      allow get: if request.auth != null;
       allow list, write: if false;
     }
 
-    // dailyCaps, groupProductConfig: 소비자 앱 공개 읽기 (상품 재고/공동구매 현황)
+    // dailyCaps: 소비자 배송일 picker가 직접 구독 (공개 잔여 ظرفیت, PII 없음).
+    // REST daily-caps는 seller 전용이므로 consumer 직접 읽기를 유지한다.
     match /dailyCaps/{docId} {
       allow read: if true;
       allow write: if false;
     }
 
+    // groupProductConfig: anonymous raw config read 제거 — 공개 현황은
+    // Public Product detail API projection을 사용한다.
+    // 인증된 seller 보조 읽기(useGroupConfigs/order-detail)는 유지한다.
     match /groupProductConfig/{docId} {
-      allow read: if true;
+      allow read: if request.auth != null;
       allow write: if false;
     }
 
@@ -100,7 +107,8 @@ service cloud.firestore {
     }
 
     match /saleRoundItems/{roundItemId} {
-      allow read: if isPublicSaleRoundItem(resource.data.roundId, resource.data.storeId);
+      allow read: if isPublicSaleRoundItem(resource.data.roundId, resource.data.storeId)
+        && resource.data.status != 'HIDDEN';
       allow write: if false;
     }
 

--- a/packages/shared/src/product.types.ts
+++ b/packages/shared/src/product.types.ts
@@ -62,6 +62,51 @@ export interface GroupProductConfig {
   deliveryFeeDiscount: number
 }
 
+/** Public group config — explicit allowlist (drops isProcessed and internals). */
+export interface GroupConfigPublic {
+  productId: string
+  minQuantity: number
+  targetQuantity: number
+  maxPerPerson: number
+  recruitDeadline: string | null
+  currentQuantity: number
+  groupDeliveryDate: string | null
+  groupDeliveryMethod: 'direct' | 'parcel'
+  deliveryFeeDiscount: number
+}
+
+/** Public group summary for list responses — minimal allowlist. */
+export interface GroupSummaryPublic {
+  currentQuantity: number
+  minQuantity: number
+  targetQuantity: number
+  recruitDeadline: string | null
+}
+
+/** Public product detail — explicit allowlist (drops sellerNote/sellerOverride/content.isEditedByUser/testOnly/raw internals). */
+export interface ProductPublic {
+  id: string
+  storeId: string
+  name: string
+  images: string[]
+  price: number
+  category: Category
+  saleType: SaleType
+  deliverySize: DeliverySize
+  isActive: boolean
+  createdAt: string
+  updatedAt: string
+  varietyId?: string
+  selection?: Selection
+  content?: {
+    headline: string
+    description: string
+  }
+  description?: string
+  colors?: ColorOption[]
+  groupConfig?: GroupConfigPublic
+}
+
 export interface Product {
   id: string
   storeId: string

--- a/packages/shared/src/store.types.ts
+++ b/packages/shared/src/store.types.ts
@@ -32,3 +32,15 @@ export interface UpdateStoreRequest {
   logoUrl?: string;
   salesMode?: SalesMode;
 }
+
+/**
+ * Public store profile — explicit allowlist for unauthenticated reads.
+ * Only id/name/logoUrl/salesMode. Never ownerId/ceoName/phone/address/
+ * businessNumber/status/timestamps.
+ */
+export interface StorePublicProfile {
+  id: string;
+  name: string;
+  logoUrl: string | null;
+  salesMode: SalesMode;
+}

--- a/tests/firestore/firestore-rules.test.mjs
+++ b/tests/firestore/firestore-rules.test.mjs
@@ -71,15 +71,43 @@ async function seedFixtures() {
   await testEnvironment.withSecurityRulesDisabled(async (context) => {
     const database = context.firestore();
     const fixtures = {
-      'products/product-1': { storeId: 'store-1', name: '공개 상품' },
-      'stores/store-1': { name: '공개 매장', salesMode: 'round_direct' },
+      'products/product-1': {
+        storeId: 'store-1',
+        name: '공개 상품',
+        isActive: true,
+        sellerNote: '내부 메모',
+        sellerOverride: true,
+        content: { headline: '제목', description: '설명', isEditedByUser: true },
+      },
+      'products/product-inactive': { storeId: 'store-1', name: '비활성 상품', isActive: false },
+      'products/product-testonly': {
+        storeId: 'store-1',
+        name: '테스트 상품',
+        isActive: true,
+        testOnly: true,
+      },
+      'stores/store-1': {
+        name: '공개 매장',
+        salesMode: 'round_direct',
+        ownerId: 'seller-1',
+        ceoName: '홍길동',
+        phone: '010-1234-5678',
+        address: '경기도 이천시',
+        businessNumber: '123-45-67890',
+        status: 'active',
+      },
       'stores/store-2': { name: '다른 매장', salesMode: 'round_direct' },
       'stores/store-legacy': { name: '기존 매장', salesMode: 'legacy' },
       'stores/store-missing-mode': { name: '모드 누락 매장' },
       'stores/store-null-mode': { name: 'null 모드 매장', salesMode: null },
       'stores/store-invalid-mode': { name: '잘못된 모드 매장', salesMode: 'unsupported' },
       'dailyCaps/store-1_2026-07-18': { storeId: 'store-1', date: '2026-07-18' },
-      'groupProductConfig/product-1': { storeId: 'store-1', productId: 'product-1' },
+      'groupProductConfig/product-1': {
+        storeId: 'store-1',
+        productId: 'product-1',
+        currentQuantity: 3,
+        isProcessed: true,
+      },
       'varieties/variety-1': {
         name: '호접란',
         category: 'orchid',
@@ -252,6 +280,25 @@ async function seedFixtures() {
         storeId: 'store-1',
         roundId: 'round-1',
         productId: 'product-1',
+        status: 'ACTIVE',
+      },
+      'saleRoundItems/item-soldout': {
+        storeId: 'store-1',
+        roundId: 'round-1',
+        productId: 'product-1',
+        status: 'SOLD_OUT',
+      },
+      'saleRoundItems/item-closed': {
+        storeId: 'store-1',
+        roundId: 'round-1',
+        productId: 'product-1',
+        status: 'CLOSED',
+      },
+      'saleRoundItems/item-hidden': {
+        storeId: 'store-1',
+        roundId: 'round-1',
+        productId: 'product-1',
+        status: 'HIDDEN',
       },
       'saleRoundItems/item-foreign-store': {
         storeId: 'store-2',
@@ -397,6 +444,7 @@ test('saleRoundItems는 공개 회차에 속한 단건 및 제한된 목록 조�
     collection(database, 'saleRoundItems'),
     where('roundId', '==', 'round-1'),
     where('storeId', '==', 'store-1'),
+    where('status', 'in', ['ACTIVE', 'SOLD_OUT', 'CLOSED']),
   );
   const roundOnlyQuery = query(
     collection(database, 'saleRoundItems'),
@@ -404,6 +452,9 @@ test('saleRoundItems는 공개 회차에 속한 단건 및 제한된 목록 조�
   );
 
   await assertSucceeds(getDoc(doc(database, 'saleRoundItems', 'item-1')));
+  await assertSucceeds(getDoc(doc(database, 'saleRoundItems', 'item-soldout')));
+  await assertSucceeds(getDoc(doc(database, 'saleRoundItems', 'item-closed')));
+  await assertFails(getDoc(doc(database, 'saleRoundItems', 'item-hidden')));
   await assertSucceeds(getDocs(publicQuery));
   for (const itemId of [
     'item-foreign-store',
@@ -429,16 +480,73 @@ for (const collectionName of PUBLIC_ROUND_COLLECTIONS) {
   });
 }
 
-test('기존 공개 상품과 매장 및 재고 조회를 보존한다', async () => {
+test('익명 products 원문 읽기는 API 사용 구간에서 거부된다', async () => {
   const database = testEnvironment.unauthenticatedContext().firestore();
 
-  await assertSucceeds(getDoc(doc(database, 'products', 'product-1')));
-  await assertSucceeds(getDocs(collection(database, 'products')));
-  await assertSucceeds(getDoc(doc(database, 'stores', 'store-1')));
+  await assertFails(getDoc(doc(database, 'products', 'product-1')));
+  await assertFails(getDoc(doc(database, 'products', 'product-inactive')));
+  await assertFails(getDoc(doc(database, 'products', 'product-testonly')));
+  await assertFails(getDocs(collection(database, 'products')));
+  await assertFails(
+    getDocs(query(collection(database, 'products'), where('storeId', '==', 'store-1'))),
+  );
+});
+
+test('비활성/testOnly product는 Firestore 우회로 얻을 수 없다', async () => {
+  const anonymous = testEnvironment.unauthenticatedContext().firestore();
+  const consumer = testEnvironment.authenticatedContext('user-1').firestore();
+
+  // 익명은 원문 자체를 읽을 수 없으므로 우회가 불가능하다.
+  await assertFails(getDoc(doc(anonymous, 'products', 'product-inactive')));
+  await assertFails(getDoc(doc(anonymous, 'products', 'product-testonly')));
+  // 인증된 원문 읽기는 owner surface용으로 유지되지만 공개 API predicate와
+  // 동일한 가시성 계약을 consumer가 직접 강제하지 않으므로,
+  // 공개 가시성 판정은 API projection이 소유한다 (아래 API 회귀 테스트로 고정).
+  await assertSucceeds(getDoc(doc(consumer, 'products', 'product-1')));
+});
+
+test('익명 stores 원문/PII 우회가 불가능하다', async () => {
+  const database = testEnvironment.unauthenticatedContext().firestore();
+
+  await assertFails(getDoc(doc(database, 'stores', 'store-1')));
+  await assertFails(getDocs(collection(database, 'stores')));
+});
+
+test('익명 groupProductConfig 원문 우회가 불가능하다', async () => {
+  const database = testEnvironment.unauthenticatedContext().firestore();
+
+  await assertFails(getDoc(doc(database, 'groupProductConfig', 'product-1')));
+  await assertFails(getDocs(collection(database, 'groupProductConfig')));
+});
+
+test('HIDDEN saleRoundItem 익명 직접 읽기가 불가능하다', async () => {
+  const database = testEnvironment.unauthenticatedContext().firestore();
+
+  await assertFails(getDoc(doc(database, 'saleRoundItems', 'item-hidden')));
+  // ACTIVE / SOLD_OUT / CLOSED는 기존 공개 의미를 유지한다.
+  await assertSucceeds(getDoc(doc(database, 'saleRoundItems', 'item-1')));
+  await assertSucceeds(getDoc(doc(database, 'saleRoundItems', 'item-soldout')));
+  await assertSucceeds(getDoc(doc(database, 'saleRoundItems', 'item-closed')));
+});
+
+test('인증된 seller owner surface 읽기( products/stores/groupConfig )를 보존한다', async () => {
+  const seller = testEnvironment
+    .authenticatedContext('seller-1', { role: 'seller', storeId: 'store-1' })
+    .firestore();
+
+  await assertSucceeds(getDoc(doc(seller, 'products', 'product-1')));
+  await assertSucceeds(
+    getDocs(query(collection(seller, 'products'), where('storeId', '==', 'store-1'))),
+  );
+  await assertSucceeds(getDoc(doc(seller, 'stores', 'store-1')));
+  await assertSucceeds(getDoc(doc(seller, 'groupProductConfig', 'product-1')));
+});
+
+test('공개 dailyCaps 직접 구독을 보존한다', async () => {
+  const database = testEnvironment.unauthenticatedContext().firestore();
+
   await assertSucceeds(getDoc(doc(database, 'dailyCaps', 'store-1_2026-07-18')));
   await assertSucceeds(getDocs(collection(database, 'dailyCaps')));
-  await assertSucceeds(getDoc(doc(database, 'groupProductConfig', 'product-1')));
-  await assertSucceeds(getDocs(collection(database, 'groupProductConfig')));
 });
 
 test('품종은 공개 단건 조회만 허용하고 목록과 모든 직접 쓰기를 거부한다', async () => {


### PR DESCRIPTION
TASK_ID: PUBLIC-CATALOG-FIRESTORE-ACCESS-CONVERGENCE-01. Reconciles A/B/C source remediations onto live main 18378f58 and closes anonymous raw reads for products/stores/groupProductConfig + HIDDEN saleRoundItems. Consumer migrated to public APIs (useProduct/useVariety). Rules tests updated. Admission: PUBLICATION_ALLOWED.