### PR TITLE
feat(auth-probe): session-only workflow binding for approved non-production probe

### DIFF
--- a/.github/workflows/probe-auth-runtime.yml
+++ b/.github/workflows/probe-auth-runtime.yml
@@ -1,11 +1,35 @@
-name: Auth runtime probe (deterministic)
+name: Auth runtime probe (deterministic + session-only)
 
 on:
   workflow_dispatch:
+    inputs:
+      expected_sha:
+        description: '세 Preview 앱이 가리켜야 하는 40자리 commit SHA'
+        required: true
+        type: string
+      consumer_deployment_id:
+        description: 'consumer의 직접 검증 대상 Vercel deployment ID'
+        required: true
+        type: string
+      seller_deployment_id:
+        description: 'seller의 직접 검증 대상 Vercel deployment ID'
+        required: true
+        type: string
+      driver_deployment_id:
+        description: 'driver의 직접 검증 대상 Vercel deployment ID'
+        required: true
+        type: string
+      approval:
+        description: '비운영 session-only auth probe 실행을 승인합니다.'
+        required: true
+        type: choice
+        options:
+          - NON_PRODUCTION_AUTH_PROBE_APPROVED
   pull_request:
     paths:
       - scripts/probe-auth-runtime.mjs
       - scripts/probe-auth-runtime.spec.mjs
+      - scripts/probe-auth-runtime.workflow.spec.mjs
       - .github/workflows/probe-auth-runtime.yml
 
 permissions:
@@ -24,4 +48,368 @@ jobs:
           node-version: '22'
 
       - name: run probe deterministic spec (mock/local only, no external calls)
-        run: node --test scripts/probe-auth-runtime.spec.mjs
+        run: node --test scripts/probe-auth-runtime.spec.mjs scripts/probe-auth-runtime.workflow.spec.mjs
+
+  approval_gate:
+    name: session-only probe approval preflight
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {}
+    steps:
+      - name: dispatch·actor·approval·SHA·deployment preflight
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          ACTOR: ${{ github.actor }}
+          TRIGGERING_ACTOR: ${{ github.triggering_actor }}
+          REPOSITORY_OWNER: ${{ github.repository_owner }}
+          APPROVAL: ${{ inputs.approval }}
+          EXPECTED_SHA: ${{ inputs.expected_sha }}
+          CONSUMER_DEPLOYMENT_ID: ${{ inputs.consumer_deployment_id }}
+          SELLER_DEPLOYMENT_ID: ${{ inputs.seller_deployment_id }}
+          DRIVER_DEPLOYMENT_ID: ${{ inputs.driver_deployment_id }}
+        run: |
+          set -euo pipefail
+          printf 'event_name=%s\n' "$EVENT_NAME"
+          printf 'actor=%s\n' "$ACTOR"
+          printf 'triggering_actor=%s\n' "$TRIGGERING_ACTOR"
+          printf 'repository_owner=%s\n' "$REPOSITORY_OWNER"
+          printf 'expected_sha=%s\n' "$EXPECTED_SHA"
+          if [[ "$EVENT_NAME" != 'workflow_dispatch' ]]; then
+            echo 'workflow_dispatch 이외의 이벤트에서는 session-only probe를 실행할 수 없습니다.' >&2
+            exit 1
+          fi
+          if [[ "$ACTOR" != "$REPOSITORY_OWNER" ]]; then
+            echo 'workflow 실행자가 repository owner와 달라 실행을 차단합니다.' >&2
+            exit 1
+          fi
+          if [[ "$TRIGGERING_ACTOR" != "$REPOSITORY_OWNER" ]]; then
+            echo 'workflow triggering actor가 repository owner와 달라 실행을 차단합니다.' >&2
+            exit 1
+          fi
+          if [[ "$APPROVAL" != 'NON_PRODUCTION_AUTH_PROBE_APPROVED' ]]; then
+            echo 'session-only probe 수동 승인이 없어 실행을 차단합니다.' >&2
+            exit 1
+          fi
+          if [[ ! "$EXPECTED_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo '지정 SHA는 40자리 소문자 16진수여야 합니다.' >&2
+            exit 1
+          fi
+          for deployment_id in \
+            "$CONSUMER_DEPLOYMENT_ID" \
+            "$SELLER_DEPLOYMENT_ID" \
+            "$DRIVER_DEPLOYMENT_ID"; do
+            if [[ ! "$deployment_id" =~ ^dpl_[A-Za-z0-9]+$ ]]; then
+              echo 'pinned Vercel deployment ID 형식이 올바르지 않습니다.' >&2
+              exit 1
+            fi
+          done
+
+  session-probe:
+    name: pinned Preview session-only auth probe
+    # Session-only boundary: this job exercises ONLY the existing
+    # scripts/probe-auth-runtime.mjs contract (pinned binding read plus
+    # /auth/login, /auth/me, /auth/logout per role). It never invokes the
+    # full multi-case suite, fixture seed/verify/cleanup scripts, order or
+    # payment flows, provider hosts, registration, or any mutation path.
+    # Negative fixture creation is out of scope: when no approved negative
+    # identity is configured the evidence records
+    # NEGATIVE_IDENTITY_NOT_CONFIGURED instead of failing the probe itself.
+    needs: approval_gate
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    concurrency:
+      group: auth-session-probe
+      cancel-in-progress: false
+    environment:
+      # Private-plan note mirrors the round-direct workflow: secret scope
+      # lives in this Environment while the single-operator preflight above
+      # keeps the fail-closed approval contract.
+      name: round-direct-e2e
+    permissions:
+      contents: read
+    env:
+      AUTH_PROBE_RUN_ID: auth-session-${{ github.run_id }}-${{ github.run_attempt }}
+      AUTH_PROBE_RUN_ATTEMPT: ${{ github.run_attempt }}
+      AUTH_PROBE_EVENT_NAME: ${{ github.event_name }}
+      AUTH_PROBE_ACTOR: ${{ github.actor }}
+      AUTH_PROBE_TRIGGERING_ACTOR: ${{ github.triggering_actor }}
+      AUTH_PROBE_WORKFLOW_SHA: ${{ github.sha }}
+      AUTH_PROBE_EXPECTED_SHA: ${{ inputs.expected_sha }}
+      AUTH_PROBE_CONSUMER_DEPLOYMENT_ID: ${{ inputs.consumer_deployment_id }}
+      AUTH_PROBE_SELLER_DEPLOYMENT_ID: ${{ inputs.seller_deployment_id }}
+      AUTH_PROBE_DRIVER_DEPLOYMENT_ID: ${{ inputs.driver_deployment_id }}
+      AUTH_PROBE_API_ORIGIN: ${{ vars.ROUND_DIRECT_E2E_API_ORIGIN }}
+      AUTH_PROBE_ALLOWED_API_ORIGINS: ${{ vars.ROUND_DIRECT_E2E_ALLOWED_API_ORIGINS }}
+      FIREBASE_PROJECT_ID: ${{ vars.ROUND_DIRECT_E2E_FIREBASE_PROJECT_ID }}
+
+    steps:
+      - name: 지정 SHA checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.expected_sha }}
+          fetch-depth: 0
+
+      - name: 수동 승인과 checkout SHA 확인
+        shell: bash
+        env:
+          APPROVAL: ${{ inputs.approval }}
+          EVENT_NAME: ${{ github.event_name }}
+          ACTOR: ${{ github.actor }}
+          TRIGGERING_ACTOR: ${{ github.triggering_actor }}
+          REPOSITORY_OWNER: ${{ github.repository_owner }}
+        run: |
+          set -euo pipefail
+          if [[ "$EVENT_NAME" != 'workflow_dispatch' ]]; then
+            echo 'workflow_dispatch 이외의 이벤트에서는 session-only probe를 실행할 수 없습니다.' >&2
+            exit 1
+          fi
+          if [[ "$ACTOR" != "$REPOSITORY_OWNER" ]]; then
+            echo 'workflow 실행자가 repository owner와 달라 실행을 차단합니다.' >&2
+            exit 1
+          fi
+          if [[ "$TRIGGERING_ACTOR" != "$REPOSITORY_OWNER" ]]; then
+            echo 'workflow triggering actor가 repository owner와 달라 실행을 차단합니다.' >&2
+            exit 1
+          fi
+          if [[ "$APPROVAL" != 'NON_PRODUCTION_AUTH_PROBE_APPROVED' ]]; then
+            echo 'session-only probe 수동 승인이 없어 실행을 차단합니다.' >&2
+            exit 1
+          fi
+          if [[ ! "$AUTH_PROBE_EXPECTED_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo '지정 SHA는 40자리 소문자 16진수여야 합니다.' >&2
+            exit 1
+          fi
+          actual_sha="$(git rev-parse HEAD)"
+          if [[ "$actual_sha" != "$AUTH_PROBE_EXPECTED_SHA" ]]; then
+            echo 'checkout SHA가 지정 SHA와 달라 실행을 차단합니다.' >&2
+            exit 1
+          fi
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - name: 세 pinned Vercel deployment metadata 직접 확인
+        shell: bash
+        env:
+          ROUND_DIRECT_E2E_VERCEL_READ_TOKEN: ${{ secrets.ROUND_DIRECT_E2E_VERCEL_READ_TOKEN }}
+        run: |
+          set -euo pipefail
+          evidence_root=".artifacts/auth-session-probe/$AUTH_PROBE_RUN_ID"
+          mkdir -p "$evidence_root/evidence"
+          set +e
+          node scripts/wait-preview-deploy.mjs \
+            --json \
+            --sha="$AUTH_PROBE_EXPECTED_SHA" \
+            --consumer-deployment-id="$AUTH_PROBE_CONSUMER_DEPLOYMENT_ID" \
+            --seller-deployment-id="$AUTH_PROBE_SELLER_DEPLOYMENT_ID" \
+            --driver-deployment-id="$AUTH_PROBE_DRIVER_DEPLOYMENT_ID" \
+            > "$evidence_root/deployment-raw.json"
+          wait_status=$?
+          set -e
+          if [[ ! -s "$evidence_root/deployment-raw.json" ]]; then
+            echo '배포 증거 JSON을 만들지 못해 실행을 차단합니다.' >&2
+            exit 1
+          fi
+          jq -c '.deploymentShas' "$evidence_root/deployment-raw.json" \
+            | sed 's/^/AUTH_PROBE_DEPLOYMENT_SHAS_JSON=/' >> "$GITHUB_ENV"
+          jq -c '.deploymentTargetUrls' "$evidence_root/deployment-raw.json" \
+            | sed 's/^/AUTH_PROBE_TARGET_URLS_JSON=/' >> "$GITHUB_ENV"
+          if [[ "$wait_status" -eq 0 ]]; then
+            jq -er '.deploymentTargetUrls.consumer' "$evidence_root/deployment-raw.json" \
+              | sed 's/^/AUTH_PROBE_CONSUMER_URL=/' >> "$GITHUB_ENV"
+            jq -er '.deploymentTargetUrls.seller' "$evidence_root/deployment-raw.json" \
+              | sed 's/^/AUTH_PROBE_SELLER_URL=/' >> "$GITHUB_ENV"
+            jq -er '.deploymentTargetUrls.driver' "$evidence_root/deployment-raw.json" \
+              | sed 's/^/AUTH_PROBE_DRIVER_URL=/' >> "$GITHUB_ENV"
+          fi
+          jq '{
+            ready,
+            evidenceSource,
+            checkedAt,
+            repository,
+            expectedSha,
+            pinnedDeploymentIds,
+            deploymentIds,
+            deploymentShas,
+            deploymentTargetUrls,
+            deploymentStates,
+            failureCodes,
+            apps: [.apps[] | {
+              app,
+              project,
+              projectId,
+              environment,
+              deploymentId,
+              deploymentSha,
+              state,
+              readyState,
+              target,
+              target_url: .targetUrl,
+              failureCode,
+              ready
+            }]
+            }' \
+            "$evidence_root/deployment-raw.json" \
+            > "$evidence_root/evidence/deployment.json"
+          jq --arg apiOrigin "$AUTH_PROBE_API_ORIGIN" \
+            '. + {apiOrigin: $apiOrigin}' \
+            "$evidence_root/deployment-raw.json" \
+            > "$evidence_root/probe-evidence.json"
+          exit "$wait_status"
+
+      - name: 승인된 비운영 API origin 확인
+        shell: bash
+        run: |
+          set -euo pipefail
+          api_origin="$(printf '%s' "${AUTH_PROBE_API_ORIGIN:-}" | tr -d '[:space:]')"
+          if [[ -z "$api_origin" ]]; then
+            echo '비운영 API origin이 비어 있어 실행을 차단합니다.' >&2
+            exit 1
+          fi
+          case "$api_origin" in
+            https://*) ;;
+            *) echo 'API origin은 https만 허용합니다.' >&2; exit 1 ;;
+          esac
+          api_host="$(printf '%s' "$api_origin" | sed -e 's#^https://##' -e 's#/.*$##' -e 's#:.*$##' | tr '[:upper:]' '[:lower:]')"
+          case "$api_host" in
+            greenlove.co.kr|*.greenlove.co.kr|api-production-*)
+              echo '운영 API origin이므로 실행을 차단합니다.' >&2
+              exit 1
+              ;;
+          esac
+          if [[ "$api_host" == 'api-production-13e7.up.railway.app' ]]; then
+            echo '운영 API origin이므로 실행을 차단합니다.' >&2
+            exit 1
+          fi
+          allowed="$(printf '%s' "${AUTH_PROBE_ALLOWED_API_ORIGINS:-}")"
+          match_found='false'
+          IFS=',' read -ra allowed_list <<< "$allowed"
+          for entry in "${allowed_list[@]}"; do
+            candidate="$(printf '%s' "$entry" | tr -d '[:space:]')"
+            if [[ -n "$candidate" && "$candidate" == "$api_origin" ]]; then
+              match_found='true'
+              break
+            fi
+          done
+          if [[ "$match_found" != 'true' ]]; then
+            echo 'API origin이 비운영 허용 목록과 달라 실행을 차단합니다.' >&2
+            exit 1
+          fi
+          printf 'api_origin=%s\n' "$api_origin"
+
+      - name: session-only auth probe 실행
+        shell: bash
+        env:
+          E2E_TEST_SECRET: ${{ secrets.ROUND_DIRECT_E2E_TEST_SECRET }}
+          ROUND_DIRECT_E2E_SHARED_SECRET: ${{ secrets.ROUND_DIRECT_E2E_SHARED_SECRET }}
+          ROUND_DIRECT_E2E_DRIVER_EMAILS: ${{ secrets.ROUND_DIRECT_E2E_DRIVER_EMAIL_CHROMIUM }}
+          ROUND_DIRECT_E2E_ENABLED: 'true'
+          VERCEL_ENV: preview
+          NODE_ENV: test
+          RAILWAY_ENVIRONMENT_NAME: staging
+          GREENHUB_LOCAL_RUNTIME: ''
+          TEST_CONSUMER_EMAIL: ${{ secrets.ROUND_DIRECT_E2E_CONSUMER_EMAIL_CHROMIUM }}
+          TEST_CONSUMER_PASSWORD: ${{ secrets.ROUND_DIRECT_E2E_CONSUMER_PASSWORD_CHROMIUM }}
+          TEST_SELLER_EMAIL: ${{ secrets.ROUND_DIRECT_E2E_SELLER_EMAIL_CHROMIUM }}
+          TEST_SELLER_PASSWORD: ${{ secrets.ROUND_DIRECT_E2E_SELLER_PASSWORD_CHROMIUM }}
+          TEST_DRIVER_EMAIL: ${{ secrets.ROUND_DIRECT_E2E_DRIVER_EMAIL_CHROMIUM }}
+          TEST_DRIVER_PASSWORD: ${{ secrets.ROUND_DIRECT_E2E_DRIVER_PASSWORD_CHROMIUM }}
+          AUTH_PROBE_CONSUMER_TOKEN: ${{ secrets.ROUND_DIRECT_E2E_TEST_SECRET }}
+          AUTH_PROBE_SELLER_TOKEN: ${{ secrets.ROUND_DIRECT_E2E_TEST_SECRET }}
+          AUTH_PROBE_DRIVER_SECRET: ${{ secrets.ROUND_DIRECT_E2E_SHARED_SECRET }}
+        run: |
+          set -euo pipefail
+          # Secret-name mapping note (values never logged):
+          # - E2E_TEST_SECRET / AUTH_PROBE_*_TOKEN <- ROUND_DIRECT_E2E_TEST_SECRET
+          # - ROUND_DIRECT_E2E_SHARED_SECRET / AUTH_PROBE_DRIVER_SECRET <-
+          #   ROUND_DIRECT_E2E_SHARED_SECRET (approved Environment secret reuse)
+          # - TEST_* per-role identity <- approved chromium Environment secrets
+          # - client pre-check allowlist <- same approved chromium driver
+          #   identity value; the server-side allowlist stays authoritative.
+          # No service-account, fixture, or provider secret is bound here.
+          evidence_root=".artifacts/auth-session-probe/$AUTH_PROBE_RUN_ID"
+          mkdir -p "$evidence_root/evidence"
+          set +e
+          node scripts/probe-auth-runtime.mjs \
+            --expected-sha="$AUTH_PROBE_EXPECTED_SHA" \
+            --consumer-url="$AUTH_PROBE_CONSUMER_URL" \
+            --seller-url="$AUTH_PROBE_SELLER_URL" \
+            --driver-url="$AUTH_PROBE_DRIVER_URL" \
+            --api-url="$AUTH_PROBE_API_ORIGIN" \
+            --evidence-json="$evidence_root/probe-evidence.json" \
+            --approval="${{ inputs.approval }}" \
+            > "$evidence_root/probe-raw.json"
+          probe_status=$?
+          set -e
+          if [[ ! -s "$evidence_root/probe-raw.json" ]]; then
+            echo 'probe 요약을 만들지 못해 실행을 차단합니다.' >&2
+            exit 1
+          fi
+          jq '{
+            runner,
+            result,
+            expectedSha,
+            targets,
+            roles: (.roles | with_entries(.value |= ({status, failureCode, steps, user}))),
+            failureCodes,
+            bindingFailure,
+            authSessionClaimRevocation
+            }' \
+            "$evidence_root/probe-raw.json" \
+            > "$evidence_root/evidence/probe-summary.json"
+          checked_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          jq -n \
+            --arg runId "$AUTH_PROBE_RUN_ID" \
+            --arg runAttempt "$AUTH_PROBE_RUN_ATTEMPT" \
+            --arg eventName "$AUTH_PROBE_EVENT_NAME" \
+            --arg actor "$AUTH_PROBE_ACTOR" \
+            --arg triggeringActor "$AUTH_PROBE_TRIGGERING_ACTOR" \
+            --arg workflowSha "$AUTH_PROBE_WORKFLOW_SHA" \
+            --arg expectedSha "$AUTH_PROBE_EXPECTED_SHA" \
+            --arg consumerDeploymentId "$AUTH_PROBE_CONSUMER_DEPLOYMENT_ID" \
+            --arg sellerDeploymentId "$AUTH_PROBE_SELLER_DEPLOYMENT_ID" \
+            --arg driverDeploymentId "$AUTH_PROBE_DRIVER_DEPLOYMENT_ID" \
+            --arg checkedAt "$checked_at" \
+            --argjson targetUrls "$AUTH_PROBE_TARGET_URLS_JSON" \
+            --argjson deploymentShas "$AUTH_PROBE_DEPLOYMENT_SHAS_JSON" \
+            --slurpfile probe "$evidence_root/evidence/probe-summary.json" \
+            --slurpfile deployment "$evidence_root/evidence/deployment.json" \
+            '{
+              runId: $runId,
+              runAttempt: $runAttempt,
+              eventName: $eventName,
+              actor: $actor,
+              triggeringActor: $triggeringActor,
+              workflowSha: $workflowSha,
+              expectedSha: $expectedSha,
+              pinnedDeploymentIds: {
+                consumer: $consumerDeploymentId,
+                seller: $sellerDeploymentId,
+                driver: $driverDeploymentId
+              },
+              targetUrls: $targetUrls,
+              deploymentShas: $deploymentShas,
+              deploymentReady: $deployment[0].ready,
+              probeResult: $probe[0].result,
+              roles: $probe[0].roles,
+              failureCodes: $probe[0].failureCodes,
+              bindingFailure: $probe[0].bindingFailure,
+              authSessionClaimRevocation: $probe[0].authSessionClaimRevocation,
+              negativeIdentityStatus: "NEGATIVE_IDENTITY_NOT_CONFIGURED",
+              checkedAt: $checkedAt
+            }' \
+            > "$evidence_root/evidence/workflow-summary.json"
+          exit "$probe_status"
+
+      - name: 비민감 증거 artifact 업로드
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: auth-session-probe-${{ github.run_id }}-${{ github.run_attempt }}
+          path: .artifacts/auth-session-probe/${{ env.AUTH_PROBE_RUN_ID }}/evidence/
+          if-no-files-found: error
+          retention-days: 7

--- a/scripts/probe-auth-runtime.workflow.spec.mjs
+++ b/scripts/probe-auth-runtime.workflow.spec.mjs
@@ -1,0 +1,242 @@
+/**
+ * PILOT-AUTH-SESSION-ONLY-WORKFLOW-14 — session-only workflow contract spec.
+ *
+ * Deterministic only: reads .github/workflows/probe-auth-runtime.yml as text
+ * plus the runner's canonical APPROVAL_VALUE. No network, no secrets, no
+ * external mutation. Run:
+ *   node --test scripts/probe-auth-runtime.workflow.spec.mjs
+ */
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import { APPROVAL_VALUE } from './probe-auth-runtime.mjs';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, '..');
+const WORKFLOW_PATH = path.join(REPO_ROOT, '.github', 'workflows', 'probe-auth-runtime.yml');
+
+function readWorkflow() {
+  return readFileSync(WORKFLOW_PATH, 'utf8');
+}
+
+function jobSlice(source, startMarker, endMarkers) {
+  const start = source.indexOf(startMarker);
+  assert.ok(start >= 0, `workflow must contain ${startMarker}`);
+  let end = source.length;
+  for (const marker of endMarkers) {
+    const idx = source.indexOf(marker, start + startMarker.length);
+    if (idx >= 0 && idx < end) end = idx;
+  }
+  return source.slice(start, end);
+}
+
+describe('session-only workflow dispatch contract', () => {
+  it('canonical probe approval value is reused (no new approval string)', () => {
+    assert.equal(APPROVAL_VALUE, 'NON_PRODUCTION_AUTH_PROBE_APPROVED');
+    const source = readWorkflow();
+    assert.ok(
+      source.includes(APPROVAL_VALUE),
+      'workflow must reuse the runner canonical approval value',
+    );
+    assert.ok(
+      !source.includes('NON_PRODUCTION_E2E_APPROVED'),
+      'session-only probe must not reuse the full-E2E approval value',
+    );
+  });
+
+  it('workflow_dispatch exposes the exact five session inputs', () => {
+    const source = readWorkflow();
+    for (const input of [
+      'expected_sha:',
+      'consumer_deployment_id:',
+      'seller_deployment_id:',
+      'driver_deployment_id:',
+      'approval:',
+    ]) {
+      assert.ok(source.includes(input), `workflow_dispatch must declare ${input}`);
+    }
+  });
+
+  it('real probe runs on manual dispatch only', () => {
+    const source = readWorkflow();
+    const guards = source.match(/github\.event_name == 'workflow_dispatch'/g) ?? [];
+    assert.ok(
+      guards.length >= 2,
+      'approval_gate and session-probe must both gate on workflow_dispatch',
+    );
+    assert.ok(
+      source.includes('workflow_dispatch 이외의 이벤트에서는'),
+      'non-dispatch events must fail closed with an explicit message',
+    );
+  });
+
+  it('round-direct-e2e Environment binds only the session probe', () => {
+    const source = readWorkflow();
+    assert.ok(source.includes('name: round-direct-e2e'), 'session probe must bind round-direct-e2e');
+    const specSlice = jobSlice(source, 'probe-spec:', ['approval_gate:', 'session-probe:']);
+    assert.ok(
+      !specSlice.includes('environment:'),
+      'deterministic probe-spec must not bind the credential Environment',
+    );
+    assert.ok(
+      !specSlice.includes('round-direct-e2e'),
+      'deterministic probe-spec must not reference the Environment',
+    );
+    const gateSlice = jobSlice(source, 'approval_gate:', ['session-probe:']);
+    assert.ok(
+      !gateSlice.includes('environment:'),
+      'approval preflight must not bind the credential Environment',
+    );
+  });
+
+  it('permissions stay minimal (read-only, no writes)', () => {
+    const source = readWorkflow();
+    assert.ok(source.includes('contents: read'), 'workflow must keep contents: read');
+    for (const forbidden of ['contents: write', 'actions: write', 'packages: write', 'deployments: write']) {
+      assert.ok(!source.includes(forbidden), `workflow must not grant ${forbidden}`);
+    }
+    const gateSlice = jobSlice(source, 'approval_gate:', ['session-probe:']);
+    assert.ok(gateSlice.includes('permissions: {}'), 'approval preflight must use empty permissions');
+  });
+
+  it('exact SHA checkout is enforced before any network call', () => {
+    const source = readWorkflow();
+    assert.ok(
+      source.includes('ref: ${{ inputs.expected_sha }}'),
+      'session probe must checkout the exact input SHA',
+    );
+    assert.ok(
+      source.includes('git rev-parse HEAD'),
+      'checkout SHA must be compared against the input SHA',
+    );
+    assert.ok(
+      source.includes('checkout SHA가 지정 SHA와 달라 실행을 차단합니다.'),
+      'SHA mismatch must fail closed with an explicit message',
+    );
+  });
+
+  it('three pinned deployment IDs are validated and bound', () => {
+    const source = readWorkflow();
+    assert.ok(source.includes('^dpl_[A-Za-z0-9]+$'), 'deployment IDs must match the pinned dpl_ format');
+    for (const flag of ['--consumer-deployment-id=', '--seller-deployment-id=', '--driver-deployment-id=']) {
+      assert.ok(source.includes(flag), `deployment binding must pass ${flag}`);
+    }
+    assert.ok(source.includes('--sha='), 'deployment binding must pass the expected SHA');
+  });
+});
+
+describe('session-only runtime boundary', () => {
+  it('only the two allowed scripts are invoked', () => {
+    const source = readWorkflow();
+    assert.ok(
+      source.includes('scripts/wait-preview-deploy.mjs'),
+      'exact target binding must reuse wait-preview-deploy',
+    );
+    assert.ok(
+      source.includes('scripts/probe-auth-runtime.mjs'),
+      'runtime probe must invoke only the existing probe runner',
+    );
+    const invocations = [...source.matchAll(/node\s+scripts\/([^\s'"]+)/g)].map((m) => m[1]);
+    assert.ok(invocations.length > 0, 'expected script invocations');
+    for (const script of invocations) {
+      assert.ok(
+        script === 'wait-preview-deploy.mjs' || script === 'probe-auth-runtime.mjs',
+        `forbidden script invocation: node scripts/${script}`,
+      );
+    }
+  });
+
+  it('production targets are rejected', () => {
+    const source = readWorkflow();
+    assert.ok(source.includes('greenlove.co.kr'), 'production frontend hosts must be rejected');
+    assert.ok(source.includes('api-production-'), 'production API hosts must be rejected');
+  });
+
+  it('provider, full-suite, fixture, and service-account paths are never invoked', () => {
+    const source = readWorkflow();
+    for (const forbidden of [
+      'api.portone.io',
+      'aligo.in',
+      'kauth.kakao.com',
+      'kapi.kakao.com',
+      'auth/kakao-login',
+      'FIREBASE_SERVICE_ACCOUNT_JSON',
+      'playwright test',
+      'round-direct-e2e-fixtures',
+      'check-round-direct-e2e-readiness',
+      'pnpm --filter e2e',
+    ]) {
+      assert.ok(!source.includes(forbidden), `workflow must never contain ${forbidden}`);
+    }
+  });
+
+  it('probe CLI passes only non-secret binding flags', () => {
+    const source = readWorkflow();
+    for (const flag of [
+      '--expected-sha=',
+      '--consumer-url=',
+      '--seller-url=',
+      '--driver-url=',
+      '--api-url=',
+      '--evidence-json=',
+      '--approval=',
+    ]) {
+      assert.ok(source.includes(flag), `probe invocation must pass ${flag}`);
+    }
+  });
+
+  it('secret values are never logged and evidence stays non-secret', () => {
+    const source = readWorkflow();
+    for (const line of source.split('\n')) {
+      const trimmed = line.trim();
+      if (trimmed.startsWith('#')) continue;
+      if (!/echo|printf/.test(line)) continue;
+      for (const sensitive of ['SECRET', 'PASSWORD', 'TOKEN', 'COOKIE', 'SERVICE_ACCOUNT', 'CREDENTIAL_JSON']) {
+        assert.ok(
+          !line.includes(sensitive),
+          `log line must not reference ${sensitive}: ${trimmed.slice(0, 120)}`,
+        );
+      }
+    }
+    for (const sensitive of ['accessToken', 'refreshToken', 'set-cookie']) {
+      assert.ok(!source.includes(sensitive), `workflow must not handle raw ${sensitive}`);
+    }
+    assert.ok(source.includes('probe-summary.json'), 'redacted probe summary must be written');
+    assert.ok(source.includes('workflow-summary.json'), 'redacted workflow summary must be written');
+    assert.ok(
+      source.includes('NEGATIVE_IDENTITY_NOT_CONFIGURED'),
+      'missing negative fixture must be recorded explicitly, not faked',
+    );
+  });
+
+  it('approved Environment secret/var names are reused (no new credentials)', () => {
+    const source = readWorkflow();
+    for (const name of [
+      'ROUND_DIRECT_E2E_VERCEL_READ_TOKEN',
+      'ROUND_DIRECT_E2E_TEST_SECRET',
+      'ROUND_DIRECT_E2E_SHARED_SECRET',
+      'ROUND_DIRECT_E2E_CONSUMER_EMAIL_CHROMIUM',
+      'ROUND_DIRECT_E2E_CONSUMER_PASSWORD_CHROMIUM',
+      'ROUND_DIRECT_E2E_SELLER_EMAIL_CHROMIUM',
+      'ROUND_DIRECT_E2E_SELLER_PASSWORD_CHROMIUM',
+      'ROUND_DIRECT_E2E_DRIVER_EMAIL_CHROMIUM',
+      'ROUND_DIRECT_E2E_DRIVER_PASSWORD_CHROMIUM',
+      'ROUND_DIRECT_E2E_API_ORIGIN',
+      'ROUND_DIRECT_E2E_ALLOWED_API_ORIGINS',
+      'ROUND_DIRECT_E2E_FIREBASE_PROJECT_ID',
+    ]) {
+      assert.ok(source.includes(name), `workflow must reuse approved name ${name}`);
+    }
+    assert.ok(
+      source.includes('retention-days: 7'),
+      'evidence artifact must keep the 7-day retention contract',
+    );
+    assert.ok(
+      source.includes('auth-session-probe-'),
+      'evidence artifact must use the session-only artifact name',
+    );
+  });
+});


### PR DESCRIPTION
PILOT-AUTH-SESSION-ONLY-WORKFLOW-14 session-only binding. Extends .github/workflows/probe-auth-runtime.yml with an Environment-bound (round-direct-e2e) session-only job reusing scripts/probe-auth-runtime.mjs; adds scripts/probe-auth-runtime.workflow.spec.mjs contract spec. No runtime dispatch in this task. Deterministic verification: probe spec 17/17 PASS, workflow contract 13/13 PASS, vercel-ignore 22/22 PASS, workflow-only delta SKIP for all three frontends, deployment-safety OK. No apps/**, runner, or credential changes.