### PR TITLE
fix(payments): enforce transaction-callback retry purity for refund provider side effects

### DIFF
--- a/apps/api/src/firestore/firestore-occ-contract.spec.ts
+++ b/apps/api/src/firestore/firestore-occ-contract.spec.ts
@@ -1,0 +1,267 @@
+// Canonical Firestore transaction/OCC contract proofs.
+//
+// Covers the target contract closed by this task:
+//   A. isolation (uncommitted writes invisible)
+//   B. read versions recorded
+//   C. external modification -> conflict
+//   D. deterministic bounded retry
+//   E. atomic multi-document commit
+//   F. failure leaves no partial writes
+//   G. deterministic interleaving (explicit hooks + setImmediate; the spec
+//      itself uses no setTimeout / wall-clock races)
+//
+// Plus high-risk production regression proofs on the canonical harness:
+//   R1. SettlementsService.createSettlement concurrent exactly-once
+//   R2. confirmDueSettlements vs cancelSettlement race converges cancelled
+//   R3. PaymentRefundService.refundByOrderId concurrent double-claim refunds once
+//
+// NOTE: no existing fake/spec is modified here; this spec only consumes the
+// new canonical harness at ../../test/helpers/firestore-occ-fake.
+
+import { createOccFirestore } from '../../test/helpers/firestore-occ-fake';
+import { OrderChargePaymentService } from '../payments/order-charge-payment.service';
+import { SettlementsService } from '../settlements/settlements.service';
+
+function configService(values: Record<string, string> = {}) {
+  return { get: jest.fn((key: string) => values[key]) };
+}
+
+describe('canonical Firestore OCC contract', () => {
+  it('A. staged writes are invisible to live state until commit, visible inside the transaction', async () => {
+    const occ = createOccFirestore();
+    occ.seed('docs/a', { n: 1 });
+
+    const pending = occ.firestore.runTransaction(async (tx) => {
+      tx.set(occ.firestore.doc('docs/b'), { n: 2 });
+      const inside = await tx.get(occ.firestore.doc('docs/b'));
+      expect(inside.data()).toEqual({ n: 2 });
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      return 'done';
+    });
+
+    // The attempt is staged (callback suspended at the yield above); live
+    // state must not observe docs/b yet. Runs synchronously before microtasks.
+    expect(occ.getData('docs/b')).toBeUndefined();
+    expect(await occ.firestore.doc('docs/b').get().then((snap) => snap.exists)).toBe(false);
+
+    await expect(pending).resolves.toBe('done');
+    expect(occ.getData('docs/b')).toEqual({ n: 2 });
+  });
+
+  it('B+C+D. external modification after a transactional read conflicts and retries with fresh data', async () => {
+    const occ = createOccFirestore();
+    occ.seed('counters/c1', { n: 0 });
+    let attempts = 0;
+
+    await occ.firestore.runTransaction(async (tx) => {
+      attempts += 1;
+      const snap = await tx.get(occ.firestore.doc('counters/c1'));
+      if (attempts === 1) {
+        // Deterministic interleaving: external write lands after this
+        // attempt's read but before its commit validation.
+        occ.updateOutsideTransaction('counters/c1', { n: 100 });
+      }
+      tx.update(occ.firestore.doc('counters/c1'), { n: (snap.data()?.['n'] as number) + 1 });
+    });
+
+    expect(attempts).toBe(2);
+    expect(occ.getData('counters/c1')).toEqual({ n: 101 });
+  });
+
+  it('D. concurrent read-modify-write increments converge via retry (lost-update guard)', async () => {
+    const occ = createOccFirestore();
+    occ.seed('counters/shared', { n: 0 });
+    let invocations = 0;
+    const increment = () =>
+      occ.firestore.runTransaction(async (tx) => {
+        invocations += 1;
+        const snap = await tx.get(occ.firestore.doc('counters/shared'));
+        tx.update(occ.firestore.doc('counters/shared'), {
+          n: (snap.data()?.['n'] as number) + 1,
+        });
+      });
+
+    // No timers: both attempts read v0 in the microtask drain, then commit
+    // in setImmediate FIFO order; the loser retries once. Exactly 3 runs.
+    await Promise.all([increment(), increment()]);
+
+    expect(occ.getData('counters/shared')).toEqual({ n: 2 });
+    expect(invocations).toBe(3);
+  });
+
+  it('D-exhaustion. persistent conflict fails bounded with no transaction writes applied', async () => {
+    const occ = createOccFirestore({ maxAttempts: 2 });
+    occ.seed('counters/hot', { n: 0 });
+    const rearm = (): void => {
+      occ.setBeforeCommit(() => {
+        occ.updateOutsideTransaction('counters/hot', { n: 1000 });
+        rearm();
+      });
+    };
+    rearm();
+
+    await expect(
+      occ.firestore.runTransaction(async (tx) => {
+        const snap = await tx.get(occ.firestore.doc('counters/hot'));
+        tx.update(occ.firestore.doc('counters/hot'), {
+          n: (snap.data()?.['n'] as number) + 1,
+        });
+      }),
+    ).rejects.toThrow('transaction retry limit exceeded');
+
+    // Only the external writes landed; no transaction increment survived.
+    expect(occ.getData('counters/hot')).toEqual({ n: 1000 });
+  });
+
+  it('F. callback failure leaves no partial writes and preserves versions', async () => {
+    const occ = createOccFirestore();
+    occ.seed('docs/keep', { n: 1 });
+    const versionBefore = occ.getVersion('docs/keep');
+
+    await expect(
+      occ.firestore.runTransaction(async (tx) => {
+        tx.set(occ.firestore.doc('docs/staged'), { n: 9 });
+        tx.update(occ.firestore.doc('docs/keep'), { n: 2 });
+        throw new Error('boom');
+      }),
+    ).rejects.toThrow('boom');
+
+    expect(occ.getData('docs/staged')).toBeUndefined();
+    expect(occ.getData('docs/keep')).toEqual({ n: 1 });
+    expect(occ.getVersion('docs/keep')).toBe(versionBefore);
+  });
+
+  it('E. commit-time failure applies atomically (nothing lands)', async () => {
+    const occ = createOccFirestore();
+    occ.seed('docs/a', { n: 1 });
+    occ.seed('docs/b', { n: 1 });
+
+    occ.setBeforeCommit(() => {
+      occ.deleteOutsideTransaction('docs/a');
+    });
+
+    await expect(
+      occ.firestore.runTransaction(async (tx) => {
+        tx.set(occ.firestore.doc('docs/c'), { n: 3 });
+        tx.update(occ.firestore.doc('docs/a'), { n: 10 });
+        tx.update(occ.firestore.doc('docs/b'), { n: 10 });
+      }),
+    ).rejects.toThrow('존재하지 않는 문서입니다: docs/a');
+
+    expect(occ.getData('docs/c')).toBeUndefined();
+    expect(occ.getData('docs/b')).toEqual({ n: 1 });
+    expect(occ.getData('docs/a')).toBeUndefined();
+  });
+
+  it('G. beforeCommit hook observes read set and staged writes for deterministic control', async () => {
+    const occ = createOccFirestore();
+    occ.seed('docs/observed', { n: 5 });
+    let observed: { readPaths: string[]; kinds: string[] } | undefined;
+    occ.setBeforeCommit((context) => {
+      observed = {
+        readPaths: [...context.readPaths],
+        kinds: context.writes.map((write) => write.kind),
+      };
+    });
+
+    await occ.firestore.runTransaction(async (tx) => {
+      const snap = await tx.get(occ.firestore.doc('docs/observed'));
+      tx.update(occ.firestore.doc('docs/observed'), {
+        n: (snap.data()?.['n'] as number) + 1,
+      });
+      return 'ok';
+    });
+
+    expect(observed).toEqual({ readPaths: ['docs/observed'], kinds: ['update'] });
+    expect(occ.getData('docs/observed')).toEqual({ n: 6 });
+  });
+
+  it('read-your-writes: a transactional get observes the same-attempt staged update', async () => {
+    const occ = createOccFirestore();
+    occ.seed('docs/rw', { n: 1 });
+
+    await occ.firestore.runTransaction(async (tx) => {
+      tx.update(occ.firestore.doc('docs/rw'), { n: 2 });
+      const snap = await tx.get(occ.firestore.doc('docs/rw'));
+      expect(snap.data()).toEqual({ n: 2 });
+    });
+
+    expect(occ.getData('docs/rw')).toEqual({ n: 2 });
+  });
+});
+
+describe('canonical harness high-risk regression proofs', () => {
+  it('R1. concurrent createSettlement converges to exactly one settlement', async () => {
+    const occ = createOccFirestore();
+    const settlements = new SettlementsService(
+      occ.firestore as never,
+      configService({ PLATFORM_FEE_RATE: '0.05' }) as never,
+    );
+    const order = { id: 'order-race-1', storeId: 'store-1', status: 'DELIVERED', totalAmount: 30000 };
+
+    await Promise.all(Array.from({ length: 8 }, () => settlements.createSettlement(order, 'DELIVERED')));
+
+    expect(occ.listData('settlements/')).toHaveLength(1);
+    expect(occ.getData('settlements/order-race-1')).toEqual(
+      expect.objectContaining({ status: 'pending', totalAmount: 30000 }),
+    );
+  });
+
+  it('R2. confirm commit racing cancel converges to cancelled (no resurrection)', async () => {
+    const occ = createOccFirestore();
+    const settlements = new SettlementsService(
+      occ.firestore as never,
+      configService({ SETTLEMENT_CONFIRM_DELAY_DAYS: '1' }) as never,
+    );
+    const orderId = 'order-confirm-cancel-1';
+    occ.seed(`settlements/${orderId}`, {
+      id: orderId,
+      storeId: 'store-1',
+      orderId,
+      totalAmount: 10000,
+      platformFeeRate: 0.05,
+      platformFee: 500,
+      netAmount: 9500,
+      status: 'pending',
+      completedStatus: 'DELIVERED',
+      settledAt: new Date('2026-08-25T00:00:00.000Z'),
+      confirmedAt: null,
+      paidAt: null,
+      createdAt: new Date('2026-08-25T00:00:00.000Z'),
+      updatedAt: new Date('2026-08-25T00:00:00.000Z'),
+    });
+    occ.setBeforeCommit(async () => {
+      await settlements.cancelSettlement(orderId);
+    });
+
+    await settlements.confirmDueSettlements();
+
+    expect(occ.getData(`settlements/${orderId}`)?.['status']).toBe('cancelled');
+  });
+
+  it('R3. concurrent markFailed converges to one FAILED plus one already_processed', async () => {
+    const occ = createOccFirestore();
+    occ.seed('orderCharges/c1', {
+      id: 'c1',
+      orderId: 'order-1',
+      status: 'PENDING',
+      type: 'REDELIVERY_FEE',
+      amount: 3000,
+      portonePaymentId: 'order-charge-c1',
+    });
+    const portone = { getPayment: jest.fn(), refund: jest.fn() };
+    const charges = new OrderChargePaymentService(occ.firestore as never, portone as never);
+
+    const results = await Promise.all([
+      charges['markFailed']('c1', 'order-charge-c1'),
+      charges['markFailed']('c1', 'order-charge-c1'),
+    ]);
+
+    // One winner commits FAILED via the OCC retry path; the loser retries,
+    // observes FAILED, and converges to already_processed with no second write.
+    expect(results).toContainEqual({ ok: true, status: 'FAILED' });
+    expect(results).toContainEqual({ ok: true, reason: 'already_processed' });
+    expect(occ.getData('orderCharges/c1')).toMatchObject({ status: 'FAILED' });
+    expect(occ.getVersion('orderCharges/c1')).toBe(1);
+  });
+});

--- a/apps/api/src/payments/order-charge-payment.service.ts
+++ b/apps/api/src/payments/order-charge-payment.service.ts
@@ -116,24 +116,31 @@ export class OrderChargePaymentService {
 
   private async refundCharge(chargeRef: any, reason: string) {
     const token = randomUUID();
-    let claimed: Record<string, any> | null = null;
-    await this.firestore.runTransaction(async (tx) => {
+    // Retry purity: only the committed attempt's return value may authorize
+    // the provider refund. An outer `let claimed` would leak an aborted
+    // attempt's decision across OCC retry. See
+    // PAYMENT-REFUND-OCC-RETRY-PURITY-CLOSURE-01.
+    const claimResult = await this.firestore.runTransaction(async (tx) => {
       const snap: any = await tx.get(chargeRef);
-      if (!snap.exists) return;
+      if (!snap.exists) return null;
       const charge = snap.data() as Record<string, any>;
-      if (charge['status'] === 'REFUNDED' || charge['refundedAt']) return;
-      if (charge['status'] !== 'PAID') return;
+      if (charge['status'] === 'REFUNDED' || charge['refundedAt']) return null;
+      if (charge['status'] !== 'PAID') return null;
       const currentClaim = charge['refundClaim'] as { expiresAt?: number } | null;
-      if (currentClaim && (currentClaim.expiresAt ?? 0) > Date.now()) return;
+      if (currentClaim && (currentClaim.expiresAt ?? 0) > Date.now()) return null;
       tx.update(chargeRef, {
         refundClaim: { token, expiresAt: Date.now() + REFUND_CLAIM_MS },
         updatedAt: this.firestore.Timestamp.now(),
       });
-      claimed = charge;
+      // Immutable payload for the external side effect.
+      return {
+        portonePaymentId: charge['portonePaymentId'],
+        amount: charge['amount'],
+      };
     });
-    if (!claimed) return;
+    if (!claimResult) return;
 
-    const charge = claimed as Record<string, any>;
+    const charge = claimResult as Record<string, any>;
     try {
       await this.portone.refund(charge['portonePaymentId'], charge['amount'], reason);
       await this.completeRefund(chargeRef, token, reason);

--- a/apps/api/src/payments/order-charge-refund-occ-retry.spec.ts
+++ b/apps/api/src/payments/order-charge-refund-occ-retry.spec.ts
@@ -1,0 +1,243 @@
+// OrderCharge refund retry-purity regression proofs on the canonical OCC harness.
+// Task: PAYMENT-REFUND-OCC-RETRY-PURITY-CLOSURE-01
+//
+// Same invariant as PaymentRefundService but for
+// OrderChargePaymentService.refundCharge via the public refundByOrderId path:
+//   1. normal claim -> provider exactly once
+//   2. first-attempt conflict -> retry loser provider 0
+//   3. concurrent claimers -> provider <= 1
+//   4. exhaustion -> side effect 0
+//   5. provider failure -> own claim release only
+//   6. successful refund -> REFUNDED convergence
+//   7. already REFUNDED/refundedAt -> side effect 0
+//
+// markFailed/finalizePaid semantics are intentionally untouched here.
+
+import { createOccFirestore } from '../../test/helpers/firestore-occ-fake';
+import { OrderChargePaymentService } from './order-charge-payment.service';
+
+function makeService(occ: ReturnType<typeof createOccFirestore>, portoneRefund: jest.Mock) {
+  const portone = { getPayment: jest.fn(), refund: portoneRefund } as never;
+  return new OrderChargePaymentService(occ.firestore as never, portone);
+}
+
+function seedPaidCharge(
+  occ: ReturnType<typeof createOccFirestore>,
+  chargeId: string,
+  orderId: string,
+) {
+  occ.seed(`orderCharges/${chargeId}`, {
+    id: chargeId,
+    orderId,
+    status: 'PAID',
+    type: 'REDELIVERY_FEE',
+    amount: 3000,
+    portonePaymentId: `order-charge-${chargeId}`,
+  });
+}
+
+describe('OrderCharge refund OCC retry purity', () => {
+  it('1. normal claim refunds exactly once and converges to REFUNDED', async () => {
+    const occ = createOccFirestore();
+    seedPaidCharge(occ, 'c-normal-1', 'order-oc-normal-1');
+    const refund = jest.fn().mockResolvedValue(undefined);
+    const service = makeService(occ, refund);
+
+    const commits: Array<{ writeCount: number }> = [];
+    const arm = (): void => {
+      occ.setBeforeCommit((ctx) => {
+        commits.push({ writeCount: ctx.writes.length });
+        arm();
+      });
+    };
+    arm();
+
+    await service.refundByOrderId('order-oc-normal-1', '주문 취소');
+    occ.clearHooks();
+
+    expect(refund).toHaveBeenCalledTimes(1);
+    expect(refund).toHaveBeenCalledWith('order-charge-c-normal-1', 3000, '주문 취소');
+    // Claim + completeRefund, each one committed attempt.
+    expect(commits).toHaveLength(2);
+    expect(occ.getData('orderCharges/c-normal-1')).toMatchObject({
+      status: 'REFUNDED',
+      refundClaim: null,
+    });
+    expect(occ.getData('orderCharges/c-normal-1')?.['refundedAt']).toBeDefined();
+  });
+
+  it('2. first-attempt conflict retries to loser: provider 0, foreign claim preserved', async () => {
+    const occ = createOccFirestore();
+    const chargePath = 'orderCharges/c-conflict-1';
+    seedPaidCharge(occ, 'c-conflict-1', 'order-oc-conflict-1');
+    const refund = jest.fn().mockResolvedValue(undefined);
+    const service = makeService(occ, refund);
+
+    const commits: Array<{ writeCount: number }> = [];
+    const arm = (): void => {
+      occ.setBeforeCommit((ctx) => {
+        commits.push({ writeCount: ctx.writes.length });
+        if (commits.length === 1) {
+          occ.updateOutsideTransaction(chargePath, {
+            refundClaim: { token: 'foreign-token', expiresAt: Date.now() + 300000 },
+          });
+        }
+        arm();
+      });
+    };
+    arm();
+
+    await service.refundByOrderId('order-oc-conflict-1', '주문 취소');
+    occ.clearHooks();
+
+    expect(commits).toHaveLength(2);
+    expect(commits[0].writeCount).toBe(1);
+    expect(commits[1].writeCount).toBe(0);
+    expect(refund).not.toHaveBeenCalled();
+    expect(occ.getData(chargePath)).toMatchObject({
+      status: 'PAID',
+      refundClaim: { token: 'foreign-token' },
+    });
+  });
+
+  it('3. concurrent claimers converge with provider <= 1', async () => {
+    const occ = createOccFirestore();
+    seedPaidCharge(occ, 'c-race-1', 'order-oc-race-1');
+    const refund = jest.fn().mockResolvedValue(undefined);
+    const service = makeService(occ, refund);
+
+    const commits: unknown[] = [];
+    const arm = (): void => {
+      occ.setBeforeCommit((ctx) => {
+        commits.push(ctx);
+        arm();
+      });
+    };
+    arm();
+
+    await Promise.all([
+      service.refundByOrderId('order-oc-race-1', '주문 취소'),
+      service.refundByOrderId('order-oc-race-1', '주문 취소'),
+    ]);
+    occ.clearHooks();
+
+    expect(refund).toHaveBeenCalledTimes(1);
+    expect(commits.length).toBeGreaterThanOrEqual(3);
+    expect(occ.getData('orderCharges/c-race-1')).toMatchObject({
+      status: 'REFUNDED',
+      refundClaim: null,
+    });
+  });
+
+  it('4. retry exhaustion fails bounded with provider 0 and no staged claim', async () => {
+    const occ = createOccFirestore({ maxAttempts: 2 });
+    const chargePath = 'orderCharges/c-hot-1';
+    seedPaidCharge(occ, 'c-hot-1', 'order-oc-hot-1');
+    const refund = jest.fn().mockResolvedValue(undefined);
+    const service = makeService(occ, refund);
+
+    let bumps = 0;
+    const rearm = (): void => {
+      occ.setBeforeCommit(() => {
+        bumps += 1;
+        occ.updateOutsideTransaction(chargePath, { probe: bumps });
+        rearm();
+      });
+    };
+    rearm();
+
+    await expect(service.refundByOrderId('order-oc-hot-1', '주문 취소')).rejects.toThrow(
+      'transaction retry limit exceeded',
+    );
+    occ.clearHooks();
+
+    expect(refund).not.toHaveBeenCalled();
+    expect(bumps).toBe(2);
+    expect(occ.getData(chargePath)).toMatchObject({ status: 'PAID', probe: 2 });
+    expect(
+      (occ.getData(chargePath) as Record<string, unknown>)['refundClaim'],
+    ).toBeUndefined();
+  });
+
+  it('5a. provider failure releases own claim without changing status', async () => {
+    const occ = createOccFirestore();
+    const chargePath = 'orderCharges/c-fail-1';
+    seedPaidCharge(occ, 'c-fail-1', 'order-oc-fail-1');
+    const refund = jest.fn().mockRejectedValue(new Error('provider down'));
+    const service = makeService(occ, refund);
+
+    await expect(service.refundByOrderId('order-oc-fail-1', '주문 취소')).rejects.toThrow(
+      'provider down',
+    );
+
+    expect(refund).toHaveBeenCalledTimes(1);
+    expect(occ.getData(chargePath)).toMatchObject({ status: 'PAID', refundClaim: null });
+  });
+
+  it('5b. provider-failure release never removes a foreign/newer claim', async () => {
+    const occ = createOccFirestore();
+    const chargePath = 'orderCharges/c-fail-foreign-1';
+    seedPaidCharge(occ, 'c-fail-foreign-1', 'order-oc-fail-foreign-1');
+    const refund = jest.fn().mockRejectedValue(new Error('provider down'));
+    const service = makeService(occ, refund);
+
+    const commits: string[] = [];
+    const arm = (): void => {
+      occ.setBeforeCommit(() => {
+        commits.push('commit');
+        if (commits.length === 2) {
+          occ.updateOutsideTransaction(chargePath, {
+            refundClaim: { token: 'newer-foreign', expiresAt: Date.now() + 300000 },
+          });
+        }
+        arm();
+      });
+    };
+    arm();
+
+    await expect(
+      service.refundByOrderId('order-oc-fail-foreign-1', '주문 취소'),
+    ).rejects.toThrow('provider down');
+    occ.clearHooks();
+
+    expect(refund).toHaveBeenCalledTimes(1);
+    expect(commits).toHaveLength(3);
+    expect(occ.getData(chargePath)?.['refundClaim']).toEqual({
+      token: 'newer-foreign',
+      expiresAt: expect.any(Number),
+    });
+    expect(occ.getData(chargePath)).toMatchObject({ status: 'PAID' });
+  });
+
+  it('6+7. REFUNDED convergence is idempotent; already REFUNDED has no side effect', async () => {
+    const occ = createOccFirestore();
+    seedPaidCharge(occ, 'c-final-1', 'order-oc-final-1');
+    const refund = jest.fn().mockResolvedValue(undefined);
+    const service = makeService(occ, refund);
+
+    await service.refundByOrderId('order-oc-final-1', '주문 취소');
+    expect(refund).toHaveBeenCalledTimes(1);
+    expect(occ.getData('orderCharges/c-final-1')).toMatchObject({
+      status: 'REFUNDED',
+      refundClaim: null,
+    });
+
+    // Completed refund followed by a retry must not call the provider again.
+    await service.refundByOrderId('order-oc-final-1', '주문 취소');
+    expect(refund).toHaveBeenCalledTimes(1);
+
+    // A document that is already REFUNDED/refundedAt never authorizes a refund.
+    occ.seed('orderCharges/c-done-1', {
+      id: 'c-done-1',
+      orderId: 'order-oc-done-1',
+      status: 'REFUNDED',
+      type: 'REDELIVERY_FEE',
+      amount: 3000,
+      portonePaymentId: 'order-charge-c-done-1',
+      refundedAt: new Date('2026-09-01T00:00:00.000Z'),
+      refundClaim: null,
+    });
+    await service.refundByOrderId('order-oc-done-1', '주문 취소');
+    expect(refund).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/api/src/payments/payment-refund-occ-retry.spec.ts
+++ b/apps/api/src/payments/payment-refund-occ-retry.spec.ts
@@ -1,0 +1,297 @@
+// PaymentRefund retry-purity regression proofs on the canonical OCC harness.
+// Task: PAYMENT-REFUND-OCC-RETRY-PURITY-CLOSURE-01
+//
+// Proves UNCOMMITTED_TRANSACTION_ATTEMPT MUST_NOT_AUTHORIZE_EXTERNAL_SIDE_EFFECT
+// for PaymentRefundService.refundByOrderId:
+//   A. normal claim -> provider exactly once
+//   B. first-attempt conflict -> retry loser provider 0 (no stale decision leak)
+//   C. concurrent claimers -> exactly one owner, provider <= 1
+//   D. retry exhaustion -> provider 0, no partial committed state
+//   E. provider failure -> own claim release only, foreign claim preserved
+//   F. success finalization -> token owner only, duplicate finalize side-effect 0
+//
+// Uses only the canonical harness (per-doc version, conflict detection, retry
+// re-execution, staged writes, failed-attempt discard, beforeCommit
+// deterministic interleaving). Serial fakes are not used.
+
+import { createOccFirestore } from '../../test/helpers/firestore-occ-fake';
+import { PaymentRefundService } from './payment-refund.service';
+
+function makeService(occ: ReturnType<typeof createOccFirestore>, portoneRefund: jest.Mock) {
+  const portone = { refund: portoneRefund } as never;
+  const issueWriter = { createOrMergeIssue: jest.fn().mockResolvedValue({ id: 'issue-1' }) };
+  const retention = { saveRecord: jest.fn().mockResolvedValue({}) };
+  const service = new PaymentRefundService(
+    occ.firestore as never,
+    portone,
+    issueWriter as never,
+    retention as never,
+  );
+  return { service, issueWriter, retention };
+}
+
+function seedPaid(occ: ReturnType<typeof createOccFirestore>, paymentPath: string, orderId: string) {
+  occ.seed(paymentPath, {
+    id: paymentPath.split('/')[1],
+    orderId,
+    storeId: 'store-1',
+    userId: 'user-1',
+    status: 'PAID',
+    amount: 100000,
+    portonePaymentId: `portone-${orderId}`,
+  });
+}
+
+describe('PaymentRefund OCC retry purity', () => {
+  it('A. normal claim commits and refunds exactly once with retention metadata', async () => {
+    const occ = createOccFirestore();
+    seedPaid(occ, 'payments/pay-normal-1', 'order-normal-1');
+    const refund = jest.fn().mockResolvedValue(undefined);
+    const { service, retention } = makeService(occ, refund);
+
+    const commits: Array<{ readPaths: string[]; writeCount: number }> = [];
+    const arm = (): void => {
+      occ.setBeforeCommit((ctx) => {
+        commits.push({ readPaths: [...ctx.readPaths], writeCount: ctx.writes.length });
+        arm();
+      });
+    };
+    arm();
+
+    await service.refundByOrderId('order-normal-1', '고객 요청');
+    occ.clearHooks();
+
+    expect(refund).toHaveBeenCalledTimes(1);
+    expect(refund).toHaveBeenCalledWith('portone-order-normal-1', 100000, '고객 요청');
+    // Claim transaction + finalize transaction, each committed once.
+    expect(commits).toHaveLength(2);
+    expect(commits[0].writeCount).toBe(1);
+    expect(commits[1].writeCount).toBe(1);
+    expect(occ.getData('payments/pay-normal-1')).toMatchObject({
+      status: 'CANCELLED',
+      refundAmount: 100000,
+      refundClaim: null,
+    });
+    expect(occ.getData('payments/pay-normal-1')?.['refundedAt']).toBeDefined();
+    expect(retention.saveRecord).toHaveBeenCalledTimes(1);
+    expect(retention.saveRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'pay-normal-1:refund',
+        purpose: 'LEGAL_DISPUTE',
+        metadata: expect.objectContaining({
+          orderId: 'order-normal-1',
+          paymentStatus: 'CANCELLED',
+          amount: 100000,
+        }),
+      }),
+    );
+  });
+
+  it('B. first-attempt conflict retries to loser: provider 0, foreign claim preserved', async () => {
+    const occ = createOccFirestore();
+    const paymentPath = 'payments/pay-conflict-1';
+    seedPaid(occ, paymentPath, 'order-conflict-1');
+    const refund = jest.fn().mockResolvedValue(undefined);
+    const { service } = makeService(occ, refund);
+
+    const commits: Array<{ writes: Array<{ kind: string; path: string }> }> = [];
+    const arm = (): void => {
+      occ.setBeforeCommit((ctx) => {
+        commits.push({
+          writes: ctx.writes.map((w) => ({
+            kind: w.kind,
+            path: (w as { path: string }).path,
+          })),
+        });
+        if (commits.length === 1) {
+          // Competing claim lands after attempt 1 read but before its commit.
+          occ.updateOutsideTransaction(paymentPath, {
+            refundClaim: { token: 'foreign-token', expiresAt: Date.now() + 300000 },
+          });
+        }
+        arm();
+      });
+    };
+    arm();
+
+    await service.refundByOrderId('order-conflict-1', '고객 요청');
+    occ.clearHooks();
+
+    // Two commit validations: attempt 1 aborted, attempt 2 observed the
+    // foreign active claim and staged nothing.
+    expect(commits).toHaveLength(2);
+    expect(commits[0].writes).toHaveLength(1);
+    expect(commits[1].writes).toHaveLength(0);
+    // The aborted attempt's decision must not authorize the provider.
+    expect(refund).not.toHaveBeenCalled();
+    expect(occ.getData(paymentPath)).toMatchObject({
+      status: 'PAID',
+      refundClaim: { token: 'foreign-token' },
+    });
+  });
+
+  it('C. concurrent claimers converge: exactly one owner, provider <= 1', async () => {
+    const occ = createOccFirestore();
+    seedPaid(occ, 'payments/pay-race-1', 'order-race-1');
+    const refund = jest.fn().mockResolvedValue(undefined);
+    const { service } = makeService(occ, refund);
+
+    const commits: unknown[] = [];
+    const arm = (): void => {
+      occ.setBeforeCommit((ctx) => {
+        commits.push(ctx);
+        arm();
+      });
+    };
+    arm();
+
+    await Promise.all([
+      service.refundByOrderId('order-race-1', '고객 요청'),
+      service.refundByOrderId('order-race-1', '고객 요청'),
+    ]);
+    occ.clearHooks();
+
+    expect(refund).toHaveBeenCalledTimes(1);
+    // Retry happened: 2 claim validations for the loser path + winner + finalize.
+    expect(commits.length).toBeGreaterThanOrEqual(3);
+    expect(occ.getData('payments/pay-race-1')).toMatchObject({
+      status: 'CANCELLED',
+      refundClaim: null,
+    });
+  });
+
+  it('D. retry exhaustion fails bounded with provider 0 and no staged claim', async () => {
+    const occ = createOccFirestore({ maxAttempts: 2 });
+    const paymentPath = 'payments/pay-hot-1';
+    seedPaid(occ, paymentPath, 'order-hot-1');
+    const refund = jest.fn().mockResolvedValue(undefined);
+    const { service } = makeService(occ, refund);
+
+    let bumps = 0;
+    const rearm = (): void => {
+      occ.setBeforeCommit(() => {
+        bumps += 1;
+        // Neutral version bump: forces conflict without itself claiming.
+        occ.updateOutsideTransaction(paymentPath, { probe: bumps });
+        rearm();
+      });
+    };
+    rearm();
+
+    await expect(service.refundByOrderId('order-hot-1', '고객 요청')).rejects.toThrow(
+      'transaction retry limit exceeded',
+    );
+    occ.clearHooks();
+
+    expect(refund).not.toHaveBeenCalled();
+    expect(bumps).toBe(2);
+    // Only the external probe writes landed; the transaction's staged claim
+    // was discarded on every aborted attempt.
+    expect(occ.getData(paymentPath)).toMatchObject({ status: 'PAID', probe: 2 });
+    expect(
+      (occ.getData(paymentPath) as Record<string, unknown>)['refundClaim'],
+    ).toBeUndefined();
+  });
+
+  it('E1. provider failure releases own claim and records the operational issue', async () => {
+    const occ = createOccFirestore();
+    const paymentPath = 'payments/pay-fail-1';
+    seedPaid(occ, paymentPath, 'order-fail-1');
+    const refund = jest.fn().mockRejectedValue(new Error('provider down'));
+    const { service, issueWriter } = makeService(occ, refund);
+
+    await expect(service.refundByOrderId('order-fail-1', '자동 취소')).rejects.toThrow(
+      'provider down',
+    );
+
+    expect(refund).toHaveBeenCalledTimes(1);
+    expect(occ.getData(paymentPath)).toMatchObject({ status: 'PAID', refundClaim: null });
+    expect(issueWriter.createOrMergeIssue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'AUTO_REFUND_FAILED',
+        idempotencyKey: 'auto-refund-failed:order-fail-1:pay-fail-1',
+      }),
+    );
+  });
+
+  it('E2. provider-failure release never removes a foreign/newer claim', async () => {
+    const occ = createOccFirestore();
+    const paymentPath = 'payments/pay-fail-foreign-1';
+    seedPaid(occ, paymentPath, 'order-fail-foreign-1');
+    const refund = jest.fn().mockRejectedValue(new Error('provider down'));
+    const { service } = makeService(occ, refund);
+
+    const commits: string[] = [];
+    const arm = (): void => {
+      occ.setBeforeCommit(() => {
+        commits.push('commit');
+        if (commits.length === 2) {
+          // Release attempt 0 has read the own claim; a newer foreign claim
+          // lands before its commit validation, forcing a retry.
+          occ.updateOutsideTransaction(paymentPath, {
+            refundClaim: { token: 'newer-foreign', expiresAt: Date.now() + 300000 },
+          });
+        }
+        arm();
+      });
+    };
+    arm();
+
+    await expect(service.refundByOrderId('order-fail-foreign-1', '자동 취소')).rejects.toThrow(
+      'provider down',
+    );
+    occ.clearHooks();
+
+    expect(refund).toHaveBeenCalledTimes(1);
+    // Claim + release attempt (aborted) + release retry (empty commit).
+    expect(commits).toHaveLength(3);
+    expect(occ.getData(paymentPath)?.['refundClaim']).toEqual({
+      token: 'newer-foreign',
+      expiresAt: expect.any(Number),
+    });
+    expect(occ.getData(paymentPath)).toMatchObject({ status: 'PAID' });
+  });
+
+  it('F. success finalization is token-owned; duplicate finalize has no side effect', async () => {
+    const occ = createOccFirestore();
+    const paymentPath = 'payments/pay-final-1';
+    seedPaid(occ, paymentPath, 'order-final-1');
+    const refund = jest.fn().mockResolvedValue(undefined);
+    const { service, retention } = makeService(occ, refund);
+
+    await service.refundByOrderId('order-final-1', '고객 요청');
+    expect(refund).toHaveBeenCalledTimes(1);
+    expect(retention.saveRecord).toHaveBeenCalledTimes(1);
+
+    // Duplicate finalize after CANCELLED/refundedAt must not refund again.
+    await service.refundByOrderId('order-final-1', '고객 요청');
+    expect(refund).toHaveBeenCalledTimes(1);
+    expect(retention.saveRecord).toHaveBeenCalledTimes(1);
+    expect(occ.getData(paymentPath)).toMatchObject({
+      status: 'CANCELLED',
+      refundAmount: 100000,
+      refundClaim: null,
+    });
+  });
+
+  it('G. already CANCELLED payment never authorizes the provider', async () => {
+    const occ = createOccFirestore();
+    occ.seed('payments/pay-done-1', {
+      id: 'pay-done-1',
+      orderId: 'order-done-1',
+      storeId: 'store-1',
+      userId: 'user-1',
+      status: 'CANCELLED',
+      amount: 100000,
+      portonePaymentId: 'portone-order-done-1',
+      refundedAt: new Date('2026-09-01T00:00:00.000Z'),
+      refundClaim: null,
+    });
+    const refund = jest.fn().mockResolvedValue(undefined);
+    const { service } = makeService(occ, refund);
+
+    await service.refundByOrderId('order-done-1', '고객 요청');
+
+    expect(refund).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/payments/payment-refund.service.ts
+++ b/apps/api/src/payments/payment-refund.service.ts
@@ -26,26 +26,38 @@ export class PaymentRefundService {
 
     const paymentRef = paymentSnap.docs[0].ref;
     const token = randomUUID();
-    let claimed: Record<string, any> | null = null;
 
-    await this.firestore.runTransaction(async (tx) => {
+    // Retry purity: the claim decision must come from the committed attempt's
+    // return value only. An outer `let claimed` mutated inside the callback
+    // would leak an aborted attempt's decision and authorize a duplicate
+    // provider refund after retry. See PAYMENT-REFUND-OCC-RETRY-PURITY-CLOSURE-01.
+    const claimResult = await this.firestore.runTransaction(async (tx) => {
       const freshSnap = await tx.get(paymentRef);
-      if (!freshSnap.exists) return;
+      if (!freshSnap.exists) return null;
       const payment = freshSnap.data() as Record<string, any>;
-      if (payment['status'] === 'CANCELLED' || payment['refundedAt']) return;
-      if (payment['status'] !== 'PAID') return;
+      if (payment['status'] === 'CANCELLED' || payment['refundedAt']) return null;
+      if (payment['status'] !== 'PAID') return null;
       const currentClaim = payment['refundClaim'] as { expiresAt?: number } | null;
-      if (currentClaim && (currentClaim.expiresAt ?? 0) > Date.now()) return;
+      if (currentClaim && (currentClaim.expiresAt ?? 0) > Date.now()) return null;
 
       tx.update(paymentRef, {
         refundClaim: { token, expiresAt: Date.now() + REFUND_CLAIM_MS },
         updatedAt: this.firestore.Timestamp.now(),
       });
-      claimed = payment;
+      // Immutable payload for the external side effect. A fresh copy, never
+      // the live snapshot object, so a later retry cannot mutate it.
+      return {
+        id: payment['id'],
+        portonePaymentId: payment['portonePaymentId'],
+        amount: payment['amount'],
+        storeId: payment['storeId'],
+        userId: payment['userId'],
+        status: payment['status'],
+      };
     });
-    if (!claimed) return;
+    if (!claimResult) return;
 
-    const payment = claimed as Record<string, any>;
+    const payment = claimResult as Record<string, any>;
     try {
       await this.portone.refund(payment['portonePaymentId'], payment['amount'], reason);
       const now = this.firestore.Timestamp.now();

--- a/apps/api/test/helpers/firestore-occ-fake.ts
+++ b/apps/api/test/helpers/firestore-occ-fake.ts
@@ -1,0 +1,399 @@
+// Canonical Firestore transaction/OCC test harness.
+//
+// Converges the divergent transaction semantics previously spread across API
+// test fakes into one contract:
+//
+//   A. ISOLATION ......... transaction writes are staged; invisible to live
+//                          state (and to other transactions) until commit.
+//   B. READ VERSION ...... every transactional read records a doc version.
+//   C. CONFLICT .......... commit aborts when a read doc changed underneath.
+//   D. RETRY ............. aborted attempts retry the callback with fresh
+//                          reads (deterministic, bounded; default 10).
+//   E. ATOMIC COMMIT ..... conflict-free writes apply as one commit.
+//   F. FAILURE ........... callback/commit failure leaves no partial writes.
+//   G. DETERMINISM ....... interleaving is driven by explicit hooks plus a
+//                          single setImmediate yield; no wall-clock timing.
+//
+// Deliberately NOT a full Firestore reimplementation: queries support the
+// operators production code uses (==, <, <=, >, >=, in), FieldValue supports
+// the increment sentinel shapes used in tests, and transaction.get supports
+// document refs (primary production shape) plus collection queries.
+//
+// Concurrent runTransaction calls are NOT globally serialized: that is the
+// point. Serial queues hide OCC races and turn concurrency specs
+// false-green. Genuine single-owner convergence must emerge from
+// read-version conflict + retry, which this harness models.
+
+export type OccData = Record<string, unknown>;
+
+export type OccDocumentRef = {
+  readonly path: string;
+  readonly id: string;
+  get(): Promise<OccSnapshot>;
+  set(data: OccData, options?: { merge?: boolean }): Promise<void>;
+  update(data: OccData): Promise<void>;
+  delete(): Promise<void>;
+};
+
+export type OccSnapshot = {
+  readonly exists: boolean;
+  readonly id: string;
+  readonly ref: OccDocumentRef;
+  data(): OccData | undefined;
+};
+
+export type OccQuerySnapshot = {
+  readonly docs: OccSnapshot[];
+  readonly empty: boolean;
+  readonly size: number;
+};
+
+export type OccTransaction = {
+  get(ref: OccDocumentRef): Promise<OccSnapshot>;
+  get(query: { get(): Promise<OccQuerySnapshot> }): Promise<OccQuerySnapshot>;
+  get(target: unknown): Promise<OccSnapshot | OccQuerySnapshot>;
+  set(ref: OccDocumentRef, data: OccData, options?: { merge?: boolean }): void;
+  update(ref: OccDocumentRef, data: OccData): void;
+  delete(ref: OccDocumentRef): void;
+};
+
+export type OccWrite =
+  | { kind: 'set'; path: string; data: OccData; merge?: boolean }
+  | { kind: 'update'; path: string; data: OccData }
+  | { kind: 'delete'; path: string };
+
+export type OccCommitContext = {
+  readonly attempt: number;
+  readonly readPaths: string[];
+  readonly writes: OccWrite[];
+};
+
+const DELETE_SENTINEL = Symbol('occ-deleted');
+
+function clone<T>(value: T): T {
+  if (value instanceof Date) return new Date(value.getTime()) as T;
+  if (Array.isArray(value)) return value.map(clone) as T;
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as OccData).map(([key, item]) => [key, clone(item)]),
+    ) as T;
+  }
+  return value;
+}
+
+function comparable(value: unknown): unknown {
+  if (value instanceof Date) return value.getTime();
+  if (typeof (value as { toDate?: () => Date })?.toDate === 'function') {
+    return (value as { toDate: () => Date }).toDate().getTime();
+  }
+  return value;
+}
+
+function incrementOf(value: unknown): number | null {
+  if (!value || typeof value !== 'object') return null;
+  const record = value as Record<string, unknown>;
+  if (record['__op'] === 'increment' && typeof record['value'] === 'number') {
+    return record['value'] as number;
+  }
+  if (typeof record['__increment'] === 'number') return record['__increment'] as number;
+  return null;
+}
+
+function applyPatch(current: OccData, patch: OccData): OccData {
+  const next = clone(current);
+  for (const [path, rawValue] of Object.entries(patch)) {
+    const keys = path.split('.');
+    const leaf = keys.pop()!;
+    let target = next;
+    for (const key of keys) {
+      const child = target[key];
+      target[key] = child && typeof child === 'object' ? clone(child as OccData) : {};
+      target = target[key] as OccData;
+    }
+    const increment = incrementOf(rawValue);
+    target[leaf] =
+      increment !== null ? Number(target[leaf] ?? 0) + increment : clone(rawValue);
+  }
+  return next;
+}
+
+function matches(data: OccData, filter: { field: string; operator: string; value: unknown }) {
+  const actual = comparable(
+    filter.field.split('.').reduce<unknown>((current, key) => (current as OccData)?.[key], data),
+  );
+  const expected = comparable(filter.value);
+  if (filter.operator === '==') return actual === expected;
+  if (filter.operator === '<=') return (actual as number) <= (expected as number);
+  if (filter.operator === '<') return (actual as number) < (expected as number);
+  if (filter.operator === '>=') return (actual as number) >= (expected as number);
+  if (filter.operator === '>') return (actual as number) > (expected as number);
+  if (filter.operator === 'in') return (expected as unknown[]).includes(actual);
+  throw new Error(`지원하지 않는 쿼리 연산자입니다: ${filter.operator}`);
+}
+
+type Filter = { field: string; operator: string; value: unknown };
+
+export function createOccFirestore(options: { maxAttempts?: number } = {}) {
+  const maxAttempts = options.maxAttempts ?? 10;
+  const documents = new Map<string, OccData>();
+  const versions = new Map<string, number>();
+  const references = new Map<string, OccDocumentRef>();
+  let sequence = 0;
+  let beforeAttempt: (() => Promise<void> | void) | undefined;
+  let beforeCommit: ((context: OccCommitContext) => Promise<void> | void) | undefined;
+
+  const readVersion = (path: string): number => versions.get(path) ?? 0;
+
+  const snapshotFor = (path: string, source: Map<string, OccData>): OccSnapshot => {
+    const ref = doc(path);
+    const data = source.get(path);
+    return {
+      exists: data !== undefined,
+      id: ref.id,
+      ref,
+      data: () => (data === undefined ? undefined : clone(data)),
+    };
+  };
+
+  function doc(path: string): OccDocumentRef {
+    const normalized = path.replace(/^\/|\/$/g, '');
+    const existing = references.get(normalized);
+    if (existing) return existing;
+    const ref: OccDocumentRef = {
+      path: normalized,
+      id: normalized.split('/').at(-1)!,
+      get: async () => snapshotFor(normalized, documents),
+      set: async (data, setOptions) => {
+        const current = documents.get(normalized);
+        documents.set(
+          normalized,
+          setOptions?.merge && current ? applyPatch(current, data) : applyPatch({}, data),
+        );
+        versions.set(normalized, readVersion(normalized) + 1);
+      },
+      update: async (data) => {
+        const current = documents.get(normalized);
+        if (!current) throw new Error(`존재하지 않는 문서입니다: ${normalized}`);
+        documents.set(normalized, applyPatch(current, data));
+        versions.set(normalized, readVersion(normalized) + 1);
+      },
+      delete: async () => {
+        documents.delete(normalized);
+        versions.set(normalized, readVersion(normalized) + 1);
+      },
+    };
+    references.set(normalized, ref);
+    return ref;
+  }
+
+  const runQuery = (
+    collectionPath: string,
+    filters: Filter[],
+    order?: { field: string; direction: 'asc' | 'desc' },
+    maximum?: number,
+  ): OccQuerySnapshot => {
+    const prefix = `${collectionPath}/`;
+    let entries = [...documents.entries()]
+      .filter(([path]) => path.startsWith(prefix) && !path.slice(prefix.length).includes('/'))
+      .filter(([, data]) => filters.every((filter) => matches(data, filter)));
+    if (order) {
+      entries.sort(([, left], [, right]) => {
+        const a = comparable(
+          order.field.split('.').reduce<unknown>((current, key) => (current as OccData)?.[key], left),
+        );
+        const b = comparable(
+          order.field.split('.').reduce<unknown>((current, key) => (current as OccData)?.[key], right),
+        );
+        const result = a === b ? 0 : (a as number) < (b as number) ? -1 : 1;
+        return order.direction === 'desc' ? -result : result;
+      });
+    }
+    if (maximum !== undefined) entries = entries.slice(0, maximum);
+    const docs = entries.map(([path]) => snapshotFor(path, documents));
+    return { docs, empty: docs.length === 0, size: docs.length };
+  };
+
+  const query = (
+    collectionPath: string,
+    filters: Filter[] = [],
+    order?: { field: string; direction: 'asc' | 'desc' },
+    maximum?: number,
+  ): any => ({
+    where: (field: string, operator: string, value: unknown) =>
+      query(collectionPath, [...filters, { field, operator, value }], order, maximum),
+    orderBy: (field: string, direction: 'asc' | 'desc' = 'asc') =>
+      query(collectionPath, filters, { field, direction }, maximum),
+    limit: (value: number) => query(collectionPath, filters, order, value),
+    get: async () => runQuery(collectionPath, filters, order, maximum),
+  });
+
+  async function runTransaction<T>(callback: (transaction: OccTransaction) => Promise<T>): Promise<T> {
+    for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+      if (beforeAttempt) {
+        const hook = beforeAttempt;
+        beforeAttempt = undefined;
+        await hook();
+      }
+
+      const readVersions = new Map<string, number>();
+      const writes: OccWrite[] = [];
+      // Read-your-writes within one attempt: staged overlay on top of live.
+      const staged = new Map<string, OccData | typeof DELETE_SENTINEL>();
+
+      const readLive = (path: string): OccData | undefined => {
+        if (staged.has(path)) {
+          const pending = staged.get(path);
+          return pending === DELETE_SENTINEL ? undefined : clone(pending as OccData);
+        }
+        const data = documents.get(path);
+        return data ? clone(data) : undefined;
+      };
+
+      const transaction: OccTransaction = {
+        get: (async (target: unknown) => {
+          // Collection query inside a transaction: record a version for
+          // every document observed so later writes to them conflict.
+          if (target && typeof target === 'object' && !('path' in (target as object))) {
+            const snapshot = await (target as { get(): Promise<OccQuerySnapshot> }).get();
+            for (const item of snapshot.docs) {
+              if (!readVersions.has(item.ref.path)) {
+                readVersions.set(item.ref.path, readVersion(item.ref.path));
+              }
+            }
+            return snapshot;
+          }
+          const ref = target as OccDocumentRef;
+          if (!readVersions.has(ref.path)) readVersions.set(ref.path, readVersion(ref.path));
+          const data = readLive(ref.path);
+          return {
+            exists: data !== undefined,
+            id: ref.path.split('/').at(-1)!,
+            ref: doc(ref.path),
+            data: () => (data === undefined ? undefined : clone(data)),
+          } satisfies OccSnapshot;
+        }) as OccTransaction['get'],
+        set: (ref, data, setOptions) => {
+          const base = setOptions?.merge ? (readLive(ref.path) ?? {}) : {};
+          staged.set(ref.path, applyPatch(base, clone(data)));
+          writes.push({ kind: 'set', path: ref.path, data: clone(data), merge: setOptions?.merge });
+        },
+        update: (ref, data) => {
+          const base = readLive(ref.path);
+          if (!base) throw new Error(`존재하지 않는 문서입니다: ${ref.path}`);
+          staged.set(ref.path, applyPatch(base, clone(data)));
+          writes.push({ kind: 'update', path: ref.path, data: clone(data) });
+        },
+        delete: (ref) => {
+          staged.set(ref.path, DELETE_SENTINEL);
+          writes.push({ kind: 'delete', path: ref.path });
+        },
+      };
+
+      const result = await callback(transaction);
+
+      // Deterministic interleaving point: lets a concurrent transaction's
+      // callback run before this attempt validates and commits. No timers.
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      if (beforeCommit) {
+        const hook = beforeCommit;
+        beforeCommit = undefined;
+        await hook({ attempt, readPaths: [...readVersions.keys()], writes: writes.map(clone) });
+      }
+
+      const conflicted = [...readVersions.entries()].some(
+        ([path, version]) => readVersion(path) !== version,
+      );
+      if (conflicted) continue;
+
+      // Atomic commit: validate against a scratch copy first so a failing
+      // write (e.g. update of a missing doc) commits nothing.
+      const scratch = new Map(documents);
+      for (const write of writes) {
+        if (write.kind === 'set') {
+          const base = write.merge ? (scratch.get(write.path) ?? {}) : {};
+          scratch.set(write.path, applyPatch(base, write.data));
+          continue;
+        }
+        if (write.kind === 'update') {
+          const current = scratch.get(write.path);
+          if (!current) throw new Error(`존재하지 않는 문서입니다: ${write.path}`);
+          scratch.set(write.path, applyPatch(current, write.data));
+          continue;
+        }
+        scratch.delete(write.path);
+      }
+      documents.clear();
+      for (const [path, data] of scratch) documents.set(path, data);
+      for (const write of writes) versions.set(write.path, readVersion(write.path) + 1);
+      return result;
+    }
+    throw new Error('transaction retry limit exceeded');
+  }
+
+  const firestore = {
+    doc,
+    collection: (path: string) => ({
+      ...query(path),
+      doc: (id = `auto-${(sequence += 1)}`) => doc(`${path}/${id}`),
+      add: async (data: OccData) => {
+        const ref = doc(`${path}/auto-${(sequence += 1)}`);
+        documents.set(ref.path, applyPatch({}, data));
+        versions.set(ref.path, readVersion(ref.path) + 1);
+        return ref;
+      },
+    }),
+    runTransaction,
+    Timestamp: {
+      now: () => new Date(),
+      fromDate: (value: Date) => new Date(value.getTime()),
+    },
+    FieldValue: {
+      increment: (value: number) => ({ __op: 'increment', value }),
+    },
+  };
+
+  return {
+    firestore,
+    seed: (path: string, data: OccData) => {
+      const normalized = path.replace(/^\/|\/$/g, '');
+      documents.set(normalized, clone(data));
+      if (!versions.has(normalized)) versions.set(normalized, 0);
+    },
+    updateOutsideTransaction: (path: string, data: OccData) => {
+      const normalized = path.replace(/^\/|\/$/g, '');
+      const current = documents.get(normalized);
+      if (!current) throw new Error(`존재하지 않는 문서입니다: ${normalized}`);
+      documents.set(normalized, applyPatch(current, data));
+      versions.set(normalized, readVersion(normalized) + 1);
+    },
+    deleteOutsideTransaction: (path: string) => {
+      const normalized = path.replace(/^\/|\/$/g, '');
+      documents.delete(normalized);
+      versions.set(normalized, readVersion(normalized) + 1);
+    },
+    setBeforeAttempt: (hook: (() => Promise<void> | void) | undefined) => {
+      beforeAttempt = hook;
+    },
+    setBeforeCommit: (
+      hook: ((context: OccCommitContext) => Promise<void> | void) | undefined,
+    ) => {
+      beforeCommit = hook;
+    },
+    clearHooks: () => {
+      beforeAttempt = undefined;
+      beforeCommit = undefined;
+    },
+    getData: (path: string): OccData | undefined => {
+      const data = documents.get(path.replace(/^\/|\/$/g, ''));
+      return data ? clone(data) : undefined;
+    },
+    getVersion: (path: string): number => readVersion(path.replace(/^\/|\/$/g, '')),
+    listData: (prefix: string): OccData[] =>
+      [...documents.entries()]
+        .filter(([path]) => path.startsWith(prefix))
+        .map(([, data]) => clone(data)),
+  };
+}
+
+export type OccFirestore = ReturnType<typeof createOccFirestore>;


### PR DESCRIPTION
Integrated closure publication for PAYMENT-REFUND-OCC-RETRY-PURITY-CLOSURE-01 + API-TEST-HARNESS-FIRESTORE-OCC-PARITY-CLOSURE-03 (task PAYMENT-REFUND-OCC-INTEGRATED-PUBLICATION-05). Base: live main c8e8dafa1b92501ac1dde71d4a8cb48232ff8e5a. Candidate: 50e0da59d818f938f5ee7f8439259d9bce532c67 (owned 6 paths only, foreign 0). Claim decisions travel only via committed transaction return values; provider refunds stay outside retryable callbacks (at-most-once). Canonical OCC harness + contract/retry proofs included. Validation: firestore-occ-contract (11), payment-refund-occ-retry (8), order-charge-refund-occ-retry (7), p0-002-race + payments.service (30) — all pass; 0 live provider calls; 0 production mutations.