### PR TITLE
feat(auth-probe): decouple session probe runner SHA from frontend target SHA

### DIFF
--- a/.github/workflows/probe-auth-runtime.yml
+++ b/.github/workflows/probe-auth-runtime.yml
@@ -3,6 +3,10 @@ name: Auth runtime probe (deterministic + session-only)
 on:
   workflow_dispatch:
     inputs:
+      runner_sha:
+        description: 'session-only probe runner를 실행할 repository exact commit SHA'
+        required: true
+        type: string
       expected_sha:
         description: '세 Preview 앱이 가리켜야 하는 40자리 commit SHA'
         required: true
@@ -68,6 +72,7 @@ jobs:
           TRIGGERING_ACTOR: ${{ github.triggering_actor }}
           REPOSITORY_OWNER: ${{ github.repository_owner }}
           APPROVAL: ${{ inputs.approval }}
+          RUNNER_SHA: ${{ inputs.runner_sha }}
           EXPECTED_SHA: ${{ inputs.expected_sha }}
           CONSUMER_DEPLOYMENT_ID: ${{ inputs.consumer_deployment_id }}
           SELLER_DEPLOYMENT_ID: ${{ inputs.seller_deployment_id }}
@@ -78,6 +83,7 @@ jobs:
           printf 'actor=%s\n' "$ACTOR"
           printf 'triggering_actor=%s\n' "$TRIGGERING_ACTOR"
           printf 'repository_owner=%s\n' "$REPOSITORY_OWNER"
+          printf 'runner_sha=%s\n' "$RUNNER_SHA"
           printf 'expected_sha=%s\n' "$EXPECTED_SHA"
           if [[ "$EVENT_NAME" != 'workflow_dispatch' ]]; then
             echo 'workflow_dispatch 이외의 이벤트에서는 session-only probe를 실행할 수 없습니다.' >&2
@@ -93,6 +99,10 @@ jobs:
           fi
           if [[ "$APPROVAL" != 'NON_PRODUCTION_AUTH_PROBE_APPROVED' ]]; then
             echo 'session-only probe 수동 승인이 없어 실행을 차단합니다.' >&2
+            exit 1
+          fi
+          if [[ ! "$RUNNER_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo 'runner SHA는 40자리 소문자 16진수여야 합니다.' >&2
             exit 1
           fi
           if [[ ! "$EXPECTED_SHA" =~ ^[0-9a-f]{40}$ ]]; then
@@ -140,6 +150,7 @@ jobs:
       AUTH_PROBE_ACTOR: ${{ github.actor }}
       AUTH_PROBE_TRIGGERING_ACTOR: ${{ github.triggering_actor }}
       AUTH_PROBE_WORKFLOW_SHA: ${{ github.sha }}
+      AUTH_PROBE_RUNNER_SHA: ${{ inputs.runner_sha }}
       AUTH_PROBE_EXPECTED_SHA: ${{ inputs.expected_sha }}
       AUTH_PROBE_CONSUMER_DEPLOYMENT_ID: ${{ inputs.consumer_deployment_id }}
       AUTH_PROBE_SELLER_DEPLOYMENT_ID: ${{ inputs.seller_deployment_id }}
@@ -149,13 +160,13 @@ jobs:
       FIREBASE_PROJECT_ID: ${{ vars.ROUND_DIRECT_E2E_FIREBASE_PROJECT_ID }}
 
     steps:
-      - name: 지정 SHA checkout
+      - name: runner SHA checkout
         uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.expected_sha }}
+          ref: ${{ inputs.runner_sha }}
           fetch-depth: 0
 
-      - name: 수동 승인과 checkout SHA 확인
+      - name: 수동 승인과 runner checkout SHA 확인
         shell: bash
         env:
           APPROVAL: ${{ inputs.approval }}
@@ -181,15 +192,20 @@ jobs:
             echo 'session-only probe 수동 승인이 없어 실행을 차단합니다.' >&2
             exit 1
           fi
+          if [[ ! "$AUTH_PROBE_RUNNER_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo 'runner SHA는 40자리 소문자 16진수여야 합니다.' >&2
+            exit 1
+          fi
           if [[ ! "$AUTH_PROBE_EXPECTED_SHA" =~ ^[0-9a-f]{40}$ ]]; then
             echo '지정 SHA는 40자리 소문자 16진수여야 합니다.' >&2
             exit 1
           fi
           actual_sha="$(git rev-parse HEAD)"
-          if [[ "$actual_sha" != "$AUTH_PROBE_EXPECTED_SHA" ]]; then
-            echo 'checkout SHA가 지정 SHA와 달라 실행을 차단합니다.' >&2
+          if [[ "$actual_sha" != "$AUTH_PROBE_RUNNER_SHA" ]]; then
+            echo 'checkout SHA가 runner SHA와 달라 실행을 차단합니다.' >&2
             exit 1
           fi
+          printf 'AUTH_PROBE_CHECKOUT_SHA=%s\n' "$actual_sha" >> "$GITHUB_ENV"
 
       - uses: actions/setup-node@v6
         with:
@@ -372,7 +388,10 @@ jobs:
             --arg actor "$AUTH_PROBE_ACTOR" \
             --arg triggeringActor "$AUTH_PROBE_TRIGGERING_ACTOR" \
             --arg workflowSha "$AUTH_PROBE_WORKFLOW_SHA" \
+            --arg runnerSha "$AUTH_PROBE_RUNNER_SHA" \
             --arg expectedSha "$AUTH_PROBE_EXPECTED_SHA" \
+            --arg expectedFrontendSha "$AUTH_PROBE_EXPECTED_SHA" \
+            --arg checkoutSha "$AUTH_PROBE_CHECKOUT_SHA" \
             --arg consumerDeploymentId "$AUTH_PROBE_CONSUMER_DEPLOYMENT_ID" \
             --arg sellerDeploymentId "$AUTH_PROBE_SELLER_DEPLOYMENT_ID" \
             --arg driverDeploymentId "$AUTH_PROBE_DRIVER_DEPLOYMENT_ID" \
@@ -388,13 +407,17 @@ jobs:
               actor: $actor,
               triggeringActor: $triggeringActor,
               workflowSha: $workflowSha,
+              runnerSha: $runnerSha,
               expectedSha: $expectedSha,
+              expectedFrontendSha: $expectedFrontendSha,
+              checkoutSha: $checkoutSha,
               pinnedDeploymentIds: {
                 consumer: $consumerDeploymentId,
                 seller: $sellerDeploymentId,
                 driver: $driverDeploymentId
               },
               targetUrls: $targetUrls,
+              deploymentTargetUrls: $targetUrls,
               deploymentShas: $deploymentShas,
               deploymentReady: $deployment[0].ready,
               probeResult: $probe[0].result,

--- a/scripts/probe-auth-runtime.workflow.spec.mjs
+++ b/scripts/probe-auth-runtime.workflow.spec.mjs
@@ -47,9 +47,10 @@ describe('session-only workflow dispatch contract', () => {
     );
   });
 
-  it('workflow_dispatch exposes the exact five session inputs', () => {
+  it('workflow_dispatch exposes the exact six session inputs', () => {
     const source = readWorkflow();
     for (const input of [
+      'runner_sha:',
       'expected_sha:',
       'consumer_deployment_id:',
       'seller_deployment_id:',
@@ -102,19 +103,19 @@ describe('session-only workflow dispatch contract', () => {
     assert.ok(gateSlice.includes('permissions: {}'), 'approval preflight must use empty permissions');
   });
 
-  it('exact SHA checkout is enforced before any network call', () => {
+  it('runner SHA checkout is enforced before any network call', () => {
     const source = readWorkflow();
     assert.ok(
-      source.includes('ref: ${{ inputs.expected_sha }}'),
-      'session probe must checkout the exact input SHA',
+      source.includes('ref: ${{ inputs.runner_sha }}'),
+      'session probe must checkout the exact runner input SHA',
     );
     assert.ok(
       source.includes('git rev-parse HEAD'),
-      'checkout SHA must be compared against the input SHA',
+      'checkout SHA must be compared against the runner SHA',
     );
     assert.ok(
-      source.includes('checkout SHA가 지정 SHA와 달라 실행을 차단합니다.'),
-      'SHA mismatch must fail closed with an explicit message',
+      source.includes('checkout SHA가 runner SHA와 달라 실행을 차단합니다.'),
+      'runner checkout mismatch must fail closed with an explicit message',
     );
   });
 
@@ -246,6 +247,180 @@ describe('session-only runtime boundary', () => {
     assert.ok(
       source.includes('auth-session-probe-'),
       'evidence artifact must use the session-only artifact name',
+    );
+  });
+});
+
+describe('runner/target SHA decoupling (PILOT-AUTH-PROBE-RUNNER-TARGET-SHA-DECOUPLE-17)', () => {
+  function sessionSlice(source) {
+    const start = source.indexOf('session-probe:');
+    assert.ok(start >= 0, 'workflow must contain the session-probe job');
+    const end = source.indexOf('callback-probe:');
+    return source.slice(start, end >= 0 ? end : source.length);
+  }
+
+  it('distinct runner_sha and expected_sha inputs are both required (no equality coupling)', () => {
+    const source = readWorkflow();
+    const dispatchStart = source.indexOf('workflow_dispatch:');
+    const dispatchEnd = source.indexOf('pull_request:');
+    assert.ok(dispatchStart >= 0 && dispatchEnd > dispatchStart, 'workflow must declare dispatch inputs');
+    const inputsBlock = source.slice(dispatchStart, dispatchEnd);
+    assert.ok(inputsBlock.includes('runner_sha:'), 'workflow_dispatch must declare runner_sha');
+    assert.ok(inputsBlock.includes('expected_sha:'), 'workflow_dispatch must declare expected_sha');
+    const requiredCount = (inputsBlock.match(/required:\s*true/g) ?? []).length;
+    assert.ok(
+      requiredCount >= 6,
+      `all six session inputs must be required (found ${requiredCount})`,
+    );
+    for (const line of source.split('\n')) {
+      assert.ok(
+        !(line.includes('RUNNER_SHA') && line.includes('EXPECTED_SHA')),
+        `no step may couple runner and frontend SHAs by equality: ${line.trim().slice(0, 120)}`,
+      );
+    }
+  });
+
+  it('checkout authority is runner_sha, never expected_sha', () => {
+    const slice = sessionSlice(readWorkflow());
+    assert.ok(
+      slice.includes('ref: ${{ inputs.runner_sha }}'),
+      'session-probe checkout must follow inputs.runner_sha',
+    );
+    assert.ok(
+      !slice.includes('ref: ${{ inputs.expected_sha }}'),
+      'session-probe checkout must never follow inputs.expected_sha',
+    );
+  });
+
+  it('deployment verifier authority is expected_sha, never runner_sha', () => {
+    const slice = sessionSlice(readWorkflow());
+    assert.ok(
+      slice.includes('--sha="$AUTH_PROBE_EXPECTED_SHA"'),
+      'wait-preview-deploy binding must follow the frontend expected SHA',
+    );
+    assert.ok(
+      !slice.includes('--sha="$AUTH_PROBE_RUNNER_SHA"'),
+      'deployment verifier must never bind the runner SHA',
+    );
+    assert.ok(
+      slice.includes('--expected-sha="$AUTH_PROBE_EXPECTED_SHA"'),
+      'probe runner binding must follow the frontend expected SHA',
+    );
+  });
+
+  it('malformed runner_sha fails closed', () => {
+    const source = readWorkflow();
+    assert.ok(
+      source.includes('if [[ ! "$RUNNER_SHA" =~ ^[0-9a-f]{40}$ ]]'),
+      'approval preflight must validate the runner SHA format',
+    );
+    assert.ok(
+      source.includes('if [[ ! "$AUTH_PROBE_RUNNER_SHA" =~ ^[0-9a-f]{40}$ ]]'),
+      'session-probe must re-validate the runner SHA format before checkout use',
+    );
+    assert.ok(
+      source.includes('runner SHA는 40자리 소문자 16진수여야 합니다.'),
+      'malformed runner SHA must fail closed with an explicit message',
+    );
+  });
+
+  it('malformed expected_sha fails closed', () => {
+    const source = readWorkflow();
+    assert.ok(
+      source.includes('if [[ ! "$EXPECTED_SHA" =~ ^[0-9a-f]{40}$ ]]'),
+      'approval preflight must validate the frontend SHA format',
+    );
+    assert.ok(
+      source.includes('if [[ ! "$AUTH_PROBE_EXPECTED_SHA" =~ ^[0-9a-f]{40}$ ]]'),
+      'session-probe must re-validate the frontend SHA format',
+    );
+    assert.ok(
+      source.includes('지정 SHA는 40자리 소문자 16진수여야 합니다.'),
+      'malformed frontend SHA must fail closed with an explicit message',
+    );
+  });
+
+  it('runner checkout mismatch fails closed and records the checkout SHA', () => {
+    const slice = sessionSlice(readWorkflow());
+    assert.ok(
+      slice.includes('if [[ "$actual_sha" != "$AUTH_PROBE_RUNNER_SHA" ]]'),
+      'checkout SHA must be compared against the runner SHA',
+    );
+    assert.ok(
+      slice.includes('checkout SHA가 runner SHA와 달라 실행을 차단합니다.'),
+      'runner checkout mismatch must fail closed with an explicit message',
+    );
+    assert.ok(
+      slice.includes('AUTH_PROBE_CHECKOUT_SHA='),
+      'verified checkout SHA must be recorded for evidence',
+    );
+  });
+
+  it('frontend deployment SHA mismatch still fails closed via exact binding', () => {
+    const slice = sessionSlice(readWorkflow());
+    assert.ok(
+      slice.includes('--sha="$AUTH_PROBE_EXPECTED_SHA"'),
+      'deployment binding must keep the exact frontend SHA',
+    );
+    assert.ok(
+      slice.includes('exit "$wait_status"'),
+      'deployment verifier exit status must propagate fail-closed',
+    );
+    assert.ok(
+      slice.includes('evidence/deployment.json'),
+      'deployment evidence must still be written before the fail-closed exit',
+    );
+  });
+
+  it('workflow summary separates runner and frontend SHA evidence', () => {
+    const slice = sessionSlice(readWorkflow());
+    for (const flag of [
+      '--arg runnerSha "$AUTH_PROBE_RUNNER_SHA"',
+      '--arg expectedSha "$AUTH_PROBE_EXPECTED_SHA"',
+      '--arg expectedFrontendSha "$AUTH_PROBE_EXPECTED_SHA"',
+      '--arg checkoutSha "$AUTH_PROBE_CHECKOUT_SHA"',
+      '--arg workflowSha "$AUTH_PROBE_WORKFLOW_SHA"',
+    ]) {
+      assert.ok(slice.includes(flag), `workflow summary must bind ${flag}`);
+    }
+    for (const field of [
+      'runnerSha: $runnerSha',
+      'expectedSha: $expectedSha',
+      'expectedFrontendSha: $expectedFrontendSha',
+      'checkoutSha: $checkoutSha',
+      'workflowSha: $workflowSha',
+      'pinnedDeploymentIds:',
+      'deploymentShas:',
+      'deploymentTargetUrls:',
+    ]) {
+      assert.ok(slice.includes(field), `workflow summary must record ${field}`);
+    }
+  });
+
+  it('new evidence fields leak no secret/token/password/raw body', () => {
+    const slice = sessionSlice(readWorkflow());
+    for (const line of slice.split('\n')) {
+      if (!/runnerSha|checkoutSha|expectedFrontendSha|RUNNER_SHA|CHECKOUT_SHA/.test(line)) continue;
+      for (const sensitive of [
+        'SECRET',
+        'PASSWORD',
+        'TOKEN',
+        'COOKIE',
+        'SERVICE_ACCOUNT',
+        'CREDENTIAL_JSON',
+        'accessToken',
+        'refreshToken',
+        'set-cookie',
+      ]) {
+        assert.ok(
+          !line.includes(sensitive),
+          `decoupled SHA evidence must not reference ${sensitive}: ${line.trim().slice(0, 120)}`,
+        );
+      }
+    }
+    assert.ok(
+      !slice.includes('AUTH_PROBE_RUNNER_TOKEN') && !slice.includes('AUTH_PROBE_RUNNER_SECRET'),
+      'runner evidence must introduce no new credential-shaped names',
     );
   });
 });


### PR DESCRIPTION
TASK_ID: PILOT-AUTH-PROBE-RUNNER-TARGET-SHA-DECOUPLE-17. Session-only probe runner checkout authority moves from expected_sha to new required input runner_sha; frontend deployment binding stays EXACT_SHA_BINDING on expected_sha (c70743d READY deployments reusable). Evidence separates runnerSha/checkoutSha/expectedFrontendSha/workflowSha. Deterministic specs: 58/58 auth-runtime (49 baseline + 9 new), 83/83 incl. callback suites. No app/API/provider/Vercel/secret mutation; no live probe dispatch.