### PR TITLE
fix(notifications): reconcile uncertain provider outcomes safely

### DIFF
--- a/apps/api/src/notifications/aligo.client.ts
+++ b/apps/api/src/notifications/aligo.client.ts
@@ -1,6 +1,7 @@
 import type { NotificationChannel } from '@greenhub/shared';
 import { Injectable } from '@nestjs/common';
 import type { ConfigService } from '@nestjs/config';
+import { v4 as uuidv4 } from 'uuid';
 import { resolveAligoTemplateCode } from './aligo-template-codes';
 import {
   type ApiNotificationTemplateCode,
@@ -8,14 +9,71 @@ import {
   renderNotificationMessage,
 } from './notification-templates';
 
+export type ProviderOutcome = 'ACCEPTED' | 'REJECTED' | 'UNKNOWN';
+
 export type NotificationDeliveryResult = {
   success: boolean;
+  outcome: ProviderOutcome;
   channel: Extract<NotificationChannel, 'alimtalk' | 'sms'> | null;
   message: string;
   alimtalkAttempts: number;
   smsAttempts: number;
+  providerReceipt: string | null;
+  attemptId: string | null;
+  needsVerify: boolean;
   errorMessage?: string;
 };
+
+type ProviderAttemptResult = {
+  outcome: ProviderOutcome;
+  providerReceipt: string | null;
+  errorMessage?: string;
+};
+
+export function normalizeProviderReceipt(value: unknown): string | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return String(value);
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export function parseAlimtalkReceipt(json: unknown): string | null {
+  if (!json || typeof json !== 'object') return null;
+  const record = json as Record<string, unknown>;
+  const info = record['info'];
+  if (info && typeof info === 'object') {
+    const mid = (info as Record<string, unknown>)['mid'];
+    const normalized = normalizeProviderReceipt(mid);
+    if (normalized) return normalized;
+  }
+  return normalizeProviderReceipt(record['mid']);
+}
+
+export function parseSmsReceipt(json: unknown): string | null {
+  if (!json || typeof json !== 'object') return null;
+  const record = json as Record<string, unknown>;
+  return normalizeProviderReceipt(record['msg_id']);
+}
+
+function localRejection(
+  message: string,
+  alimtalkAttempts: number,
+  smsAttempts: number,
+  errorMessage: string,
+): NotificationDeliveryResult {
+  return {
+    success: false,
+    outcome: 'REJECTED',
+    channel: null,
+    message,
+    alimtalkAttempts,
+    smsAttempts,
+    providerReceipt: null,
+    attemptId: null,
+    needsVerify: false,
+    errorMessage,
+  };
+}
 
 @Injectable()
 export class AligoClient {
@@ -45,76 +103,118 @@ export class AligoClient {
     variables: Record<string, string>,
   ): Promise<NotificationDeliveryResult> {
     const rendered = this.renderMessage(templateCode, variables);
-    if ('errorMessage' in rendered) return rendered;
-    const message = rendered.message;
-    if (this.outboundDenied) {
+    if ('errorMessage' in rendered) {
       return {
-        success: false,
-        channel: null,
-        message,
-        alimtalkAttempts: 0,
-        smsAttempts: 0,
-        errorMessage: 'local runtime에서는 외부 발송을 거부합니다.',
+        ...rendered,
+        outcome: 'REJECTED',
+        providerReceipt: null,
+        attemptId: null,
+        needsVerify: false,
       };
     }
-    if (!this.apiKey || !this.userId || !this.senderKey || !this.senderPhone) {
-      return {
-        success: false,
-        channel: null,
+    const message = rendered.message;
+    if (this.outboundDenied) {
+      return localRejection(
         message,
-        alimtalkAttempts: 0,
-        smsAttempts: 0,
-        errorMessage: '알림 발송 필수 설정이 누락되었습니다.',
-      };
+        0,
+        0,
+        'local runtime에서는 외부 발송을 거부합니다.',
+      );
+    }
+    if (!this.apiKey || !this.userId || !this.senderKey || !this.senderPhone) {
+      return localRejection(message, 0, 0, '알림 발송 필수 설정이 누락되었습니다.');
     }
 
     let providerTemplateCode: string;
     try {
       providerTemplateCode = resolveAligoTemplateCode(this.templateCodesJson, templateCode);
     } catch (error) {
-      return {
-        success: false,
-        channel: null,
+      return localRejection(
         message,
-        alimtalkAttempts: 0,
-        smsAttempts: 0,
-        errorMessage: error instanceof Error ? error.message : 'ALIGO 템플릿 코드 설정 오류입니다.',
-      };
+        0,
+        0,
+        error instanceof Error ? error.message : 'ALIGO 템플릿 코드 설정 오류입니다.',
+      );
     }
 
+    const attemptId = uuidv4();
     let errorMessage = '알림톡 발송에 실패했습니다.';
 
     for (let attempt = 0; attempt < 3; attempt += 1) {
       const result = await this.sendAlimtalkOnce(phone, providerTemplateCode, message);
-      if (result.success) {
+      if (result.outcome === 'ACCEPTED') {
         return {
           success: true,
+          outcome: 'ACCEPTED',
           channel: 'alimtalk',
           message,
           alimtalkAttempts: attempt + 1,
           smsAttempts: 0,
+          providerReceipt: result.providerReceipt,
+          attemptId,
+          needsVerify: false,
+        };
+      }
+      if (result.outcome === 'UNKNOWN') {
+        return {
+          success: false,
+          outcome: 'UNKNOWN',
+          channel: null,
+          message,
+          alimtalkAttempts: attempt + 1,
+          smsAttempts: 0,
+          providerReceipt: null,
+          attemptId,
+          needsVerify: true,
+          errorMessage:
+            result.errorMessage ??
+            'provider 접수 여부를 확인할 수 없습니다. blind retry 없이 수동 확인이 필요합니다.',
         };
       }
       errorMessage = result.errorMessage ?? errorMessage;
     }
 
     const smsResult = await this.sendSmsMessage(phone, message);
-    if (smsResult.success) {
+    if (smsResult.outcome === 'ACCEPTED') {
       return {
         success: true,
+        outcome: 'ACCEPTED',
         channel: 'sms',
         message,
         alimtalkAttempts: 3,
         smsAttempts: 1,
+        providerReceipt: smsResult.providerReceipt,
+        attemptId,
+        needsVerify: false,
+      };
+    }
+    if (smsResult.outcome === 'UNKNOWN') {
+      return {
+        success: false,
+        outcome: 'UNKNOWN',
+        channel: null,
+        message,
+        alimtalkAttempts: 3,
+        smsAttempts: 1,
+        providerReceipt: null,
+        attemptId,
+        needsVerify: true,
+        errorMessage:
+          smsResult.errorMessage ??
+          'provider 접수 여부를 확인할 수 없습니다. blind retry 없이 수동 확인이 필요합니다.',
       };
     }
 
     return {
       success: false,
+      outcome: 'REJECTED',
       channel: null,
       message,
       alimtalkAttempts: 3,
       smsAttempts: 1,
+      providerReceipt: null,
+      attemptId,
+      needsVerify: false,
       errorMessage: smsResult.errorMessage ?? errorMessage,
     };
   }
@@ -125,35 +225,68 @@ export class AligoClient {
     variables: Record<string, string>,
   ): Promise<NotificationDeliveryResult> {
     const rendered = this.renderMessage(templateCode, variables);
-    if ('errorMessage' in rendered) return rendered;
+    if ('errorMessage' in rendered) {
+      return {
+        ...rendered,
+        outcome: 'REJECTED',
+        providerReceipt: null,
+        attemptId: null,
+        needsVerify: false,
+      };
+    }
     const message = rendered.message;
     if (this.outboundDenied) {
-      return {
-        success: false,
-        channel: null,
+      return localRejection(
         message,
-        alimtalkAttempts: 0,
-        smsAttempts: 0,
-        errorMessage: 'local runtime에서는 외부 발송을 거부합니다.',
-      };
+        0,
+        0,
+        'local runtime에서는 외부 발송을 거부합니다.',
+      );
     }
     if (!this.apiKey || !this.userId || !this.senderPhone) {
+      return localRejection(message, 0, 0, '문자 발송 필수 설정이 누락되었습니다.');
+    }
+    const attemptId = uuidv4();
+    const result = await this.sendSmsMessage(phone, message);
+    if (result.outcome === 'ACCEPTED') {
+      return {
+        success: true,
+        outcome: 'ACCEPTED',
+        channel: 'sms',
+        message,
+        alimtalkAttempts: 0,
+        smsAttempts: 1,
+        providerReceipt: result.providerReceipt,
+        attemptId,
+        needsVerify: false,
+      };
+    }
+    if (result.outcome === 'UNKNOWN') {
       return {
         success: false,
+        outcome: 'UNKNOWN',
         channel: null,
         message,
         alimtalkAttempts: 0,
-        smsAttempts: 0,
-        errorMessage: '문자 발송 필수 설정이 누락되었습니다.',
+        smsAttempts: 1,
+        providerReceipt: null,
+        attemptId,
+        needsVerify: true,
+        errorMessage:
+          result.errorMessage ??
+          'provider 접수 여부를 확인할 수 없습니다. blind retry 없이 수동 확인이 필요합니다.',
       };
     }
-    const result = await this.sendSmsMessage(phone, message);
     return {
-      success: result.success,
-      channel: result.success ? 'sms' : null,
+      success: false,
+      outcome: 'REJECTED',
+      channel: null,
       message,
       alimtalkAttempts: 0,
       smsAttempts: 1,
+      providerReceipt: null,
+      attemptId,
+      needsVerify: false,
       errorMessage: result.errorMessage,
     };
   }
@@ -161,7 +294,16 @@ export class AligoClient {
   private renderMessage(
     templateCode: ApiNotificationTemplateCode,
     variables: Record<string, string>,
-  ): { message: string } | NotificationDeliveryResult {
+  ):
+    | { message: string }
+    | {
+        success: false;
+        channel: null;
+        message: string;
+        alimtalkAttempts: number;
+        smsAttempts: number;
+        errorMessage: string;
+      } {
     try {
       return { message: renderNotificationMessage(templateCode, variables) };
     } catch (error) {
@@ -180,7 +322,7 @@ export class AligoClient {
     phone: string,
     templateCode: string,
     message: string,
-  ): Promise<{ success: boolean; errorMessage?: string }> {
+  ): Promise<ProviderAttemptResult> {
     try {
       const params = new URLSearchParams({
         apikey: this.apiKey,
@@ -197,20 +339,45 @@ export class AligoClient {
         method: 'POST',
         body: params,
       });
-      const json = (await res.json()) as { code: number; message: string };
-      if (json.code !== 0) {
-        return { success: false, errorMessage: json.message };
+      let json: unknown;
+      try {
+        json = (await res.json()) as unknown;
+      } catch (e) {
+        return {
+          outcome: 'UNKNOWN',
+          providerReceipt: null,
+          errorMessage: `알림톡 응답 파싱 실패: ${String(e)}`,
+        };
       }
-      return { success: true };
+      const record = (json ?? {}) as Record<string, unknown>;
+      if (typeof record['code'] !== 'number' || !Number.isFinite(record['code'])) {
+        return {
+          outcome: 'UNKNOWN',
+          providerReceipt: null,
+          errorMessage: '알림톡 응답 코드 파싱 실패로 접수 여부를 확인할 수 없습니다.',
+        };
+      }
+      if (record['code'] !== 0) {
+        const messageText =
+          typeof record['message'] === 'string' && record['message'].trim().length > 0
+            ? (record['message'] as string)
+            : '알림톡 발송에 실패했습니다.';
+        return { outcome: 'REJECTED', providerReceipt: null, errorMessage: messageText };
+      }
+      return { outcome: 'ACCEPTED', providerReceipt: parseAlimtalkReceipt(json) };
     } catch (e) {
-      return { success: false, errorMessage: String(e) };
+      return {
+        outcome: 'UNKNOWN',
+        providerReceipt: null,
+        errorMessage: `알림톡 transport 불확실: ${String(e)}`,
+      };
     }
   }
 
   private async sendSmsMessage(
     phone: string,
     message: string,
-  ): Promise<{ success: boolean; errorMessage?: string }> {
+  ): Promise<ProviderAttemptResult> {
     try {
       const params = new URLSearchParams({
         key: this.apiKey,
@@ -224,18 +391,39 @@ export class AligoClient {
         method: 'POST',
         body: params,
       });
-      const json = (await res.json()) as {
-        code?: number;
-        result_code?: number | string;
-        message?: string;
-      };
-      const resultCode = Number(json.result_code ?? json.code);
-      if (resultCode !== 0 && resultCode !== 1) {
-        return { success: false, errorMessage: json.message ?? '문자 대체 발송에 실패했습니다.' };
+      let json: unknown;
+      try {
+        json = (await res.json()) as unknown;
+      } catch (e) {
+        return {
+          outcome: 'UNKNOWN',
+          providerReceipt: null,
+          errorMessage: `문자 응답 파싱 실패: ${String(e)}`,
+        };
       }
-      return { success: true };
+      const record = (json ?? {}) as Record<string, unknown>;
+      const resultCode = Number(record['result_code'] ?? record['code']);
+      if (!Number.isFinite(resultCode)) {
+        return {
+          outcome: 'UNKNOWN',
+          providerReceipt: null,
+          errorMessage: '문자 응답 코드 파싱 실패로 접수 여부를 확인할 수 없습니다.',
+        };
+      }
+      if (resultCode !== 0 && resultCode !== 1) {
+        const messageText =
+          typeof record['message'] === 'string' && record['message'].trim().length > 0
+            ? (record['message'] as string)
+            : '문자 대체 발송에 실패했습니다.';
+        return { outcome: 'REJECTED', providerReceipt: null, errorMessage: messageText };
+      }
+      return { outcome: 'ACCEPTED', providerReceipt: parseSmsReceipt(json) };
     } catch (e) {
-      return { success: false, errorMessage: String(e) };
+      return {
+        outcome: 'UNKNOWN',
+        providerReceipt: null,
+        errorMessage: `문자 transport 불확실: ${String(e)}`,
+      };
     }
   }
 }

--- a/apps/api/src/notifications/e2e-aligo.client.ts
+++ b/apps/api/src/notifications/e2e-aligo.client.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import type { NotificationChannel } from '@greenhub/shared';
+import { v4 as uuidv4 } from 'uuid';
 import { resolveE2EProviderMode } from '../common/e2e-provider-mode';
 import type { NotificationDeliveryResult } from './aligo.client';
 import {
@@ -51,29 +52,42 @@ export class E2EAligoClient {
   ): Promise<NotificationDeliveryResult> {
     const scenario = scenarioFromVariables(variables);
     const message = renderNotificationMessage(templateCode, variables);
-    const result =
+    const attemptId = uuidv4();
+    const result: NotificationDeliveryResult =
       scenario === 'alimtalk_success'
         ? {
             success: true,
+            outcome: 'ACCEPTED',
             channel: 'alimtalk' as const,
             message,
             alimtalkAttempts: 1,
             smsAttempts: 0,
+            providerReceipt: 'e2e-alimtalk-mid-stub-001',
+            attemptId,
+            needsVerify: false,
           }
         : scenario === 'alimtalk_retry_sms_success'
           ? {
               success: true,
+              outcome: 'ACCEPTED',
               channel: 'sms' as const,
               message,
               alimtalkAttempts: 3,
               smsAttempts: 1,
+              providerReceipt: 'e2e-sms-msg-id-stub-001',
+              attemptId,
+              needsVerify: false,
             }
           : {
               success: false,
+              outcome: 'REJECTED',
               channel: null,
               message,
               alimtalkAttempts: 3,
               smsAttempts: 1,
+              providerReceipt: null,
+              attemptId,
+              needsVerify: false,
               errorMessage: 'E2E 알림톡과 문자 최종 실패 fixture입니다.',
             };
     this.record('sendAlimtalk', templateCode, scenario, result.channel);
@@ -90,10 +104,14 @@ export class E2EAligoClient {
     const success = scenario !== 'final_failure';
     const result: NotificationDeliveryResult = {
       success,
+      outcome: success ? 'ACCEPTED' : 'REJECTED',
       channel: success ? 'sms' : null,
       message,
       alimtalkAttempts: 0,
       smsAttempts: 1,
+      providerReceipt: success ? 'e2e-sms-msg-id-stub-001' : null,
+      attemptId: uuidv4(),
+      needsVerify: false,
       errorMessage: success ? undefined : 'E2E 문자 최종 실패 fixture입니다.',
     };
     this.record('sendSms', templateCode, scenario, result.channel);

--- a/apps/api/src/notifications/notifications-provider-outcome.spec.ts
+++ b/apps/api/src/notifications/notifications-provider-outcome.spec.ts
@@ -1,0 +1,588 @@
+import type { ConfigService } from '@nestjs/config';
+import { createHash } from 'node:crypto';
+import { AligoClient } from './aligo.client';
+import {
+  NOTIFICATION_DELIVERY_PROCESSING_LEASE_TTL_MS,
+  NotificationsService,
+} from './notifications.service';
+
+type Data = Record<string, unknown>;
+
+const phone = '01012345678';
+const templateCode = 'ORDER_DELIVERY_HELD';
+const variables = { orderId: 'order-1', reason: '연락 불가' };
+
+const configured = {
+  ALIGO_API_KEY: 'test-api-key',
+  ALIGO_USER_ID: 'test-user',
+  ALIGO_SENDER_KEY: 'test-sender-key',
+  ALIGO_SENDER_PHONE: '0212345678',
+  ALIGO_TEMPLATE_CODES_JSON: JSON.stringify({ [templateCode]: 'provider-delivery-held' }),
+};
+
+function makeClient(config: Data = {}) {
+  const configService = {
+    get: jest.fn((key: string, fallback: string) => config[key] ?? fallback),
+  } as unknown as ConfigService;
+  return new AligoClient(configService);
+}
+
+function alimtalkOk(mid: string) {
+  return { json: jest.fn().mockResolvedValue({ code: 0, message: '성공', info: { mid } }) };
+}
+
+function alimtalkReject(code = -1, message = '일시 오류') {
+  return { json: jest.fn().mockResolvedValue({ code, message }) };
+}
+
+function smsOk(msgId: string) {
+  return {
+    json: jest.fn().mockResolvedValue({ result_code: 1, message: '성공', msg_id: msgId }),
+  };
+}
+
+// ── service harness ──
+
+function deliveryDocId(key: string): string {
+  return createHash('sha256').update(key).digest('hex');
+}
+
+function deliveryPath(key: string): string {
+  return `notificationDeliveries/${deliveryDocId(key)}`;
+}
+
+const BASE_NOW = Date.UTC(2026, 8, 11, 0, 0, 0);
+
+function clone<T>(value: T): T {
+  if (value instanceof Date) return new Date(value.getTime()) as T;
+  if (Array.isArray(value)) return value.map(clone) as T;
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Data).map(([k, v]) => [k, clone(v)]),
+    ) as T;
+  }
+  return value;
+}
+
+function makeServiceHarness(opts: {
+  aligoImpl?: Data;
+  failFinishWithStatus?: string | null;
+} = {}) {
+  const records = new Map<string, Data>();
+  records.set('users/user-1', { id: 'user-1', phone: '01011112222' });
+  records.set('orders/order-1', {
+    id: 'order-1',
+    storeId: 'store-1',
+    userId: 'user-1',
+    status: 'DELIVERY_HELD',
+    deliveryPhone: phone,
+  });
+  let nowMillis = BASE_NOW;
+  let transactionQueue = Promise.resolve();
+  let runTxCount = 0;
+
+  function snapshot(path: string, source: Map<string, Data>) {
+    const data = source.get(path);
+    return {
+      exists: data !== undefined,
+      data: () => (data === undefined ? undefined : clone(data)),
+    };
+  }
+
+  function doc(path: string) {
+    return {
+      path,
+      get: jest.fn(async () => snapshot(path, records)),
+      set: jest.fn(async (data: Data, options?: { merge?: boolean }) => {
+        const current = records.get(path);
+        const next = options?.merge && current ? { ...clone(current), ...clone(data) } : clone(data);
+        records.set(path, next);
+      }),
+      update: jest.fn(async (data: Data) => {
+        const current = records.get(path);
+        if (!current) throw new Error(`missing doc: ${path}`);
+        records.set(path, { ...clone(current), ...clone(data) });
+      }),
+    };
+  }
+
+  const firestore = {
+    doc,
+    runTransaction: jest.fn((callback: (tx: any) => Promise<unknown>) => {
+      runTxCount += 1;
+      const callIndex = runTxCount;
+      const result = transactionQueue.then(async () => {
+        const staged = new Map<string, Data>(
+          Array.from(records.entries()).map(([p, d]) => [p, clone(d)]),
+        );
+        const transaction = {
+          get: jest.fn(async (ref: { path: string }) => snapshot(ref.path, staged)),
+          set: jest.fn((ref: { path: string }, data: Data, options?: { merge?: boolean }) => {
+            if (
+              opts.failFinishWithStatus &&
+              typeof data?.['status'] === 'string' &&
+              data['status'] === opts.failFinishWithStatus &&
+              callIndex >= 3
+            ) {
+              throw new Error(`injected finalize failure for ${data['status']}`);
+            }
+            const current = staged.get(ref.path);
+            const next =
+              options?.merge && current ? { ...clone(current), ...clone(data) } : clone(data);
+            staged.set(ref.path, next);
+          }),
+          update: jest.fn((ref: { path: string }, data: Data) => {
+            const current = staged.get(ref.path);
+            if (!current) throw new Error(`missing doc: ${ref.path}`);
+            staged.set(ref.path, { ...clone(current), ...clone(data) });
+          }),
+        };
+        const value = await callback(transaction);
+        records.clear();
+        for (const [p, d] of staged) records.set(p, d);
+        return value;
+      });
+      transactionQueue = result.then(
+        () => undefined,
+        () => undefined,
+      );
+      return result;
+    }),
+    Timestamp: {
+      now: jest.fn(() => new Date(nowMillis)),
+      fromDate: jest.fn((date: Date) => new Date(date.getTime())),
+    },
+  };
+
+  const defaultAligo = {
+    success: true,
+    outcome: 'ACCEPTED',
+    channel: 'alimtalk',
+    message: 'ok',
+    alimtalkAttempts: 1,
+    smsAttempts: 0,
+    providerReceipt: 'DEFAULT-MID',
+    attemptId: 'default-attempt-1',
+    needsVerify: false,
+  };
+  const aligo = {
+    sendAlimtalk: jest.fn().mockResolvedValue({ ...defaultAligo, ...(opts.aligoImpl ?? {}) }),
+    sendSms: jest.fn().mockResolvedValue({
+      success: true,
+      outcome: 'ACCEPTED',
+      channel: 'sms',
+      message: 'ok-sms',
+      alimtalkAttempts: 0,
+      smsAttempts: 1,
+      providerReceipt: 'DEFAULT-SMS-ID',
+      attemptId: 'default-sms-attempt-1',
+      needsVerify: false,
+    }),
+  };
+  const issueWriter = { createOrMergeIssue: jest.fn(async (issue: Data) => issue) };
+  const service = new (NotificationsService as any)(firestore, aligo, {}, issueWriter) as any;
+
+  return {
+    service: service as NotificationsService,
+    records,
+    firestore,
+    aligo,
+    issueWriter,
+    readDelivery: (key: string) => clone(records.get(deliveryPath(key))),
+    readNotifications: () =>
+      Array.from(records.entries())
+        .filter(([p]) => p.startsWith('notifications/'))
+        .map(([, d]) => clone(d)),
+    advance: (ms: number) => {
+      nowMillis += ms;
+    },
+  };
+}
+
+describe('provider outcome contract (AligoClient)', () => {
+  const originalFetch = global.fetch;
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+
+  it('CASE 1: alimtalk code=0 + info.mid는 ACCEPTED + receipt 보존, SMS fallback 0', async () => {
+    (global as any).fetch = jest.fn().mockResolvedValue(alimtalkOk('MID-KNOWN-001'));
+    const client = makeClient(configured);
+    const result = await client.sendAlimtalk(phone, templateCode, variables);
+    expect(result).toMatchObject({
+      success: true,
+      outcome: 'ACCEPTED',
+      channel: 'alimtalk',
+      alimtalkAttempts: 1,
+      smsAttempts: 0,
+      providerReceipt: 'MID-KNOWN-001',
+      needsVerify: false,
+    });
+    expect(typeof result.attemptId).toBe('string');
+    expect((global.fetch as jest.Mock)).toHaveBeenCalledTimes(1);
+  });
+
+  it('CASE 2: SMS result_code=1 + msg_id는 ACCEPTED + receipt 보존', async () => {
+    (global as any).fetch = jest.fn().mockResolvedValue(smsOk('MSGID-KNOWN-002'));
+    const client = makeClient(configured);
+    const result = await client.sendSms(phone, templateCode, variables);
+    expect(result).toMatchObject({
+      success: true,
+      outcome: 'ACCEPTED',
+      channel: 'sms',
+      smsAttempts: 1,
+      providerReceipt: 'MSGID-KNOWN-002',
+      needsVerify: false,
+    });
+  });
+
+  it('CASE 2b: alimtalk 3회 REJECTED 뒤 SMS ACCEPTED는 sms receipt를 보존한다', async () => {
+    (global as any).fetch = jest
+      .fn()
+      .mockResolvedValueOnce(alimtalkReject(-1, '실패1'))
+      .mockResolvedValueOnce(alimtalkReject(-1, '실패2'))
+      .mockResolvedValueOnce(alimtalkReject(-1, '실패3'))
+      .mockResolvedValueOnce(smsOk('MSGID-FALLBACK-003'));
+    const client = makeClient(configured);
+    const result = await client.sendAlimtalk(phone, templateCode, variables);
+    expect(result).toMatchObject({
+      success: true,
+      outcome: 'ACCEPTED',
+      channel: 'sms',
+      alimtalkAttempts: 3,
+      smsAttempts: 1,
+      providerReceipt: 'MSGID-FALLBACK-003',
+    });
+    expect((global.fetch as jest.Mock)).toHaveBeenCalledTimes(4);
+  });
+
+  it('CASE 3: 첫 alimtalk throw는 UNKNOWN, retry 0, SMS fallback 0, FAILED 아님', async () => {
+    (global as any).fetch = jest.fn().mockRejectedValue(new Error('timeout'));
+    const client = makeClient(configured);
+    const result = await client.sendAlimtalk(phone, templateCode, variables);
+    expect(result).toMatchObject({
+      success: false,
+      outcome: 'UNKNOWN',
+      channel: null,
+      alimtalkAttempts: 1,
+      smsAttempts: 0,
+      providerReceipt: null,
+      needsVerify: true,
+    });
+    expect((global.fetch as jest.Mock)).toHaveBeenCalledTimes(1);
+  });
+
+  it('CASE 3b: 응답 파싱 실패도 UNKNOWN으로 분류한다', async () => {
+    (global as any).fetch = jest.fn().mockResolvedValue({
+      json: jest.fn().mockRejectedValue(new Error('bad json')),
+    });
+    const client = makeClient(configured);
+    const result = await client.sendAlimtalk(phone, templateCode, variables);
+    expect(result.outcome).toBe('UNKNOWN');
+    expect(result.needsVerify).toBe(true);
+    expect((global.fetch as jest.Mock)).toHaveBeenCalledTimes(1);
+  });
+
+  it('CASE 4: 명시적 실패 코드는 REJECTED이며 기존 범위에서 retry/fallback한다', async () => {
+    (global as any).fetch = jest
+      .fn()
+      .mockResolvedValueOnce(alimtalkReject(-1, '일시 오류'))
+      .mockResolvedValueOnce(alimtalkReject(-1, '일시 오류'))
+      .mockResolvedValueOnce(alimtalkOk('MID-RETRY-OK'));
+    const client = makeClient(configured);
+    const result = await client.sendAlimtalk(phone, templateCode, variables);
+    expect(result).toMatchObject({
+      success: true,
+      outcome: 'ACCEPTED',
+      channel: 'alimtalk',
+      alimtalkAttempts: 3,
+      smsAttempts: 0,
+      providerReceipt: 'MID-RETRY-OK',
+    });
+    expect((global.fetch as jest.Mock)).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe('delivery outcome reconciliation (NotificationsService)', () => {
+  it('CASE 1 (service): ACCEPTED는 SENT + receipt + attempt 연결, SMS 0, 이슘 0', async () => {
+    const h = makeServiceHarness({
+      aligoImpl: {
+        success: true,
+        outcome: 'ACCEPTED',
+        channel: 'alimtalk',
+        message: '보류 본문',
+        alimtalkAttempts: 1,
+        smsAttempts: 0,
+        providerReceipt: 'MID-KNOWN-001',
+        attemptId: 'attempt-001',
+        needsVerify: false,
+      },
+    });
+    const key = 'outcome-case1-accepted';
+    await (h.service as any).sendToUser('user-1', templateCode, variables, 'order-1', key);
+
+    const delivery = h.readDelivery(key) as Data;
+    expect(delivery).toMatchObject({
+      status: 'SENT',
+      lastAttemptId: 'attempt-001',
+      providerReceipt: 'MID-KNOWN-001',
+      lastOutcome: 'ACCEPTED',
+      needsVerify: false,
+    });
+    const notifs = h.readNotifications();
+    expect(notifs).toHaveLength(1);
+    expect(notifs[0]).toMatchObject({
+      status: 'sent',
+      attemptId: 'attempt-001',
+      providerReceipt: 'MID-KNOWN-001',
+      providerOutcome: 'ACCEPTED',
+      idempotencyKey: key,
+    });
+    expect(h.aligo.sendSms).not.toHaveBeenCalled();
+    expect(h.issueWriter.createOrMergeIssue).not.toHaveBeenCalled();
+  });
+
+  it('SENT는 provider-accepted terminal이다 (단말 DELIVERED와 동일하지 않음)', async () => {
+    const h = makeServiceHarness({
+      aligoImpl: {
+        success: true,
+        outcome: 'ACCEPTED',
+        channel: 'alimtalk',
+        message: 'ok',
+        alimtalkAttempts: 1,
+        smsAttempts: 0,
+        providerReceipt: 'MID-TERM-001',
+        attemptId: 'attempt-term-1',
+        needsVerify: false,
+      },
+    });
+    const key = 'outcome-sent-terminal-proof';
+    await (h.service as any).sendToUser('user-1', templateCode, variables, 'order-1', key);
+    expect(h.readDelivery(key)).toMatchObject({ status: 'SENT', lastOutcome: 'ACCEPTED' });
+    const retry = await (h.service as any).claimNotificationDelivery({
+      idempotencyKey: key,
+      orderId: 'order-1',
+      templateCode,
+      userId: 'user-1',
+    });
+    expect(retry).toBeNull();
+  });
+
+  it('CASE 3 (service): UNKNOWN은 NEEDS_VERIFY, retry/fallback 0, FAILED 아님', async () => {
+    const h = makeServiceHarness({
+      aligoImpl: {
+        success: false,
+        outcome: 'UNKNOWN',
+        channel: null,
+        message: '보류 본문',
+        alimtalkAttempts: 1,
+        smsAttempts: 0,
+        providerReceipt: null,
+        attemptId: 'attempt-unknown-1',
+        needsVerify: true,
+        errorMessage: 'transport 불확실',
+      },
+    });
+    const key = 'outcome-case3-unknown';
+    await (h.service as any).sendToUser('user-1', templateCode, variables, 'order-1', key);
+
+    const delivery = h.readDelivery(key) as Data;
+    expect(delivery['status']).toBe('NEEDS_VERIFY');
+    expect(delivery).toMatchObject({
+      lastAttemptId: 'attempt-unknown-1',
+      providerReceipt: null,
+      lastOutcome: 'UNKNOWN',
+      needsVerify: true,
+    });
+    expect(delivery['status']).not.toBe('FAILED');
+    const notifs = h.readNotifications();
+    expect(notifs).toHaveLength(1);
+    expect(notifs[0]).toMatchObject({ status: 'pending', providerOutcome: 'UNKNOWN' });
+    expect(h.aligo.sendSms).not.toHaveBeenCalled();
+    expect(h.issueWriter.createOrMergeIssue).not.toHaveBeenCalled();
+
+    h.advance(NOTIFICATION_DELIVERY_PROCESSING_LEASE_TTL_MS + 1);
+    const reclaim = await (h.service as any).claimNotificationDelivery({
+      idempotencyKey: key,
+      orderId: 'order-1',
+      templateCode,
+      userId: 'user-1',
+    });
+    expect(reclaim).toBeNull();
+  });
+
+  it('CASE 4 (service): REJECTED만 FAILED retryable이며 이슈를 만든다', async () => {
+    const h = makeServiceHarness({
+      aligoImpl: {
+        success: false,
+        outcome: 'REJECTED',
+        channel: null,
+        message: '보류 본문',
+        alimtalkAttempts: 3,
+        smsAttempts: 1,
+        providerReceipt: null,
+        attemptId: 'attempt-rejected-1',
+        needsVerify: false,
+        errorMessage: '명시적 거부',
+      },
+    });
+    const key = 'outcome-case4-rejected';
+    await (h.service as any).sendToUser('user-1', templateCode, variables, 'order-1', key);
+    expect(h.readDelivery(key)).toMatchObject({ status: 'FAILED', lastOutcome: 'REJECTED' });
+    expect(h.issueWriter.createOrMergeIssue).toHaveBeenCalledTimes(1);
+
+    const retry = await (h.service as any).claimNotificationDelivery({
+      idempotencyKey: key,
+      orderId: 'order-1',
+      templateCode,
+      userId: 'user-1',
+    });
+    expect(typeof retry).toBe('string');
+  });
+
+  it('CASE 5: ACCEPTED 후 finalize 실패는 FAILED로 붕괴하지 않고 reclaim blind resend 금지', async () => {
+    const h = makeServiceHarness({
+      aligoImpl: {
+        success: true,
+        outcome: 'ACCEPTED',
+        channel: 'alimtalk',
+        message: '보류 본문',
+        alimtalkAttempts: 1,
+        smsAttempts: 0,
+        providerReceipt: 'MID-CASE5-001',
+        attemptId: 'attempt-case5-1',
+        needsVerify: false,
+      },
+      failFinishWithStatus: 'SENT',
+    });
+    const key = 'outcome-case5-finalize-fail';
+    await expect(
+      (h.service as any).sendToUser('user-1', templateCode, variables, 'order-1', key),
+    ).rejects.toThrow();
+    const delivery = h.readDelivery(key) as Data;
+    expect(delivery['status']).not.toBe('FAILED');
+    expect(delivery).toMatchObject({
+      providerReceipt: 'MID-CASE5-001',
+      lastAttemptId: 'attempt-case5-1',
+      lastOutcome: 'ACCEPTED',
+    });
+    h.advance(NOTIFICATION_DELIVERY_PROCESSING_LEASE_TTL_MS + 1);
+    const reclaim = await (h.service as any).claimNotificationDelivery({
+      idempotencyKey: key,
+      orderId: 'order-1',
+      templateCode,
+      userId: 'user-1',
+    });
+    expect(reclaim).toBeNull();
+    h.aligo.sendAlimtalk.mockClear();
+    await (h.service as any).sendToUser('user-1', templateCode, variables, 'order-1', key);
+    expect(h.aligo.sendAlimtalk).not.toHaveBeenCalled();
+  });
+
+  it('CASE 6: stale owner ACCEPTED는 DB owner를 덮지 못하고 시도는 관찰 가능하다', async () => {
+    const h = makeServiceHarness();
+    const key = 'outcome-case6-stale';
+    const stale = await (h.service as any).claimNotificationDelivery({
+      idempotencyKey: key,
+      orderId: 'order-1',
+      templateCode,
+      userId: 'user-1',
+    });
+    h.advance(NOTIFICATION_DELIVERY_PROCESSING_LEASE_TTL_MS + 1);
+    const current = await (h.service as any).claimNotificationDelivery({
+      idempotencyKey: key,
+      orderId: 'order-1',
+      templateCode,
+      userId: 'user-1',
+    });
+    expect(current).not.toBe(stale);
+
+    const recorded = await (h.service as any).recordDeliveryAttempt(key, stale, {
+      outcome: 'ACCEPTED',
+      providerReceipt: 'MID-STALE-001',
+      attemptId: 'attempt-stale-1',
+    });
+    expect(recorded).toBe(false);
+    await (h.service as any).finishNotificationDelivery(key, 'SENT', stale, {
+      outcome: 'ACCEPTED',
+      providerReceipt: 'MID-STALE-001',
+      attemptId: 'attempt-stale-1',
+    });
+    expect(h.readDelivery(key)).toMatchObject({ status: 'PROCESSING', leaseId: current });
+
+    await (h.service as any).finishNotificationDelivery(key, 'SENT', current, {
+      outcome: 'ACCEPTED',
+      providerReceipt: 'MID-CURRENT-001',
+      attemptId: 'attempt-current-1',
+    });
+    expect(h.readDelivery(key)).toMatchObject({
+      status: 'SENT',
+      leaseId: current,
+      providerReceipt: 'MID-CURRENT-001',
+    });
+  });
+
+  it('manual resend는 원본 연결 + 새 attempt + receipt를 남기고 UNKNOWN을 무조건 재시도하지 않는다', async () => {
+    const h = makeServiceHarness();
+    h.records.set('notifications/origin-1', {
+      id: 'origin-1',
+      userId: 'user-1',
+      orderId: 'order-1',
+      channel: 'alimtalk',
+      templateCode,
+      variables,
+      message: '원본',
+      phone,
+      status: 'failed',
+      attemptId: 'attempt-origin-1',
+      providerReceipt: null,
+      providerOutcome: 'REJECTED',
+      idempotencyKey: 'outcome-resend-origin-key',
+    });
+    const issue = { latestSnapshot: { notificationId: 'origin-1' } };
+
+    h.aligo.sendSms.mockResolvedValueOnce({
+      success: true,
+      outcome: 'ACCEPTED',
+      channel: 'sms',
+      message: '재발송 본문',
+      alimtalkAttempts: 0,
+      smsAttempts: 1,
+      providerReceipt: 'MSGID-RESEND-001',
+      attemptId: 'attempt-resend-1',
+      needsVerify: false,
+    });
+    const result = await (h.service as any).resendSms(issue);
+    expect(result).toMatchObject({ outcome: 'ACCEPTED', providerReceipt: 'MSGID-RESEND-001' });
+    const notifs = h.readNotifications();
+    const resend = notifs.find((n) => (n as Data)['resendOfNotificationId'] === 'origin-1') as Data;
+    expect(resend).toMatchObject({
+      attemptId: 'attempt-resend-1',
+      providerReceipt: 'MSGID-RESEND-001',
+      providerOutcome: 'ACCEPTED',
+      idempotencyKey: 'outcome-resend-origin-key',
+    });
+    expect(h.aligo.sendSms).toHaveBeenCalledTimes(1);
+
+    h.aligo.sendSms.mockResolvedValueOnce({
+      success: false,
+      outcome: 'UNKNOWN',
+      channel: null,
+      message: '재발송 본문',
+      alimtalkAttempts: 0,
+      smsAttempts: 1,
+      providerReceipt: null,
+      attemptId: 'attempt-resend-unknown-1',
+      needsVerify: true,
+      errorMessage: 'transport 불확실',
+    });
+    await expect((h.service as any).resendSms(issue)).rejects.toThrow();
+    expect(h.aligo.sendSms).toHaveBeenCalledTimes(2);
+    const unknowns = h
+      .readNotifications()
+      .filter((n) => (n as Data)['attemptId'] === 'attempt-resend-unknown-1');
+    expect(unknowns).toHaveLength(1);
+    expect(unknowns[0]).toMatchObject({ status: 'pending', providerOutcome: 'UNKNOWN' });
+  });
+});

--- a/apps/api/src/notifications/notifications.service.ts
+++ b/apps/api/src/notifications/notifications.service.ts
@@ -5,12 +5,29 @@ import { v4 as uuidv4 } from 'uuid';
 import { FirestoreService } from '../firestore/firestore.service';
 import { OperationIssueWriterService } from '../operations/operation-issue-writer.service';
 import { PaymentsService } from '../payments/payments.service';
-import { AligoClient } from './aligo.client';
+import { AligoClient, type ProviderOutcome } from './aligo.client';
 import type { ApiNotificationTemplateCode } from './notification-templates';
 
 export type NotificationTemplateCode = ApiNotificationTemplateCode;
 
+export type NotificationDeliveryStatus = 'PROCESSING' | 'SENT' | 'FAILED' | 'NEEDS_VERIFY';
+
 export const NOTIFICATION_DELIVERY_PROCESSING_LEASE_TTL_MS = 5 * 60 * 1000;
+
+const PROVIDER_OUTCOMES: readonly ProviderOutcome[] = ['ACCEPTED', 'REJECTED', 'UNKNOWN'];
+
+function normalizeProviderOutcome(value: unknown, fallbackSuccess: boolean): ProviderOutcome {
+  if (typeof value === 'string' && (PROVIDER_OUTCOMES as readonly string[]).includes(value)) {
+    return value as ProviderOutcome;
+  }
+  return fallbackSuccess ? 'ACCEPTED' : 'REJECTED';
+}
+
+function normalizeNullableString(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
 
 function notificationTimestampMillis(value: unknown): number {
   if (value instanceof Date) return value.getTime();
@@ -105,6 +122,10 @@ export class NotificationsService {
       }
     }
 
+    let observedOutcome: ProviderOutcome | null = null;
+    let observedReceipt: string | null = null;
+    let observedAttemptId: string | null = null;
+
     try {
       const orderSnap = orderId ? await this.firestore.doc(`orders/${orderId}`).get() : null;
       const userSnap = await this.firestore.doc(`users/${userId}`).get();
@@ -116,33 +137,115 @@ export class NotificationsService {
         if (orderId) {
           await this.createCustomerNoticeFailedIssue(orderId, templateCode, null);
         }
-        await this.finishNotificationDelivery(idempotencyKey, 'FAILED', leaseId);
+        await this.finishNotificationDelivery(idempotencyKey, 'FAILED', leaseId, {
+          outcome: 'REJECTED',
+          attemptId: null,
+          providerReceipt: null,
+        });
         return;
       }
 
-      const result = await this.aligo.sendAlimtalk(phone, templateCode, variables);
+      const raw = (await this.aligo.sendAlimtalk(phone, templateCode, variables)) as Record<
+        string,
+        unknown
+      >;
+      const fallbackSuccess = (raw as { success?: unknown })['success'] === true;
+      const outcome = normalizeProviderOutcome(
+        (raw as { outcome?: unknown })['outcome'],
+        fallbackSuccess,
+      );
+      const providerReceipt =
+        normalizeNullableString((raw as { providerReceipt?: unknown })['providerReceipt']);
+      const attemptId =
+        normalizeNullableString((raw as { attemptId?: unknown })['attemptId']) ?? uuidv4();
+      const needsVerify =
+        typeof (raw as { needsVerify?: unknown })['needsVerify'] === 'boolean'
+          ? ((raw as { needsVerify?: boolean })['needsVerify'] as boolean)
+          : outcome === 'UNKNOWN';
+      const channel =
+        ((raw as { channel?: unknown })['channel'] as string | null) ?? 'alimtalk';
+      const message = String((raw as { message?: unknown })['message'] ?? '');
+      const alimtalkAttempts = Number((raw as { alimtalkAttempts?: unknown })['alimtalkAttempts'] ?? 0);
+      const smsAttempts = Number((raw as { smsAttempts?: unknown })['smsAttempts'] ?? 0);
+      const errorMessage =
+        typeof (raw as { errorMessage?: unknown })['errorMessage'] === 'string'
+          ? ((raw as { errorMessage?: string })['errorMessage'] as string)
+          : null;
+      observedOutcome = outcome;
+      observedReceipt = providerReceipt;
+      observedAttemptId = attemptId;
+
+      if (idempotencyKey && leaseId) {
+        await this.recordDeliveryAttempt(idempotencyKey, leaseId, {
+          outcome,
+          providerReceipt,
+          attemptId,
+        });
+      }
+
+      const notificationStatus =
+        outcome === 'ACCEPTED' ? 'sent' : outcome === 'UNKNOWN' ? 'pending' : 'failed';
       const notificationId = await this.logNotification({
         userId,
         orderId: orderId ?? null,
-        channel: result.channel ?? 'alimtalk',
+        channel,
         templateCode,
         variables,
-        message: result.message,
+        message,
         phone,
-        status: result.success ? 'sent' : 'failed',
-        attemptCount: result.alimtalkAttempts + result.smsAttempts,
-        errorMessage: result.errorMessage ?? null,
+        status: notificationStatus,
+        attemptCount: alimtalkAttempts + smsAttempts,
+        errorMessage,
+        attemptId,
+        providerReceipt,
+        providerOutcome: outcome,
+        needsVerify,
+        idempotencyKey: idempotencyKey ?? null,
       });
 
-      if (!result.success && orderId) {
+      if (outcome === 'UNKNOWN') {
+        await this.finishNotificationDelivery(idempotencyKey, 'NEEDS_VERIFY', leaseId, {
+          outcome,
+          providerReceipt,
+          attemptId,
+        });
+        return;
+      }
+
+      if (outcome === 'ACCEPTED') {
+        await this.finishNotificationDelivery(idempotencyKey, 'SENT', leaseId, {
+          outcome,
+          providerReceipt,
+          attemptId,
+        });
+        return;
+      }
+
+      if (orderId) {
         await this.createCustomerNoticeFailedIssue(orderId, templateCode, notificationId);
       }
-      await this.finishNotificationDelivery(
-        idempotencyKey,
-        result.success ? 'SENT' : 'FAILED',
-        leaseId,
-      );
+      await this.finishNotificationDelivery(idempotencyKey, 'FAILED', leaseId, {
+        outcome,
+        providerReceipt,
+        attemptId,
+      });
     } catch (error) {
+      if (observedOutcome === 'ACCEPTED') {
+        await this.finishNotificationDelivery(idempotencyKey, 'SENT', leaseId, {
+          outcome: 'ACCEPTED',
+          providerReceipt: observedReceipt,
+          attemptId: observedAttemptId,
+        }).catch(() => undefined);
+        throw error;
+      }
+      if (observedOutcome === 'UNKNOWN') {
+        await this.finishNotificationDelivery(idempotencyKey, 'NEEDS_VERIFY', leaseId, {
+          outcome: 'UNKNOWN',
+          providerReceipt: observedReceipt,
+          attemptId: observedAttemptId,
+        }).catch(() => undefined);
+        throw error;
+      }
       await this.finishNotificationDelivery(idempotencyKey, 'FAILED', leaseId).catch(
         () => undefined,
       );
@@ -173,27 +276,74 @@ export class NotificationsService {
       throw new Error('재발송할 알림 정보가 올바르지 않습니다.');
     }
 
-    const result = await this.aligo.sendSms(
+    const raw = (await this.aligo.sendSms(
       phone,
       templateCode as NotificationTemplateCode,
       variables as Record<string, string>,
+    )) as unknown as Record<string, unknown>;
+    const fallbackSuccess = (raw as { success?: unknown })['success'] === true;
+    const outcome = normalizeProviderOutcome(
+      (raw as { outcome?: unknown })['outcome'],
+      fallbackSuccess,
     );
+    const providerReceipt = normalizeNullableString(
+      (raw as { providerReceipt?: unknown })['providerReceipt'],
+    );
+    const attemptId =
+      normalizeNullableString((raw as { attemptId?: unknown })['attemptId']) ?? uuidv4();
+    const needsVerify =
+      typeof (raw as { needsVerify?: unknown })['needsVerify'] === 'boolean'
+        ? ((raw as { needsVerify?: boolean })['needsVerify'] as boolean)
+        : outcome === 'UNKNOWN';
+    const message = String((raw as { message?: unknown })['message'] ?? '');
+    const smsAttempts = Number((raw as { smsAttempts?: unknown })['smsAttempts'] ?? 1);
+    const errorMessage =
+      typeof (raw as { errorMessage?: unknown })['errorMessage'] === 'string'
+        ? ((raw as { errorMessage?: string })['errorMessage'] as string)
+        : null;
+    const originIdempotencyKey =
+      typeof notification['idempotencyKey'] === 'string'
+        ? (notification['idempotencyKey'] as string)
+        : null;
     await this.logNotification({
       userId: String(notification['userId']),
       orderId: (notification['orderId'] as string | null) ?? null,
-      channel: 'sms',
+      channel: outcome === 'ACCEPTED' ? 'sms' : 'sms',
       templateCode,
       variables: variables as Record<string, string>,
-      message: result.message,
+      message,
       phone,
-      status: result.success ? 'sent' : 'failed',
-      attemptCount: result.smsAttempts,
-      errorMessage: result.errorMessage ?? null,
+      status: outcome === 'ACCEPTED' ? 'sent' : outcome === 'UNKNOWN' ? 'pending' : 'failed',
+      attemptCount: smsAttempts,
+      errorMessage,
+      attemptId,
+      providerReceipt,
+      providerOutcome: outcome,
+      needsVerify,
+      idempotencyKey: originIdempotencyKey,
+      resendOfNotificationId: notificationId,
     });
-    if (!result.success) {
-      throw new Error(result.errorMessage ?? '문자 재발송에 실패했습니다.');
+    if (outcome === 'UNKNOWN') {
+      throw new Error(
+        errorMessage ??
+          '문자 재발송 접수 여부를 확인할 수 없습니다. blind 재시도 없이 수동 확인이 필요합니다.',
+      );
     }
-    return result;
+    if (outcome !== 'ACCEPTED') {
+      throw new Error(errorMessage ?? '문자 재발송에 실패했습니다.');
+    }
+    return {
+      success: true,
+      outcome,
+      channel: 'sms' as const,
+      message,
+      alimtalkAttempts: 0,
+      smsAttempts,
+      providerReceipt,
+      attemptId,
+      needsVerify: false,
+      errorMessage: undefined,
+    };
   }
 
   async sendToGroupParticipants(
@@ -430,11 +580,23 @@ export class NotificationsService {
     status: string;
     attemptCount: number;
     errorMessage: string | null;
+    attemptId?: string | null;
+    providerReceipt?: string | null;
+    providerOutcome?: ProviderOutcome | null;
+    needsVerify?: boolean;
+    idempotencyKey?: string | null;
+    resendOfNotificationId?: string | null;
   }) {
     const id = uuidv4();
     await this.firestore.doc(`notifications/${id}`).set({
       id,
       ...data,
+      attemptId: data.attemptId ?? null,
+      providerReceipt: data.providerReceipt ?? null,
+      providerOutcome: data.providerOutcome ?? null,
+      needsVerify: data.needsVerify ?? false,
+      idempotencyKey: data.idempotencyKey ?? null,
+      resendOfNotificationId: data.resendOfNotificationId ?? null,
       fcmToken: null,
       sentAt: data.status === 'sent' ? this.firestore.Timestamp.now() : null,
       createdAt: this.firestore.Timestamp.now(),
@@ -459,7 +621,16 @@ export class NotificationsService {
         ? (snapshot.data() as Record<string, unknown>)
         : null;
       const status = (data?.['status'] as string | null | undefined) ?? null;
+      // SENT is provider-accepted terminal (not device DELIVERED). Never re-dispatch.
       if (status === 'SENT') return;
+      // NEEDS_VERIFY requires manual verification. Lease expiry alone must not
+      // trigger blind provider redispatch.
+      if (status === 'NEEDS_VERIFY') return;
+      if (data?.['needsVerify'] === true) return;
+      // ACCEPTED observed but SENT finalize not yet durable (e.g. crash between
+      // receipt record and SENT finish). Do not blind-resend; wait for manual
+      // verification instead of treating as retryable.
+      if (data?.['lastOutcome'] === 'ACCEPTED') return;
       const now = this.firestore.Timestamp.now();
       const nowMillis = notificationTimestampMillis(now);
       if (!Number.isFinite(nowMillis)) return;
@@ -485,6 +656,10 @@ export class NotificationsService {
           leaseId,
           leaseExpiresAt,
           attempt: previousAttempt + 1,
+          lastAttemptId: null,
+          providerReceipt: null,
+          lastOutcome: null,
+          needsVerify: false,
           updatedAt: now,
           createdAt: snapshot.exists ? (data?.['createdAt'] ?? now) : now,
         },
@@ -495,10 +670,52 @@ export class NotificationsService {
     return acquired;
   }
 
+  private async recordDeliveryAttempt(
+    idempotencyKey: string | undefined,
+    leaseId: string | null | undefined,
+    detail: {
+      outcome: ProviderOutcome;
+      providerReceipt: string | null;
+      attemptId: string | null;
+    },
+  ): Promise<boolean> {
+    if (!idempotencyKey) return false;
+    if (typeof leaseId !== 'string' || leaseId.length === 0) return false;
+    const ref = this.firestore.doc(
+      `notificationDeliveries/${this.notificationDeliveryId(idempotencyKey)}`,
+    );
+    let recorded = false;
+    await this.firestore.runTransaction(async (transaction) => {
+      const snapshot = await transaction.get(ref);
+      if (!snapshot.exists) return;
+      const data = snapshot.data() as Record<string, unknown>;
+      if (data?.['status'] !== 'PROCESSING') return;
+      if (data?.['leaseId'] !== leaseId) return;
+      transaction.set(
+        ref,
+        {
+          lastAttemptId: detail.attemptId,
+          providerReceipt: detail.providerReceipt,
+          lastOutcome: detail.outcome,
+          needsVerify: detail.outcome === 'UNKNOWN',
+          updatedAt: this.firestore.Timestamp.now(),
+        },
+        { merge: true },
+      );
+      recorded = true;
+    });
+    return recorded;
+  }
+
   private async finishNotificationDelivery(
     idempotencyKey: string | undefined,
-    status: 'SENT' | 'FAILED',
+    status: 'SENT' | 'FAILED' | 'NEEDS_VERIFY',
     leaseId?: string | null,
+    detail?: {
+      outcome?: ProviderOutcome | null;
+      providerReceipt?: string | null;
+      attemptId?: string | null;
+    },
   ): Promise<void> {
     if (!idempotencyKey) return;
     if (typeof leaseId !== 'string' || leaseId.length === 0) return;
@@ -512,15 +729,22 @@ export class NotificationsService {
       if (data?.['status'] !== 'PROCESSING') return;
       if (data?.['leaseId'] !== leaseId) return;
       const now = this.firestore.Timestamp.now();
-      transaction.set(
-        ref,
-        {
-          status,
-          updatedAt: now,
-          completedAt: status === 'SENT' ? now : null,
-        },
-        { merge: true },
-      );
+      const patch: Record<string, unknown> = {
+        status,
+        updatedAt: now,
+        completedAt: status === 'SENT' ? now : null,
+        needsVerify: status === 'NEEDS_VERIFY',
+      };
+      if (detail) {
+        patch['lastAttemptId'] = detail.attemptId ?? null;
+        patch['providerReceipt'] = detail.providerReceipt ?? null;
+        patch['lastOutcome'] =
+          detail.outcome ?? (status === 'SENT' ? 'ACCEPTED' : status === 'NEEDS_VERIFY' ? 'UNKNOWN' : 'REJECTED');
+      } else if (data?.['lastOutcome'] == null) {
+        patch['lastOutcome'] =
+          status === 'SENT' ? 'ACCEPTED' : status === 'NEEDS_VERIFY' ? 'UNKNOWN' : 'REJECTED';
+      }
+      transaction.set(ref, patch, { merge: true });
     });
   }
 


### PR DESCRIPTION
## Summary
Local-only NOTIFICATION-DELIVERY-PROVIDER-OUTCOME-RECONCILIATION-01 publication. No new feature design.

## Semantic contract
- UNKNOWN is not FAILED
- UNKNOWN blocks blind redispatch (retry 0 / fallback 0 on uncertain transport)
- provider receipt + attempt correlation (providerReceipt + attemptId durable)
- NEEDS_VERIFY semantics (UNKNOWN -> NEEDS_VERIFY, no auto redispatch on lease expiry)
- lease fencing (claim/record/finish leaseId-guarded, stale owner cannot overwrite)
- provider-accepted SENT semantics (SENT = provider-accepted terminal, not device DELIVERED)
- exactly-once NOT_CLAIMED

## Owned delta (4 paths, 0 foreign)
- apps/api/src/notifications/aligo.client.ts
- apps/api/src/notifications/notifications.service.ts
- apps/api/src/notifications/e2e-aligo.client.ts
- apps/api/src/notifications/notifications-provider-outcome.spec.ts

## Remaining gaps
- manual resend vs automatic delivery concurrency gap remains (out of scope, no fix in this Task)
- sendToGroupParticipants / sendToStoreOwner key design out of scope
- payment-finalization / order transition unkeyed caller migration out of scope

## Tests executed
- npx jest src/notifications --runInBand: 9 suites / 78 tests PASS (shared dirty + clean owned-only worktree)
- adjacent owned-only worktree (live main 183f6637 + owned 4): mvp-order-flow + legacy-consumer-cancel-convergence + payments.service + operations.service = 4 suites / 90 tests PASS
- shared checkout adjacent: legacy-consumer-cancel + operations PASS (21); mvp-order-flow + payments FAIL due to foreign dirty (order-capacity/payment-finalization/mvp spec), not owned

## Safety
- production/provider mutation: 0
- actual ALIGO calls: 0
- credential changes: 0
- exactly-once: NOT_CLAIMED
