### PR TITLE
feat(auth-probe): normalize native HTTP response and classify login rejection

### DIFF
--- a/.github/workflows/probe-auth-runtime.yml
+++ b/.github/workflows/probe-auth-runtime.yml
@@ -354,7 +354,7 @@ jobs:
             result,
             expectedSha,
             targets,
-            roles: (.roles | with_entries(.value |= ({status, failureCode, steps, user}))),
+            roles: (.roles | with_entries(.value |= ({status, failureCode, steps, user, httpStatus, rejectionClass, step, role}))),
             failureCodes,
             bindingFailure,
             authSessionClaimRevocation

--- a/scripts/probe-auth-runtime.mjs
+++ b/scripts/probe-auth-runtime.mjs
@@ -79,15 +79,18 @@ const FRONTEND_APPS = Object.freeze(['consumer', 'seller', 'driver']);
 const ALLOWED_API_PATHS = Object.freeze(['/auth/login', '/auth/me', '/auth/logout']);
 
 export class ProbeContractError extends Error {
-  constructor(code, message) {
+  constructor(code, message, details) {
     super(message);
     this.name = 'ProbeContractError';
     this.code = code;
+    if (details !== undefined) {
+      this.details = details;
+    }
   }
 }
 
-function fail(code, message) {
-  throw new ProbeContractError(code, message);
+function fail(code, message, details) {
+  throw new ProbeContractError(code, message, details);
 }
 
 function isNonEmptyString(value) {
@@ -339,6 +342,75 @@ export function evaluateDriverGate({
   return { ok: true, code: null };
 }
 
+// ---- HTTP response normalization -------------------------------------------
+// Production runtime uses native fetch Response ({ ok, status, headers, text/json })
+// while deterministic tests historically use plain { ok, status, data } mocks.
+// Both shapes are normalized to a single internal contract { ok, status, data }
+// without ever surfacing raw bodies, tokens, or credentials.
+
+export function classifyLoginRejection(status) {
+  const code = Number(status);
+  if (code === 401) return 'AUTH_LOGIN_UNAUTHORIZED';
+  if (code === 403) return 'AUTH_LOGIN_FORBIDDEN';
+  if (code === 404) return 'AUTH_LOGIN_ROUTE_NOT_FOUND';
+  if (Number.isInteger(code) && code >= 500 && code <= 599) return 'AUTH_LOGIN_SERVER_ERROR';
+  return 'AUTH_LOGIN_HTTP_REJECTED';
+}
+
+function isNativeResponseLike(raw) {
+  if (!raw || typeof raw !== 'object') return false;
+  if (typeof raw.status !== 'number') return false;
+  if (typeof raw.text !== 'function' && typeof raw.json !== 'function') return false;
+  // Mock { ok, status, data } has no headers.get / text / json fns.
+  if (typeof raw.headers?.get === 'function') return true;
+  if (typeof raw.text === 'function' && !('data' in raw)) return true;
+  return false;
+}
+
+export async function normalizeProbeHttpResponse(raw) {
+  if (!raw || typeof raw !== 'object') {
+    return { ok: false, status: 0, data: null };
+  }
+  if (isNativeResponseLike(raw)) {
+    const status = typeof raw.status === 'number' ? raw.status : 0;
+    const ok = raw.ok === true ? true : status >= 200 && status < 300;
+    let data = null;
+    try {
+      let text = '';
+      if (typeof raw.text === 'function') {
+        text = await raw.text();
+      } else if (typeof raw.json === 'function') {
+        // Fallback when only json() exists: resolve then treat as data.
+        const parsed = await raw.json();
+        return { ok, status, data: parsed ?? null };
+      }
+      if (typeof text !== 'string') {
+        return { ok, status, data: null };
+      }
+      const trimmed = text.trim();
+      if (!trimmed) {
+        return { ok, status, data: null };
+      }
+      try {
+        data = JSON.parse(trimmed);
+      } catch {
+        // Non-JSON / malformed body: never surface raw text.
+        data = null;
+      }
+    } catch {
+      data = null;
+    }
+    return { ok, status, data };
+  }
+  // Legacy deterministic mock contract { ok, status, data }.
+  const status = typeof raw.status === 'number' ? raw.status : 0;
+  return {
+    ok: raw.ok === true,
+    status,
+    data: 'data' in raw ? raw.data : null,
+  };
+}
+
 // ---- Guarded fetch -----------------------------------------------------------
 
 function apiPathOf(urlString, apiUrl) {
@@ -369,7 +441,8 @@ export function createGuardedFetch(fetchImpl, { apiUrl }) {
       fail('AUTH_MUTATION_FORBIDDEN', `probe 허용 경로가 아닌 호출을 차단합니다: ${method} ${apiPath ?? 'cross-origin'}`);
     }
     calls.push({ method, path: apiPath });
-    return fetchImpl(target, init);
+    const raw = await fetchImpl(target, init);
+    return normalizeProbeHttpResponse(raw);
   };
   guarded.calls = calls;
   return guarded;
@@ -377,7 +450,14 @@ export function createGuardedFetch(fetchImpl, { apiUrl }) {
 
 function requireOkJson(res, { role, step }) {
   if (!res || res.ok !== true) {
-    fail(`${role}_LOGIN_FAILED`, `${role} login이 거부됐습니다 (${step}).`);
+    const httpStatus = typeof res?.status === 'number' ? res.status : 0;
+    const rejectionClass = classifyLoginRejection(httpStatus);
+    const normalizedRole = String(role).toLowerCase();
+    fail(
+      `${role}_LOGIN_FAILED`,
+      `${role} login이 거부됐습니다 (${step} http=${httpStatus} class=${rejectionClass}).`,
+      { role: normalizedRole, step, httpStatus, rejectionClass },
+    );
   }
   return res.data;
 }
@@ -425,7 +505,7 @@ export async function runRoleProbe(role, { apiUrl, email, password, accessTokenF
     body: JSON.stringify({ email, password }),
   });
   const loginData = requireOkJson(loginRes, { role: ROLE, step: 'login' });
-  if (typeof loginData.accessToken !== 'string' || !loginData.accessToken) {
+  if (!loginData || typeof loginData.accessToken !== 'string' || !loginData.accessToken) {
     fail(`${ROLE}_LOGIN_FAILED`, `${role} login 응답에 accessToken이 없습니다.`);
   }
   if (typeof loginData.refreshToken !== 'string' || !loginData.refreshToken) {
@@ -466,6 +546,9 @@ export async function runRoleProbe(role, { apiUrl, email, password, accessTokenF
     ok: true,
     steps: { login: 'ok', reread: 'ok', logout: 'ok' },
     user: { id: loginData.user.id, role: String(loginData.user.role) },
+    // In-memory only: reused for the API boundary read. Never serialized
+    // into summary/artifact (see runAuthRuntimeProbe).
+    accessToken: loginData.accessToken,
     fetchCalls: [...fetch.calls],
   };
 }
@@ -496,7 +579,19 @@ export async function runApiProbe({ apiUrl, accessToken, fetchImpl }) {
 function toFailure(summary, role, error) {
   const code = error instanceof ProbeContractError ? error.code : 'PROBE_INTERNAL_ERROR';
   summary.failureCodes.push(code);
-  summary.roles[role] = { status: 'FAIL', failureCode: code, message: String(error?.message ?? error) };
+  const entry = { status: 'FAIL', failureCode: code, message: String(error?.message ?? error) };
+  // Preserve only non-sensitive diagnostic fields (role/step/status/class).
+  // Never copy email, password, token, secret, header, or raw body.
+  const details = error?.details;
+  if (details && typeof details === 'object') {
+    if (typeof details.role === 'string' && details.role) entry.role = details.role;
+    if (typeof details.step === 'string' && details.step) entry.step = details.step;
+    if (typeof details.httpStatus === 'number') entry.httpStatus = details.httpStatus;
+    if (typeof details.rejectionClass === 'string' && details.rejectionClass) {
+      entry.rejectionClass = details.rejectionClass;
+    }
+  }
+  summary.roles[role] = entry;
 }
 
 /**
@@ -589,6 +684,9 @@ export async function runAuthRuntimeProbe(options = {}, deps = {}) {
       driver: { email: driverEmail, password: options.driverPassword ?? env.TEST_DRIVER_PASSWORD },
     };
 
+    // In-memory only: successful role logins contribute real access tokens
+    // for the API boundary read. Tokens are never written into summary.
+    const roleTokens = [];
     for (const role of ['consumer', 'seller', 'driver']) {
       try {
         const result = await runRoleProbe(role, {
@@ -603,15 +701,37 @@ export async function runAuthRuntimeProbe(options = {}, deps = {}) {
           steps: result.steps,
           user: result.user,
         };
+        if (typeof result.accessToken === 'string' && result.accessToken) {
+          roleTokens.push(result.accessToken);
+        }
       } catch (error) {
         toFailure(summary, role, error);
       }
     }
 
     try {
-      const apiToken = deps.apiToken ?? options.apiToken ?? 'probe-boundary-token';
-      const apiResult = await runApiProbe({ apiUrl: binding.targets.api, accessToken: apiToken, fetchImpl });
-      summary.roles.api = { status: 'PASS', failureCode: null, steps: apiResult.steps };
+      const provided = deps.apiToken ?? options.apiToken;
+      const providedToken = isNonEmptyString(provided) ? String(provided) : '';
+      // Never fall back to a fake "probe-boundary-token": use an explicitly
+      // provided real token or a real login token from this run, held in
+      // memory only. Without any real token the boundary read is skipped
+      // with an explicit code instead of a misleading API_ME_FAILED.
+      const apiToken = providedToken || roleTokens[0] || '';
+      if (!isNonEmptyString(apiToken)) {
+        const skipError = new ProbeContractError(
+          'API_ME_SKIPPED_NO_TOKEN',
+          'API boundary read를 건너뜁니다 (사용 가능한 실제 access token 없음).',
+        );
+        summary.failureCodes.push(skipError.code);
+        summary.roles.api = {
+          status: 'SKIP',
+          failureCode: skipError.code,
+          steps: { read: 'skipped' },
+        };
+      } else {
+        const apiResult = await runApiProbe({ apiUrl: binding.targets.api, accessToken: apiToken, fetchImpl });
+        summary.roles.api = { status: 'PASS', failureCode: null, steps: apiResult.steps };
+      }
     } catch (error) {
       toFailure(summary, 'api', error);
     }

--- a/scripts/probe-auth-runtime.spec.mjs
+++ b/scripts/probe-auth-runtime.spec.mjs
@@ -9,11 +9,13 @@ import {
   APPROVAL_VALUE,
   ProbeContractError,
   assertExpectedSha,
+  classifyLoginRejection,
   createGuardedFetch,
   evaluateConsumerGate,
   evaluateDriverGate,
   evaluateSellerGate,
   isProductionUrl,
+  normalizeProbeHttpResponse,
   normalizeTargetUrl,
   runApiProbe,
   runAuthRuntimeProbe,
@@ -402,5 +404,274 @@ describe('FE-PILOT-AUTH-RUNTIME-PROBE-RUNNER-01 role contract', () => {
     assert.equal(summary.roles.api.status, 'PASS');
     assert.deepEqual(summary.failureCodes, []);
     assert.equal(summary.authSessionClaimRevocation, 'EXPLICITLY_NOT_CLOSED');
+  });
+});
+
+describe('PILOT-AUTH-PROBE-16 native HTTP adapter + login diagnostic', () => {
+  function nativeRoleFetch({ loginStatus = 200, loginBody = null, meBody = null, logoutStatus = 204 } = {}) {
+    const defaultUser = {
+      id: 'user-consumer-1',
+      email: 'consumer@example.test',
+      role: 'consumer',
+    };
+    const loginPayload =
+      loginBody ?? { accessToken: 'at-user-consumer-1', refreshToken: 'rt-user-consumer-1', user: defaultUser };
+    const mePayload = meBody ?? defaultUser;
+    return async (url, init = {}) => {
+      const method = String(init.method ?? 'GET').toUpperCase();
+      const path = new URL(url).pathname;
+      if (path === '/auth/login' && method === 'POST') {
+        if (loginStatus >= 200 && loginStatus < 300) {
+          return new Response(JSON.stringify(loginPayload), {
+            status: loginStatus,
+            headers: { 'content-type': 'application/json' },
+          });
+        }
+        const body = typeof loginBody === 'string' ? loginBody : JSON.stringify({ error: 'rejected' });
+        const ct = typeof loginBody === 'string' ? 'text/html' : 'application/json';
+        return new Response(body, { status: loginStatus, headers: { 'content-type': ct } });
+      }
+      if (path === '/auth/me' && method === 'GET') {
+        return new Response(JSON.stringify(mePayload), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      if (path === '/auth/logout' && method === 'POST') {
+        if (logoutStatus === 204) return new Response(null, { status: 204 });
+        return new Response(JSON.stringify({}), {
+          status: logoutStatus,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      return new Response('not-found', { status: 404, headers: { 'content-type': 'text/plain' } });
+    };
+  }
+
+  it('1. native Response 200 JSON login success를 소비한다', async () => {
+    const result = await runRoleProbe('consumer', {
+      apiUrl: URLS.api,
+      email: 'consumer@example.test',
+      password: 'pw-consumer',
+      fetchImpl: nativeRoleFetch({ loginStatus: 200, logoutStatus: 200 }),
+    });
+    assert.equal(result.ok, true);
+    assert.deepEqual(result.steps, { login: 'ok', reread: 'ok', logout: 'ok' });
+  });
+
+  it('2. native Response /auth/me success를 소비한다', async () => {
+    const meUser = { id: 'user-seller-1', email: 'seller@example.test', role: 'seller', storeId: 'store-1' };
+    const fetchImpl = async (url, init = {}) => {
+      const method = String(init.method ?? 'GET').toUpperCase();
+      const path = new URL(url).pathname;
+      if (path === '/auth/login' && method === 'POST') {
+        return new Response(
+          JSON.stringify({ accessToken: 'at-user-seller-1', refreshToken: 'rt-user-seller-1', user: meUser }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      if (path === '/auth/me') {
+        return new Response(JSON.stringify(meUser), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      return new Response(null, { status: 204 });
+    };
+    const result = await runRoleProbe('seller', {
+      apiUrl: URLS.api,
+      email: 'seller@example.test',
+      password: 'pw-seller',
+      fetchImpl,
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.user.id, 'user-seller-1');
+  });
+
+  it('3. native Response logout 2xx success를 소비한다', async () => {
+    for (const logoutStatus of [200, 204]) {
+      const result = await runRoleProbe('consumer', {
+        apiUrl: URLS.api,
+        email: 'consumer@example.test',
+        password: 'pw-consumer',
+        fetchImpl: nativeRoleFetch({ logoutStatus }),
+      });
+      assert.equal(result.ok, true);
+    }
+  });
+
+  it('4. native Response 401 login rejection은 sanitized unauthorized class를 남긴다', async () => {
+    await assert.rejects(
+      runRoleProbe('consumer', {
+        apiUrl: URLS.api,
+        email: 'consumer@example.test',
+        password: 'pw-consumer',
+        fetchImpl: nativeRoleFetch({ loginStatus: 401 }),
+      }),
+      (e) => {
+        assert.ok(e instanceof ProbeContractError);
+        assert.equal(e.code, 'CONSUMER_LOGIN_FAILED');
+        assert.equal(e.details?.httpStatus, 401);
+        assert.equal(e.details?.rejectionClass, 'AUTH_LOGIN_UNAUTHORIZED');
+        assert.equal(e.details?.role, 'consumer');
+        assert.equal(e.details?.step, 'login');
+        assert.ok(!String(e.message).includes('consumer@example.test'));
+        return true;
+      },
+    );
+    assert.equal(classifyLoginRejection(401), 'AUTH_LOGIN_UNAUTHORIZED');
+  });
+
+  it('5. native Response 403 login rejection은 sanitized forbidden class를 남긴다', async () => {
+    await assert.rejects(
+      runRoleProbe('driver', {
+        apiUrl: URLS.api,
+        email: 'driver@example.test',
+        password: 'pw-driver',
+        fetchImpl: nativeRoleFetch({ loginStatus: 403 }),
+      }),
+      (e) => {
+        assert.equal(e.code, 'DRIVER_LOGIN_FAILED');
+        assert.equal(e.details?.httpStatus, 403);
+        assert.equal(e.details?.rejectionClass, 'AUTH_LOGIN_FORBIDDEN');
+        return true;
+      },
+    );
+    assert.equal(classifyLoginRejection(403), 'AUTH_LOGIN_FORBIDDEN');
+    assert.equal(classifyLoginRejection(404), 'AUTH_LOGIN_ROUTE_NOT_FOUND');
+    assert.equal(classifyLoginRejection(500), 'AUTH_LOGIN_SERVER_ERROR');
+    assert.equal(classifyLoginRejection(503), 'AUTH_LOGIN_SERVER_ERROR');
+    assert.equal(classifyLoginRejection(418), 'AUTH_LOGIN_HTTP_REJECTED');
+  });
+
+  it('6. malformed/non-JSON error response가 secret/raw body 없이 안전하게 분류된다', async () => {
+    const rawMarker = `raw-secret-marker-html`;
+    const fetchImpl = async (url, init = {}) => {
+      const path = new URL(url).pathname;
+      if (path === '/auth/login') {
+        return new Response(`<html>${rawMarker} probe-boundary-token</html>`, {
+          status: 500,
+          headers: { 'content-type': 'text/html' },
+        });
+      }
+      return new Response('x', { status: 404 });
+    };
+    await assert.rejects(
+      runRoleProbe('seller', {
+        apiUrl: URLS.api,
+        email: 'seller@example.test',
+        password: 'pw-seller',
+        fetchImpl,
+      }),
+      (e) => {
+        assert.equal(e.code, 'SELLER_LOGIN_FAILED');
+        assert.equal(e.details?.rejectionClass, 'AUTH_LOGIN_SERVER_ERROR');
+        assert.equal(e.details?.httpStatus, 500);
+        assert.ok(!String(e.message).includes(rawMarker));
+        assert.ok(!String(e.message).includes('probe-boundary-token'));
+        assert.ok(!JSON.stringify(e.details ?? {}).includes(rawMarker));
+        return true;
+      },
+    );
+    const normalized = await normalizeProbeHttpResponse(
+      new Response('<html>oops</html>', { status: 500, headers: { 'content-type': 'text/html' } }),
+    );
+    assert.equal(normalized.ok, false);
+    assert.equal(normalized.status, 500);
+    assert.equal(normalized.data, null);
+  });
+
+  it('7. fake probe-boundary-token이 더 이상 runtime proof에 사용되지 않는다', async () => {
+    const seenAuth = [];
+    const spyFetch = async (url, init = {}) => {
+      const path = new URL(url).pathname;
+      const method = String(init.method ?? 'GET').toUpperCase();
+      if (path === '/auth/me' && method === 'GET') {
+        seenAuth.push(String(init.headers?.Authorization ?? ''));
+        return { ok: false, status: 401, data: null };
+      }
+      if (path === '/auth/login') return { ok: false, status: 401, data: null };
+      return { ok: false, status: 404, data: null };
+    };
+    const summary = await runAuthRuntimeProbe(validOptions(), { env: validEnv(), fetchImpl: spyFetch });
+    assert.ok(!seenAuth.some((v) => v.includes('probe-boundary-token')));
+    assert.notEqual(summary.roles.api?.failureCode, 'API_ME_FAILED');
+    assert.equal(summary.roles.api?.failureCode, 'API_ME_SKIPPED_NO_TOKEN');
+    assert.equal(summary.roles.api?.status, 'SKIP');
+  });
+
+  it('7b. role login 성공 시 실제 token을 메모리에서 재사용해 API boundary를 PASS한다', async () => {
+    const summary = await runAuthRuntimeProbe(validOptions({ apiToken: undefined }), {
+      env: validEnv(),
+      fetchImpl: mockApiFetch(),
+      // no explicit apiToken: must reuse real login token, not fake
+    });
+    assert.equal(summary.result, 'PASS');
+    assert.equal(summary.roles.api.status, 'PASS');
+  });
+
+  it('8. summary/artifact에 credential/token이 포함되지 않는다', async () => {
+    const summary = await runAuthRuntimeProbe(validOptions(), {
+      env: validEnv(),
+      fetchImpl: mockApiFetch(),
+      apiToken: 'at-user-consumer-1',
+    });
+    const serialized = JSON.stringify(summary);
+    for (const sensitive of [
+      'pw-consumer',
+      'pw-seller',
+      'pw-driver',
+      'consumer@example.test',
+      'at-user-consumer-1',
+      'rt-user-consumer-1',
+      'probe-boundary-token',
+      'e2e-secret',
+      'driver-shared',
+    ]) {
+      assert.ok(!serialized.includes(sensitive), `summary must not contain ${sensitive}`);
+    }
+    // Role failure diagnostic carries only non-sensitive fields.
+    const failSummary = await runAuthRuntimeProbe(validOptions(), {
+      env: validEnv(),
+      fetchImpl: async (url, init = {}) => {
+        const path = new URL(url).pathname;
+        if (path === '/auth/login') {
+          return new Response(JSON.stringify({ error: 'x' }), {
+            status: 401,
+            headers: { 'content-type': 'application/json' },
+          });
+        }
+        return new Response('x', { status: 404 });
+      },
+    });
+    const failSerialized = JSON.stringify(failSummary);
+    assert.ok(!failSerialized.includes('consumer@example.test'));
+    assert.ok(!failSerialized.includes('pw-consumer'));
+    assert.ok(!failSerialized.includes('probe-boundary-token'));
+    assert.equal(failSummary.roles.consumer.rejectionClass, 'AUTH_LOGIN_UNAUTHORIZED');
+    assert.equal(failSummary.roles.consumer.httpStatus, 401);
+  });
+
+  it('mock {ok,status,data} 계약이 계속 지원된다', async () => {
+    const viaMock = await runRoleProbe('consumer', {
+      apiUrl: URLS.api,
+      email: 'consumer@example.test',
+      password: 'pw-consumer',
+      fetchImpl: mockApiFetch(),
+    });
+    assert.equal(viaMock.ok, true);
+    const normalized = await normalizeProbeHttpResponse({ ok: true, status: 200, data: { a: 1 } });
+    assert.deepEqual(normalized, { ok: true, status: 200, data: { a: 1 } });
+    const nullish = await normalizeProbeHttpResponse(null);
+    assert.deepEqual(nullish, { ok: false, status: 0, data: null });
+  });
+
+  it('9-11. safety/provider/production guard가 normalization 이후에도 유지된다', async () => {
+    assert.throws(() => validateSafetyGates({ approval: '' }, validEnv()), (e) => e.code === 'MISSING_APPROVAL');
+    assert.equal(isProductionUrl('https://greenlove.co.kr'), true);
+    const guarded = createGuardedFetch(async () => ({ ok: true, status: 200, data: {} }), { apiUrl: URLS.api });
+    await assert.rejects(guarded(`${URLS.api}/auth/register`, { method: 'POST' }), (e) => e.code === 'AUTH_MUTATION_FORBIDDEN');
+    await assert.rejects(guarded('https://api.portone.io/x', { method: 'GET' }), (e) => e.code === 'PROVIDER_EGRESS_FORBIDDEN');
+    await assert.rejects(guarded(`${URLS.api}/auth/kakao-login`, { method: 'POST' }), (e) => e.code === 'KAKAO_COMPLETION_NOT_ALLOWED');
   });
 });


### PR DESCRIPTION
PILOT-AUTH-PROBE-HTTP-ADAPTER-AND-LOGIN-DIAGNOSTIC-16: session-only auth probe HTTP adapter fix. Scope: scripts/probe-auth-runtime.mjs, spec, workflow jq only. No app/API business change, no credential/fixture/deployment mutation. Tests: node --test scripts/probe-auth-runtime.spec.mjs scripts/probe-auth-runtime.workflow.spec.mjs (41 PASS).