### PR TITLE
feat(auth-probe): isolated locked Consumer callback input-binding probe

### DIFF
--- a/.github/workflows/probe-auth-runtime.yml
+++ b/.github/workflows/probe-auth-runtime.yml
@@ -30,6 +30,9 @@ on:
       - scripts/probe-auth-runtime.mjs
       - scripts/probe-auth-runtime.spec.mjs
       - scripts/probe-auth-runtime.workflow.spec.mjs
+      - scripts/probe-consumer-callback.mjs
+      - scripts/probe-consumer-callback.spec.mjs
+      - scripts/probe-consumer-callback.workflow.spec.mjs
       - .github/workflows/probe-auth-runtime.yml
 
 permissions:
@@ -48,7 +51,7 @@ jobs:
           node-version: '22'
 
       - name: run probe deterministic spec (mock/local only, no external calls)
-        run: node --test scripts/probe-auth-runtime.spec.mjs scripts/probe-auth-runtime.workflow.spec.mjs
+        run: node --test scripts/probe-auth-runtime.spec.mjs scripts/probe-auth-runtime.workflow.spec.mjs scripts/probe-consumer-callback.spec.mjs scripts/probe-consumer-callback.workflow.spec.mjs
 
   approval_gate:
     name: session-only probe approval preflight
@@ -411,5 +414,302 @@ jobs:
         with:
           name: auth-session-probe-${{ github.run_id }}-${{ github.run_attempt }}
           path: .artifacts/auth-session-probe/${{ env.AUTH_PROBE_RUN_ID }}/evidence/
+          if-no-files-found: error
+          retention-days: 7
+
+  callback-probe:
+    name: locked Consumer callback input-binding probe
+    # Callback isolation boundary: this job exercises ONLY the
+    # scripts/probe-consumer-callback.mjs contract against the locked
+    # Consumer Preview deployment (CSRF GET -> credentials callback POST
+    # with manual redirect -> same-context session readback). It never
+    # invokes scripts/probe-auth-runtime.mjs, never widens that runner's
+    # ALLOWED_API_PATHS, never merges network allowlists, and never calls
+    # seller/driver frontend origins. The session-probe job above is left
+    # untouched; this job needs only approval_gate so a session-probe
+    # failure cannot mask or block callback provenance evidence.
+    needs: approval_gate
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    concurrency:
+      group: auth-callback-probe
+      cancel-in-progress: false
+    environment:
+      # Same approved Environment as the session probe: secret scope lives
+      # here while the single-operator preflight above keeps the
+      # fail-closed approval contract. No secret value is ever logged.
+      name: round-direct-e2e
+    permissions:
+      contents: read
+    env:
+      AUTH_CALLBACK_RUN_ID: auth-callback-${{ github.run_id }}-${{ github.run_attempt }}
+      AUTH_CALLBACK_RUN_ATTEMPT: ${{ github.run_attempt }}
+      AUTH_CALLBACK_EVENT_NAME: ${{ github.event_name }}
+      AUTH_CALLBACK_ACTOR: ${{ github.actor }}
+      AUTH_CALLBACK_TRIGGERING_ACTOR: ${{ github.triggering_actor }}
+      AUTH_CALLBACK_WORKFLOW_SHA: ${{ github.sha }}
+      AUTH_CALLBACK_EXPECTED_SHA: ${{ inputs.expected_sha }}
+      AUTH_CALLBACK_CONSUMER_DEPLOYMENT_ID: ${{ inputs.consumer_deployment_id }}
+      AUTH_CALLBACK_SELLER_DEPLOYMENT_ID: ${{ inputs.seller_deployment_id }}
+      AUTH_CALLBACK_DRIVER_DEPLOYMENT_ID: ${{ inputs.driver_deployment_id }}
+
+    steps:
+      - name: probe 코드 checkout (workflow ref)
+        uses: actions/checkout@v6
+        with:
+          # Binding/provenance input (inputs.expected_sha) is the LOCKED
+          # deployment source SHA and intentionally differs from the probe
+          # code version: the callback runner only exists on post-publication
+          # main, so code follows the workflow ref while deployment binding
+          # follows inputs.expected_sha. Both SHAs are recorded in evidence.
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+
+      - name: 수동 승인과 checkout SHA 확인
+        shell: bash
+        env:
+          APPROVAL: ${{ inputs.approval }}
+          EVENT_NAME: ${{ github.event_name }}
+          ACTOR: ${{ github.actor }}
+          TRIGGERING_ACTOR: ${{ github.triggering_actor }}
+          REPOSITORY_OWNER: ${{ github.repository_owner }}
+        run: |
+          set -euo pipefail
+          if [[ "$EVENT_NAME" != 'workflow_dispatch' ]]; then
+            echo 'workflow_dispatch 이외의 이벤트에서는 callback probe를 실행할 수 없습니다.' >&2
+            exit 1
+          fi
+          if [[ "$ACTOR" != "$REPOSITORY_OWNER" ]]; then
+            echo 'workflow 실행자가 repository owner와 달라 실행을 차단합니다.' >&2
+            exit 1
+          fi
+          if [[ "$TRIGGERING_ACTOR" != "$REPOSITORY_OWNER" ]]; then
+            echo 'workflow triggering actor가 repository owner와 달라 실행을 차단합니다.' >&2
+            exit 1
+          fi
+          if [[ "$APPROVAL" != 'NON_PRODUCTION_AUTH_PROBE_APPROVED' ]]; then
+            echo 'callback probe 수동 승인이 없어 실행을 차단합니다.' >&2
+            exit 1
+          fi
+          if [[ ! "$AUTH_CALLBACK_WORKFLOW_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo 'workflow SHA는 40자리 소문자 16진수여야 합니다.' >&2
+            exit 1
+          fi
+          if [[ ! "$AUTH_CALLBACK_EXPECTED_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo 'binding SHA는 40자리 소문자 16진수여야 합니다.' >&2
+            exit 1
+          fi
+          actual_sha="$(git rev-parse HEAD)"
+          if [[ "$actual_sha" != "$AUTH_CALLBACK_WORKFLOW_SHA" ]]; then
+            echo 'checkout SHA가 workflow SHA와 달라 실행을 차단합니다.' >&2
+            exit 1
+          fi
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - name: locked Consumer deployment binding 직접 확인
+        shell: bash
+        env:
+          ROUND_DIRECT_E2E_VERCEL_READ_TOKEN: ${{ secrets.ROUND_DIRECT_E2E_VERCEL_READ_TOKEN }}
+        run: |
+          set -euo pipefail
+          evidence_root=".artifacts/auth-callback-probe/$AUTH_CALLBACK_RUN_ID"
+          mkdir -p "$evidence_root/evidence"
+          set +e
+          node scripts/wait-preview-deploy.mjs \
+            --json \
+            --sha="$AUTH_CALLBACK_EXPECTED_SHA" \
+            --consumer-deployment-id="$AUTH_CALLBACK_CONSUMER_DEPLOYMENT_ID" \
+            --seller-deployment-id="$AUTH_CALLBACK_SELLER_DEPLOYMENT_ID" \
+            --driver-deployment-id="$AUTH_CALLBACK_DRIVER_DEPLOYMENT_ID" \
+            > "$evidence_root/deployment-raw.json"
+          wait_status=$?
+          set -e
+          if [[ ! -s "$evidence_root/deployment-raw.json" ]]; then
+            echo '배포 증거 JSON을 만들지 못해 실행을 차단합니다.' >&2
+            exit 1
+          fi
+          jq -c '.deploymentShas' "$evidence_root/deployment-raw.json" \
+            | sed 's/^/AUTH_CALLBACK_DEPLOYMENT_SHAS_JSON=/' >> "$GITHUB_ENV"
+          jq -c '.deploymentTargetUrls' "$evidence_root/deployment-raw.json" \
+            | sed 's/^/AUTH_CALLBACK_TARGET_URLS_JSON=/' >> "$GITHUB_ENV"
+          jq -er '.ready' "$evidence_root/deployment-raw.json" \
+            | sed 's/^/AUTH_CALLBACK_DEPLOYMENT_READY=/' >> "$GITHUB_ENV"
+          if [[ "$wait_status" -eq 0 ]]; then
+            jq -er '.deploymentTargetUrls.consumer' "$evidence_root/deployment-raw.json" \
+              | sed 's/^/AUTH_CALLBACK_CONSUMER_URL=/' >> "$GITHUB_ENV"
+          fi
+          jq '{
+            ready,
+            evidenceSource,
+            checkedAt,
+            repository,
+            expectedSha,
+            pinnedDeploymentIds,
+            deploymentIds,
+            deploymentShas,
+            deploymentTargetUrls,
+            deploymentStates,
+            failureCodes,
+            apps: [.apps[] | {
+              app,
+              project,
+              projectId,
+              environment,
+              deploymentId,
+              deploymentSha,
+              state,
+              readyState,
+              target,
+              target_url: .targetUrl,
+              failureCode,
+              ready
+            }]
+            }' \
+            "$evidence_root/deployment-raw.json" \
+            > "$evidence_root/evidence/deployment.json"
+          jq --arg expectedSha "$AUTH_CALLBACK_EXPECTED_SHA" \
+            '. + {expectedSha: $expectedSha}' \
+            "$evidence_root/deployment-raw.json" \
+            > "$evidence_root/probe-evidence.json"
+          exit "$wait_status"
+
+      - name: locked Consumer frontend origin 확인
+        shell: bash
+        run: |
+          set -euo pipefail
+          consumer_url="$(printf '%s' "${AUTH_CALLBACK_CONSUMER_URL:-}" | tr -d '[:space:]')"
+          if [[ -z "$consumer_url" ]]; then
+            echo 'callback 대상 consumer URL이 비어 있어 실행을 차단합니다.' >&2
+            exit 1
+          fi
+          case "$consumer_url" in
+            https://*) ;;
+            *) echo 'callback 대상은 https만 허용합니다.' >&2; exit 1 ;;
+          esac
+          consumer_host="$(printf '%s' "$consumer_url" | sed -e 's#^https://##' -e 's#/.*$##' -e 's#:.*$##' | tr '[:upper:]' '[:lower:]')"
+          case "$consumer_host" in
+            greenlove.co.kr|*.greenlove.co.kr|api-production-*)
+              echo '운영 consumer origin이므로 실행을 차단합니다.' >&2
+              exit 1
+              ;;
+          esac
+          if [[ "$consumer_host" == 'api-production-13e7.up.railway.app' ]]; then
+            echo '운영 consumer origin이므로 실행을 차단합니다.' >&2
+            exit 1
+          fi
+          case "$consumer_host" in
+            *.vercel.app) ;;
+            *) echo 'callback 대상이 locked Preview deployment 호스트가 아닙니다.' >&2; exit 1 ;;
+          esac
+          printf 'consumer_host=%s\n' "$consumer_host"
+
+      - name: locked Consumer callback probe 실행
+        shell: bash
+        env:
+          E2E_TEST_SECRET: ${{ secrets.ROUND_DIRECT_E2E_TEST_SECRET }}
+          TEST_CONSUMER_EMAIL: ${{ secrets.ROUND_DIRECT_E2E_CONSUMER_EMAIL_CHROMIUM }}
+          TEST_CONSUMER_PASSWORD: ${{ secrets.ROUND_DIRECT_E2E_CONSUMER_PASSWORD_CHROMIUM }}
+        run: |
+          set -euo pipefail
+          # Secret-name mapping note (values never logged):
+          # - E2E_TEST_SECRET <- ROUND_DIRECT_E2E_TEST_SECRET
+          # - TEST_CONSUMER_EMAIL <- ROUND_DIRECT_E2E_CONSUMER_EMAIL_CHROMIUM
+          # - TEST_CONSUMER_PASSWORD <- ROUND_DIRECT_E2E_CONSUMER_PASSWORD_CHROMIUM
+          # The approved Environment secret input is passed to the probe via
+          # env only; the probe records credentialSource/headerName/
+          # headerPresent provenance metadata and never serializes values.
+          # No seller/driver frontend origin is called by this step.
+          evidence_root=".artifacts/auth-callback-probe/$AUTH_CALLBACK_RUN_ID"
+          mkdir -p "$evidence_root/evidence"
+          set +e
+          node scripts/probe-consumer-callback.mjs \
+            --expected-sha="$AUTH_CALLBACK_EXPECTED_SHA" \
+            --consumer-url="$AUTH_CALLBACK_CONSUMER_URL" \
+            --consumer-deployment-id="$AUTH_CALLBACK_CONSUMER_DEPLOYMENT_ID" \
+            --evidence-json="$evidence_root/probe-evidence.json" \
+            --approval="${{ inputs.approval }}" \
+            > "$evidence_root/probe-raw.json"
+          probe_status=$?
+          set -e
+          if [[ ! -s "$evidence_root/probe-raw.json" ]]; then
+            echo 'callback probe 요약을 만들지 못해 실행을 차단합니다.' >&2
+            exit 1
+          fi
+          jq '{
+            artifact,
+            authErrorClass,
+            callbackLocationClass,
+            callbackStatus,
+            checkedAt,
+            credentialSource,
+            deploymentId,
+            deploymentSourceSha,
+            headerName,
+            headerPresent,
+            requestBuilder,
+            runner,
+            sessionState,
+            setCookiePresent,
+            workflowSourceSha
+            }' \
+            "$evidence_root/probe-raw.json" \
+            > "$evidence_root/evidence/callback-summary.json"
+          checked_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          jq -n \
+            --arg runId "$AUTH_CALLBACK_RUN_ID" \
+            --arg runAttempt "$AUTH_CALLBACK_RUN_ATTEMPT" \
+            --arg eventName "$AUTH_CALLBACK_EVENT_NAME" \
+            --arg actor "$AUTH_CALLBACK_ACTOR" \
+            --arg triggeringActor "$AUTH_CALLBACK_TRIGGERING_ACTOR" \
+            --arg workflowSha "$AUTH_CALLBACK_WORKFLOW_SHA" \
+            --arg expectedSha "$AUTH_CALLBACK_EXPECTED_SHA" \
+            --arg consumerDeploymentId "$AUTH_CALLBACK_CONSUMER_DEPLOYMENT_ID" \
+            --arg consumerTargetUrl "$AUTH_CALLBACK_CONSUMER_URL" \
+            --arg checkedAt "$checked_at" \
+            --argjson targetUrls "$AUTH_CALLBACK_TARGET_URLS_JSON" \
+            --argjson deploymentShas "$AUTH_CALLBACK_DEPLOYMENT_SHAS_JSON" \
+            --slurpfile callback "$evidence_root/evidence/callback-summary.json" \
+            --slurpfile deployment "$evidence_root/evidence/deployment.json" \
+            '{
+              runId: $runId,
+              runAttempt: $runAttempt,
+              eventName: $eventName,
+              actor: $actor,
+              triggeringActor: $triggeringActor,
+              workflowSha: $workflowSha,
+              callbackProbeSourceSha: $workflowSha,
+              expectedSha: $expectedSha,
+              environment: "round-direct-e2e",
+              consumerDeploymentId: $consumerDeploymentId,
+              consumerTargetUrl: $consumerTargetUrl,
+              targetUrls: $targetUrls,
+              deploymentShas: $deploymentShas,
+              deploymentReady: $deployment[0].ready,
+              bindingVerdict: (if $deployment[0].ready == true then "LOCKED_BINDING_VERIFIED" else "BINDING_NOT_READY" end),
+              credentialSource: ($callback[0].credentialSource // "E2E_TEST_SECRET"),
+              headerName: ($callback[0].headerName // "x-e2e-test-token"),
+              headerPresent: $callback[0].headerPresent,
+              secretPlaintextAccessed: false,
+              secretDerivedDiagnosticEmitted: false,
+              callbackStatus: $callback[0].callbackStatus,
+              callbackLocationClass: $callback[0].callbackLocationClass,
+              authErrorClass: $callback[0].authErrorClass,
+              setCookiePresent: $callback[0].setCookiePresent,
+              sessionState: $callback[0].sessionState,
+              checkedAt: $checkedAt
+            }' \
+            > "$evidence_root/evidence/workflow-summary.json"
+          exit "$probe_status"
+
+      - name: 비민감 증거 artifact 업로드
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: auth-callback-probe-${{ github.run_id }}-${{ github.run_attempt }}
+          path: .artifacts/auth-callback-probe/${{ env.AUTH_CALLBACK_RUN_ID }}/evidence/
           if-no-files-found: error
           retention-days: 7

--- a/scripts/probe-auth-runtime.workflow.spec.mjs
+++ b/scripts/probe-auth-runtime.workflow.spec.mjs
@@ -73,7 +73,7 @@ describe('session-only workflow dispatch contract', () => {
     );
   });
 
-  it('round-direct-e2e Environment binds only the session probe', () => {
+  it('round-direct-e2e Environment binds only the runtime probe jobs', () => {
     const source = readWorkflow();
     assert.ok(source.includes('name: round-direct-e2e'), 'session probe must bind round-direct-e2e');
     const specSlice = jobSlice(source, 'probe-spec:', ['approval_gate:', 'session-probe:']);
@@ -129,7 +129,7 @@ describe('session-only workflow dispatch contract', () => {
 });
 
 describe('session-only runtime boundary', () => {
-  it('only the two allowed scripts are invoked', () => {
+  it('only the allowed scripts are invoked (session runner + isolated callback runner)', () => {
     const source = readWorkflow();
     assert.ok(
       source.includes('scripts/wait-preview-deploy.mjs'),
@@ -143,10 +143,19 @@ describe('session-only runtime boundary', () => {
     assert.ok(invocations.length > 0, 'expected script invocations');
     for (const script of invocations) {
       assert.ok(
-        script === 'wait-preview-deploy.mjs' || script === 'probe-auth-runtime.mjs',
+        script === 'wait-preview-deploy.mjs' ||
+          script === 'probe-auth-runtime.mjs' ||
+          script === 'probe-consumer-callback.mjs',
         `forbidden script invocation: node scripts/${script}`,
       );
     }
+    // Isolation: the callback runner is invoked only from the callback-probe
+    // job, never from the session-probe job (see
+    // probe-consumer-callback.workflow.spec.mjs for the job boundary).
+    assert.ok(
+      source.includes('callback-probe:'),
+      'callback invocation must live in the isolated callback-probe job',
+    );
   });
 
   it('production targets are rejected', () => {

--- a/scripts/probe-consumer-callback.mjs
+++ b/scripts/probe-consumer-callback.mjs
@@ -1,0 +1,626 @@
+/**
+ * PILOT-AUTH-CONSUMER-CALLBACK-INPUT-BINDING-PROOF-16 — locked Consumer
+ * Preview deployment NextAuth credentials callback provenance probe.
+ *
+ * Purpose (CASE B1 closeout):
+ *   Prove, at runtime, whether the locked Consumer Preview deployment's
+ *   NextAuth credentials callback request was actually constructed with the
+ *   approved E2E_TEST_SECRET input as the `x-e2e-test-token` header, and how
+ *   far that request progressed through the runtime gate. The callback gate
+ *   itself is used as the opaque equality proof — secret plaintext, value,
+ *   hash, fingerprint, prefix/suffix, and length are NEVER accessed for
+ *   output, comparison logging, or diagnostics.
+ *
+ * What this probe does (callback path only, never the direct API path):
+ *   1. Fail-closed guards BEFORE any network call (approval, production
+ *      target, locked deployment/branch/SHA binding, evidence binding,
+ *      credential-source presence).
+ *   2. GET  /api/auth/csrf with the constructed header (provenance recorded
+ *      as headerName/headerPresent BEFORE the request is sent).
+ *   3. POST /api/auth/callback/credentials with the same header object
+ *      (manual redirect: the 302 Location / JSON url is classified, never
+ *      followed blindly and never logged).
+ *   4. GET  /api/auth/session with the same in-memory cookie jar
+ *      (Set-Cookie values never leave memory; only presence is recorded).
+ *
+ * Non-sensitive evidence ONLY (structurally fixed key set — see
+ * buildCallbackArtifact; the serializer cannot emit secret-derived keys):
+ *   requestBuilder, credentialSource, headerName, headerPresent,
+ *   callbackStatus, callbackLocationClass, authErrorClass, setCookiePresent,
+ *   sessionState, deploymentId, deploymentSourceSha, workflowSourceSha.
+ *
+ * Exit codes: 0 whenever the callback path was executed and a sanitized
+ * artifact was produced (ANY gate outcome is adjudicable evidence);
+ * 1 only on fail-closed contract violations (no callback attempted).
+ *
+ * Usage (real run — via the approved workflow with Environment-injected
+ * secrets; never pass secrets as CLI literals):
+ *   node scripts/probe-consumer-callback.mjs \
+ *     --expected-sha=<40hex> \
+ *     --consumer-url=https://<locked-consumer-preview> \
+ *     --consumer-deployment-id=dpl_... \
+ *     --evidence-json=.artifacts/.../probe-evidence.json \
+ *     --approval=NON_PRODUCTION_AUTH_PROBE_APPROVED
+ *
+ * Secrets come from env (never logged, never serialized):
+ *   E2E_TEST_SECRET, TEST_CONSUMER_EMAIL, TEST_CONSUMER_PASSWORD
+ */
+
+export const APPROVAL_VALUE = 'NON_PRODUCTION_AUTH_PROBE_APPROVED';
+
+export const HEADER_NAME = 'x-e2e-test-token';
+export const CREDENTIAL_SOURCE = 'E2E_TEST_SECRET';
+export const REQUEST_BUILDER =
+  'scripts/probe-consumer-callback.mjs#runConsumerCallbackProbe';
+
+// Locked runtime target (CASE B1 canonical input). Requests to any other
+// deployment/branch/SHA fail closed with TARGET_BINDING_MOVED — the callback
+// is never retargeted to a different deployment.
+export const LOCKED_DEPLOYMENT_ID = 'dpl_B7TCW4CzUgWZv9JTUffMdpjCY7Qd';
+export const LOCKED_SOURCE_SHA = '67632ede1d7196456bcf1fe5320a7a7e7d509c0c';
+export const LOCKED_BRANCH = 'tmp/pilot-auth-verifier-cookie-04a-publication-01';
+
+const SHA_PATTERN = /^[0-9a-f]{40}$/;
+const DEPLOYMENT_ID_PATTERN = /^dpl_[A-Za-z0-9]+$/;
+
+const KNOWN_AUTH_ERROR_CLASSES = Object.freeze([
+  'authorize-rejected',
+  'upstream-rejected',
+  'api-binding-failure',
+]);
+
+// Exact sanitized artifact key set. buildCallbackArtifact() can only produce
+// these keys — secret/token/cookie values are structurally unrepresentable.
+export const ARTIFACT_KEYS = Object.freeze([
+  'artifact',
+  'authErrorClass',
+  'callbackLocationClass',
+  'callbackStatus',
+  'checkedAt',
+  'credentialSource',
+  'deploymentId',
+  'deploymentSourceSha',
+  'headerName',
+  'headerPresent',
+  'requestBuilder',
+  'runner',
+  'sessionState',
+  'setCookiePresent',
+  'workflowSourceSha',
+]);
+
+export class CallbackProbeContractError extends Error {
+  constructor(code, message) {
+    super(message);
+    this.name = 'CallbackProbeContractError';
+    this.code = code;
+  }
+}
+
+function fail(code, message) {
+  throw new CallbackProbeContractError(code, message);
+}
+
+function isNonEmptyString(value) {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+export function assertExpectedSha(value) {
+  if (!isNonEmptyString(value)) {
+    fail('EXPECTED_SHA_REQUIRED', 'expected SHA가 없습니다. --expected-sha=<40hex>가 필요합니다.');
+  }
+  const normalized = String(value).trim().toLowerCase();
+  if (!SHA_PATTERN.test(normalized)) {
+    fail('EXPECTED_SHA_MALFORMED', 'expected SHA 형식이 올바르지 않습니다 (40자리 소문자 16진수).');
+  }
+  return normalized;
+}
+
+export function assertDeploymentId(value) {
+  if (!isNonEmptyString(value) || !DEPLOYMENT_ID_PATTERN.test(String(value).trim())) {
+    fail('DEPLOYMENT_ID_MALFORMED', 'pinned Vercel deployment ID 형식이 올바르지 않습니다.');
+  }
+  return String(value).trim();
+}
+
+function hostnameOf(urlString) {
+  try {
+    return new URL(urlString).hostname.toLowerCase();
+  } catch {
+    return '';
+  }
+}
+
+export function isProductionHostname(hostname) {
+  const host = String(hostname ?? '').toLowerCase();
+  if (!host) return true; // unparseable -> fail closed as production-like
+  if (host === 'greenlove.co.kr' || host.endsWith('.greenlove.co.kr')) return true;
+  if (host.startsWith('api-production-')) return true;
+  if (host === 'api-production-13e7.up.railway.app') return true;
+  return false;
+}
+
+export function normalizeConsumerUrl(value) {
+  if (!isNonEmptyString(value)) {
+    fail('RUNTIME_NOT_BOUND', 'consumer URL이 없어 runtime binding을 증명할 수 없습니다.');
+  }
+  let url;
+  try {
+    url = new URL(String(value).trim());
+  } catch {
+    fail('RUNTIME_NOT_BOUND', 'consumer URL 형식이 올바르지 않아 runtime binding을 거부합니다.');
+  }
+  if (url.username || url.password || url.search || url.hash) {
+    fail('RUNTIME_NOT_BOUND', 'consumer URL에 인증정보/query/fragment가 있어 binding을 거부합니다.');
+  }
+  const isLoopback =
+    url.hostname === 'localhost' || url.hostname === '127.0.0.1' || url.hostname === '::1';
+  if (!isLoopback && url.protocol !== 'https:') {
+    fail('RUNTIME_NOT_BOUND', 'consumer URL은 loopback이 아니면 https만 허용합니다.');
+  }
+  if (isProductionHostname(url.hostname)) {
+    fail('PRODUCTION_TARGET_REJECTED', 'consumer target이 운영 호스트이므로 차단합니다.');
+  }
+  if (!url.hostname.endsWith('.vercel.app')) {
+    fail('RUNTIME_NOT_BOUND', 'consumer target이 locked Preview deployment 호스트가 아닙니다.');
+  }
+  return url.toString().replace(/\/$/, '');
+}
+
+/**
+ * Locked-target pinning: the probe may only address the CASE B1 locked
+ * deployment/source. Anything else fails closed without a network call.
+ */
+export function assertLockedBinding({ deploymentId, expectedSha }) {
+  const id = assertDeploymentId(deploymentId);
+  const sha = assertExpectedSha(expectedSha);
+  if (id !== LOCKED_DEPLOYMENT_ID || sha !== LOCKED_SOURCE_SHA) {
+    fail(
+      'TARGET_BINDING_MOVED',
+      'locked runtime target 바인딩과 달라 callback을 다른 배포로 대체하지 않습니다.',
+    );
+  }
+  return { deploymentId: id, expectedSha: sha };
+}
+
+/**
+ * Evidence binding (consumer slice of wait-preview-deploy JSON): the pinned
+ * deployment id + expected SHA + target URL must all agree before any
+ * network call.
+ */
+export function validateEvidenceBinding({ expectedSha, deploymentId, consumerUrl, evidence }) {
+  const sha = assertExpectedSha(expectedSha);
+  const id = assertDeploymentId(deploymentId);
+  if (!evidence || typeof evidence !== 'object' || Array.isArray(evidence)) {
+    fail('RUNTIME_NOT_BOUND', 'runtime binding evidence가 없어 실행을 차단합니다.');
+  }
+  if (evidence.ready === false) {
+    fail('RUNTIME_NOT_BOUND', 'binding evidence가 ready 상태가 아닙니다.');
+  }
+  const evidenceSha = String(evidence.expectedSha ?? '').trim().toLowerCase();
+  if (evidenceSha !== sha) {
+    fail('EXPECTED_SHA_MISMATCH', 'binding evidence SHA가 --expected-sha와 다릅니다.');
+  }
+  const shas = evidence.deploymentShas ?? evidence.statusShas ?? {};
+  if (shas.consumer !== sha) {
+    fail('DEPLOYMENT_SHA_MISMATCH', 'consumer 배포 SHA가 지정 SHA와 일치하지 않습니다.');
+  }
+  const pinned =
+    evidence.pinnedDeploymentIds ?? evidence.deploymentIds ?? evidence.pinnedDeploymentIDs ?? {};
+  const pinnedConsumer = pinned.consumer ?? evidence.consumerDeploymentId ?? '';
+  if (isNonEmptyString(pinnedConsumer) && String(pinnedConsumer).trim() !== id) {
+    fail('RUNTIME_BINDING_MISMATCH', 'consumer deployment ID가 evidence binding과 다릅니다.');
+  }
+  const targets = evidence.deploymentTargetUrls ?? evidence.statusTargetUrls ?? evidence.targetUrls ?? {};
+  if (isNonEmptyString(targets.consumer)) {
+    const observed = normalizeConsumerUrl(targets.consumer);
+    if (observed !== consumerUrl) {
+      fail('RUNTIME_BINDING_MISMATCH', 'consumer target이 evidence binding과 다릅니다.');
+    }
+  }
+  return { expectedSha: sha, deploymentId: id };
+}
+
+export function validateProbeGuards(input = {}, env = process.env) {
+  const approval = String(input.approval ?? env.NON_PRODUCTION_AUTH_PROBE_APPROVAL ?? '').trim();
+  if (approval !== APPROVAL_VALUE) {
+    fail('MISSING_APPROVAL', 'explicit non-production approval이 없어 실행을 차단합니다.');
+  }
+  const e2eSecret = input.e2eSecret ?? env.E2E_TEST_SECRET ?? '';
+  if (!isNonEmptyString(e2eSecret)) {
+    fail(
+      'CREDENTIAL_SOURCE_UNAVAILABLE',
+      'header를 구성할 승인된 E2E_TEST_SECRET input이 없어 callback을 시도하지 않습니다.',
+    );
+  }
+  const email = input.email ?? env.TEST_CONSUMER_EMAIL ?? '';
+  const password = input.password ?? env.TEST_CONSUMER_PASSWORD ?? '';
+  if (!isNonEmptyString(email) || !isNonEmptyString(password)) {
+    fail('CONSUMER_CREDENTIALS_MISSING', 'consumer test credential이 없어 실행을 차단합니다.');
+  }
+  return { approval };
+}
+
+// ---- Safe classifiers (pure, no network) -----------------------------------
+
+/** Location path class for the callback redirect target. */
+export function classifyLocationClass(pathname) {
+  if (pathname === '/' || pathname === '') return 'ROOT';
+  if (typeof pathname === 'string' && pathname.startsWith('/login')) return 'LOGIN_ERROR';
+  return 'OTHER';
+}
+
+/**
+ * Mirror of the runtime gate taxonomy (apps/consumer/src/auth.ts +
+ * loginViaCredentials category mapping), over non-sensitive inputs only:
+ * numeric status + whitelisted error/code params.
+ */
+export function classifyAuthError({ status, codeParam, errorParam }) {
+  if (KNOWN_AUTH_ERROR_CLASSES.includes(codeParam)) return codeParam;
+  if (codeParam === 'unknown') return 'other';
+  if (codeParam != null) return 'other';
+  if (errorParam === 'CredentialsSignin' || errorParam === 'CallbackRouteError') {
+    return 'authorize-rejected';
+  }
+  if (errorParam != null && errorParam !== 'unknown') return 'other';
+  if (typeof status === 'number' && status >= 500) return 'api-binding-failure';
+  if (errorParam === 'unknown') return 'other';
+  return 'NONE';
+}
+
+function safeCodeParam(value) {
+  if (typeof value !== 'string' || !value) return null;
+  if (KNOWN_AUTH_ERROR_CLASSES.includes(value)) return value;
+  return 'unknown';
+}
+
+function safeErrorParam(value) {
+  if (typeof value !== 'string' || !value) return null;
+  if (value === 'CredentialsSignin' || value === 'CallbackRouteError') return value;
+  if (value === 'AccessDenied' || value === 'MissingCSRF') return value;
+  return 'unknown';
+}
+
+function parseLocationEvidence(location, base) {
+  if (typeof location !== 'string' || !location.trim()) {
+    return { locationClass: 'OTHER', codeParam: null, errorParam: null };
+  }
+  try {
+    const url = new URL(location, base);
+    return {
+      locationClass: classifyLocationClass(url.pathname || '/'),
+      codeParam: safeCodeParam(url.searchParams.get('code')),
+      errorParam: safeErrorParam(url.searchParams.get('error')),
+    };
+  } catch {
+    return { locationClass: 'OTHER', codeParam: null, errorParam: null };
+  }
+}
+
+// ---- In-memory cookie jar (values never emitted) ----------------------------
+
+function readSetCookieHeaders(headers) {
+  if (!headers) return [];
+  if (typeof headers.getSetCookie === 'function') {
+    const values = headers.getSetCookie();
+    return Array.isArray(values) ? values.filter((v) => typeof v === 'string') : [];
+  }
+  if (typeof headers.raw === 'function') {
+    const raw = headers.raw()['set-cookie'];
+    if (Array.isArray(raw)) return raw.filter((v) => typeof v === 'string');
+  }
+  if (typeof headers.get === 'function') {
+    const single = headers.get('set-cookie');
+    if (typeof single === 'string' && single) return [single];
+  }
+  if (Array.isArray(headers)) {
+    return headers
+      .filter((entry) => Array.isArray(entry) && String(entry[0]).toLowerCase() === 'set-cookie')
+      .map((entry) => String(entry[1]));
+  }
+  return [];
+}
+
+function storeCookies(jar, headers) {
+  for (const line of readSetCookieHeaders(headers)) {
+    const pair = String(line).split(';', 1)[0] ?? '';
+    const eq = pair.indexOf('=');
+    if (eq > 0) {
+      const name = pair.slice(0, eq).trim();
+      const value = pair.slice(eq + 1).trim();
+      if (name) jar.set(name, value);
+    }
+  }
+}
+
+function jarCookieHeader(jar) {
+  return [...jar.entries()].map(([name, value]) => `${name}=${value}`).join('; ');
+}
+
+function parseJsonBody(value) {
+  try {
+    const parsed = JSON.parse(String(value));
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Exact sanitized artifact builder. Only ARTIFACT_KEYS can appear in the
+ * output — there is no parameter, code path, or spread through which a
+ * secret/token/cookie value could enter the artifact.
+ */
+export function buildCallbackArtifact(fields) {
+  const artifact = {
+    artifact: 'pilot-auth-consumer-callback-input-binding-proof-16',
+    authErrorClass: fields.authErrorClass,
+    callbackLocationClass: fields.callbackLocationClass,
+    callbackStatus: fields.callbackStatus,
+    checkedAt: fields.checkedAt,
+    credentialSource: CREDENTIAL_SOURCE,
+    deploymentId: fields.deploymentId,
+    deploymentSourceSha: fields.deploymentSourceSha,
+    headerName: HEADER_NAME,
+    headerPresent: fields.headerPresent,
+    requestBuilder: REQUEST_BUILDER,
+    runner: 'PILOT-AUTH-CONSUMER-CALLBACK-PROBE-16',
+    sessionState: fields.sessionState,
+    setCookiePresent: fields.setCookiePresent,
+    workflowSourceSha: fields.workflowSourceSha,
+  };
+  const keys = Object.keys(artifact).sort();
+  const expected = [...ARTIFACT_KEYS].sort();
+  if (keys.length !== expected.length || keys.some((key, index) => key !== expected[index])) {
+    fail('PROBE_INTERNAL_ERROR', 'sanitized artifact key set이 고정 계약과 다릅니다.');
+  }
+  return artifact;
+}
+
+/**
+ * One callback provenance lifecycle against the locked Consumer deployment:
+ * CSRF -> credentials callback POST -> same-jar session readback.
+ *
+ * fetchImpl is injectable (mock in tests, global fetch in real runs with
+ * redirect:'manual' enforced below). Returns { artifact, calls } where calls
+ * is the non-sensitive list of request paths (direct-API confusion check).
+ */
+export async function runConsumerCallbackProbe(
+  {
+    consumerUrl,
+    expectedSha,
+    deploymentId,
+    evidence,
+    e2eSecret,
+    email,
+    password,
+    approval,
+    workflowSha = '',
+    checkedAt = '',
+    fetchImpl,
+  } = {},
+  deps = {},
+) {
+  const env = deps.env ?? process.env;
+  const fetch = deps.fetchImpl ?? fetchImpl ?? globalThis.fetch?.bind(globalThis);
+  if (typeof fetch !== 'function') {
+    fail('PROBE_INTERNAL_ERROR', 'fetch 구현이 없어 probe를 실행할 수 없습니다.');
+  }
+  validateProbeGuards(
+    { approval: approval ?? env.NON_PRODUCTION_AUTH_PROBE_APPROVAL, e2eSecret, email, password },
+    env,
+  );
+  const base = normalizeConsumerUrl(consumerUrl);
+  const locked = assertLockedBinding({ deploymentId, expectedSha });
+  validateEvidenceBinding({
+    expectedSha: locked.expectedSha,
+    deploymentId: locked.deploymentId,
+    consumerUrl: base,
+    evidence,
+  });
+
+  // Provenance is recorded HERE: the header object carries the approved
+  // E2E_TEST_SECRET input under the expected key on BOTH the CSRF GET and
+  // the callback POST (same construction as loginViaCredentials). Only the
+  // key name + presence boolean ever leave this scope.
+  const secret = String(e2eSecret ?? env.E2E_TEST_SECRET ?? '');
+  const headers = { [HEADER_NAME]: secret };
+  const headerPresent = isNonEmptyString(secret);
+  if (!headerPresent) {
+    fail(
+      'CREDENTIAL_SOURCE_UNAVAILABLE',
+      'header를 구성할 승인된 E2E_TEST_SECRET input이 없어 callback을 시도하지 않습니다.',
+    );
+  }
+
+  const calls = [];
+  const jar = new Map();
+  const requestInit = (extra = {}) => ({ redirect: 'manual', ...extra });
+
+  // 1) CSRF (same header object as the callback POST).
+  const csrfRes = await fetch(
+    `${base}/api/auth/csrf`,
+    requestInit({ method: 'GET', headers: { ...headers } }),
+  ).catch(() => null);
+  calls.push('/api/auth/csrf');
+  if (!csrfRes) {
+    fail('CALLBACK_TRANSPORT_FAILED', 'CSRF 요청 전송에 실패해 callback을 시도하지 않습니다.');
+  }
+  storeCookies(jar, csrfRes.headers);
+  const csrfStatus = typeof csrfRes.status === 'number' ? csrfRes.status : 0;
+  const csrfOk = csrfRes.ok === true || (csrfStatus >= 200 && csrfStatus < 300);
+  if (!csrfOk) {
+    fail('CALLBACK_TRANSPORT_FAILED', 'CSRF 응답이 비정상이라 callback을 시도하지 않습니다.');
+  }
+  let csrfToken = '';
+  try {
+    const text = typeof csrfRes.text === 'function' ? await csrfRes.text() : '';
+    const body = parseJsonBody(text);
+    if (typeof body.csrfToken === 'string') csrfToken = body.csrfToken;
+  } catch {
+    csrfToken = '';
+  }
+  if (!csrfToken) {
+    fail('CALLBACK_TRANSPORT_FAILED', 'CSRF token을 확인하지 못해 callback을 시도하지 않습니다.');
+  }
+
+  // 2) Credentials callback POST (the request under proof — must execute).
+  const form = new URLSearchParams();
+  form.set('email', String(email));
+  form.set('password', String(password));
+  form.set('csrfToken', csrfToken);
+  form.set('callbackUrl', base);
+  form.set('json', 'true');
+  const callbackRes = await fetch(
+    `${base}/api/auth/callback/credentials`,
+    requestInit({
+      method: 'POST',
+      headers: {
+        ...headers,
+        'Content-Type': 'application/x-www-form-urlencoded',
+        ...(jar.size > 0 ? { Cookie: jarCookieHeader(jar) } : {}),
+      },
+      body: form.toString(),
+    }),
+  ).catch(() => null);
+  calls.push('/api/auth/callback/credentials');
+  if (!callbackRes) {
+    fail('CALLBACK_TRANSPORT_FAILED', 'callback 요청 전송에 실패했습니다.');
+  }
+  storeCookies(jar, callbackRes.headers);
+  const callbackStatus = typeof callbackRes.status === 'number' ? callbackRes.status : 0;
+  const setCookiePresent = readSetCookieHeaders(callbackRes.headers).length > 0;
+  let locationValue = null;
+  if (callbackRes.headers && typeof callbackRes.headers.get === 'function') {
+    try {
+      locationValue = callbackRes.headers.get('location');
+    } catch {
+      locationValue = null;
+    }
+  }
+  try {
+    const text = typeof callbackRes.text === 'function' ? await callbackRes.text() : '';
+    const body = parseJsonBody(text);
+    if (!locationValue && typeof body.url === 'string' && body.url) {
+      locationValue = body.url;
+    }
+  } catch {
+    // Body is only a location fallback source — never evidence content.
+  }
+  const locationEvidence = parseLocationEvidence(locationValue, base);
+  const authErrorClass = classifyAuthError({
+    status: callbackStatus,
+    codeParam: locationEvidence.codeParam,
+    errorParam: locationEvidence.errorParam,
+  });
+
+  // 3) Same-jar session readback (cookie VALUES stay in memory only).
+  let sessionState = 'NOT_CHECKED';
+  try {
+    const sessionRes = await fetch(
+      `${base}/api/auth/session`,
+      requestInit({
+        method: 'GET',
+        headers: { ...(jar.size > 0 ? { Cookie: jarCookieHeader(jar) } : {}) },
+      }),
+    );
+    calls.push('/api/auth/session');
+    const sessionStatus = typeof sessionRes?.status === 'number' ? sessionRes.status : 0;
+    const sessionOk = sessionRes?.ok === true || (sessionStatus >= 200 && sessionStatus < 300);
+    if (sessionOk && typeof sessionRes.text === 'function') {
+      const body = parseJsonBody(await sessionRes.text());
+      const user = body.user;
+      const userRecord =
+        user && typeof user === 'object' && !Array.isArray(user)
+          ? user
+          : null;
+      const token = userRecord?.accessToken;
+      sessionState = typeof token === 'string' && token.length > 0 ? 'VALID' : 'INVALID';
+    } else if (sessionRes) {
+      sessionState = 'INVALID';
+    }
+  } catch {
+    sessionState = 'NOT_CHECKED';
+  }
+
+  const artifact = buildCallbackArtifact({
+    authErrorClass,
+    callbackLocationClass: locationEvidence.locationClass,
+    callbackStatus,
+    checkedAt: String(checkedAt || new Date().toISOString()),
+    deploymentId: locked.deploymentId,
+    deploymentSourceSha: locked.expectedSha,
+    headerPresent,
+    sessionState,
+    setCookiePresent,
+    workflowSourceSha: String(workflowSha || env.GITHUB_SHA || 'local-unpublished'),
+  });
+  return { artifact, calls };
+}
+
+function parseArgs(argv) {
+  const out = {};
+  for (const arg of argv) {
+    const match = String(arg).match(/^--([^=]+)=(.*)$/);
+    if (match) out[match[1]] = match[2];
+  }
+  return out;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const { readFileSync } = await import('node:fs');
+  let evidence = null;
+  const evidencePath = args['evidence-json'] ?? process.env.AUTH_PROBE_EVIDENCE_JSON_PATH;
+  if (isNonEmptyString(evidencePath)) {
+    try {
+      evidence = JSON.parse(readFileSync(evidencePath, 'utf8'));
+    } catch {
+      evidence = null;
+    }
+  } else if (isNonEmptyString(process.env.AUTH_PROBE_EVIDENCE_JSON)) {
+    try {
+      evidence = JSON.parse(process.env.AUTH_PROBE_EVIDENCE_JSON);
+    } catch {
+      evidence = null;
+    }
+  }
+  try {
+    const { artifact } = await runConsumerCallbackProbe(
+      {
+        consumerUrl: args['consumer-url'],
+        expectedSha: args['expected-sha'],
+        deploymentId: args['consumer-deployment-id'],
+        evidence,
+        approval: args.approval,
+        workflowSha: process.env.GITHUB_SHA ?? '',
+        checkedAt: '',
+      },
+      { env: process.env },
+    );
+    process.stdout.write(`${JSON.stringify(artifact, null, 2)}\n`);
+    process.exitCode = 0;
+  } catch (error) {
+    const code = error instanceof CallbackProbeContractError ? error.code : 'PROBE_INTERNAL_ERROR';
+    process.stdout.write(
+      `${JSON.stringify({ runner: 'PILOT-AUTH-CONSUMER-CALLBACK-PROBE-16', result: 'FAIL', failureCode: code, message: String(error?.message ?? error) }, null, 2)}\n`,
+    );
+    process.exitCode = 1;
+  }
+}
+
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const isDirectRun =
+  Boolean(process.argv[1]) && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isDirectRun) {
+  main().catch((error) => {
+    const code = error instanceof CallbackProbeContractError ? error.code : 'PROBE_INTERNAL_ERROR';
+    process.stdout.write(
+      `${JSON.stringify({ runner: 'PILOT-AUTH-CONSUMER-CALLBACK-PROBE-16', result: 'FAIL', failureCode: code, message: String(error?.message ?? error) }, null, 2)}\n`,
+    );
+    process.exitCode = 1;
+  });
+}

--- a/scripts/probe-consumer-callback.spec.mjs
+++ b/scripts/probe-consumer-callback.spec.mjs
@@ -1,0 +1,450 @@
+/**
+ * PILOT-AUTH-CONSUMER-CALLBACK-INPUT-BINDING-PROOF-16 deterministic tests.
+ *
+ * Mock/local only: no network, no real secrets, no external mutation. The
+ * mock credential values below are synthetic test fixtures — real secret
+ * material is never present in this file. Run:
+ *   node --test scripts/probe-consumer-callback.spec.mjs
+ */
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  APPROVAL_VALUE,
+  ARTIFACT_KEYS,
+  CREDENTIAL_SOURCE,
+  HEADER_NAME,
+  LOCKED_BRANCH,
+  LOCKED_DEPLOYMENT_ID,
+  LOCKED_SOURCE_SHA,
+  REQUEST_BUILDER,
+  assertDeploymentId,
+  assertExpectedSha,
+  assertLockedBinding,
+  buildCallbackArtifact,
+  classifyAuthError,
+  classifyLocationClass,
+  isProductionHostname,
+  normalizeConsumerUrl,
+  runConsumerCallbackProbe,
+  validateEvidenceBinding,
+  validateProbeGuards,
+} from './probe-consumer-callback.mjs';
+
+const CONSUMER_URL = 'https://greenhubconsumer-2v8t54nvh-jos-projects-d1cecc0c.vercel.app';
+const MOCK_SECRET = 'mock-e2e-secret-fixture-16';
+const MOCK_PASSWORD = 'mock-consumer-password-fixture-16';
+const MOCK_CSRF = 'mock-csrf-token-fixture-16';
+const MOCK_SESSION_TOKEN = 'mock-access-token-fixture-16';
+const MOCK_COOKIE_VALUE = 'mock-session-cookie-value-fixture-16';
+
+function fakeHeaders(entries = {}) {
+  const lower = new Map();
+  const setCookies = [];
+  for (const [name, value] of Object.entries(entries)) {
+    if (String(name).toLowerCase() === 'set-cookie') {
+      if (Array.isArray(value)) setCookies.push(...value);
+      else setCookies.push(String(value));
+    } else {
+      lower.set(String(name).toLowerCase(), String(value));
+    }
+  }
+  return {
+    get(name) {
+      if (String(name).toLowerCase() === 'set-cookie') return setCookies[0] ?? null;
+      return lower.get(String(name).toLowerCase()) ?? null;
+    },
+    getSetCookie() {
+      return [...setCookies];
+    },
+  };
+}
+
+function jsonResponse({ status = 200, body = {}, headers = fakeHeaders({}) }) {
+  const text = typeof body === 'string' ? body : JSON.stringify(body);
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers,
+    text: async () => text,
+  };
+}
+
+function validEvidence(overrides = {}) {
+  return {
+    ready: true,
+    expectedSha: LOCKED_SOURCE_SHA,
+    deploymentShas: { consumer: LOCKED_SOURCE_SHA },
+    pinnedDeploymentIds: { consumer: LOCKED_DEPLOYMENT_ID },
+    deploymentTargetUrls: { consumer: CONSUMER_URL },
+    ...overrides,
+  };
+}
+
+function validInput(overrides = {}) {
+  return {
+    consumerUrl: CONSUMER_URL,
+    expectedSha: LOCKED_SOURCE_SHA,
+    deploymentId: LOCKED_DEPLOYMENT_ID,
+    evidence: validEvidence(),
+    e2eSecret: MOCK_SECRET,
+    email: 'consumer-proof-16@example.test',
+    password: MOCK_PASSWORD,
+    approval: APPROVAL_VALUE,
+    workflowSha: 'workflow-sha-fixture-16',
+    checkedAt: '2026-09-11T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+/** Mock fetch with per-path scripted responses; records request headers. */
+function mockFetch(scripts) {
+  const seen = [];
+  const fetch = async (url, init = {}) => {
+    const path = new URL(String(url)).pathname;
+    seen.push({ path, headers: { ...(init.headers ?? {}) } });
+    const script = scripts[path];
+    if (!script) throw new Error(`unexpected fetch path in test: ${path}`);
+    return typeof script === 'function' ? script(url, init) : script;
+  };
+  fetch.seen = seen;
+  fetch.paths = () => seen.map((entry) => entry.path);
+  return fetch;
+}
+
+const csrfOk = () =>
+  jsonResponse({ status: 200, body: { csrfToken: MOCK_CSRF } });
+
+const callbackRedirect = (location, setCookie) =>
+  jsonResponse({
+    status: 302,
+    body: {},
+    headers: fakeHeaders({
+      Location: location,
+      ...(setCookie ? { 'Set-Cookie': setCookie } : {}),
+    }),
+  });
+
+const sessionValid = () =>
+  jsonResponse({
+    status: 200,
+    body: { user: { id: 'user-16', accessToken: MOCK_SESSION_TOKEN } },
+  });
+
+const sessionInvalid = () => jsonResponse({ status: 200, body: {} });
+
+describe('callback probe input contract (E2E_TEST_SECRET -> x-e2e-test-token)', () => {
+  it('locked target constants match the CASE B1 canonical input', () => {
+    assert.equal(LOCKED_DEPLOYMENT_ID, 'dpl_B7TCW4CzUgWZv9JTUffMdpjCY7Qd');
+    assert.equal(LOCKED_SOURCE_SHA, '67632ede1d7196456bcf1fe5320a7a7e7d509c0c');
+    assert.equal(LOCKED_BRANCH, 'tmp/pilot-auth-verifier-cookie-04a-publication-01');
+    assert.equal(HEADER_NAME, 'x-e2e-test-token');
+    assert.equal(CREDENTIAL_SOURCE, 'E2E_TEST_SECRET');
+    assert.equal(APPROVAL_VALUE, 'NON_PRODUCTION_AUTH_PROBE_APPROVED');
+  });
+
+  it('authorize-rejected lifecycle proves header path with runtime rejection', async () => {
+    const fetch = mockFetch({
+      '/api/auth/csrf': csrfOk(),
+      '/api/auth/callback/credentials': callbackRedirect(
+        `${CONSUMER_URL}/login?error=CredentialsSignin&code=authorize-rejected`,
+      ),
+      '/api/auth/session': sessionInvalid(),
+    });
+    const { artifact, calls } = await runConsumerCallbackProbe(validInput(), {
+      env: {},
+      fetchImpl: fetch,
+    });
+    assert.equal(artifact.credentialSource, 'E2E_TEST_SECRET');
+    assert.equal(artifact.headerName, 'x-e2e-test-token');
+    assert.equal(artifact.headerPresent, true);
+    assert.equal(artifact.requestBuilder, REQUEST_BUILDER);
+    assert.equal(artifact.callbackStatus, 302);
+    assert.equal(artifact.callbackLocationClass, 'LOGIN_ERROR');
+    assert.equal(artifact.authErrorClass, 'authorize-rejected');
+    assert.equal(artifact.setCookiePresent, false);
+    assert.equal(artifact.sessionState, 'INVALID');
+    assert.equal(artifact.deploymentId, LOCKED_DEPLOYMENT_ID);
+    assert.equal(artifact.deploymentSourceSha, LOCKED_SOURCE_SHA);
+    // Exact callback path executed in order; direct API probe never used.
+    assert.deepEqual(calls, [
+      '/api/auth/csrf',
+      '/api/auth/callback/credentials',
+      '/api/auth/session',
+    ]);
+    assert.ok(!calls.includes('/auth/login'), 'direct API /auth/login must never be called');
+    assert.ok(
+      fetch.paths().every((path) => path.startsWith('/api/auth/')),
+      'only NextAuth callback-path endpoints may be called',
+    );
+  });
+
+  it('header object is constructed from the approved input on CSRF and callback', async () => {
+    const fetch = mockFetch({
+      '/api/auth/csrf': csrfOk(),
+      '/api/auth/callback/credentials': callbackRedirect(
+        `${CONSUMER_URL}/login?error=CredentialsSignin&code=authorize-rejected`,
+      ),
+      '/api/auth/session': sessionInvalid(),
+    });
+    await runConsumerCallbackProbe(validInput(), { env: {}, fetchImpl: fetch });
+    const csrfHeaders = fetch.seen.find((entry) => entry.path === '/api/auth/csrf').headers;
+    const callbackHeaders = fetch.seen.find(
+      (entry) => entry.path === '/api/auth/callback/credentials',
+    ).headers;
+    // Same construction as loginViaCredentials: approved input under the
+    // expected key on BOTH requests (mock value compared in-memory only).
+    assert.equal(csrfHeaders[HEADER_NAME], MOCK_SECRET);
+    assert.equal(callbackHeaders[HEADER_NAME], MOCK_SECRET);
+  });
+
+  it('gate pass with VALID session maps to NONE + ROOT + VALID', async () => {
+    const fetch = mockFetch({
+      '/api/auth/csrf': csrfOk(),
+      '/api/auth/callback/credentials': callbackRedirect(
+        `${CONSUMER_URL}/`,
+        `__Secure-authjs.session-token=${MOCK_COOKIE_VALUE}; Path=/; HttpOnly`,
+      ),
+      '/api/auth/session': sessionValid(),
+    });
+    const { artifact } = await runConsumerCallbackProbe(validInput(), {
+      env: {},
+      fetchImpl: fetch,
+    });
+    assert.equal(artifact.headerPresent, true);
+    assert.equal(artifact.authErrorClass, 'NONE');
+    assert.equal(artifact.callbackLocationClass, 'ROOT');
+    assert.equal(artifact.setCookiePresent, true);
+    assert.equal(artifact.sessionState, 'VALID');
+  });
+
+  it('upstream-rejected and api-binding-failure classes are distinguished', async () => {
+    const upstreamFetch = mockFetch({
+      '/api/auth/csrf': csrfOk(),
+      '/api/auth/callback/credentials': callbackRedirect(
+        `${CONSUMER_URL}/login?error=CallbackRouteError&code=upstream-rejected`,
+      ),
+      '/api/auth/session': sessionInvalid(),
+    });
+    const upstream = await runConsumerCallbackProbe(validInput(), {
+      env: {},
+      fetchImpl: upstreamFetch,
+    });
+    assert.equal(upstream.artifact.authErrorClass, 'upstream-rejected');
+
+    const bindingFetch = mockFetch({
+      '/api/auth/csrf': csrfOk(),
+      '/api/auth/callback/credentials': callbackRedirect(
+        `${CONSUMER_URL}/login?error=CallbackRouteError&code=api-binding-failure`,
+      ),
+      '/api/auth/session': sessionInvalid(),
+    });
+    const binding = await runConsumerCallbackProbe(validInput(), {
+      env: {},
+      fetchImpl: bindingFetch,
+    });
+    assert.equal(binding.artifact.authErrorClass, 'api-binding-failure');
+
+    const serverErrorFetch = mockFetch({
+      '/api/auth/csrf': csrfOk(),
+      '/api/auth/callback/credentials': jsonResponse({ status: 500, body: {} }),
+      '/api/auth/session': sessionInvalid(),
+    });
+    const serverError = await runConsumerCallbackProbe(validInput(), {
+      env: {},
+      fetchImpl: serverErrorFetch,
+    });
+    assert.equal(serverError.artifact.authErrorClass, 'api-binding-failure');
+  });
+});
+
+describe('callback probe fail-closed guards (no callback attempted)', () => {
+  it('missing credential source blocks before any network call', async () => {
+    const fetch = mockFetch({});
+    await assert.rejects(
+      runConsumerCallbackProbe(validInput({ e2eSecret: '' }), { env: {}, fetchImpl: fetch }),
+      (error) => error.code === 'CREDENTIAL_SOURCE_UNAVAILABLE',
+    );
+    assert.deepEqual(fetch.paths(), []);
+  });
+
+  it('retargeting to another deployment fails with TARGET_BINDING_MOVED', async () => {
+    const fetch = mockFetch({});
+    await assert.rejects(
+      runConsumerCallbackProbe(validInput({ deploymentId: 'dpl_AAAAAAAAAAAAAAAAAAAA' }), {
+        env: {},
+        fetchImpl: fetch,
+      }),
+      (error) => error.code === 'TARGET_BINDING_MOVED',
+    );
+    await assert.rejects(
+      runConsumerCallbackProbe(validInput({ expectedSha: 'a'.repeat(40) }), {
+        env: {},
+        fetchImpl: fetch,
+      }),
+      (error) => error.code === 'TARGET_BINDING_MOVED',
+    );
+    assert.deepEqual(fetch.paths(), []);
+  });
+
+  it('production targets and missing approval are rejected', async () => {
+    const fetch = mockFetch({});
+    await assert.rejects(
+      runConsumerCallbackProbe(validInput({ consumerUrl: 'https://shop.greenlove.co.kr' }), {
+        env: {},
+        fetchImpl: fetch,
+      }),
+      (error) => error.code === 'PRODUCTION_TARGET_REJECTED',
+    );
+    await assert.rejects(
+      runConsumerCallbackProbe(validInput({ approval: 'WRONG' }), {
+        env: {},
+        fetchImpl: fetch,
+      }),
+      (error) => error.code === 'MISSING_APPROVAL',
+    );
+    assert.deepEqual(fetch.paths(), []);
+  });
+
+  it('evidence binding mismatch blocks without a network call', async () => {
+    const fetch = mockFetch({});
+    await assert.rejects(
+      runConsumerCallbackProbe(
+        validInput({ evidence: validEvidence({ expectedSha: 'b'.repeat(40) }) }),
+        { env: {}, fetchImpl: fetch },
+      ),
+      (error) => error.code === 'EXPECTED_SHA_MISMATCH',
+    );
+    await assert.rejects(
+      runConsumerCallbackProbe(validInput({ evidence: null }), {
+        env: {},
+        fetchImpl: fetch,
+      }),
+      (error) => error.code === 'RUNTIME_NOT_BOUND',
+    );
+    assert.deepEqual(fetch.paths(), []);
+  });
+});
+
+describe('callback probe pure classifiers and guards', () => {
+  it('location classes are ROOT | LOGIN_ERROR | OTHER', () => {
+    assert.equal(classifyLocationClass('/'), 'ROOT');
+    assert.equal(classifyLocationClass('/login'), 'LOGIN_ERROR');
+    assert.equal(classifyLocationClass('/login?error=x'), 'LOGIN_ERROR');
+    assert.equal(classifyLocationClass('/orders'), 'OTHER');
+  });
+
+  it('auth error classes mirror the runtime gate taxonomy', () => {
+    assert.equal(
+      classifyAuthError({ status: 302, codeParam: 'authorize-rejected', errorParam: null }),
+      'authorize-rejected',
+    );
+    assert.equal(
+      classifyAuthError({ status: 302, codeParam: null, errorParam: 'CredentialsSignin' }),
+      'authorize-rejected',
+    );
+    assert.equal(
+      classifyAuthError({ status: 302, codeParam: 'upstream-rejected', errorParam: null }),
+      'upstream-rejected',
+    );
+    assert.equal(
+      classifyAuthError({ status: 302, codeParam: 'api-binding-failure', errorParam: null }),
+      'api-binding-failure',
+    );
+    assert.equal(classifyAuthError({ status: 500, codeParam: null, errorParam: null }), 'api-binding-failure');
+    assert.equal(classifyAuthError({ status: 302, codeParam: null, errorParam: null }), 'NONE');
+    assert.equal(classifyAuthError({ status: 302, codeParam: 'unknown', errorParam: null }), 'other');
+  });
+
+  it('production hostnames fail closed', () => {
+    assert.equal(isProductionHostname('greenlove.co.kr'), true);
+    assert.equal(isProductionHostname('shop.greenlove.co.kr'), true);
+    assert.equal(isProductionHostname('api-production-13e7.up.railway.app'), true);
+    assert.equal(
+      isProductionHostname('greenhubconsumer-2v8t54nvh-jos-projects-d1cecc0c.vercel.app'),
+      false,
+    );
+  });
+
+  it('SHA and deployment ID shapes are enforced', () => {
+    assert.equal(assertExpectedSha(LOCKED_SOURCE_SHA), LOCKED_SOURCE_SHA);
+    assert.throws(() => assertExpectedSha('xyz'), (error) => error.code === 'EXPECTED_SHA_MALFORMED');
+    assert.equal(assertDeploymentId(LOCKED_DEPLOYMENT_ID), LOCKED_DEPLOYMENT_ID);
+    assert.throws(() => assertDeploymentId('nope'), (error) => error.code === 'DEPLOYMENT_ID_MALFORMED');
+    assert.deepEqual(assertLockedBinding({ deploymentId: LOCKED_DEPLOYMENT_ID, expectedSha: LOCKED_SOURCE_SHA }), {
+      deploymentId: LOCKED_DEPLOYMENT_ID,
+      expectedSha: LOCKED_SOURCE_SHA,
+    });
+    assert.throws(
+      () => normalizeConsumerUrl('https://greenlove.co.kr'),
+      (error) => error.code === 'PRODUCTION_TARGET_REJECTED',
+    );
+    assert.throws(
+      () => validateProbeGuards({ approval: APPROVAL_VALUE, e2eSecret: '', email: 'a', password: 'b' }, {}),
+      (error) => error.code === 'CREDENTIAL_SOURCE_UNAVAILABLE',
+    );
+    assert.deepEqual(
+      validateEvidenceBinding({
+        expectedSha: LOCKED_SOURCE_SHA,
+        deploymentId: LOCKED_DEPLOYMENT_ID,
+        consumerUrl: CONSUMER_URL,
+        evidence: validEvidence(),
+      }),
+      { expectedSha: LOCKED_SOURCE_SHA, deploymentId: LOCKED_DEPLOYMENT_ID },
+    );
+  });
+});
+
+describe('callback probe serializer safety (no secret-derived output)', () => {
+  it('artifact key set is exactly the non-sensitive allowlist', () => {
+    const artifact = buildCallbackArtifact({
+      authErrorClass: 'authorize-rejected',
+      callbackLocationClass: 'LOGIN_ERROR',
+      callbackStatus: 302,
+      checkedAt: '2026-09-11T00:00:00.000Z',
+      deploymentId: LOCKED_DEPLOYMENT_ID,
+      deploymentSourceSha: LOCKED_SOURCE_SHA,
+      headerPresent: true,
+      sessionState: 'INVALID',
+      setCookiePresent: false,
+      workflowSourceSha: 'workflow-sha-fixture-16',
+    });
+    assert.deepEqual(Object.keys(artifact).sort(), [...ARTIFACT_KEYS].sort());
+  });
+
+  it('serialized runtime artifact contains no mock secret-derived material', async () => {
+    const fetch = mockFetch({
+      '/api/auth/csrf': csrfOk(),
+      '/api/auth/callback/credentials': callbackRedirect(
+        `${CONSUMER_URL}/`,
+        `__Secure-authjs.session-token=${MOCK_COOKIE_VALUE}; Path=/; HttpOnly`,
+      ),
+      '/api/auth/session': sessionValid(),
+    });
+    const { artifact } = await runConsumerCallbackProbe(validInput(), {
+      env: {},
+      fetchImpl: fetch,
+    });
+    const serialized = JSON.stringify(artifact);
+    for (const forbidden of [MOCK_SECRET, MOCK_PASSWORD, MOCK_CSRF, MOCK_SESSION_TOKEN, MOCK_COOKIE_VALUE]) {
+      assert.ok(!serialized.includes(forbidden), 'artifact must not contain secret-derived material');
+    }
+    // Forbidden STRUCTURAL keys can never appear (exact allowlist enforced by builder).
+    for (const key of [
+      'secret',
+      'e2eSecret',
+      'token',
+      'accessToken',
+      'refreshToken',
+      'csrfToken',
+      'cookie',
+      'cookies',
+      'setCookie',
+      'password',
+      'email',
+      'value',
+      'authorization',
+    ]) {
+      assert.ok(!(key in artifact), `artifact must not contain key: ${key}`);
+    }
+  });
+});

--- a/scripts/probe-consumer-callback.workflow.spec.mjs
+++ b/scripts/probe-consumer-callback.workflow.spec.mjs
@@ -1,0 +1,231 @@
+/**
+ * PILOT-AUTH-CALLBACK-PROBE-PUBLICATION-AND-DISPATCH-17 — callback workflow
+ * contract spec.
+ *
+ * Deterministic only: reads .github/workflows/probe-auth-runtime.yml as text
+ * plus the callback runner's canonical constants and the session runner's
+ * network allowlist. No network, no secrets, no external mutation. Run:
+ *   node --test scripts/probe-consumer-callback.workflow.spec.mjs
+ */
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import {
+  APPROVAL_VALUE,
+  CREDENTIAL_SOURCE,
+  HEADER_NAME,
+  LOCKED_DEPLOYMENT_ID,
+  LOCKED_SOURCE_SHA,
+} from './probe-consumer-callback.mjs';
+import { readFileSync as readRunnerSource } from 'node:fs';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, '..');
+const WORKFLOW_PATH = path.join(REPO_ROOT, '.github', 'workflows', 'probe-auth-runtime.yml');
+const SESSION_RUNNER_PATH = path.join(REPO_ROOT, 'scripts', 'probe-auth-runtime.mjs');
+
+function readWorkflow() {
+  return readFileSync(WORKFLOW_PATH, 'utf8');
+}
+
+/** Slice of the callback-probe job (last job in the workflow file). */
+function callbackSlice(source) {
+  const start = source.indexOf('callback-probe:');
+  assert.ok(start >= 0, 'workflow must contain the callback-probe job');
+  return source.slice(start);
+}
+
+function sessionSlice(source) {
+  const start = source.indexOf('session-probe:');
+  assert.ok(start >= 0, 'workflow must contain the session-probe job');
+  const end = source.indexOf('callback-probe:');
+  return source.slice(start, end >= 0 ? end : source.length);
+}
+
+describe('callback probe workflow isolation contract', () => {
+  it('callback runner canonical input binding matches CASE B1', () => {
+    assert.equal(LOCKED_DEPLOYMENT_ID, 'dpl_B7TCW4CzUgWZv9JTUffMdpjCY7Qd');
+    assert.equal(LOCKED_SOURCE_SHA, '67632ede1d7196456bcf1fe5320a7a7e7d509c0c');
+    assert.equal(HEADER_NAME, 'x-e2e-test-token');
+    assert.equal(CREDENTIAL_SOURCE, 'E2E_TEST_SECRET');
+    assert.equal(APPROVAL_VALUE, 'NON_PRODUCTION_AUTH_PROBE_APPROVED');
+  });
+
+  it('callback-probe is an isolated job gated on manual dispatch only', () => {
+    const source = readWorkflow();
+    const slice = callbackSlice(source);
+    assert.ok(
+      slice.includes("name: locked Consumer callback input-binding probe"),
+      'callback job must carry its isolation name',
+    );
+    assert.ok(slice.includes('needs: approval_gate'), 'callback job must need only approval_gate');
+    assert.ok(!/^(\s*)needs:.*session-probe/m.test(slice), 'callback must not depend on session-probe');
+    assert.ok(
+      slice.includes("github.event_name == 'workflow_dispatch'"),
+      'callback job must gate on workflow_dispatch',
+    );
+    assert.ok(
+      slice.includes('workflow_dispatch 이외의 이벤트에서는 callback probe를 실행할 수 없습니다.'),
+      'non-dispatch events must fail closed with an explicit callback message',
+    );
+    assert.ok(slice.includes('group: auth-callback-probe'), 'callback job must use its own concurrency group');
+  });
+
+  it('session-probe job is untouched by the callback integration', () => {
+    const source = readWorkflow();
+    const slice = sessionSlice(source);
+    assert.ok(
+      slice.includes('name: pinned Preview session-only auth probe'),
+      'session job name must be preserved',
+    );
+    assert.ok(
+      slice.includes('node scripts/probe-auth-runtime.mjs'),
+      'session job must still invoke only the session runner',
+    );
+    assert.ok(
+      !slice.includes('probe-consumer-callback.mjs'),
+      'session job must never invoke the callback runner',
+    );
+    assert.ok(
+      !slice.includes('auth-callback-probe-'),
+      'session job must not reference callback artifact paths',
+    );
+  });
+
+  it('callback code checkout follows the workflow ref, binding follows the locked SHA', () => {
+    const slice = callbackSlice(readWorkflow());
+    assert.ok(
+      slice.includes('ref: ${{ github.sha }}'),
+      'callback job must checkout the workflow ref (probe code only exists post-publication)',
+    );
+    assert.ok(
+      slice.includes('git rev-parse HEAD'),
+      'checkout SHA must be compared against the workflow SHA',
+    );
+    assert.ok(
+      slice.includes('checkout SHA가 workflow SHA와 달라 실행을 차단합니다.'),
+      'code checkout mismatch must fail closed with an explicit message',
+    );
+    assert.ok(
+      slice.includes('--sha="$AUTH_CALLBACK_EXPECTED_SHA"'),
+      'deployment binding must still follow inputs.expected_sha (locked source)',
+    );
+    assert.ok(
+      slice.includes('--expected-sha="$AUTH_CALLBACK_EXPECTED_SHA"'),
+      'callback probe binding must follow inputs.expected_sha (locked source)',
+    );
+  });
+
+  it('callback job binds round-direct-e2e without touching session allowlists', () => {
+    const source = readWorkflow();
+    const slice = callbackSlice(source);
+    assert.ok(slice.includes('name: round-direct-e2e'), 'callback job must bind round-direct-e2e');
+    assert.ok(slice.includes('contents: read'), 'callback job must keep contents: read');
+    assert.ok(
+      !slice.includes('node scripts/probe-auth-runtime.mjs'),
+      'callback job must never invoke the session/API runner',
+    );
+  });
+
+  it('session runner ALLOWED_API_PATHS is not widened for callback purposes', () => {
+    const runner = readRunnerSource(SESSION_RUNNER_PATH, 'utf8');
+    assert.ok(
+      runner.includes("'/auth/login', '/auth/me', '/auth/logout'"),
+      'session runner allowlist must stay exactly the three session paths',
+    );
+    assert.ok(
+      !runner.includes('/api/auth/callback'),
+      'session runner must not gain a callback path',
+    );
+    const source = readWorkflow();
+    assert.ok(
+      !source.includes('/api/auth/callback'),
+      'workflow must not hardcode callback URL paths outside the runner',
+    );
+  });
+
+  it('callback job targets only the Consumer frontend origin', () => {
+    const slice = callbackSlice(readWorkflow());
+    assert.ok(slice.includes('--consumer-url='), 'callback invocation must pass --consumer-url=');
+    assert.ok(slice.includes('--consumer-deployment-id='), 'callback invocation must pass --consumer-deployment-id=');
+    assert.ok(slice.includes('--expected-sha='), 'callback invocation must pass --expected-sha=');
+    assert.ok(slice.includes('--evidence-json='), 'callback invocation must pass --evidence-json=');
+    assert.ok(slice.includes('--approval='), 'callback invocation must pass --approval=');
+    for (const forbidden of ['--seller-url=', '--driver-url=', '--api-url=']) {
+      assert.ok(!slice.includes(forbidden), `callback job must never use ${forbidden}`);
+    }
+    assert.ok(slice.includes('.vercel.app'), 'callback target must be a Preview deployment host');
+    assert.ok(slice.includes('greenlove.co.kr'), 'callback job must reject production frontend hosts');
+    assert.ok(slice.includes('api-production-'), 'callback job must reject production API hosts');
+  });
+
+  it('callback credential input reuses the approved Environment secret name', () => {
+    const slice = callbackSlice(readWorkflow());
+    assert.ok(
+      slice.includes('E2E_TEST_SECRET: ${{ secrets.ROUND_DIRECT_E2E_TEST_SECRET }}'),
+      'callback job must map E2E_TEST_SECRET from the approved Environment secret',
+    );
+    assert.ok(
+      slice.includes('TEST_CONSUMER_EMAIL: ${{ secrets.ROUND_DIRECT_E2E_CONSUMER_EMAIL_CHROMIUM }}'),
+      'callback job must reuse the approved consumer email secret',
+    );
+    assert.ok(
+      slice.includes('TEST_CONSUMER_PASSWORD: ${{ secrets.ROUND_DIRECT_E2E_CONSUMER_PASSWORD_CHROMIUM }}'),
+      'callback job must reuse the approved consumer password secret',
+    );
+    for (const line of slice.split('\n')) {
+      const trimmed = line.trim();
+      if (trimmed.startsWith('#')) continue;
+      if (!/echo|printf/.test(line)) continue;
+      for (const sensitive of ['SECRET', 'PASSWORD', 'TOKEN', 'COOKIE', 'SERVICE_ACCOUNT', 'CREDENTIAL_JSON']) {
+        assert.ok(
+          !line.includes(sensitive),
+          `callback log line must not reference ${sensitive}: ${trimmed.slice(0, 120)}`,
+        );
+      }
+    }
+    for (const sensitive of ['accessToken', 'refreshToken', 'set-cookie']) {
+      assert.ok(!slice.includes(sensitive), `callback job must not handle raw ${sensitive}`);
+    }
+  });
+
+  it('callback evidence records non-sensitive provenance only', () => {
+    const slice = callbackSlice(readWorkflow());
+    assert.ok(slice.includes('callback-summary.json'), 'redacted callback summary must be written');
+    assert.ok(slice.includes('workflow-summary.json'), 'redacted callback workflow summary must be written');
+    assert.ok(slice.includes('credentialSource'), 'provenance wrapper must record credentialSource');
+    assert.ok(slice.includes('headerName'), 'provenance wrapper must record headerName');
+    assert.ok(slice.includes('headerPresent'), 'provenance wrapper must record headerPresent');
+    assert.ok(slice.includes('bindingVerdict'), 'provenance wrapper must record bindingVerdict');
+    assert.ok(slice.includes('secretPlaintextAccessed: false'), 'secret non-access must be attested');
+    assert.ok(slice.includes('secretDerivedDiagnosticEmitted: false'), 'secret-derived diagnostics must be denied');
+    assert.ok(slice.includes('environment: "round-direct-e2e"'), 'environment name must be recorded');
+    assert.ok(
+      slice.includes('name: auth-callback-probe-'),
+      'evidence artifact must use the callback artifact name',
+    );
+    assert.ok(slice.includes('retention-days: 7'), 'evidence artifact must keep the 7-day retention contract');
+  });
+
+  it('deterministic probe-spec and PR triggers cover the callback contract', () => {
+    const source = readWorkflow();
+    assert.ok(
+      source.includes('scripts/probe-consumer-callback.spec.mjs'),
+      'probe-spec must run the callback deterministic spec',
+    );
+    assert.ok(
+      source.includes('scripts/probe-consumer-callback.workflow.spec.mjs'),
+      'probe-spec must run the callback workflow contract spec',
+    );
+    for (const trigger of [
+      'scripts/probe-consumer-callback.mjs',
+      'scripts/probe-consumer-callback.spec.mjs',
+      'scripts/probe-consumer-callback.workflow.spec.mjs',
+    ]) {
+      assert.ok(source.includes(trigger), `pull_request paths must include ${trigger}`);
+    }
+  });
+});


### PR DESCRIPTION
PILOT-AUTH-CALLBACK-PROBE-PUBLICATION-AND-DISPATCH-17 Phase C publication.

Scope (owned only):
- scripts/probe-consumer-callback.mjs (new, from prior-task candidate, unchanged)
- scripts/probe-consumer-callback.spec.mjs (new, unchanged)
- scripts/probe-consumer-callback.workflow.spec.mjs (new callback workflow contract)
- .github/workflows/probe-auth-runtime.yml (additive isolated callback-probe job; session-probe untouched)
- scripts/probe-auth-runtime.workflow.spec.mjs (minimal allowlist alignment for the isolated runner)

Isolation: callback job needs only approval_gate, binds round-direct-e2e, targets Consumer frontend origin only, reuses approved secret names, never widens ALLOWED_API_PATHS, never merges allowlists. Probe code follows workflow ref; deployment binding follows inputs.expected_sha (locked source 67632ed).

Base: f6bc4215 (post-#156 live main). No foreign files included.