### PR TITLE
feat(deploy): dependency-aware Vercel ignore predicate to stop unrelated frontend fan-out

### DIFF
--- a/apps/consumer/vercel.json
+++ b/apps/consumer/vercel.json
@@ -4,7 +4,7 @@
   "buildCommand": "cd ../.. && pnpm --filter @greenhub/shared build && pnpm --filter consumer build",
   "installCommand": "cd ../.. && pnpm install --frozen-lockfile",
   "outputDirectory": ".next",
-  "ignoreCommand": "git diff --name-only HEAD^ HEAD | grep -qvE '(^docs/|[.]md$)' && exit 1 || exit 0",
+  "ignoreCommand": "node ../../scripts/vercel/ignore-build.mjs --app consumer",
   "git": {
     "deploymentEnabled": {
       "main": false

--- a/apps/driver/vercel.json
+++ b/apps/driver/vercel.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "git diff --name-only HEAD^ HEAD | grep -qvE '(^docs/|[.]md$)' && exit 1 || exit 0",
+  "ignoreCommand": "node ../../scripts/vercel/ignore-build.mjs --app driver",
   "git": {
     "deploymentEnabled": {
       "main": false

--- a/apps/seller/vercel.json
+++ b/apps/seller/vercel.json
@@ -4,7 +4,7 @@
   "buildCommand": "cd ../.. && pnpm --filter @greenhub/shared build && pnpm --filter seller build",
   "installCommand": "cd ../.. && pnpm install --frozen-lockfile",
   "outputDirectory": ".next",
-  "ignoreCommand": "git diff --name-only HEAD^ HEAD | grep -qvE '(^docs/|[.]md$)' && exit 1 || exit 0",
+  "ignoreCommand": "node ../../scripts/vercel/ignore-build.mjs --app seller",
   "git": {
     "deploymentEnabled": {
       "main": false

--- a/docs/plans/PLAN_deployment_safety_guards_20260823.md
+++ b/docs/plans/PLAN_deployment_safety_guards_20260823.md
@@ -97,12 +97,48 @@ production은 다음 조건을 모두 충족한 뒤에만 실행한다.
 - docs-only `main` merge는 `preview` 동기화·일반 E2E dispatch를 만들지 않아야 한다.
 - 위 세 항목은 PR #33까지 실증 완료했다.
 
+## 의존성 인식 배포 선택 계약 (COORD-DEPLOY-FANOUT-01)
+
+배경: docs-only `ignoreCommand`(`git diff HEAD^` + docs grep)는 문서가 아닌 모든
+변경를 세 앱 모두에게 relevant로 취급했다. API-only(PR #145·#146 상당 delta)와
+Firestore-rules-only(PR #144 상당 delta) publication에서도 세 Preview가 모두
+생성된 직접 원인이 이것이다. `HEAD^` 기준은 merge/transport-freshness sync
+commit에서도 오판한다.
+
+현재 계약 (단일 공유 predicate `scripts/vercel/ignore-build.mjs`, 앱별
+`--app` 인자로 호출; 세 `apps/*/vercel.json`의 `ignoreCommand`가 이를 가리킨다):
+
+- API-only 변경 → 세 Preview 0개 (`apps/api`는 어떤 frontend의 workspace
+  의존성도 아니다; HTTP 계약 drift는 동일한 frontend source를 rebuild해도
+  고쳐지지 않으므로 rebuild하지 않는다).
+- Firestore Rules-only 변경 → 세 Preview 0개.
+- docs-only 변경 → 세 Preview 0개 (기존 계약 유지).
+- Consumer-only → Consumer만 BUILD, Seller-only → Seller만 BUILD,
+  Driver-only → Driver만 BUILD.
+- `packages/ui`·`packages/shared` 변경 → workspace graph상 실제 dependent만
+  BUILD (현재 세 앱 모두 의존하므로 세 앱 BUILD; 하드코딩이 아니라
+  `package.json`의 `workspace:` closure로 판정).
+- root `pnpm-lock.yaml`·`package.json`·`pnpm-workspace.yaml`·
+  `tsconfig.base.json`·`.vercelignore`·`scripts/copy-fonts.cjs` 변경 →
+  필요 앱 BUILD (보수적으로 세 앱 BUILD).
+- 기준은 `VERCEL_GIT_PREVIOUS_SHA`(해당 project+branch의 마지막 성공 배포
+  SHA)..HEAD effective delta이며, bare `HEAD^`를 쓰지 않는다. 따라서
+  publication transport freshness update나 preview sync merge만으로는
+  frontend Preview가 재생성되지 않는다. 신뢰 가능한 base가 없으면
+  fail-open(BUILD)한다.
+- 미분류 경로는 fail-open(BUILD)한다. production 배포 정책
+  (`git.deploymentEnabled.main=false`, exact-SHA 승인 절차)은 변경하지 않는다.
+
+증거: `scripts/vercel/ignore-build.spec.mjs` (`pnpm test:vercel-ignore`)가
+위 matrix와 freshness-merge 시나리오를 자동 검증한다.
+
 ## 회귀 방지
 
 다음 중 하나라도 깨지면 deployment safety regression으로 P0 처리한다.
 
 - 세 앱 중 하나의 `git.deploymentEnabled.main !== false`
-- docs-only `ignoreCommand` 제거/변경
+- 공유 `ignoreCommand`(`scripts/vercel/ignore-build.mjs --app <name>`) 제거/변경
+- predicate(`scripts/vercel/ignore-build.mjs`) 변경 후 `pnpm test:vercel-ignore` 미실행
 - `sync-preview.yml`의 docs ignore 제거
 - `AGENTS.md`의 no-direct-main 규칙 제거
 - safety CI 제거 또는 실패를 무시하고 merge

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "load:readiness": "node scripts/load/run-k6.mjs readiness",
     "load:run": "node scripts/load/run-k6.mjs",
     "test:e2e": "pnpm --filter e2e test",
-    "test:e2e:ui": "pnpm --filter e2e test:ui"
+    "test:e2e:ui": "pnpm --filter e2e test:ui",
+    "test:vercel-ignore": "node --test scripts/vercel/ignore-build.spec.mjs"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.14",

--- a/scripts/vercel/ignore-build.mjs
+++ b/scripts/vercel/ignore-build.mjs
@@ -1,0 +1,401 @@
+/**
+ * Shared Vercel "Ignored Build Step" predicate for consumer / seller / driver.
+ *
+ * One semantic contract, three call sites:
+ *   apps/consumer/vercel.json -> node ../../scripts/vercel/ignore-build.mjs --app consumer
+ *   apps/seller/vercel.json   -> node ../../scripts/vercel/ignore-build.mjs --app seller
+ *   apps/driver/vercel.json   -> node ../../scripts/vercel/ignore-build.mjs --app driver
+ *
+ * Exit codes follow the Vercel Ignored Build Step contract:
+ *   0 = SKIP (no app-relevant change since the base -> deployment CANCELED)
+ *   1 = BUILD (app-relevant change -> build continues)
+ *
+ * Design notes (COORD-DEPLOY-FANOUT-01):
+ * - The previous per-app `git diff HEAD^ HEAD | grep -qvE docs/md` predicate
+ *   treated every non-docs change as relevant for every app, so API-only and
+ *   Firestore-rules-only publications built all three frontends.
+ * - The base is NEVER a bare `HEAD^`. Vercel exposes VERCEL_GIT_PREVIOUS_SHA
+ *   (last successful deployment SHA for this project+branch) exactly when an
+ *   Ignored Build Step is configured. Diffing base..HEAD measures the
+ *   effective delta since the last successful build, so merge commits,
+ *   publication-transport freshness updates, and preview-sync merges cannot
+ *   misattribute unrelated movement to this app. Without a trustworthy base
+ *   the predicate fails OPEN (BUILD) instead of guessing.
+ * - Relevance = own app dir + transitive `workspace:` dependency closure
+ *   (the same signal Vercel's native unaffected-project skipping uses) +
+ *   explicit global frontend build inputs (lockfile, workspace definition,
+ *   shared tsconfig base, font prebuild, this predicate itself, .vercelignore).
+ * - A diff that touches ONLY backend/ops/test/docs paths is SKIP even when it
+ *   also touches another frontend app: relevance is evaluated per app over the
+ *   whole changed-file set, never as "any api file -> skip everything".
+ * - Unknown paths fail OPEN (BUILD): a new top-level config or package must
+ *   never be silently skipped.
+ *
+ * Runtime needs: `node` + `git` only. No dependencies, no install step.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export const APPS = Object.freeze(['consumer', 'seller', 'driver']);
+
+export const EXIT_SKIP = 0;
+export const EXIT_BUILD = 1;
+
+const SHA_PATTERN = /^[0-9a-f]{40}$/i;
+
+// Files read by `pnpm install` or by `next build` (via @greenhub/shared or the
+// font prebuild) of every frontend app. A change here must rebuild all three.
+export const GLOBAL_FRONTEND_INPUTS = Object.freeze([
+  'package.json',
+  'pnpm-lock.yaml',
+  'pnpm-workspace.yaml',
+  'tsconfig.base.json',
+  '.vercelignore',
+  'scripts/copy-fonts.cjs',
+  // Trailing '/' entries are directory prefixes.
+  'scripts/vercel/',
+]);
+
+// The predicate itself: a change to the deployment selector must rebuild so
+// the new selector is exercised against a real build at least once.
+const PREDICATE_DIR_PREFIX = 'scripts/vercel/';
+
+// Known backend / ops / test-only paths. None of them is read by a frontend
+// `next build`, so on their own they never justify a frontend deployment.
+const BACKEND_ONLY_DIR_PREFIXES = Object.freeze([
+  'apps/api/',
+  'apps/e2e/',
+  'tests/',
+  'test-results/',
+  '.github/',
+  '.artifacts/',
+  'backups/',
+  '.codex/',
+]);
+
+const BACKEND_ONLY_FILES = Object.freeze([
+  'firestore.rules',
+  'storage.rules',
+  'firestore.indexes.json',
+  'firebase.json',
+  'cors.json',
+  'Dockerfile',
+  'nixpacks.toml',
+  'Justfile',
+  'dev.bat',
+  'dev-local.bat',
+  'biome.json',
+  '.gitignore',
+  '.trufflehog.yml',
+  'AGENTS.md',
+  'CLAUDE.md',
+]);
+
+function toPosixPath(value) {
+  return String(value).replace(/\\/g, '/');
+}
+
+function isDocsOnlyPath(posixPath) {
+  return posixPath === 'docs' || posixPath.startsWith('docs/') || posixPath.endsWith('.md');
+}
+
+function isPredicatePath(posixPath) {
+  return posixPath === 'scripts/vercel' || posixPath.startsWith(PREDICATE_DIR_PREFIX);
+}
+
+function isBackendOnlyPath(posixPath) {
+  if (isDocsOnlyPath(posixPath)) return true;
+  if (BACKEND_ONLY_FILES.includes(posixPath)) return true;
+  if (posixPath.startsWith('scripts/') && !isPredicatePath(posixPath)) return true;
+  return BACKEND_ONLY_DIR_PREFIXES.some((prefix) => posixPath.startsWith(prefix));
+}
+
+/**
+ * A path inside another workspace member scope (`apps/<member>/...` or
+ * `packages/<member>/...`) that is NOT part of this app's source closure.
+ * Sibling frontends, the API, e2e, and undepended packages are never built
+ * into this app's artifact, so their files are known-irrelevant. (A newly
+ * added member is still safe: registering or depending on it always touches
+ * a Tier-1 path — root package.json, pnpm-workspace.yaml, or the depending
+ * app's own package.json.)
+ */
+function isOtherWorkspaceScope(posixPath) {
+  return /^(apps|packages)\/[^/]+\//.test(posixPath);
+}
+
+/**
+ * Read the workspace member directories from pnpm-workspace.yaml globs.
+ * Only `*` globs (`apps/*`, `packages/*`) are supported; anything else is
+ * ignored so an unreadable workspace file fails OPEN at the call site.
+ */
+export function readWorkspaceGlobs(repositoryRoot) {
+  try {
+    const raw = readFileSync(path.join(repositoryRoot, 'pnpm-workspace.yaml'), 'utf8');
+    const globs = [];
+    let inPackages = false;
+    for (const line of raw.split('\n')) {
+      if (/^\s*packages\s*:\s*$/.test(line)) {
+        inPackages = true;
+        continue;
+      }
+      if (inPackages) {
+        const match = line.match(/^\s*-\s*['"]?([^'"\s]+)['"]?\s*$/);
+        if (match) {
+          globs.push(match[1]);
+        } else if (!/^\s*(#|$)/.test(line)) {
+          inPackages = false;
+        }
+      }
+    }
+    return globs;
+  } catch {
+    return [];
+  }
+}
+
+function readJsonFile(filePath) {
+  try {
+    return JSON.parse(readFileSync(filePath, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+/** Map workspace package name -> repo-relative posix dir (e.g. packages/shared). */
+export function readWorkspacePackageDirs(repositoryRoot) {
+  const byName = new Map();
+  for (const glob of readWorkspaceGlobs(repositoryRoot)) {
+    const prefix = glob.endsWith('/*') ? glob.slice(0, -2) : null;
+    if (prefix == null) continue;
+    let entries = [];
+    try {
+      entries = readdirSync(path.join(repositoryRoot, prefix), { withFileTypes: true })
+        .filter((entry) => entry.isDirectory())
+        .map((entry) => entry.name);
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      const manifest = readJsonFile(path.join(repositoryRoot, prefix, entry, 'package.json'));
+      if (manifest != null && typeof manifest.name === 'string' && manifest.name.length > 0) {
+        byName.set(manifest.name, `${prefix}/${entry}`);
+      }
+    }
+  }
+  return byName;
+}
+
+function readAppManifest(repositoryRoot, app) {
+  return readJsonFile(path.join(repositoryRoot, 'apps', app, 'package.json'));
+}
+
+/**
+ * Transitive closure of repo-relative workspace dirs the app builds from:
+ * its own dir plus every `workspace:` dependency (dependencies,
+ * devDependencies, peerDependencies), recursed.
+ */
+export function resolveAppSourceDirs({ repositoryRoot, app, packageDirsByName = null }) {
+  const byName = packageDirsByName ?? readWorkspacePackageDirs(repositoryRoot);
+  const appDir = `apps/${app}`;
+  const relevant = new Set([`${appDir}/`]);
+  const queue = [];
+  const manifest = readAppManifest(repositoryRoot, app);
+  if (manifest == null) return { relevant: [...relevant], complete: false };
+  const directDeps = {
+    ...(manifest.dependencies ?? {}),
+    ...(manifest.devDependencies ?? {}),
+    ...(manifest.peerDependencies ?? {}),
+  };
+  for (const [name, range] of Object.entries(directDeps)) {
+    if (typeof range === 'string' && range.startsWith('workspace:') && byName.has(name)) {
+      queue.push(name);
+    }
+  }
+  const visited = new Set();
+  let complete = true;
+  while (queue.length > 0) {
+    const name = queue.pop();
+    if (visited.has(name)) continue;
+    visited.add(name);
+    const dir = byName.get(name);
+    if (dir == null) {
+      complete = false;
+      continue;
+    }
+    relevant.add(`${dir}/`);
+    const depManifest = readJsonFile(path.join(repositoryRoot, dir, 'package.json'));
+    if (depManifest == null) {
+      complete = false;
+      continue;
+    }
+    const nested = {
+      ...(depManifest.dependencies ?? {}),
+      ...(depManifest.devDependencies ?? {}),
+      ...(depManifest.peerDependencies ?? {}),
+    };
+    for (const [nestedName, nestedRange] of Object.entries(nested)) {
+      if (typeof nestedRange === 'string' && nestedRange.startsWith('workspace:')) {
+        if (byName.has(nestedName)) queue.push(nestedName);
+        else complete = false;
+      }
+    }
+  }
+  return { relevant: [...relevant].sort(), complete };
+}
+
+/**
+ * Pure per-app decision over a changed-file list (repo-relative paths).
+ * Returns { build, matched, reason }. Unknown paths fail OPEN (build).
+ */
+export function decideForChangedFiles({ app, changedFiles, appSourceDirs }) {
+  if (!APPS.includes(app)) {
+    throw new Error(`unknown app: ${JSON.stringify(app)} (expected one of ${APPS.join(', ')})`);
+  }
+  const files = [...new Set(changedFiles.map(toPosixPath))].sort();
+  if (files.length === 0) {
+    return { build: false, matched: [], reason: 'empty effective delta since base: SKIP' };
+  }
+  const relevantPrefixes = [...appSourceDirs, ...GLOBAL_FRONTEND_INPUTS];
+  const matched = files.filter((file) =>
+    relevantPrefixes.some((prefix) =>
+      prefix.endsWith('/') ? file === prefix.slice(0, -1) || file.startsWith(prefix) : file === prefix,
+    ),
+  );
+  if (matched.length > 0) {
+    return {
+      build: true,
+      matched,
+      reason: `app-relevant change for ${app}: ${matched.join(', ')}`,
+    };
+  }
+  const unknown = files.filter(
+    (file) => !isBackendOnlyPath(file) && !isPredicatePath(file) && !isOtherWorkspaceScope(file),
+  );
+  if (unknown.length > 0) {
+    return {
+      build: true,
+      matched: unknown,
+      reason: `unclassified path change (fail OPEN) for ${app}: ${unknown.join(', ')}`,
+    };
+  }
+  return {
+    build: false,
+    matched: [],
+    reason: `only backend/ops/test/docs paths changed, none relevant to ${app}: SKIP`,
+  };
+}
+
+function runGit(repositoryRoot, args) {
+  return execFileSync('git', args, {
+    cwd: repositoryRoot,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
+function resolveRepositoryRoot() {
+  const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+  try {
+    return runGit(scriptDir, ['rev-parse', '--show-toplevel']).trim().replace(/\\/g, '/');
+  } catch {
+    // Fall back to the monorepo layout scripts/vercel -> repo root.
+    return path.resolve(scriptDir, '..', '..');
+  }
+}
+
+function objectExists(repositoryRoot, sha) {
+  try {
+    runGit(repositoryRoot, ['cat-file', '-e', `${sha}^{commit}`]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function tryFetchSha(repositoryRoot, sha) {
+  try {
+    execFileSync('git', ['fetch', 'origin', sha, '--depth=100'], {
+      cwd: repositoryRoot,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 60_000,
+    });
+    return objectExists(repositoryRoot, sha);
+  } catch {
+    return false;
+  }
+}
+
+/** Resolve the diff base. Never defaults to a bare HEAD^. */
+export function resolveBaseSha({ repositoryRoot, env = process.env }) {
+  const previous = String(env.VERCEL_GIT_PREVIOUS_SHA ?? '').trim();
+  if (SHA_PATTERN.test(previous)) {
+    if (objectExists(repositoryRoot, previous)) {
+      return { sha: previous, source: 'VERCEL_GIT_PREVIOUS_SHA' };
+    }
+    if (tryFetchSha(repositoryRoot, previous)) {
+      return { sha: previous, source: 'VERCEL_GIT_PREVIOUS_SHA (fetched)' };
+    }
+    return {
+      sha: null,
+      source: 'none',
+      reason:
+        'VERCEL_GIT_PREVIOUS_SHA is set but unavailable locally and could not be fetched; failing OPEN (BUILD).',
+    };
+  }
+  return {
+    sha: null,
+    source: 'none',
+    reason:
+      'VERCEL_GIT_PREVIOUS_SHA is not set (first deployment or local run); failing OPEN (BUILD).',
+  };
+}
+
+export function listChangedFiles({ repositoryRoot, baseSha, headSha = 'HEAD' }) {
+  const stdout = runGit(repositoryRoot, ['diff', '--name-only', '--no-renames', '-z', baseSha, headSha, '--']);
+  return stdout.split('\0').map((entry) => entry.trim()).filter((entry) => entry.length > 0);
+}
+
+function parseArgs(argv) {
+  const appFlag = argv.indexOf('--app');
+  const app = appFlag >= 0 && appFlag + 1 < argv.length ? argv[appFlag + 1] : null;
+  const repoFlag = argv.indexOf('--repo');
+  const repo = repoFlag >= 0 && repoFlag + 1 < argv.length ? repoFlag + 1 : null;
+  return { app, repoRootOverride: repo != null ? argv[repo] : null };
+}
+
+const invokedAsMainScript =
+  process.argv[1] != null && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (invokedAsMainScript) {
+  const { app, repoRootOverride } = parseArgs(process.argv.slice(2));
+  if (app == null || !APPS.includes(app)) {
+    console.error(`usage: node scripts/vercel/ignore-build.mjs --app <${APPS.join('|')}> [--repo <dir>]`);
+    process.exit(EXIT_BUILD);
+  }
+  try {
+    const repositoryRoot = repoRootOverride ?? resolveRepositoryRoot();
+    const base = resolveBaseSha({ repositoryRoot });
+    if (base.sha == null) {
+      console.log(`[vercel-ignore:${app}] BUILD: ${base.reason}`);
+      process.exit(EXIT_BUILD);
+    }
+    const changedFiles = listChangedFiles({ repositoryRoot, baseSha: base.sha });
+    const { relevant, complete } = resolveAppSourceDirs({ repositoryRoot, app });
+    if (!complete) {
+      console.log(`[vercel-ignore:${app}] BUILD: workspace dependency graph incomplete; failing OPEN.`);
+      process.exit(EXIT_BUILD);
+    }
+    const decision = decideForChangedFiles({ app, changedFiles, appSourceDirs: relevant });
+    console.log(
+      `[vercel-ignore:${app}] ${decision.build ? 'BUILD' : 'SKIP'}: ${decision.reason} (base=${base.source} ${base.sha.slice(0, 8)}, files=${changedFiles.length})`,
+    );
+    process.exit(decision.build ? EXIT_BUILD : EXIT_SKIP);
+  } catch (error) {
+    console.error(`[vercel-ignore:${app}] BUILD: predicate error, failing OPEN: ${error.message}`);
+    process.exit(EXIT_BUILD);
+  }
+}

--- a/scripts/vercel/ignore-build.spec.mjs
+++ b/scripts/vercel/ignore-build.spec.mjs
@@ -1,0 +1,332 @@
+/**
+ * Deterministic verification for the shared Vercel deployment predicate
+ * (COORD-DEPLOY-FANOUT-01 acceptance matrix).
+ *
+ * Run: node --test scripts/vercel/ignore-build.spec.mjs
+ *
+ * Layers:
+ *  1. Workspace-graph truth: per-app source dirs resolved from the REAL repo
+ *     (never hardcoded) — proves packages/ui + packages/shared attribution.
+ *  2. Pure matrix: decideForChangedFiles over fixture path sets for all ten
+ *     acceptance cases.
+ *  3. Git integration: throwaway repos exercising VERCEL_GIT_PREVIOUS_SHA base
+ *     semantics, including a publication-transport-style freshness merge where
+ *     a naive `HEAD^` diff misjudges and this predicate does not.
+ */
+
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import {
+  APPS,
+  decideForChangedFiles,
+  resolveAppSourceDirs,
+} from './ignore-build.mjs';
+
+const SCRIPT_PATH = fileURLToPath(new URL('./ignore-build.mjs', import.meta.url));
+const REPO_ROOT = path.resolve(path.dirname(SCRIPT_PATH), '..', '..');
+
+function runNode(args, options = {}) {
+  try {
+    const stdout = execFileSync(process.execPath, [SCRIPT_PATH, ...args], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      ...options,
+    });
+    return { exitCode: 0, stdout };
+  } catch (error) {
+    return { exitCode: error.status ?? 1, stdout: String(error.stdout ?? '') };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 1. Workspace-graph truth (real repo, not fixtures)
+// ---------------------------------------------------------------------------
+
+const sourceDirsByApp = new Map();
+
+for (const app of APPS) {
+  test(`workspace graph resolves source dirs for ${app}`, () => {
+    const { relevant, complete } = resolveAppSourceDirs({ repositoryRoot: REPO_ROOT, app });
+    assert.equal(complete, true, 'dependency graph must resolve completely');
+    assert.ok(relevant.includes(`apps/${app}/`), 'own app dir must be relevant');
+    assert.ok(relevant.includes('packages/shared/'), '@greenhub/shared is a real workspace dep');
+    assert.ok(relevant.includes('packages/ui/'), '@greenhub/ui is a real workspace dep');
+    assert.ok(!relevant.some((dir) => dir.startsWith('apps/api/')), 'apps/api must not be a source dir');
+    sourceDirsByApp.set(app, relevant);
+  });
+}
+
+function decideAllApps(changedFiles) {
+  const result = new Map();
+  for (const app of APPS) {
+    result.set(
+      app,
+      decideForChangedFiles({ app, changedFiles, appSourceDirs: sourceDirsByApp.get(app) }),
+    );
+  }
+  return result;
+}
+
+function assertMatrix(name, changedFiles, expected) {
+  test(`matrix: ${name}`, () => {
+    const decisions = decideAllApps(changedFiles);
+    for (const app of APPS) {
+      assert.equal(
+        decisions.get(app).build,
+        expected[app],
+        `${name}: ${app} must be ${expected[app] ? 'BUILD' : 'SKIP'} (reason: ${decisions.get(app).reason})`,
+      );
+    }
+  });
+}
+
+// ---------------------------------------------------------------------------
+// 2. Acceptance matrix (cases 1-10)
+// ---------------------------------------------------------------------------
+
+assertMatrix('1. apps/api only -> all SKIP', ['apps/api/src/orders/orders.service.ts'], {
+  consumer: false,
+  seller: false,
+  driver: false,
+});
+
+assertMatrix('2. firestore.rules only -> all SKIP', ['firestore.rules'], {
+  consumer: false,
+  seller: false,
+  driver: false,
+});
+
+assertMatrix('3. docs only -> all SKIP', ['docs/specs/api/orders.md', 'README.md', 'apps/api/README.md'], {
+  consumer: false,
+  seller: false,
+  driver: false,
+});
+
+assertMatrix('4. apps/consumer only -> consumer BUILD', ['apps/consumer/src/app/page.tsx'], {
+  consumer: true,
+  seller: false,
+  driver: false,
+});
+
+assertMatrix('5. apps/seller only -> seller BUILD', ['apps/seller/src/app/dashboard/page.tsx'], {
+  consumer: false,
+  seller: true,
+  driver: false,
+});
+
+assertMatrix('6. apps/driver only -> driver BUILD', ['apps/driver/src/app/board/page.tsx'], {
+  consumer: false,
+  seller: false,
+  driver: true,
+});
+
+test('7/8. shared package attribution follows the workspace graph, not guesses', () => {
+  for (const changed of ['packages/ui/src/theme.ts', 'packages/shared/src/index.ts']) {
+    const decisions = decideAllApps([changed]);
+    for (const app of APPS) {
+      const depends = sourceDirsByApp
+        .get(app)
+        .some((dir) => changed === dir.slice(0, -1) || changed.startsWith(dir));
+      assert.equal(
+        decisions.get(app).build,
+        depends,
+        `${changed}: ${app} BUILD must equal real graph dependence (${depends})`,
+      );
+    }
+  }
+  // In the current graph every frontend depends on both shared packages.
+  const uiDecisions = decideAllApps(['packages/ui/src/theme.ts']);
+  const sharedDecisions = decideAllApps(['packages/shared/src/index.ts']);
+  for (const app of APPS) {
+    assert.equal(uiDecisions.get(app).build, true, `packages/ui change must BUILD ${app}`);
+    assert.equal(sharedDecisions.get(app).build, true, `packages/shared change must BUILD ${app}`);
+  }
+});
+
+assertMatrix('9. lockfile / shared build config -> all BUILD', ['pnpm-lock.yaml'], {
+  consumer: true,
+  seller: true,
+  driver: true,
+});
+
+assertMatrix('9b. tsconfig base -> all BUILD', ['tsconfig.base.json'], {
+  consumer: true,
+  seller: true,
+  driver: true,
+});
+
+assertMatrix(
+  '10. api change never forces a frontend build, mixed diffs still build the affected app',
+  ['apps/api/src/notifications/notifications.service.ts', 'apps/seller/src/app/orders/page.tsx'],
+  { consumer: false, seller: true, driver: false },
+);
+
+assertMatrix('unknown paths fail OPEN', ['brand-new-service/main.go'], {
+  consumer: true,
+  seller: true,
+  driver: true,
+});
+
+assertMatrix('empty delta -> all SKIP', [], {
+  consumer: false,
+  seller: false,
+  driver: false,
+});
+
+assertMatrix('backend/ops-only bundle -> all SKIP', [
+  'apps/api/src/auth/auth.service.ts',
+  'apps/e2e/specs/checkout.spec.ts',
+  'tests/firestore/firestore-rules.test.mjs',
+  '.github/workflows/e2e.yml',
+  'storage.rules',
+  'Dockerfile',
+  'scripts/seed.mjs',
+], {
+  consumer: false,
+  seller: false,
+  driver: false,
+});
+
+assertMatrix('predicate change rebuilds (self-exercise)', ['scripts/vercel/ignore-build.mjs'], {
+  consumer: true,
+  seller: true,
+  driver: true,
+});
+
+// ---------------------------------------------------------------------------
+// 3. Git integration with throwaway repos
+// ---------------------------------------------------------------------------
+
+function initFixtureRepo() {
+  const dir = mkdtempRepoDir();
+  const git = (args, options = {}) =>
+    execFileSync('git', args, { cwd: dir, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], ...options });
+  git(['init', '-b', 'main']);
+  git(['config', 'user.email', 'test@example.com']);
+  git(['config', 'user.name', 'test']);
+  writeFileSync(path.join(dir, 'pnpm-workspace.yaml'), "packages:\n  - 'apps/*'\n  - 'packages/*'\n");
+  writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ name: 'fixture', private: true }));
+  for (const app of APPS) {
+    writeAppPackage(dir, app);
+    writeFile(dir, `apps/${app}/src/page.tsx`, `// ${app}\n`);
+  }
+  for (const pkg of ['shared', 'ui']) {
+    writeFile(dir, `packages/${pkg}/package.json`, JSON.stringify({ name: `@greenhub/${pkg}`, private: true }));
+    writeFile(dir, `packages/${pkg}/src/index.ts`, `// ${pkg}\n`);
+  }
+  writeFile(dir, 'apps/api/src/main.ts', '// api\n');
+  git(['add', '-A']);
+  git(['commit', '-m', 'initial']);
+  return { dir, git };
+}
+
+function mkdtempRepoDir() {
+  return mkdtempSync(path.join(tmpdir(), 'ignore-build-'));
+}
+
+function writeFile(repoDir, relativePath, content) {
+  const absolute = path.join(repoDir, relativePath);
+  mkdirSync(path.dirname(absolute), { recursive: true });
+  writeFileSync(absolute, content);
+}
+
+function writeAppPackage(repoDir, app) {
+  writeFile(
+    repoDir,
+    `apps/${app}/package.json`,
+    JSON.stringify({
+      name: app,
+      private: true,
+      dependencies: { '@greenhub/shared': 'workspace:*', '@greenhub/ui': 'workspace:*' },
+    }),
+  );
+}
+
+function commitAll(git, message) {
+  git(['add', '-A']);
+  git(['commit', '-m', message]);
+  return git(['rev-parse', 'HEAD']).trim();
+}
+
+test('integration: api-only delta since PREV_SHA skips all apps', () => {
+  const { dir, git } = initFixtureRepo();
+  const base = git(['rev-parse', 'HEAD']).trim();
+  writeFile(dir, 'apps/api/src/orders.ts', '// api change\n');
+  commitAll(git, 'api only');
+  writeFile(dir, 'firestore.rules', '// rules\n');
+  commitAll(git, 'rules only');
+  for (const app of APPS) {
+    const result = runNode(['--app', app, '--repo', dir], {
+      env: { ...process.env, VERCEL_GIT_PREVIOUS_SHA: base },
+    });
+    assert.equal(result.exitCode, 0, `${app} must SKIP api+rules delta (output: ${result.stdout})`);
+  }
+});
+
+test('integration: per-app attribution from PREV_SHA base', () => {
+  const { dir, git } = initFixtureRepo();
+  const base = git(['rev-parse', 'HEAD']).trim();
+  writeFile(dir, 'apps/seller/src/page.tsx', '// seller change\n');
+  commitAll(git, 'seller only');
+  const expected = { consumer: 0, seller: 1, driver: 0 };
+  for (const app of APPS) {
+    const result = runNode(['--app', app, '--repo', dir], {
+      env: { ...process.env, VERCEL_GIT_PREVIOUS_SHA: base },
+    });
+    assert.equal(result.exitCode, expected[app], `${app} exit must be ${expected[app]} (${result.stdout})`);
+  }
+});
+
+test('integration: freshness merge does not misjudge (HEAD^ would BUILD, predicate SKIPs)', () => {
+  const { dir, git } = initFixtureRepo();
+  // Last successful frontend build happened at the initial commit.
+  const lastSuccessful = git(['rev-parse', 'HEAD']).trim();
+  // Candidate work: api-only change on a publication branch.
+  git(['checkout', '-b', 'publication']);
+  writeFile(dir, 'apps/api/src/lease.ts', '// api candidate\n');
+  commitAll(git, 'api candidate');
+  // Unrelated main movement that is also frontend-irrelevant.
+  git(['checkout', 'main']);
+  writeFile(dir, 'apps/api/src/other.ts', '// unrelated api movement\n');
+  commitAll(git, 'unrelated movement');
+  // Transport freshness update: merge main into the publication branch.
+  git(['checkout', 'publication']);
+  git(['merge', 'main', '--no-edit', '-m', 'transport freshness update']);
+  const head = git(['rev-parse', 'HEAD']).trim();
+  assert.ok(head);
+
+  // A naive HEAD^ predicate sees the sync-merge diff (unrelated api files,
+  // all non-docs) and votes BUILD for every frontend.
+  const naiveDiff = git(['diff', '--name-only', 'HEAD^1', 'HEAD']).trim();
+  assert.ok(naiveDiff.length > 0, 'freshness merge must have a non-empty first-parent diff');
+  const naiveWouldBuild = naiveDiff.split('\n').some((line) => !/(\.md$|^docs\/)/.test(line.trim()));
+  assert.equal(naiveWouldBuild, true, 'naive HEAD^ predicate would BUILD on the freshness merge');
+
+  // The shared predicate diffs last-successful..HEAD: no frontend-relevant
+  // path moved, so every frontend skips.
+  for (const app of APPS) {
+    const result = runNode(['--app', app, '--repo', dir], {
+      env: { ...process.env, VERCEL_GIT_PREVIOUS_SHA: lastSuccessful },
+    });
+    assert.equal(result.exitCode, 0, `${app} must SKIP after freshness update (${result.stdout})`);
+  }
+});
+
+test('integration: missing base fails OPEN (BUILD)', () => {
+  const { dir } = initFixtureRepo();
+  const env = { ...process.env };
+  delete env.VERCEL_GIT_PREVIOUS_SHA;
+  const result = runNode(['--app', 'consumer', '--repo', dir], { env });
+  assert.equal(result.exitCode, 1, 'without a trustworthy base the predicate must BUILD');
+});
+
+test('cli: unknown app fails OPEN (BUILD)', () => {
+  const result = runNode(['--app', 'nope', '--repo', REPO_ROOT]);
+  assert.equal(result.exitCode, 1);
+});

--- a/scripts/verify-deployment-safety.mjs
+++ b/scripts/verify-deployment-safety.mjs
@@ -1,9 +1,14 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 
 const apps = ['consumer', 'seller', 'driver'];
-const docsOnlyIgnoreCommand =
-  "git diff --name-only HEAD^ HEAD | grep -qvE '(^docs/|[.]md$)' && exit 1 || exit 0";
+
+// COORD-DEPLOY-FANOUT-01: one shared dependency-aware predicate, per-app entry
+// point. The old docs-only `git diff HEAD^` grep treated every non-docs change
+// as relevant for every app (API/rules publications built all three previews)
+// and misjudged merge/transport-freshness updates. The shared predicate diffs
+// VERCEL_GIT_PREVIOUS_SHA..HEAD scoped to the app's workspace closure.
+const ignoreCommandFor = (app) => `node ../../scripts/vercel/ignore-build.mjs --app ${app}`;
 
 for (const app of apps) {
   const path = `apps/${app}/vercel.json`;
@@ -16,8 +21,8 @@ for (const app of apps) {
   );
   assert.equal(
     config.ignoreCommand,
-    docsOnlyIgnoreCommand,
-    `${path}: docs-only Vercel ignoreCommand must remain enabled`,
+    ignoreCommandFor(app),
+    `${path}: shared dependency-aware Vercel ignoreCommand must remain enabled`,
   );
 }
 
@@ -25,6 +30,17 @@ const syncPreview = readFileSync('.github/workflows/sync-preview.yml', 'utf8');
 assert.match(syncPreview, /paths-ignore:/, 'sync-preview.yml must keep a docs-only ignore gate');
 assert.match(syncPreview, /['"]docs\/\*\*['"]/, 'sync-preview.yml must ignore docs/**');
 assert.match(syncPreview, /['"]\*\*\/\*\.md['"]/, 'sync-preview.yml must ignore **/*.md');
+
+assert.equal(
+  existsSync('scripts/vercel/ignore-build.mjs'),
+  true,
+  'scripts/vercel/ignore-build.mjs (shared deployment predicate) must exist',
+);
+assert.equal(
+  existsSync('scripts/vercel/ignore-build.spec.mjs'),
+  true,
+  'scripts/vercel/ignore-build.spec.mjs (predicate matrix proof) must exist',
+);
 
 const agents = readFileSync('AGENTS.md', 'utf8');
 assert.match(


### PR DESCRIPTION
COORD-DEPLOY-FANOUT-01 readjudicated against live main 65d0870d. Replaces per-app docs-only HEAD^ grep with shared workspace-closure predicate diffing VERCEL_GIT_PREVIOUS_SHA..HEAD. API/rules/docs-only SKIP all three frontends; per-app attribution independent; shared-dep via workspace graph; unknown/missing base fails OPEN. deploymentEnabled.main=false unchanged. Proof: node --test scripts/vercel/ignore-build.spec.mjs (22 pass), node scripts/verify-deployment-safety.mjs OK.