### PR TITLE
fix(e2e): close Auth.js session-cookie verifier false negative with single-owner matcher

### DIFF
--- a/apps/e2e/global-setup.ts
+++ b/apps/e2e/global-setup.ts
@@ -33,6 +33,7 @@ import {
   ADMIN_STATE_PATH,
   AUTH_STATE_PATH,
   BYPASS_STATE_PATH,
+  isAuthJsSessionCookieName,
   loginViaCredentials,
   ROUND_DIRECT_STATE_PATHS,
 } from './tests/_helpers/auth'
@@ -125,7 +126,7 @@ async function verifyRoleSession(page: Page, base: string, expectedRole: string)
     throw new Error(`${expectedRole} 세션 만료 시각 검증 실패`)
   }
   const cookies = await page.context().cookies(base)
-  if (!cookies.some(({ name }) => /authjs\.session-token/.test(name))) {
+  if (!cookies.some(({ name }) => isAuthJsSessionCookieName(name))) {
     throw new Error(`${expectedRole} 대상 도메인의 세션 쿠키 검증 실패`)
   }
 }

--- a/apps/e2e/tests/_helpers/auth.test.mjs
+++ b/apps/e2e/tests/_helpers/auth.test.mjs
@@ -1,9 +1,10 @@
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 import { describe, it } from 'node:test';
 import { resolve } from 'node:path';
 
 globalThis.__dirname = resolve(process.cwd(), 'apps/e2e/tests/_helpers');
-const { classifyAuthFailure, cookieNamesFromHeaders, sanitizeAuthLocation } = await import('./auth.ts');
+const { classifyAuthFailure, cookieNamesFromHeaders, isAuthJsSessionCookieName, sanitizeAuthLocation } = await import('./auth.ts');
 
 function evidence(overrides = {}) {
   return {
@@ -159,5 +160,61 @@ describe('Auth.js 콜백 진단 계약', () => {
       ),
       'SESSION_COOKIE_PRESENT_BUT_SESSION_INVALID',
     );
+  });
+
+  describe('Auth.js session cookie 이름 판정 (단일 owner)', () => {
+    it('bare / __Secure- / __Host- / numeric chunk session cookie를 인식한다', () => {
+      for (const name of [
+        'authjs.session-token',
+        'authjs.session-token.0',
+        'authjs.session-token.1',
+        '__Secure-authjs.session-token',
+        '__Secure-authjs.session-token.0',
+        '__Secure-authjs.session-token.1',
+        '__Host-authjs.session-token',
+        '__Host-authjs.session-token.0',
+        '__Host-authjs.session-token.1',
+      ]) {
+        assert.equal(isAuthJsSessionCookieName(name), true, name);
+      }
+      // cookie jar 수준: chunked secure 이름 하나만 있어도 세션으로 판정한다.
+      assert.equal(['__Secure-authjs.session-token.0'].some(isAuthJsSessionCookieName), true);
+      assert.equal(['__Host-authjs.session-token.1', 'authjs.csrf-token'].some(isAuthJsSessionCookieName), true);
+    });
+
+    it('csrf/callback/substring/non-numeric suffix를 session cookie로 인정하지 않는다', () => {
+      for (const name of [
+        'authjs.csrf-token',
+        '__Secure-authjs.csrf-token',
+        '__Host-authjs.csrf-token',
+        'authjs.callback-url',
+        'authjs.session-tokenx',
+        'fooauthjs.session-token',
+        '__Secure-authjs.session-token.foo',
+      ]) {
+        assert.equal(isAuthJsSessionCookieName(name), false, name);
+      }
+      assert.equal(['authjs.csrf-token', '__Secure-authjs.csrf-token'].some(isAuthJsSessionCookieName), false);
+    });
+
+    it('chunked secure Set-Cookie evidence에서도 value를 노출하지 않는다', () => {
+      const result = cookieNamesFromHeaders([
+        { name: 'set-cookie', value: '__Secure-authjs.session-token.0=redacted-chunked-value; Path=/; HttpOnly; Secure' },
+        { name: 'set-cookie', value: '__Host-authjs.session-token.1=redacted-host-value; Path=/; HttpOnly; Secure' },
+      ]);
+      assert.deepEqual(result, ['__Host-authjs.session-token.1', '__Secure-authjs.session-token.0']);
+      assert.equal(result.some(isAuthJsSessionCookieName), true);
+      assert.equal(JSON.stringify(result).includes('redacted-chunked-value'), false);
+      assert.equal(JSON.stringify(result).includes('redacted-host-value'), false);
+    });
+
+    it('global-setup은 별도 matcher를 소유하지 않고 단일 owner를 사용한다', () => {
+      const source = readFileSync(resolve(process.cwd(), 'apps/e2e/global-setup.ts'), 'utf8');
+      assert.ok(source.includes('isAuthJsSessionCookieName'));
+      const nonCommentOwners = source
+        .split('\n')
+        .filter((line) => line.includes('authjs.session-token') && !line.trim().startsWith('//'));
+      assert.deepEqual(nonCommentOwners, []);
+    });
   });
 });

--- a/apps/e2e/tests/_helpers/auth.ts
+++ b/apps/e2e/tests/_helpers/auth.ts
@@ -108,8 +108,28 @@ export function cookieNamesFromHeaders(
   )].sort()
 }
 
+/**
+ * Auth.js session cookie 이름 판정의 단일 semantic owner.
+ *
+ * 허용:
+ *  - bare: authjs.session-token
+ *  - HTTPS secure prefix: __Secure-authjs.session-token
+ *  - host prefix: __Host-authjs.session-token
+ *  - 위 세 형태 모두에서 Auth.js chunk suffix .0 / .1 / .2 ... 허용
+ *
+ * 거부:
+ *  - authjs.csrf-token / __Secure-authjs.csrf-token 등 base 불일치
+ *  - authjs.callback-url
+ *  - authjs.session-tokenx / fooauthjs.session-token 등 substring 일치
+ *  - 임의 non-numeric suffix (예: __Secure-authjs.session-token.foo)
+ */
+export function isAuthJsSessionCookieName(name: unknown): boolean {
+  if (typeof name !== 'string' || !name) return false
+  return /^(?:__Secure-|__Host-)?authjs\.session-token(?:\.\d+)?$/.test(name)
+}
+
 function hasSessionCookie(names: string[]): boolean {
-  return names.some((name) => /(?:^|\.)authjs\.session-token(?:\.|$)/.test(name))
+  return names.some(isAuthJsSessionCookieName)
 }
 
 export function classifyAuthFailure(evidence: AuthDiagnosticEvidence): AuthFailureCategory | null {


### PR DESCRIPTION
PILOT-AUTH-VERIFIER-COOKIE-04A ordinary publication. Candidate 67632ede1d7196456bcf1fe5320a7a7e7d509c0c onto live main cd83d873c07ee1f105af7d583b7fa66b3d32240d (PRE_PR PUBLICATION_ALLOWED, 3 owned paths). Single-owner isAuthJsSessionCookieName; global-setup converged; focused fixtures 7/7 + tsc + admission/transport specs 15/15 PASS. No runtime/secret/env/preview changes; taxonomy unchanged.