### PR TITLE
feat(auth-probe): invocation-owned 3-role identity lifecycle for staging probe

### DIFF
--- a/.github/workflows/probe-auth-runtime.yml
+++ b/.github/workflows/probe-auth-runtime.yml
@@ -37,6 +37,8 @@ on:
       - scripts/probe-consumer-callback.mjs
       - scripts/probe-consumer-callback.spec.mjs
       - scripts/probe-consumer-callback.workflow.spec.mjs
+      - scripts/probe-auth-identities.mjs
+      - scripts/probe-auth-identities.spec.mjs
       - .github/workflows/probe-auth-runtime.yml
 
 permissions:
@@ -55,7 +57,7 @@ jobs:
           node-version: '22'
 
       - name: run probe deterministic spec (mock/local only, no external calls)
-        run: node --test scripts/probe-auth-runtime.spec.mjs scripts/probe-auth-runtime.workflow.spec.mjs scripts/probe-consumer-callback.spec.mjs scripts/probe-consumer-callback.workflow.spec.mjs
+        run: node --test scripts/probe-auth-runtime.spec.mjs scripts/probe-auth-runtime.workflow.spec.mjs scripts/probe-consumer-callback.spec.mjs scripts/probe-consumer-callback.workflow.spec.mjs scripts/probe-auth-identities.spec.mjs
 
   approval_gate:
     name: session-only probe approval preflight
@@ -119,6 +121,153 @@ jobs:
             fi
           done
 
+  auth_identity_seed:
+    name: auth probe identity seed (3-role, invocation-owned)
+    # Bounded identity lifecycle (PILOT-AUTH-PROBE-IDENTITY-LIFECYCLE-26A):
+    # approval_gate -> auth_identity_seed -> session-probe/callback-probe
+    # -> auth_identity_cleanup(always). This job prepares exactly 3 owned
+    # user docs (consumer/seller/driver) in the staging dataset
+    # greenhub-round-direct-e2e via scripts/probe-auth-identities.mjs. It
+    # never runs the full round-direct fixture seed and never creates
+    # products/orders/saleRounds/storage objects or a production store.
+    # Credential source reuses only the approved chromium Environment
+    # secrets (mapped to TEST_* env below); no new secret is introduced.
+    # Service-account usage is scoped to this job and the cleanup job only;
+    # session/callback probe jobs never handle raw service-account material.
+    needs: approval_gate
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    concurrency:
+      group: auth-probe-identities
+      cancel-in-progress: false
+    environment:
+      name: round-direct-e2e
+    permissions:
+      contents: read
+    env:
+      AUTH_PROBE_IDENTITY_RUN_ID: auth-probe-${{ github.run_id }}-${{ github.run_attempt }}
+      AUTH_PROBE_RUNNER_SHA: ${{ inputs.runner_sha }}
+      AUTH_PROBE_EXPECTED_SHA: ${{ inputs.expected_sha }}
+      ROUND_DIRECT_E2E_ENABLED: 'true'
+      ROUND_DIRECT_E2E_ENV: preview
+      NODE_ENV: test
+      VERCEL_ENV: preview
+      RAILWAY_ENVIRONMENT_NAME: staging
+      FIREBASE_PROJECT_ID: ${{ vars.ROUND_DIRECT_E2E_FIREBASE_PROJECT_ID }}
+      ROUND_DIRECT_E2E_ALLOWED_FIREBASE_PROJECTS: ${{ vars.ROUND_DIRECT_E2E_ALLOWED_FIREBASE_PROJECTS }}
+    steps:
+      - name: runner SHA checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.runner_sha }}
+          fetch-depth: 0
+
+      - name: 수동 승인과 runner checkout SHA 확인
+        shell: bash
+        env:
+          APPROVAL: ${{ inputs.approval }}
+          EVENT_NAME: ${{ github.event_name }}
+          ACTOR: ${{ github.actor }}
+          TRIGGERING_ACTOR: ${{ github.triggering_actor }}
+          REPOSITORY_OWNER: ${{ github.repository_owner }}
+        run: |
+          set -euo pipefail
+          if [[ "$EVENT_NAME" != 'workflow_dispatch' ]]; then
+            echo 'workflow_dispatch 이외의 이벤트에서는 auth probe identity를 준비할 수 없습니다.' >&2
+            exit 1
+          fi
+          if [[ "$ACTOR" != "$REPOSITORY_OWNER" ]]; then
+            echo 'workflow 실행자가 repository owner와 달라 실행을 차단합니다.' >&2
+            exit 1
+          fi
+          if [[ "$TRIGGERING_ACTOR" != "$REPOSITORY_OWNER" ]]; then
+            echo 'workflow triggering actor가 repository owner와 달라 실행을 차단합니다.' >&2
+            exit 1
+          fi
+          if [[ "$APPROVAL" != 'NON_PRODUCTION_AUTH_PROBE_APPROVED' ]]; then
+            echo 'auth probe 수동 승인이 없어 실행을 차단합니다.' >&2
+            exit 1
+          fi
+          if [[ ! "$AUTH_PROBE_RUNNER_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo 'runner SHA는 40자리 소문자 16진수여야 합니다.' >&2
+            exit 1
+          fi
+          actual_sha="$(git rev-parse HEAD)"
+          if [[ "$actual_sha" != "$AUTH_PROBE_RUNNER_SHA" ]]; then
+            echo 'checkout SHA가 runner SHA와 달라 실행을 차단합니다.' >&2
+            exit 1
+          fi
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - uses: pnpm/action-setup@v6
+
+      - name: 의존성 설치 (identity seed only)
+        run: pnpm install --frozen-lockfile
+
+      - name: auth probe identities seed/verify (3-role, non-production only)
+        shell: bash
+        env:
+          NON_PRODUCTION_AUTH_PROBE_APPROVAL: ${{ inputs.approval }}
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.ROUND_DIRECT_E2E_FIREBASE_SERVICE_ACCOUNT_JSON }}
+          TEST_CONSUMER_EMAIL: ${{ secrets.ROUND_DIRECT_E2E_CONSUMER_EMAIL_CHROMIUM }}
+          TEST_CONSUMER_PASSWORD: ${{ secrets.ROUND_DIRECT_E2E_CONSUMER_PASSWORD_CHROMIUM }}
+          TEST_SELLER_EMAIL: ${{ secrets.ROUND_DIRECT_E2E_SELLER_EMAIL_CHROMIUM }}
+          TEST_SELLER_PASSWORD: ${{ secrets.ROUND_DIRECT_E2E_SELLER_PASSWORD_CHROMIUM }}
+          TEST_DRIVER_EMAIL: ${{ secrets.ROUND_DIRECT_E2E_DRIVER_EMAIL_CHROMIUM }}
+          TEST_DRIVER_PASSWORD: ${{ secrets.ROUND_DIRECT_E2E_DRIVER_PASSWORD_CHROMIUM }}
+        run: |
+          set -euo pipefail
+          # Secret-name mapping note (values never logged):
+          # - FIREBASE_SERVICE_ACCOUNT_JSON <- ROUND_DIRECT_E2E_FIREBASE_SERVICE_ACCOUNT_JSON
+          # - TEST_* per-role identity <- approved chromium Environment secrets
+          # Target guard (enabled/preview/non-production/staging project/
+          # allowlist/service-account match) runs inside the script before
+          # any Firestore mutation. No product/order/round/storage seed.
+          evidence_root=".artifacts/auth-probe-identities/$AUTH_PROBE_IDENTITY_RUN_ID"
+          mkdir -p "$evidence_root/evidence"
+          set +e
+          node scripts/probe-auth-identities.mjs \
+            seed \
+            --run-id="$AUTH_PROBE_IDENTITY_RUN_ID" \
+            --manifest="$evidence_root/evidence/identity-manifest.json" \
+            > "$evidence_root/seed-raw.json"
+          seed_status=$?
+          set -e
+          if [[ ! -s "$evidence_root/seed-raw.json" ]]; then
+            echo 'identity seed 요약을 만들지 못해 실행을 차단합니다.' >&2
+            exit 1
+          fi
+          jq '{
+            action,
+            runId,
+            ready,
+            evidence: (.evidence | {
+              purpose,
+              runId,
+              documentPaths,
+              storeIdPresent,
+              storeIdIsProduction,
+              roles,
+              failureCodes
+            })
+            }' \
+            "$evidence_root/seed-raw.json" \
+            > "$evidence_root/evidence/identity-summary.json"
+          exit "$seed_status"
+
+      - name: 비민감 identity 증거 artifact 업로드
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: auth-probe-identities-${{ github.run_id }}-${{ github.run_attempt }}
+          path: .artifacts/auth-probe-identities/${{ env.AUTH_PROBE_IDENTITY_RUN_ID }}/evidence/
+          if-no-files-found: error
+          retention-days: 7
+
   session-probe:
     name: pinned Preview session-only auth probe
     # Session-only boundary: this job exercises ONLY the existing
@@ -129,7 +278,11 @@ jobs:
     # Negative fixture creation is out of scope: when no approved negative
     # identity is configured the evidence records
     # NEGATIVE_IDENTITY_NOT_CONFIGURED instead of failing the probe itself.
-    needs: approval_gate
+    # Identity lifecycle: this job runs ONLY after auth_identity_seed
+    # succeeds (owned 3-role identities exist in staging). It never handles
+    # raw service-account material; identity mutation lives only in the
+    # seed/cleanup jobs.
+    needs: auth_identity_seed
     if: ${{ github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -448,10 +601,12 @@ jobs:
     # with manual redirect -> same-context session readback). It never
     # invokes scripts/probe-auth-runtime.mjs, never widens that runner's
     # ALLOWED_API_PATHS, never merges network allowlists, and never calls
-    # seller/driver frontend origins. The session-probe job above is left
-    # untouched; this job needs only approval_gate so a session-probe
-    # failure cannot mask or block callback provenance evidence.
-    needs: approval_gate
+    # seller/driver frontend origins. Identity lifecycle: this job runs
+    # ONLY after auth_identity_seed succeeds (owned consumer identity
+    # exists in staging) and stays independent of session-probe so a
+    # session-probe failure cannot mask or block callback provenance
+    # evidence. It never handles raw service-account material.
+    needs: auth_identity_seed
     if: ${{ github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -763,5 +918,109 @@ jobs:
         with:
           name: auth-callback-probe-${{ github.run_id }}-${{ github.run_attempt }}
           path: .artifacts/auth-callback-probe/${{ env.AUTH_CALLBACK_RUN_ID }}/evidence/
+          if-no-files-found: error
+          retention-days: 7
+
+  auth_identity_cleanup:
+    name: auth probe identity cleanup (always, owned-only)
+    # Bounded lifecycle closeout: deletes ONLY invocation-owned
+    # auth-probe docs (purpose + runId match). Foreign docs are never
+    # deleted; missing docs are idempotent success. Runs always() even
+    # when seed/session/callback fail or are skipped, so partial seeds
+    # cannot leak staging identities. Manifest transfer uses only the
+    # redacted (non-sensitive) artifact: no password/hash/email/token/
+    # service-account material is ever persisted or logged.
+    needs: [auth_identity_seed, session-probe, callback-probe]
+    if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    concurrency:
+      group: auth-probe-identities
+      cancel-in-progress: false
+    environment:
+      name: round-direct-e2e
+    permissions:
+      contents: read
+    env:
+      AUTH_PROBE_IDENTITY_RUN_ID: auth-probe-${{ github.run_id }}-${{ github.run_attempt }}
+      AUTH_PROBE_RUNNER_SHA: ${{ inputs.runner_sha }}
+      ROUND_DIRECT_E2E_ENABLED: 'true'
+      ROUND_DIRECT_E2E_ENV: preview
+      NODE_ENV: test
+      VERCEL_ENV: preview
+      RAILWAY_ENVIRONMENT_NAME: staging
+      FIREBASE_PROJECT_ID: ${{ vars.ROUND_DIRECT_E2E_FIREBASE_PROJECT_ID }}
+      ROUND_DIRECT_E2E_ALLOWED_FIREBASE_PROJECTS: ${{ vars.ROUND_DIRECT_E2E_ALLOWED_FIREBASE_PROJECTS }}
+    steps:
+      - name: runner SHA checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.runner_sha }}
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - uses: pnpm/action-setup@v6
+
+      - name: 의존성 설치 (identity cleanup only)
+        run: pnpm install --frozen-lockfile
+
+      - name: identity manifest 복원 (non-sensitive artifact only)
+        continue-on-error: true
+        uses: actions/download-artifact@v7
+        with:
+          name: auth-probe-identities-${{ github.run_id }}-${{ github.run_attempt }}
+          path: .artifacts/auth-probe-identities/${{ env.AUTH_PROBE_IDENTITY_RUN_ID }}/evidence/
+
+      - name: auth probe identities cleanup + verification (owned-only, idempotent)
+        shell: bash
+        env:
+          NON_PRODUCTION_AUTH_PROBE_APPROVAL: ${{ inputs.approval }}
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.ROUND_DIRECT_E2E_FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          set -euo pipefail
+          # No secret values are logged. Manifest holds only redacted
+          # paths/roles/namespaced storeId/_e2e markers (see seed job).
+          evidence_root=".artifacts/auth-probe-identities/$AUTH_PROBE_IDENTITY_RUN_ID"
+          mkdir -p "$evidence_root/evidence"
+          manifest="$evidence_root/evidence/identity-manifest.json"
+          if [[ ! -f "$manifest" ]]; then
+            printf '{"action":"cleanup","runId":"%s","status":"not-seeded"}\n' "$AUTH_PROBE_IDENTITY_RUN_ID" \
+              > "$evidence_root/evidence/cleanup-summary.json"
+            printf 'identity manifest가 없어 cleanup을 건너뜁니다 (not-seeded).\n'
+            exit 0
+          fi
+          set +e
+          node scripts/probe-auth-identities.mjs \
+            cleanup \
+            --manifest="$manifest" \
+            > "$evidence_root/cleanup-raw.json"
+          cleanup_status=$?
+          set -e
+          if [[ ! -s "$evidence_root/cleanup-raw.json" ]]; then
+            echo 'identity cleanup 요약을 만들지 못해 실행을 차단합니다.' >&2
+            exit 1
+          fi
+          jq '{
+            action,
+            runId,
+            ready,
+            deleted,
+            skippedForeign,
+            missing,
+            remainingOwned
+            }' \
+            "$evidence_root/cleanup-raw.json" \
+            > "$evidence_root/evidence/cleanup-summary.json"
+          exit "$cleanup_status"
+
+      - name: 비민감 cleanup 증거 artifact 업로드
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: auth-probe-identities-cleanup-${{ github.run_id }}-${{ github.run_attempt }}
+          path: .artifacts/auth-probe-identities/${{ env.AUTH_PROBE_IDENTITY_RUN_ID }}/evidence/
           if-no-files-found: error
           retention-days: 7

--- a/.github/workflows/probe-auth-runtime.yml
+++ b/.github/workflows/probe-auth-runtime.yml
@@ -48,13 +48,18 @@ jobs:
   probe-spec:
     name: probe runner deterministic spec
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
 
       - uses: actions/setup-node@v6
         with:
           node-version: '22'
+
+      - uses: pnpm/action-setup@v6
+
+      - name: 의존성 설치 (deterministic spec bcrypt/fixture parity)
+        run: pnpm install --frozen-lockfile
 
       - name: run probe deterministic spec (mock/local only, no external calls)
         run: node --test scripts/probe-auth-runtime.spec.mjs scripts/probe-auth-runtime.workflow.spec.mjs scripts/probe-consumer-callback.spec.mjs scripts/probe-consumer-callback.workflow.spec.mjs scripts/probe-auth-identities.spec.mjs

--- a/scripts/probe-auth-identities.mjs
+++ b/scripts/probe-auth-identities.mjs
@@ -1,0 +1,673 @@
+/**
+ * PILOT-AUTH-PROBE-IDENTITY-LIFECYCLE-26A — invocation-owned 3-role identity lifecycle.
+ *
+ * Purpose:
+ * - Prepare exactly 3 test identities (consumer/seller/driver) in the
+ *   non-production staging dataset (greenhub-round-direct-e2e) before the
+ *   session + callback probes, then always clean them up.
+ * - Bounded lifecycle per probe invocation:
+ *     approval -> exact non-production target guard -> seed/verify
+ *     -> session + callback jobs -> always cleanup -> cleanup verification
+ * - This source task implements + deterministically verifies the lifecycle.
+ *   It does NOT dispatch the real auth/callback probe.
+ *
+ * Credential source (no new secrets):
+ * - Workflow maps the approved Environment chromium secrets to TEST_* env:
+ *     TEST_CONSUMER_EMAIL / TEST_CONSUMER_PASSWORD
+ *     TEST_SELLER_EMAIL / TEST_SELLER_PASSWORD
+ *     TEST_DRIVER_EMAIL / TEST_DRIVER_PASSWORD
+ *   which originate from:
+ *     ROUND_DIRECT_E2E_CONSUMER_EMAIL_CHROMIUM (+PASSWORD)
+ *     ROUND_DIRECT_E2E_SELLER_EMAIL_CHROMIUM (+PASSWORD)
+ *     ROUND_DIRECT_E2E_DRIVER_EMAIL_CHROMIUM (+PASSWORD)
+ * - Secret values are never logged, never serialized into manifests/evidence.
+ *
+ * User document schema (read from current main):
+ * - apps/api/src/auth/auth.service.ts — register() stores bcrypt(password,12),
+ *   role, providers:['email'], driverApproved:false for driver at creation,
+ *   login() requires bcrypt.compare, rejects suspended===true, rejects
+ *   driver with driverApproved!==true. No store existence check on login.
+ * - scripts/round-direct-e2e-fixtures.mjs buildFixtureManifest() — consumer:
+ *   role/passwordHash/providers, seller: + storeId (namespaced, never the
+ *   production store), driver: + driverApproved:true. _e2e ownership tag.
+ * - This lifecycle reuses that account/user construction at a small-helper
+ *   level only. It never runs the full round-direct fixture seed and never
+ *   creates products/orders/saleRounds/storage objects or a production store.
+ *
+ * Seller store binding contract (minimal, probe-valid):
+ * - seller doc MUST contain a non-empty string storeId
+ *   (probe-auth-runtime.mjs validateLoginUser requires 'storeId' in user).
+ * - storeId MUST be invocation-namespaced (`<runId>-store`), MUST NOT equal
+ *   the production store, MUST NOT be empty. No store document is created:
+ *   the API login path does not validate store existence, and creating
+ *   store/products would widen this lifecycle beyond the 3 user docs.
+ *
+ * Ownership / collision safety:
+ * - Every doc carries _e2e = { purpose:'auth-probe', runId, role }.
+ * - Same-email unrelated user (different purpose/runId or no marker) causes
+ *   fail-closed IDENTITY_COLLISION — never overwritten.
+ * - Cleanup deletes ONLY docs whose _e2e.purpose/runId match the manifest.
+ *   Foreign docs are skipped, missing docs are idempotent success.
+ * - Partial seed failure cleans up already-created owned docs.
+ *
+ * Target safety (fail-closed before any mutation):
+ * - ROUND_DIRECT_E2E_ENABLED must be 'true'.
+ * - ROUND_DIRECT_E2E_ENV must be 'preview' and NODE/VERCEL/RAILWAY must not
+ *   be 'production'.
+ * - FIREBASE_PROJECT_ID must equal greenhub-round-direct-e2e (never
+ *   green-e4fe3) and must be in the allowed list.
+ * - Service-account project_id must equal FIREBASE_PROJECT_ID (reuses
+ *   inspectFirebaseServiceAccount from check-round-direct-e2e-readiness.mjs).
+ *
+ * Secret-safe evidence:
+ * - Manifests persisted to artifacts are redacted: email/password/
+ *   passwordHash/accountEmails are structurally removed. Only doc paths,
+ *   roles, storeId strings (namespaced, non-sensitive), booleans, and
+ *   _e2e markers remain.
+ * - verify/cleanup outputs contain only booleans/counts/paths/codes.
+ *
+ * Usage (real run — NOT executed in this source task):
+ *   node scripts/probe-auth-identities.mjs seed --run-id=<runId> --manifest=<path>
+ *   node scripts/probe-auth-identities.mjs verify --manifest=<path>
+ *   node scripts/probe-auth-identities.mjs cleanup --manifest=<path>
+ */
+
+import { inspectFirebaseServiceAccount } from './check-round-direct-e2e-readiness.mjs';
+
+export const APPROVAL_VALUE = 'NON_PRODUCTION_AUTH_PROBE_APPROVED';
+export const PRODUCTION_FIREBASE_PROJECT = 'green-e4fe3';
+export const TARGET_FIREBASE_PROJECT = 'greenhub-round-direct-e2e';
+export const PRODUCTION_STORE_ID = '80189070-2c3d-45f2-bc11-68a870b13951';
+export const IDENTITY_PURPOSE = 'auth-probe';
+export const ROLES = Object.freeze(['consumer', 'seller', 'driver']);
+
+const RUN_ID_PATTERN = /^[a-z0-9][a-z0-9-]{6,46}[a-z0-9]$/;
+const BCRYPT_HASH_PATTERN = /^\$2[aby]\$\d{2}\$.{53}$/;
+
+export class IdentityContractError extends Error {
+  constructor(code, message, details) {
+    super(message);
+    this.name = 'IdentityContractError';
+    this.code = code;
+    if (details !== undefined) {
+      this.details = details;
+    }
+  }
+}
+
+function fail(code, message, details) {
+  throw new IdentityContractError(code, message, details);
+}
+
+function isNonEmptyString(value) {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function splitList(value) {
+  if (Array.isArray(value)) return value.map(String).map((s) => s.trim()).filter(Boolean);
+  if (typeof value !== 'string') return [];
+  return value.split(',').map((s) => s.trim()).filter(Boolean);
+}
+
+export function normalizeRunId(value) {
+  const runId = String(value ?? '').trim();
+  if (!RUN_ID_PATTERN.test(runId)) {
+    fail('RUN_ID_INVALID', 'auth probe run ID 형식이 올바르지 않습니다.');
+  }
+  return runId;
+}
+
+function readServiceAccountRaw(options = {}, env = process.env) {
+  if (isNonEmptyString(options.serviceAccountJson)) return options.serviceAccountJson;
+  // Approved Environment secret reuse: the round-direct Environment exposes
+  // the staging service account under this name; the generic name is kept as
+  // a fallback for local/diagnostic parity. No new secret is introduced.
+  if (isNonEmptyString(env.ROUND_DIRECT_E2E_FIREBASE_SERVICE_ACCOUNT_JSON)) {
+    return env.ROUND_DIRECT_E2E_FIREBASE_SERVICE_ACCOUNT_JSON;
+  }
+  if (isNonEmptyString(env.FIREBASE_SERVICE_ACCOUNT_JSON)) return env.FIREBASE_SERVICE_ACCOUNT_JSON;
+  return '';
+}
+
+/**
+ * Fail-closed non-production target guard. No network, no mutation.
+ * Reuses inspectFirebaseServiceAccount() from the verified readiness guard.
+ */
+export function validateIdentityTarget(options = {}, env = process.env) {
+  const approval = String(options.approval ?? env.NON_PRODUCTION_AUTH_PROBE_APPROVAL ?? env.APPROVAL ?? '').trim();
+  if (approval !== APPROVAL_VALUE) {
+    fail('MISSING_APPROVAL', 'explicit non-production approval이 없어 identity lifecycle을 차단합니다.');
+  }
+  const enabled = String(options.enabled ?? env.ROUND_DIRECT_E2E_ENABLED ?? '').trim();
+  if (enabled !== 'true') {
+    fail('E2E_NOT_ENABLED', 'ROUND_DIRECT_E2E_ENABLED가 true가 아닙니다.');
+  }
+  const environment = String(options.environment ?? env.ROUND_DIRECT_E2E_ENV ?? '').trim();
+  if (environment !== 'preview') {
+    fail('ENVIRONMENT_NOT_PREVIEW', '실행 환경이 preview가 아닙니다.');
+  }
+  const nodeEnv = String(options.nodeEnv ?? env.NODE_ENV ?? '').trim();
+  const vercelEnv = String(options.vercelEnv ?? env.VERCEL_ENV ?? '').trim();
+  const railwayEnv = String(options.railwayEnvironment ?? env.RAILWAY_ENVIRONMENT_NAME ?? '').trim();
+  if (nodeEnv === 'production' || vercelEnv === 'production' || railwayEnv === 'production') {
+    fail('PRODUCTION_ENVIRONMENT', 'production runtime marker가 있어 identity lifecycle을 차단합니다.');
+  }
+  const firebaseProjectId = String(options.firebaseProjectId ?? env.FIREBASE_PROJECT_ID ?? '').trim();
+  if (!firebaseProjectId) {
+    fail('FIREBASE_TARGET_MISSING', 'Firebase 비운영 대상 project ID가 없습니다.');
+  }
+  if (firebaseProjectId === PRODUCTION_FIREBASE_PROJECT) {
+    fail('PRODUCTION_FIREBASE_PROJECT', '운영 Firebase project는 사용할 수 없습니다.');
+  }
+  if (firebaseProjectId !== TARGET_FIREBASE_PROJECT) {
+    fail('FIREBASE_PROJECT_NOT_ALLOWED', 'Firebase project가 auth probe staging target과 다릅니다.');
+  }
+  const allowedRaw = options.allowedFirebaseProjects ?? env.ROUND_DIRECT_E2E_ALLOWED_FIREBASE_PROJECTS ?? '';
+  const allowed = splitList(allowedRaw);
+  if (allowed.length === 0) {
+    fail('FIREBASE_ALLOWED_PROJECTS_MISSING', 'Firebase 비운영 허용 project 목록이 없습니다.');
+  }
+  if (!allowed.includes(firebaseProjectId)) {
+    fail('FIREBASE_PROJECT_NOT_ALLOWED', 'Firebase project가 비운영 허용 목록과 다릅니다.');
+  }
+  const serviceAccount = inspectFirebaseServiceAccount(readServiceAccountRaw(options, env));
+  if (!serviceAccount.configured) {
+    fail('FIREBASE_SERVICE_ACCOUNT_MISSING', 'Firebase 서비스 계정 자격이 없어 target identity를 확인할 수 없습니다.');
+  }
+  if (!serviceAccount.parseable) {
+    fail('FIREBASE_SERVICE_ACCOUNT_INVALID', 'Firebase 서비스 계정 자격 JSON을 해석할 수 없습니다.');
+  }
+  if (!serviceAccount.projectId) {
+    fail('FIREBASE_SERVICE_ACCOUNT_PROJECT_MISSING', 'Firebase 서비스 계정 project identity가 없습니다.');
+  }
+  if (serviceAccount.projectId === PRODUCTION_FIREBASE_PROJECT) {
+    fail('PRODUCTION_FIREBASE_SERVICE_ACCOUNT', '운영 Firebase 서비스 계정은 사용할 수 없습니다.');
+  }
+  if (serviceAccount.projectId !== firebaseProjectId) {
+    fail('FIREBASE_SERVICE_ACCOUNT_PROJECT_MISMATCH', '서비스 계정 project identity와 명시된 비운영 target이 다릅니다.');
+  }
+  return {
+    approval,
+    firebaseProjectId,
+    serviceAccountProjectId: serviceAccount.projectId,
+  };
+}
+
+export function resolveIdentityCredentials(options = {}, env = process.env) {
+  const consumerEmail = String(options.consumerEmail ?? env.TEST_CONSUMER_EMAIL ?? '').trim();
+  const consumerPassword = String(options.consumerPassword ?? env.TEST_CONSUMER_PASSWORD ?? '');
+  const sellerEmail = String(options.sellerEmail ?? env.TEST_SELLER_EMAIL ?? '').trim();
+  const sellerPassword = String(options.sellerPassword ?? env.TEST_SELLER_PASSWORD ?? '');
+  const driverEmail = String(options.driverEmail ?? env.TEST_DRIVER_EMAIL ?? '').trim();
+  const driverPassword = String(options.driverPassword ?? env.TEST_DRIVER_PASSWORD ?? '');
+  if (!isNonEmptyString(consumerEmail) || !consumerPassword) {
+    fail('CONSUMER_CREDENTIALS_MISSING', 'consumer test credential이 없어 identity seed를 차단합니다.');
+  }
+  if (!isNonEmptyString(sellerEmail) || !sellerPassword) {
+    fail('SELLER_CREDENTIALS_MISSING', 'seller test credential이 없어 identity seed를 차단합니다.');
+  }
+  if (!isNonEmptyString(driverEmail) || !driverPassword) {
+    fail('DRIVER_CREDENTIALS_MISSING', 'driver test credential이 없어 identity seed를 차단합니다.');
+  }
+  const lowered = [consumerEmail.toLowerCase(), sellerEmail.toLowerCase(), driverEmail.toLowerCase()];
+  if (new Set(lowered).size !== 3) {
+    fail('IDENTITY_EMAIL_COLLISION', '세 role의 test email이 서로 달라야 합니다.');
+  }
+  return {
+    consumer: { email: consumerEmail, password: consumerPassword },
+    seller: { email: sellerEmail, password: sellerPassword },
+    driver: { email: driverEmail, password: driverPassword },
+  };
+}
+
+export async function hashPassword(password) {
+  if (typeof password !== 'string' || !password) {
+    fail('PASSWORD_MISSING', 'password가 없어 hash를 만들 수 없습니다.');
+  }
+  const bcrypt = await import('bcrypt');
+  const impl = bcrypt.default ?? bcrypt;
+  return impl.hash(password, 12);
+}
+
+export function isBcryptHash(value) {
+  return typeof value === 'string' && BCRYPT_HASH_PATTERN.test(value);
+}
+
+function sellerStoreIdFor(runId, override) {
+  if (override !== undefined) {
+    const candidate = String(override).trim();
+    if (!candidate) fail('SELLER_STORE_BINDING_INVALID', 'seller store binding이 비어 있습니다.');
+    if (candidate === PRODUCTION_STORE_ID) fail('PRODUCTION_STORE', '운영 store는 사용할 수 없습니다.');
+    if (!candidate.startsWith(`${runId}-`)) {
+      fail('SELLER_STORE_BINDING_INVALID', 'seller store binding이 invocation namespace 밖입니다.');
+    }
+    return candidate;
+  }
+  const storeId = `${runId}-store`;
+  if (storeId === PRODUCTION_STORE_ID) fail('PRODUCTION_STORE', '운영 store는 사용할 수 없습니다.');
+  return storeId;
+}
+
+/**
+ * Small-helper reuse of the round-direct account/user construction:
+ * consumer/seller/driver docs with bcrypt passwordHash, providers, role,
+ * seller storeId, driver driverApproved. No products/orders/rounds/storage.
+ */
+export function buildAuthProbeManifest({ runId, emails, passwordHashes, sellerStoreId } = {}) {
+  const normalizedRunId = normalizeRunId(runId);
+  for (const role of ROLES) {
+    if (!isNonEmptyString(emails?.[role])) {
+      fail('IDENTITY_EMAIL_MISSING', `${role} email이 없어 manifest를 만들 수 없습니다.`);
+    }
+    if (typeof passwordHashes?.[role] !== 'string' || !passwordHashes[role]) {
+      fail('IDENTITY_HASH_MISSING', `${role} passwordHash가 없어 manifest를 만들 수 없습니다.`);
+    }
+  }
+  const lowered = ROLES.map((role) => String(emails[role]).trim().toLowerCase());
+  if (new Set(lowered).size !== 3) {
+    fail('IDENTITY_EMAIL_COLLISION', '세 role의 email이 서로 달라야 합니다.');
+  }
+  const storeId = sellerStoreIdFor(normalizedRunId, sellerStoreId);
+  const now = new Date().toISOString();
+  const tagFor = (role) => ({ purpose: IDENTITY_PURPOSE, runId: normalizedRunId, role });
+  const documents = [
+    {
+      path: `users/${normalizedRunId}-consumer`,
+      data: {
+        id: `${normalizedRunId}-consumer`,
+        email: String(emails.consumer).trim(),
+        name: 'Auth Probe Consumer',
+        role: 'consumer',
+        passwordHash: passwordHashes.consumer,
+        providers: ['email'],
+        savedAddresses: [],
+        createdAt: now,
+        updatedAt: now,
+        _e2e: tagFor('consumer'),
+      },
+    },
+    {
+      path: `users/${normalizedRunId}-seller`,
+      data: {
+        id: `${normalizedRunId}-seller`,
+        email: String(emails.seller).trim(),
+        name: 'Auth Probe Seller',
+        role: 'seller',
+        storeId,
+        passwordHash: passwordHashes.seller,
+        providers: ['email'],
+        savedAddresses: [],
+        createdAt: now,
+        updatedAt: now,
+        _e2e: tagFor('seller'),
+      },
+    },
+    {
+      path: `users/${normalizedRunId}-driver`,
+      data: {
+        id: `${normalizedRunId}-driver`,
+        email: String(emails.driver).trim(),
+        name: 'Auth Probe Driver',
+        role: 'driver',
+        driverApproved: true,
+        passwordHash: passwordHashes.driver,
+        providers: ['email'],
+        savedAddresses: [],
+        createdAt: now,
+        updatedAt: now,
+        _e2e: tagFor('driver'),
+      },
+    },
+  ];
+  return {
+    version: 1,
+    kind: 'auth-probe-identities',
+    purpose: IDENTITY_PURPOSE,
+    runId: normalizedRunId,
+    namespace: normalizedRunId,
+    storeId,
+    documentPaths: documents.map(({ path }) => path),
+    documents,
+  };
+}
+
+export function assertAuthProbeManifest(manifest) {
+  if (!manifest || typeof manifest !== 'object') fail('MANIFEST_INVALID', 'identity manifest가 올바르지 않습니다.');
+  const runId = normalizeRunId(manifest.runId);
+  if (manifest.purpose !== IDENTITY_PURPOSE) fail('MANIFEST_INVALID', 'identity manifest purpose가 올바르지 않습니다.');
+  if (!Array.isArray(manifest.documents) || manifest.documents.length !== 3) {
+    fail('MANIFEST_INVALID', 'identity manifest는 정확히 3개 문서를 가져야 합니다.');
+  }
+  const roles = new Set();
+  for (const entry of manifest.documents) {
+    if (!isNonEmptyString(entry?.path) || !entry?.data) fail('MANIFEST_INVALID', 'identity manifest 문서가 올바르지 않습니다.');
+    if (entry.data._e2e?.purpose !== IDENTITY_PURPOSE || entry.data._e2e?.runId !== runId) {
+      fail('MANIFEST_INVALID', 'identity manifest 소유 표식이 올바르지 않습니다.');
+    }
+    roles.add(entry.data.role);
+  }
+  if (roles.size !== 3 || !roles.has('consumer') || !roles.has('seller') || !roles.has('driver')) {
+    fail('MANIFEST_INVALID', 'identity manifest는 consumer/seller/driver 3 role이어야 합니다.');
+  }
+  return runId;
+}
+
+function isOwnedDoc(data, runId) {
+  return Boolean(data) && data._e2e?.purpose === IDENTITY_PURPOSE && data._e2e?.runId === runId;
+}
+
+async function findUserByEmail(adapter, email) {
+  if (typeof adapter.findUserByEmail === 'function') {
+    return adapter.findUserByEmail(email);
+  }
+  return null;
+}
+
+/**
+ * Seed exactly 3 owned user docs. Fail-closed on unrelated-email collision.
+ * Partial failure cleans up already-created owned docs from this invocation.
+ */
+export async function seedAuthProbeIdentities(adapter, manifest) {
+  const runId = assertAuthProbeManifest(manifest);
+  const created = [];
+  try {
+    for (const entry of manifest.documents) {
+      const existing = await adapter.getDoc(entry.path);
+      if (existing && !isOwnedDoc(existing, runId)) {
+        fail('IDENTITY_COLLISION', `다른 소유자의 identity 문서가 존재합니다: ${entry.path}.`, {
+          path: entry.path,
+        });
+      }
+      // Same-email unrelated user must never be overwritten. The path-level
+      // check above covers same-path collisions; the email scan covers the
+      // case where the same email lives under a different document id.
+      const collision = await findUserByEmail(adapter, entry.data.email);
+      if (collision && collision.path !== entry.path) {
+        const collisionOwned = isOwnedDoc(collision.data, runId);
+        if (!collisionOwned) {
+          fail('IDENTITY_COLLISION', '같은 email의 unrelated user가 있어 seed를 차단합니다.', {
+            path: entry.path,
+          });
+        }
+      }
+      if (existing && isOwnedDoc(existing, runId)) {
+        // Idempotent re-seed for the same invocation: refresh owned doc.
+        await adapter.setDoc(entry.path, entry.data);
+        if (!created.includes(entry.path)) created.push(entry.path);
+        continue;
+      }
+      await adapter.setDoc(entry.path, entry.data);
+      created.push(entry.path);
+    }
+  } catch (error) {
+    // Best-effort bounded cleanup of docs created by this invocation only.
+    for (const docPath of [...created].reverse()) {
+      try {
+        const current = await adapter.getDoc(docPath);
+        if (isOwnedDoc(current, runId)) {
+          await adapter.deleteDoc(docPath);
+        }
+      } catch {
+        // Cleanup errors must not mask the original seed failure.
+      }
+    }
+    throw error;
+  }
+  return { ready: true, created };
+}
+
+/**
+ * Secret-safe verification: booleans only, never email/password/hash/token.
+ */
+export async function verifyAuthProbeIdentities(adapter, manifest) {
+  const runId = assertAuthProbeManifest(manifest);
+  const roles = {};
+  const failureCodes = [];
+  for (const entry of manifest.documents) {
+    const role = entry.data.role;
+    const expectedStoreId = manifest.storeId;
+    const data = await adapter.getDoc(entry.path);
+    const checks = {
+      exists: Boolean(data),
+      owned: isOwnedDoc(data, runId),
+      roleOk: Boolean(data) && data.role === role,
+      providersOk: Boolean(data) && Array.isArray(data.providers) && data.providers.includes('email'),
+      hashPresent: Boolean(data) && isBcryptHash(data.passwordHash),
+      suspendedOk: Boolean(data) && data.suspended !== true,
+      storeBindingOk: true,
+      driverApprovedOk: true,
+    };
+    if (role === 'seller') {
+      checks.storeBindingOk =
+        Boolean(data) &&
+        typeof data.storeId === 'string' &&
+        data.storeId.length > 0 &&
+        data.storeId !== PRODUCTION_STORE_ID &&
+        data.storeId === expectedStoreId &&
+        data.storeId.startsWith(`${runId}-`);
+    }
+    if (role === 'driver') {
+      checks.driverApprovedOk = Boolean(data) && data.driverApproved === true;
+    }
+    const ok = Object.values(checks).every(Boolean);
+    roles[role] = { ok, ...checks };
+    if (!ok) failureCodes.push(`${String(role).toUpperCase()}_IDENTITY_NOT_READY`);
+  }
+  return { ready: failureCodes.length === 0, roles, failureCodes };
+}
+
+/**
+ * Idempotent owned-only cleanup. Foreign docs are never deleted.
+ */
+export async function cleanupAuthProbeIdentities(adapter, manifest) {
+  const runId = assertAuthProbeManifest(manifest);
+  let deleted = 0;
+  let skippedForeign = 0;
+  let missing = 0;
+  for (const entry of [...manifest.documents].reverse()) {
+    const data = await adapter.getDoc(entry.path);
+    if (!data) {
+      missing += 1;
+      continue;
+    }
+    if (!isOwnedDoc(data, runId)) {
+      skippedForeign += 1;
+      continue;
+    }
+    await adapter.deleteDoc(entry.path);
+    deleted += 1;
+  }
+  const verification = await verifyAuthProbeIdentities(adapter, manifest).catch(() => null);
+  // verify reports NOT_READY while owned docs remain; for cleanup the
+  // success signal is "no owned docs remain", reported as absent-ready.
+  let remainingOwned = 0;
+  if (verification) {
+    for (const entry of manifest.documents) {
+      const data = await adapter.getDoc(entry.path);
+      if (isOwnedDoc(data, runId)) remainingOwned += 1;
+    }
+  }
+  return {
+    ready: remainingOwned === 0,
+    deleted,
+    skippedForeign,
+    missing,
+    remainingOwned,
+  };
+}
+
+/**
+ * Strip credential material before persisting evidence/artifacts.
+ * Removes email/password/passwordHash/accountEmails; keeps paths, roles,
+ * namespaced storeId, providers-shape booleans, and _e2e markers.
+ */
+export function redactPersistedManifest(manifest) {
+  const persisted = structuredClone(manifest);
+  delete persisted.accountEmails;
+  delete persisted.accountPasswords;
+  for (const entry of persisted.documents ?? []) {
+    if (entry.data) {
+      delete entry.data.email;
+      delete entry.data.password;
+      delete entry.data.passwordHash;
+    }
+  }
+  return persisted;
+}
+
+export function buildPersistedEvidence({ manifest, verifyResult, cleanupResult } = {}) {
+  const redacted = manifest ? redactPersistedManifest(manifest) : null;
+  const evidence = {
+    kind: 'auth-probe-identities-evidence',
+    purpose: IDENTITY_PURPOSE,
+    runId: manifest?.runId ?? null,
+    documentPaths: manifest?.documentPaths ?? [],
+    storeIdPresent: Boolean(manifest?.storeId),
+    storeIdIsProduction: manifest?.storeId === PRODUCTION_STORE_ID,
+    roles: {},
+    failureCodes: [],
+  };
+  if (verifyResult?.roles) {
+    for (const [role, checks] of Object.entries(verifyResult.roles)) {
+      evidence.roles[role] = {
+        ok: Boolean(checks.ok),
+        exists: Boolean(checks.exists),
+        owned: Boolean(checks.owned),
+        roleOk: Boolean(checks.roleOk),
+        providersOk: Boolean(checks.providersOk),
+        hashPresent: Boolean(checks.hashPresent),
+        suspendedOk: Boolean(checks.suspendedOk),
+        storeBindingOk: Boolean(checks.storeBindingOk),
+        driverApprovedOk: Boolean(checks.driverApprovedOk),
+      };
+    }
+    evidence.failureCodes = [...(verifyResult.failureCodes ?? [])];
+  }
+  if (cleanupResult) {
+    evidence.cleanup = {
+      ready: Boolean(cleanupResult.ready),
+      deleted: Number(cleanupResult.deleted ?? 0),
+      skippedForeign: Number(cleanupResult.skippedForeign ?? 0),
+      missing: Number(cleanupResult.missing ?? 0),
+      remainingOwned: Number(cleanupResult.remainingOwned ?? 0),
+    };
+  }
+  return { manifest: redacted, evidence };
+}
+
+function argument(name) {
+  return process.argv
+    .slice(2)
+    .find((value) => value.startsWith(`--${name}=`))
+    ?.split('=')
+    .slice(1)
+    .join('=');
+}
+
+async function firebaseAdapter(environment) {
+  const rawCredential = readServiceAccountRaw({}, process.env);
+  if (!rawCredential.trim()) throw new Error('비운영 FIREBASE_SERVICE_ACCOUNT_JSON이 필요합니다.');
+  const withoutBom = rawCredential.charCodeAt(0) === 0xfeff ? rawCredential.slice(1) : rawCredential;
+  const serviceAccount = JSON.parse(withoutBom);
+  const { cert, initializeApp } = await import('firebase-admin/app');
+  const { getFirestore } = await import('firebase-admin/firestore');
+  const app = initializeApp(
+    {
+      credential: cert(serviceAccount),
+      projectId: environment.firebaseProjectId,
+    },
+    `auth-probe-${environment.runId}-${Date.now()}`,
+  );
+  const db = getFirestore(app);
+  return {
+    async getDoc(docPath) {
+      const snapshot = await db.doc(docPath).get();
+      return snapshot.exists ? snapshot.data() : null;
+    },
+    async setDoc(docPath, data) {
+      await db.doc(docPath).set(data);
+    },
+    async deleteDoc(docPath) {
+      await db.doc(docPath).delete();
+    },
+    async findUserByEmail(email) {
+      const snap = await db.collection('users').where('email', '==', email).limit(1).get();
+      if (snap.empty) return null;
+      const doc = snap.docs[0];
+      return { path: `users/${doc.id}`, data: doc.data() };
+    },
+  };
+}
+
+async function main() {
+  const { readFileSync, writeFileSync, mkdirSync } = await import('node:fs');
+  const { default: path } = await import('node:path');
+  const action = process.argv[2];
+  if (!['seed', 'verify', 'cleanup'].includes(action)) {
+    throw new Error('사용법: node scripts/probe-auth-identities.mjs seed|verify|cleanup --manifest=<경로> [--run-id=<runId>]');
+  }
+  // Target guard runs BEFORE any Firestore mutation or credential hashing.
+  const target = validateIdentityTarget({}, process.env);
+  const manifestPath = path.resolve(argument('manifest') ?? '');
+  if (!manifestPath) throw new Error('manifest 경로가 필요합니다: --manifest=<경로>');
+  const adapter = await firebaseAdapter({
+    firebaseProjectId: target.firebaseProjectId,
+    runId: String(process.env.AUTH_PROBE_IDENTITY_RUN_ID ?? process.env.AUTH_PROBE_RUN_ID ?? 'local').trim() || 'local',
+  });
+  if (action === 'seed') {
+    const runId = normalizeRunId(
+      argument('run-id') ?? process.env.AUTH_PROBE_IDENTITY_RUN_ID ?? process.env.AUTH_PROBE_RUN_ID ?? '',
+    );
+    const credentials = resolveIdentityCredentials({}, process.env);
+    const passwordHashes = {
+      consumer: await hashPassword(credentials.consumer.password),
+      seller: await hashPassword(credentials.seller.password),
+      driver: await hashPassword(credentials.driver.password),
+    };
+    const manifest = buildAuthProbeManifest({
+      runId,
+      emails: {
+        consumer: credentials.consumer.email,
+        seller: credentials.seller.email,
+        driver: credentials.driver.email,
+      },
+      passwordHashes,
+    });
+    await seedAuthProbeIdentities(adapter, manifest);
+    const verifyResult = await verifyAuthProbeIdentities(adapter, manifest);
+    const { manifest: persisted, evidence } = buildPersistedEvidence({ manifest, verifyResult });
+    mkdirSync(path.dirname(manifestPath), { recursive: true });
+    writeFileSync(manifestPath, `${JSON.stringify(persisted, null, 2)}\n`, { flag: 'wx' });
+    process.stdout.write(
+      `${JSON.stringify({ action, runId, ready: verifyResult.ready, evidence }, null, 2)}\n`,
+    );
+    if (!verifyResult.ready) process.exitCode = 1;
+    return;
+  }
+  const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+  if (action === 'verify') {
+    const result = await verifyAuthProbeIdentities(adapter, manifest);
+    const { evidence } = buildPersistedEvidence({ manifest, verifyResult: result });
+    process.stdout.write(`${JSON.stringify({ action, runId: manifest.runId, ...evidence }, null, 2)}\n`);
+    if (!result.ready) process.exitCode = 1;
+    return;
+  }
+  const result = await cleanupAuthProbeIdentities(adapter, manifest);
+  const { evidence } = buildPersistedEvidence({ manifest, cleanupResult: result });
+  process.stdout.write(`${JSON.stringify({ action, runId: manifest.runId, ...evidence }, null, 2)}\n`);
+  if (!result.ready) process.exitCode = 1;
+}
+
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const isDirectRun =
+  Boolean(process.argv[1]) && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isDirectRun) {
+  main().catch((error) => {
+    const code = error instanceof IdentityContractError ? error.code : 'PROBE_INTERNAL_ERROR';
+    process.stdout.write(`${JSON.stringify({ result: 'FAIL', failureCode: code, message: String(error?.message ?? error) }, null, 2)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/probe-auth-identities.spec.mjs
+++ b/scripts/probe-auth-identities.spec.mjs
@@ -1,0 +1,369 @@
+/**
+ * PILOT-AUTH-PROBE-IDENTITY-LIFECYCLE-26A deterministic tests (mock/local only).
+ * No network, no secrets, no external mutation. Run:
+ *   node --test scripts/probe-auth-identities.spec.mjs
+ */
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import {
+  APPROVAL_VALUE,
+  IDENTITY_PURPOSE,
+  PRODUCTION_STORE_ID,
+  TARGET_FIREBASE_PROJECT,
+  buildAuthProbeManifest,
+  buildPersistedEvidence,
+  cleanupAuthProbeIdentities,
+  hashPassword,
+  isBcryptHash,
+  normalizeRunId,
+  redactPersistedManifest,
+  seedAuthProbeIdentities,
+  validateIdentityTarget,
+  verifyAuthProbeIdentities,
+} from './probe-auth-identities.mjs';
+
+const RUN_ID = 'auth-probe-34678810429-1';
+const EMAILS = Object.freeze({
+  consumer: 'consumer-probe@example.test',
+  seller: 'seller-probe@example.test',
+  driver: 'driver-probe@example.test',
+});
+const HASHES = Object.freeze({
+  consumer: `$2b$12$${'C'.repeat(53)}`,
+  seller: `$2b$12$${'S'.repeat(53)}`,
+  driver: `$2b$12$${'D'.repeat(53)}`,
+});
+
+function validEnv(overrides = {}) {
+  return {
+    NON_PRODUCTION_AUTH_PROBE_APPROVAL: APPROVAL_VALUE,
+    ROUND_DIRECT_E2E_ENABLED: 'true',
+    ROUND_DIRECT_E2E_ENV: 'preview',
+    NODE_ENV: 'test',
+    VERCEL_ENV: 'preview',
+    RAILWAY_ENVIRONMENT_NAME: 'staging',
+    FIREBASE_PROJECT_ID: TARGET_FIREBASE_PROJECT,
+    ROUND_DIRECT_E2E_ALLOWED_FIREBASE_PROJECTS: TARGET_FIREBASE_PROJECT,
+    ROUND_DIRECT_E2E_FIREBASE_SERVICE_ACCOUNT_JSON: JSON.stringify({ project_id: TARGET_FIREBASE_PROJECT }),
+    ...overrides,
+  };
+}
+
+function validOptions(overrides = {}) {
+  return {
+    approval: APPROVAL_VALUE,
+    enabled: 'true',
+    environment: 'preview',
+    nodeEnv: 'test',
+    vercelEnv: 'preview',
+    railwayEnvironment: 'staging',
+    firebaseProjectId: TARGET_FIREBASE_PROJECT,
+    allowedFirebaseProjects: TARGET_FIREBASE_PROJECT,
+    serviceAccountJson: JSON.stringify({ project_id: TARGET_FIREBASE_PROJECT }),
+    ...overrides,
+  };
+}
+
+function memoryAdapter({ failAfterWrites = Number.POSITIVE_INFINITY } = {}) {
+  const docs = new Map();
+  let writes = 0;
+  return {
+    docs,
+    async getDoc(docPath) {
+      return docs.get(docPath) ?? null;
+    },
+    async setDoc(docPath, data) {
+      writes += 1;
+      if (writes > failAfterWrites) throw new Error('부분 seed 실패');
+      docs.set(docPath, structuredClone(data));
+    },
+    async deleteDoc(docPath) {
+      docs.delete(docPath);
+    },
+    async findUserByEmail(email) {
+      const needle = String(email).trim().toLowerCase();
+      for (const [docPath, data] of docs.entries()) {
+        if (!docPath.startsWith('users/')) continue;
+        if (String(data?.email ?? '').trim().toLowerCase() === needle) {
+          return { path: docPath, data: structuredClone(data) };
+        }
+      }
+      return null;
+    },
+  };
+}
+
+function validManifest(overrides = {}) {
+  return buildAuthProbeManifest({
+    runId: RUN_ID,
+    emails: { ...EMAILS },
+    passwordHashes: { ...HASHES },
+    ...overrides,
+  });
+}
+
+describe('PILOT-AUTH-PROBE-IDENTITY-LIFECYCLE-26A target safety', () => {
+  it('1. production Firebase target을 거부한다', () => {
+    assert.throws(
+      () => validateIdentityTarget(validOptions({ firebaseProjectId: 'green-e4fe3', allowedFirebaseProjects: 'green-e4fe3', serviceAccountJson: JSON.stringify({ project_id: 'green-e4fe3' }) }), validEnv()),
+      (e) => e.code === 'PRODUCTION_FIREBASE_PROJECT',
+    );
+    assert.throws(
+      () =>
+        validateIdentityTarget(
+          {},
+          validEnv({
+            FIREBASE_PROJECT_ID: 'green-e4fe3',
+            ROUND_DIRECT_E2E_ALLOWED_FIREBASE_PROJECTS: 'green-e4fe3',
+            ROUND_DIRECT_E2E_FIREBASE_SERVICE_ACCOUNT_JSON: JSON.stringify({ project_id: 'green-e4fe3' }),
+          }),
+        ),
+      (e) => e.code === 'PRODUCTION_FIREBASE_PROJECT',
+    );
+  });
+
+  it('2. wrong service-account project를 거부한다', () => {
+    assert.throws(
+      () => validateIdentityTarget(validOptions({ serviceAccountJson: JSON.stringify({ project_id: 'other-project' }) }), validEnv()),
+      (e) => e.code === 'FIREBASE_SERVICE_ACCOUNT_PROJECT_MISMATCH',
+    );
+    assert.throws(
+      () => validateIdentityTarget(validOptions({ serviceAccountJson: '' }), validEnv({ ROUND_DIRECT_E2E_FIREBASE_SERVICE_ACCOUNT_JSON: '' })),
+      (e) => e.code === 'FIREBASE_SERVICE_ACCOUNT_MISSING',
+    );
+    assert.throws(
+      () => validateIdentityTarget(validOptions({ serviceAccountJson: '{broken' }), validEnv()),
+      (e) => e.code === 'FIREBASE_SERVICE_ACCOUNT_INVALID',
+    );
+  });
+
+  it('non-preview / production env / disabled harness를 거부한다', () => {
+    assert.throws(() => validateIdentityTarget(validOptions({ enabled: 'false' }), validEnv()), (e) => e.code === 'E2E_NOT_ENABLED');
+    assert.throws(() => validateIdentityTarget(validOptions({ environment: 'production' }), validEnv()), (e) => e.code === 'ENVIRONMENT_NOT_PREVIEW');
+    assert.throws(() => validateIdentityTarget(validOptions({ nodeEnv: 'production' }), validEnv()), (e) => e.code === 'PRODUCTION_ENVIRONMENT');
+    assert.throws(() => validateIdentityTarget(validOptions({ approval: 'WRONG' }), validEnv()), (e) => e.code === 'MISSING_APPROVAL');
+    assert.throws(
+      () => validateIdentityTarget(validOptions({ firebaseProjectId: 'other-project', allowedFirebaseProjects: 'other-project', serviceAccountJson: JSON.stringify({ project_id: 'other-project' }) }), validEnv()),
+      (e) => e.code === 'FIREBASE_PROJECT_NOT_ALLOWED',
+    );
+  });
+
+  it('staging target + matching service account를 허용한다', () => {
+    const result = validateIdentityTarget(validOptions(), validEnv());
+    assert.equal(result.firebaseProjectId, TARGET_FIREBASE_PROJECT);
+    assert.equal(result.serviceAccountProjectId, TARGET_FIREBASE_PROJECT);
+  });
+});
+
+describe('PILOT-AUTH-PROBE-IDENTITY-LIFECYCLE-26A identity contract', () => {
+  it('3. consumer/seller/driver 정확히 3 identity를 생성한다', () => {
+    const manifest = validManifest();
+    assert.equal(manifest.documents.length, 3);
+    assert.deepEqual(manifest.documentPaths.sort(), [
+      `users/${RUN_ID}-consumer`,
+      `users/${RUN_ID}-driver`,
+      `users/${RUN_ID}-seller`,
+    ].sort());
+    const roles = new Set(manifest.documents.map(({ data }) => data.role));
+    assert.deepEqual([...roles].sort(), ['consumer', 'driver', 'seller']);
+    for (const entry of manifest.documents) {
+      assert.equal(entry.data._e2e.purpose, IDENTITY_PURPOSE);
+      assert.equal(entry.data._e2e.runId, RUN_ID);
+    }
+  });
+
+  it('4. driverApproved=true 이고 suspended=true가 아니다', async () => {
+    const manifest = validManifest();
+    const adapter = memoryAdapter();
+    await seedAuthProbeIdentities(adapter, manifest);
+    const driver = await adapter.getDoc(`users/${RUN_ID}-driver`);
+    assert.equal(driver.driverApproved, true);
+    assert.notEqual(driver.suspended, true);
+    const verify = await verifyAuthProbeIdentities(adapter, manifest);
+    assert.equal(verify.roles.driver.driverApprovedOk, true);
+    assert.equal(verify.roles.driver.suspendedOk, true);
+    assert.equal(verify.ready, true);
+  });
+
+  it('5. seller store binding 계약 (namespaced + non-production + present)', async () => {
+    const manifest = validManifest();
+    assert.ok(typeof manifest.storeId === 'string' && manifest.storeId.length > 0);
+    assert.equal(manifest.storeId, `${RUN_ID}-store`);
+    assert.notEqual(manifest.storeId, PRODUCTION_STORE_ID);
+    const sellerEntry = manifest.documents.find(({ data }) => data.role === 'seller');
+    assert.ok('storeId' in sellerEntry.data);
+    assert.equal(sellerEntry.data.storeId, manifest.storeId);
+    const adapter = memoryAdapter();
+    await seedAuthProbeIdentities(adapter, manifest);
+    const verify = await verifyAuthProbeIdentities(adapter, manifest);
+    assert.equal(verify.roles.seller.storeBindingOk, true);
+    assert.throws(
+      () => buildAuthProbeManifest({ runId: RUN_ID, emails: { ...EMAILS }, passwordHashes: { ...HASHES }, sellerStoreId: PRODUCTION_STORE_ID }),
+      (e) => e.code === 'PRODUCTION_STORE',
+    );
+    assert.throws(
+      () => buildAuthProbeManifest({ runId: RUN_ID, emails: { ...EMAILS }, passwordHashes: { ...HASHES }, sellerStoreId: 'foreign-store' }),
+      (e) => e.code === 'SELLER_STORE_BINDING_INVALID',
+    );
+  });
+
+  it('6. bcrypt password hash를 생성한다', async () => {
+    const hash = await hashPassword('probe-password-123');
+    assert.equal(isBcryptHash(hash), true);
+    const bcrypt = await import('bcrypt');
+    const impl = bcrypt.default ?? bcrypt;
+    assert.equal(await impl.compare('probe-password-123', hash), true);
+    assert.equal(await impl.compare('wrong-password', hash), false);
+    // Manifest accepts real bcrypt hashes and verify reports presence only.
+    const manifest = buildAuthProbeManifest({
+      runId: RUN_ID,
+      emails: { ...EMAILS },
+      passwordHashes: { consumer: hash, seller: hash, driver: hash },
+    });
+    const adapter = memoryAdapter();
+    await seedAuthProbeIdentities(adapter, manifest);
+    const verify = await verifyAuthProbeIdentities(adapter, manifest);
+    assert.equal(verify.roles.consumer.hashPresent, true);
+    assert.equal(verify.roles.seller.hashPresent, true);
+    assert.equal(verify.roles.driver.hashPresent, true);
+  });
+
+  it('7. persisted evidence에서 password/passwordHash/email을 제거한다', async () => {
+    const manifest = validManifest();
+    const persisted = redactPersistedManifest(manifest);
+    assert.ok(manifest.documents.some(({ data }) => typeof data.passwordHash === 'string'));
+    assert.equal(persisted.documents.some(({ data }) => Object.hasOwn(data, 'passwordHash')), false);
+    assert.equal(persisted.documents.some(({ data }) => Object.hasOwn(data, 'password')), false);
+    assert.equal(persisted.documents.some(({ data }) => Object.hasOwn(data, 'email')), false);
+    assert.equal('accountEmails' in persisted, false);
+    // persisted still carries ownership + binding for cleanup.
+    assert.equal(persisted.runId, RUN_ID);
+    assert.equal(persisted.storeId, `${RUN_ID}-store`);
+
+    const adapter = memoryAdapter();
+    await seedAuthProbeIdentities(adapter, manifest);
+    const verify = await verifyAuthProbeIdentities(adapter, manifest);
+    const { manifest: redacted, evidence } = buildPersistedEvidence({ manifest, verifyResult: verify });
+    const serialized = JSON.stringify({ redacted, evidence });
+    for (const sensitive of [...Object.values(HASHES), ...Object.values(EMAILS)]) {
+      assert.ok(!serialized.includes(sensitive), 'evidence must not contain raw credential material');
+    }
+    // verify reports booleans only.
+    assert.equal(typeof evidence.roles.consumer.hashPresent, 'boolean');
+    assert.equal(typeof evidence.roles.seller.storeBindingOk, 'boolean');
+    assert.equal(typeof evidence.roles.driver.driverApprovedOk, 'boolean');
+  });
+
+  it('runId 형식을 검증한다', () => {
+    assert.equal(normalizeRunId(RUN_ID), RUN_ID);
+    assert.throws(() => normalizeRunId('bad'), (e) => e.code === 'RUN_ID_INVALID');
+    assert.throws(() => normalizeRunId(''), (e) => e.code === 'RUN_ID_INVALID');
+  });
+});
+
+describe('PILOT-AUTH-PROBE-IDENTITY-LIFECYCLE-26A ownership / cleanup', () => {
+  it('8. unrelated existing user overwrite를 금지한다 (path + email)', async () => {
+    const manifest = validManifest();
+    const adapter = memoryAdapter();
+    // Same-path foreign doc.
+    adapter.docs.set(`users/${RUN_ID}-consumer`, { id: 'foreign', email: 'other@example.test', role: 'consumer' });
+    await assert.rejects(seedAuthProbeIdentities(adapter, manifest), (e) => e.code === 'IDENTITY_COLLISION');
+    assert.deepEqual(adapter.docs.get(`users/${RUN_ID}-consumer`), { id: 'foreign', email: 'other@example.test', role: 'consumer' });
+
+    // Same-email under a different path.
+    const adapter2 = memoryAdapter();
+    adapter2.docs.set('users/unrelated-id', { id: 'unrelated-id', email: EMAILS.seller, role: 'seller' });
+    await assert.rejects(seedAuthProbeIdentities(adapter2, manifest), (e) => e.code === 'IDENTITY_COLLISION');
+    // Unrelated doc is preserved and no owned docs leak.
+    assert.ok(adapter2.docs.has('users/unrelated-id'));
+    assert.equal(adapter2.docs.has(`users/${RUN_ID}-seller`), false);
+  });
+
+  it('9. owned docs cleanup이 동작한다', async () => {
+    const manifest = validManifest();
+    const adapter = memoryAdapter();
+    await seedAuthProbeIdentities(adapter, manifest);
+    const cleanup = await cleanupAuthProbeIdentities(adapter, manifest);
+    assert.equal(cleanup.ready, true);
+    assert.equal(cleanup.deleted, 3);
+    assert.equal(cleanup.remainingOwned, 0);
+    for (const docPath of manifest.documentPaths) {
+      assert.equal(await adapter.getDoc(docPath), null);
+    }
+  });
+
+  it('10. foreign docs cleanup을 금지한다', async () => {
+    const manifest = validManifest();
+    const adapter = memoryAdapter();
+    await seedAuthProbeIdentities(adapter, manifest);
+    adapter.docs.set('users/foreign-keep', { id: 'foreign-keep', email: 'keep@example.test', role: 'consumer' });
+    const cleanup = await cleanupAuthProbeIdentities(adapter, manifest);
+    assert.equal(cleanup.ready, true);
+    assert.deepEqual(await adapter.getDoc('users/foreign-keep'), { id: 'foreign-keep', email: 'keep@example.test', role: 'consumer' });
+    // Foreign doc at a manifest path is skipped, not deleted.
+    const adapter2 = memoryAdapter();
+    adapter2.docs.set(`users/${RUN_ID}-driver`, { id: `users/${RUN_ID}-driver`, email: 'hijack@example.test', role: 'driver' });
+    const cleanup2 = await cleanupAuthProbeIdentities(adapter2, validManifest());
+    assert.equal(cleanup2.skippedForeign, 1);
+    assert.equal(cleanup2.deleted, 0);
+    assert.ok(await adapter2.getDoc(`users/${RUN_ID}-driver`));
+  });
+
+  it('cleanup은 idempotent하다', async () => {
+    const manifest = validManifest();
+    const adapter = memoryAdapter();
+    const first = await cleanupAuthProbeIdentities(adapter, manifest);
+    assert.equal(first.ready, true);
+    assert.equal(first.missing, 3);
+    await seedAuthProbeIdentities(adapter, manifest);
+    await cleanupAuthProbeIdentities(adapter, manifest);
+    const second = await cleanupAuthProbeIdentities(adapter, manifest);
+    assert.equal(second.ready, true);
+    assert.equal(second.missing, 3);
+  });
+
+  it('11. partial seed failure 시 이미 생성한 owned docs를 정리한다', async () => {
+    const manifest = validManifest();
+    const adapter = memoryAdapter({ failAfterWrites: 1 });
+    adapter.docs.set('users/unrelated', { keep: true });
+    await assert.rejects(seedAuthProbeIdentities(adapter, manifest), /부분 seed 실패/);
+    assert.deepEqual(await adapter.getDoc('users/unrelated'), { keep: true });
+    for (const docPath of manifest.documentPaths) {
+      assert.equal(await adapter.getDoc(docPath), null);
+    }
+  });
+});
+
+describe('PILOT-AUTH-PROBE-IDENTITY-LIFECYCLE-26A workflow + regression', () => {
+  const HERE = path.dirname(fileURLToPath(import.meta.url));
+  const WORKFLOW_PATH = path.join(HERE, '..', '.github', 'workflows', 'probe-auth-runtime.yml');
+
+  it('12. workflow dependency가 approval → identity → probes → always cleanup이다', () => {
+    const source = readFileSync(WORKFLOW_PATH, 'utf8');
+    assert.ok(source.includes('auth_identity_seed:'), 'workflow must contain the identity seed job');
+    assert.ok(source.includes('auth_identity_cleanup:'), 'workflow must contain the identity cleanup job');
+    const seedStart = source.indexOf('auth_identity_seed:');
+    const sessionStart = source.indexOf('session-probe:');
+    const callbackStart = source.indexOf('callback-probe:');
+    const cleanupStart = source.indexOf('auth_identity_cleanup:');
+    assert.ok(seedStart >= 0 && sessionStart > seedStart, 'seed must precede session-probe');
+    assert.ok(callbackStart > seedStart, 'seed must precede callback-probe');
+    assert.ok(cleanupStart > sessionStart && cleanupStart > callbackStart, 'cleanup must follow both probes');
+    const cleanupSlice = source.slice(cleanupStart);
+    assert.ok(cleanupSlice.includes('if: ${{ always() }}'), 'cleanup must run always()');
+    assert.ok(cleanupSlice.includes('auth_identity_seed'), 'cleanup must need the seed job');
+  });
+
+  it('13. callback/session 기존 auth contract regression이 없다', async () => {
+    const runtime = await import('./probe-auth-runtime.mjs');
+    assert.equal(runtime.APPROVAL_VALUE, 'NON_PRODUCTION_AUTH_PROBE_APPROVED');
+    const guarded = runtime.createGuardedFetch(async () => ({ ok: true, status: 200, data: {} }), { apiUrl: 'https://api-staging.example.test' });
+    await assert.rejects(guarded('https://api-staging.example.test/auth/register', { method: 'POST' }), (e) => e.code === 'AUTH_MUTATION_FORBIDDEN');
+    // Seller still requires storeId; driver still requires approval (runner contract).
+    const sellerMismatch = runtime.validateRuntimeBinding;
+    assert.equal(typeof sellerMismatch, 'function');
+  });
+});

--- a/scripts/probe-auth-runtime.workflow.spec.mjs
+++ b/scripts/probe-auth-runtime.workflow.spec.mjs
@@ -77,7 +77,7 @@ describe('session-only workflow dispatch contract', () => {
   it('round-direct-e2e Environment binds only the runtime probe jobs', () => {
     const source = readWorkflow();
     assert.ok(source.includes('name: round-direct-e2e'), 'session probe must bind round-direct-e2e');
-    const specSlice = jobSlice(source, 'probe-spec:', ['approval_gate:', 'session-probe:']);
+    const specSlice = jobSlice(source, 'probe-spec:', ['approval_gate:', 'auth_identity_seed:', 'session-probe:']);
     assert.ok(
       !specSlice.includes('environment:'),
       'deterministic probe-spec must not bind the credential Environment',
@@ -86,11 +86,17 @@ describe('session-only workflow dispatch contract', () => {
       !specSlice.includes('round-direct-e2e'),
       'deterministic probe-spec must not reference the Environment',
     );
-    const gateSlice = jobSlice(source, 'approval_gate:', ['session-probe:']);
+    const gateSlice = jobSlice(source, 'approval_gate:', ['auth_identity_seed:']);
     assert.ok(
       !gateSlice.includes('environment:'),
       'approval preflight must not bind the credential Environment',
     );
+    // Identity lifecycle jobs bind the same approved Environment; probes
+    // keep their existing binding. No new Environment is introduced.
+    for (const job of ['auth_identity_seed:', 'session-probe:', 'callback-probe:', 'auth_identity_cleanup:']) {
+      const slice = jobSlice(source, job, ['auth_identity_seed:', 'session-probe:', 'callback-probe:', 'auth_identity_cleanup:'].filter((m) => m !== job));
+      assert.ok(slice.includes('name: round-direct-e2e'), `${job} must bind round-direct-e2e`);
+    }
   });
 
   it('permissions stay minimal (read-only, no writes)', () => {
@@ -99,7 +105,7 @@ describe('session-only workflow dispatch contract', () => {
     for (const forbidden of ['contents: write', 'actions: write', 'packages: write', 'deployments: write']) {
       assert.ok(!source.includes(forbidden), `workflow must not grant ${forbidden}`);
     }
-    const gateSlice = jobSlice(source, 'approval_gate:', ['session-probe:']);
+    const gateSlice = jobSlice(source, 'approval_gate:', ['auth_identity_seed:']);
     assert.ok(gateSlice.includes('permissions: {}'), 'approval preflight must use empty permissions');
   });
 
@@ -130,7 +136,7 @@ describe('session-only workflow dispatch contract', () => {
 });
 
 describe('session-only runtime boundary', () => {
-  it('only the allowed scripts are invoked (session runner + isolated callback runner)', () => {
+  it('only the allowed scripts are invoked (session + callback + identity lifecycle)', () => {
     const source = readWorkflow();
     assert.ok(
       source.includes('scripts/wait-preview-deploy.mjs'),
@@ -140,13 +146,18 @@ describe('session-only runtime boundary', () => {
       source.includes('scripts/probe-auth-runtime.mjs'),
       'runtime probe must invoke only the existing probe runner',
     );
+    assert.ok(
+      source.includes('scripts/probe-auth-identities.mjs'),
+      'identity lifecycle must invoke the owned identity script',
+    );
     const invocations = [...source.matchAll(/node\s+scripts\/([^\s'"]+)/g)].map((m) => m[1]);
     assert.ok(invocations.length > 0, 'expected script invocations');
     for (const script of invocations) {
       assert.ok(
         script === 'wait-preview-deploy.mjs' ||
           script === 'probe-auth-runtime.mjs' ||
-          script === 'probe-consumer-callback.mjs',
+          script === 'probe-consumer-callback.mjs' ||
+          script === 'probe-auth-identities.mjs',
         `forbidden script invocation: node scripts/${script}`,
       );
     }
@@ -157,6 +168,16 @@ describe('session-only runtime boundary', () => {
       source.includes('callback-probe:'),
       'callback invocation must live in the isolated callback-probe job',
     );
+    // Identity isolation: seed/cleanup own the identity script; probes never
+    // invoke it and identity jobs never invoke probe runners.
+    const sessionStart = source.indexOf('session-probe:');
+    const callbackStart = source.indexOf('callback-probe:');
+    const sessionSlice = source.slice(sessionStart, callbackStart >= 0 ? callbackStart : source.length);
+    assert.ok(!sessionSlice.includes('probe-auth-identities.mjs'), 'session job must never invoke the identity script');
+    const callbackSlice = source.slice(callbackStart);
+    const cleanupStart = callbackSlice.indexOf('auth_identity_cleanup:');
+    const callbackOnly = cleanupStart >= 0 ? callbackSlice.slice(0, cleanupStart) : callbackSlice;
+    assert.ok(!callbackOnly.includes('probe-auth-identities.mjs'), 'callback job must never invoke the identity script');
   });
 
   it('production targets are rejected', () => {
@@ -165,22 +186,40 @@ describe('session-only runtime boundary', () => {
     assert.ok(source.includes('api-production-'), 'production API hosts must be rejected');
   });
 
-  it('provider, full-suite, fixture, and service-account paths are never invoked', () => {
+  it('provider, full-suite, fixture, and service-account paths are scoped', () => {
     const source = readWorkflow();
+    // Global forbiddens: never appear anywhere (no Vercel bypass, no full
+    // fixture seed, no provider egress, no broad E2E execution).
     for (const forbidden of [
       'api.portone.io',
       'aligo.in',
       'kauth.kakao.com',
       'kapi.kakao.com',
       'auth/kakao-login',
-      'FIREBASE_SERVICE_ACCOUNT_JSON',
       'playwright test',
       'round-direct-e2e-fixtures',
       'check-round-direct-e2e-readiness',
       'pnpm --filter e2e',
+      'x-vercel-protection-bypass',
+      'x-vercel-trusted-oidc-idp-token',
+      'id-token: write',
     ]) {
       assert.ok(!source.includes(forbidden), `workflow must never contain ${forbidden}`);
     }
+    // Service-account material is scoped to identity jobs only; session and
+    // callback probes must never handle it.
+    const sessionStart = source.indexOf('session-probe:');
+    const callbackStart = source.indexOf('callback-probe:');
+    const cleanupStart = source.indexOf('auth_identity_cleanup:');
+    assert.ok(sessionStart >= 0 && callbackStart > sessionStart && cleanupStart > callbackStart, 'lifecycle job order must hold');
+    const sessionSlice = source.slice(sessionStart, callbackStart);
+    const callbackOnly = source.slice(callbackStart, cleanupStart);
+    assert.ok(!sessionSlice.includes('FIREBASE_SERVICE_ACCOUNT_JSON'), 'session probe must never handle service-account material');
+    assert.ok(!callbackOnly.includes('FIREBASE_SERVICE_ACCOUNT_JSON'), 'callback probe must never handle service-account material');
+    const seedSlice = source.slice(source.indexOf('auth_identity_seed:'), sessionStart);
+    const cleanupSlice = source.slice(cleanupStart);
+    assert.ok(seedSlice.includes('FIREBASE_SERVICE_ACCOUNT_JSON'), 'identity seed must bind the approved service-account secret');
+    assert.ok(cleanupSlice.includes('FIREBASE_SERVICE_ACCOUNT_JSON'), 'identity cleanup must bind the approved service-account secret');
   });
 
   it('probe CLI passes only non-secret binding flags', () => {
@@ -422,5 +461,91 @@ describe('runner/target SHA decoupling (PILOT-AUTH-PROBE-RUNNER-TARGET-SHA-DECOU
       !slice.includes('AUTH_PROBE_RUNNER_TOKEN') && !slice.includes('AUTH_PROBE_RUNNER_SECRET'),
       'runner evidence must introduce no new credential-shaped names',
     );
+  });
+});
+
+describe('auth probe identity lifecycle (PILOT-AUTH-PROBE-IDENTITY-LIFECYCLE-26A)', () => {
+  function seedSlice(source) {
+    const start = source.indexOf('auth_identity_seed:');
+    assert.ok(start >= 0, 'workflow must contain the identity seed job');
+    const end = source.indexOf('session-probe:');
+    return source.slice(start, end >= 0 ? end : source.length);
+  }
+
+  function cleanupSlice(source) {
+    const start = source.indexOf('auth_identity_cleanup:');
+    assert.ok(start >= 0, 'workflow must contain the identity cleanup job');
+    return source.slice(start);
+  }
+
+  it('approval → identity → probes → always cleanup dependency holds', () => {
+    const source = readWorkflow();
+    const seedStart = source.indexOf('auth_identity_seed:');
+    const sessionStart = source.indexOf('session-probe:');
+    const callbackStart = source.indexOf('callback-probe:');
+    const cleanupStart = source.indexOf('auth_identity_cleanup:');
+    assert.ok(seedStart >= 0 && sessionStart > seedStart, 'seed must precede session-probe');
+    assert.ok(callbackStart > seedStart, 'seed must precede callback-probe');
+    assert.ok(cleanupStart > sessionStart && cleanupStart > callbackStart, 'cleanup must follow both probes');
+    assert.ok(source.slice(seedStart, sessionStart).includes('needs: approval_gate'), 'seed must need approval_gate');
+    assert.ok(source.slice(sessionStart, callbackStart).includes('needs: auth_identity_seed'), 'session must need identity seed');
+    const callbackOnly = source.slice(callbackStart, cleanupStart);
+    assert.ok(callbackOnly.includes('needs: auth_identity_seed'), 'callback must need identity seed');
+    assert.ok(!/^(\s*)needs:.*session-probe/m.test(callbackOnly), 'callback must not depend on session-probe');
+    const cleanup = source.slice(cleanupStart);
+    assert.ok(cleanup.includes('needs: [auth_identity_seed, session-probe, callback-probe]'), 'cleanup must need seed + both probes');
+    assert.ok(cleanup.includes('if: ${{ always()'), 'cleanup must run always()');
+  });
+
+  it('identity seed prepares exactly the 3 chromium roles without new secrets', () => {
+    const slice = seedSlice(readWorkflow());
+    assert.ok(slice.includes('scripts/probe-auth-identities.mjs'), 'seed must invoke the identity script');
+    assert.ok(!slice.includes('probe-auth-runtime.mjs'), 'seed must not invoke the session runner');
+    assert.ok(!slice.includes('probe-consumer-callback.mjs'), 'seed must not invoke the callback runner');
+    for (const name of [
+      'ROUND_DIRECT_E2E_CONSUMER_EMAIL_CHROMIUM',
+      'ROUND_DIRECT_E2E_CONSUMER_PASSWORD_CHROMIUM',
+      'ROUND_DIRECT_E2E_SELLER_EMAIL_CHROMIUM',
+      'ROUND_DIRECT_E2E_SELLER_PASSWORD_CHROMIUM',
+      'ROUND_DIRECT_E2E_DRIVER_EMAIL_CHROMIUM',
+      'ROUND_DIRECT_E2E_DRIVER_PASSWORD_CHROMIUM',
+    ]) {
+      assert.ok(slice.includes(name), `seed must reuse approved name ${name}`);
+    }
+    assert.ok(slice.includes('--run-id='), 'seed must pass --run-id=');
+    assert.ok(slice.includes('--manifest='), 'seed must pass --manifest=');
+    assert.ok(slice.includes('identity-manifest.json'), 'seed must write the redacted identity manifest');
+    assert.ok(slice.includes('identity-summary.json'), 'seed must write the non-sensitive identity summary');
+  });
+
+  it('identity evidence stays non-sensitive with 7-day retention', () => {
+    const seed = seedSlice(readWorkflow());
+    const cleanup = cleanupSlice(readWorkflow());
+    for (const slice of [seed, cleanup]) {
+      for (const line of slice.split('\n')) {
+        if (line.trim().startsWith('#')) continue;
+        if (!/echo|printf/.test(line)) continue;
+        for (const sensitive of ['SECRET', 'PASSWORD', 'TOKEN', 'COOKIE', 'SERVICE_ACCOUNT', 'CREDENTIAL_JSON']) {
+          assert.ok(!line.includes(sensitive), `identity log line must not reference ${sensitive}`);
+        }
+      }
+      for (const sensitive of ['passwordHash', 'accessToken', 'refreshToken', 'set-cookie', 'private_key']) {
+        assert.ok(!slice.includes(sensitive), `identity job must not handle raw ${sensitive}`);
+      }
+    }
+    assert.ok(seed.includes('auth-probe-identities-'), 'identity artifact must use the lifecycle artifact name');
+    assert.ok(cleanup.includes('auth-probe-identities-cleanup-'), 'cleanup artifact must use its own name');
+    assert.ok(seed.includes('retention-days: 7'), 'identity evidence must keep the 7-day retention contract');
+    assert.ok(cleanup.includes('retention-days: 7'), 'cleanup evidence must keep the 7-day retention contract');
+    assert.ok(!seed.includes('bypass'), 'identity seed must not introduce protection bypass');
+    assert.ok(!cleanup.includes('bypass'), 'identity cleanup must not introduce protection bypass');
+  });
+
+  it('deterministic probe-spec and PR triggers cover the identity contract', () => {
+    const source = readWorkflow();
+    assert.ok(source.includes('scripts/probe-auth-identities.spec.mjs'), 'probe-spec must run the identity deterministic spec');
+    for (const trigger of ['scripts/probe-auth-identities.mjs', 'scripts/probe-auth-identities.spec.mjs']) {
+      assert.ok(source.includes(trigger), `pull_request paths must include ${trigger}`);
+    }
   });
 });

--- a/scripts/probe-auth-runtime.workflow.spec.mjs
+++ b/scripts/probe-auth-runtime.workflow.spec.mjs
@@ -74,6 +74,13 @@ describe('session-only workflow dispatch contract', () => {
     );
   });
 
+  it('deterministic probe-spec installs workspace deps for bcrypt parity', () => {
+    const source = readWorkflow();
+    const specSlice = jobSlice(source, 'probe-spec:', ['approval_gate:', 'auth_identity_seed:', 'session-probe:']);
+    assert.ok(specSlice.includes('pnpm/action-setup'), 'probe-spec must set up pnpm for bcrypt parity');
+    assert.ok(specSlice.includes('pnpm install --frozen-lockfile'), 'probe-spec must install deps before bcrypt tests');
+  });
+
   it('round-direct-e2e Environment binds only the runtime probe jobs', () => {
     const source = readWorkflow();
     assert.ok(source.includes('name: round-direct-e2e'), 'session probe must bind round-direct-e2e');

--- a/scripts/probe-consumer-callback.workflow.spec.mjs
+++ b/scripts/probe-consumer-callback.workflow.spec.mjs
@@ -33,11 +33,12 @@ function readWorkflow() {
   return readFileSync(WORKFLOW_PATH, 'utf8');
 }
 
-/** Slice of the callback-probe job (last job in the workflow file). */
+/** Slice of the callback-probe job (bounded by the cleanup job). */
 function callbackSlice(source) {
   const start = source.indexOf('callback-probe:');
   assert.ok(start >= 0, 'workflow must contain the callback-probe job');
-  return source.slice(start);
+  const end = source.indexOf('auth_identity_cleanup:');
+  return source.slice(start, end >= 0 ? end : source.length);
 }
 
 function sessionSlice(source) {
@@ -86,7 +87,7 @@ describe('callback probe workflow isolation contract', () => {
       slice.includes("name: locked Consumer callback input-binding probe"),
       'callback job must carry its isolation name',
     );
-    assert.ok(slice.includes('needs: approval_gate'), 'callback job must need only approval_gate');
+    assert.ok(slice.includes('needs: auth_identity_seed'), 'callback job must need the identity seed job');
     assert.ok(!/^(\s*)needs:.*session-probe/m.test(slice), 'callback must not depend on session-probe');
     assert.ok(
       slice.includes("github.event_name == 'workflow_dispatch'"),
@@ -99,7 +100,7 @@ describe('callback probe workflow isolation contract', () => {
     assert.ok(slice.includes('group: auth-callback-probe'), 'callback job must use its own concurrency group');
   });
 
-  it('session-probe job is untouched by the callback integration', () => {
+  it('session-probe job keeps its isolation while gaining the identity dependency', () => {
     const source = readWorkflow();
     const slice = sessionSlice(source);
     assert.ok(
@@ -117,6 +118,14 @@ describe('callback probe workflow isolation contract', () => {
     assert.ok(
       !slice.includes('auth-callback-probe-'),
       'session job must not reference callback artifact paths',
+    );
+    assert.ok(
+      slice.includes('needs: auth_identity_seed'),
+      'session job must need the identity seed job (lifecycle)',
+    );
+    assert.ok(
+      !slice.includes('probe-auth-identities.mjs'),
+      'session job must never invoke the identity script',
     );
   });
 


### PR DESCRIPTION
PILOT-AUTH-PROBE-IDENTITY-LIFECYCLE-PUBLICATION-26A

Bounded lifecycle: approval -> exact non-production target guard (greenhub-round-direct-e2e) -> seed/verify 3 owned users (consumer/seller/driver, bcrypt12, seller namespaced store, driverApproved) -> session+callback -> always owned-only cleanup.

Reuse: chromium secrets + staging SA only in identity jobs; redacted manifests; no Vercel bypass; no dispatch in this task.

Deterministic: 153 tests PASS (probe-auth-identities 17 + existing probe/fixture suites).

Transport: exact candidate 129f95047899641b764f6a22362a02d590325996 via temp ref, shared checkout stays on main.