### PR TITLE
fix(orders): make cancellation transaction decisions retry-pure

### DIFF
--- a/apps/api/src/orders/legacy-consumer-cancellation-occ-retry.spec.ts
+++ b/apps/api/src/orders/legacy-consumer-cancellation-occ-retry.spec.ts
@@ -1,0 +1,254 @@
+// Legacy consumer cancellation OCC retry-purity proofs on the canonical harness.
+// Task: PILOT-CANCELLATION-TRANSACTION-RETRY-PURITY-27B
+//
+// Proves COMMITTED_CALLBACK_RETURN_ONLY for
+// OrdersLifecycleService.claimLegacyConsumerCancellation:
+//   L1. aborted done -> committed claim (stale done must not escape)
+//   L2. aborted in_progress -> committed claim (stale in_progress must not escape)
+//   L3. aborted claim -> committed foreign (aborted token must not call provider)
+//
+// Uses only the canonical harness at ../../test/helpers/firestore-occ-fake
+// (per-doc versions, conflict detection, bounded retry, staged-write discard,
+// beforeCommit deterministic interleaving). No serial fakes, no timers.
+// PortOne is mocked; no Firebase external calls.
+
+import { ConflictException, ForbiddenException } from '@nestjs/common';
+import { createOccFirestore } from '../../test/helpers/firestore-occ-fake';
+import { OrdersLifecycleService } from './orders-lifecycle.service';
+import type { RoundOrderLifecycleService } from './round-order-lifecycle.service';
+
+type Occ = ReturnType<typeof createOccFirestore>;
+
+const ORDER_ID = 'order-1';
+const ORDER_PATH = `orders/${ORDER_ID}`;
+const GC_PATH = 'groupProductConfig/product-1';
+
+function makeService(occ: Occ) {
+  const notifications = { sendToUser: jest.fn().mockResolvedValue(undefined) };
+  const payments = { processRefundByOrderId: jest.fn().mockResolvedValue(undefined) };
+  const settlements = { cancelSettlement: jest.fn().mockResolvedValue(undefined) };
+  const capacity = {};
+  const roundLifecycle = {
+    cancelByConsumer: jest.fn(),
+  };
+  const service = new OrdersLifecycleService(
+    occ.firestore as never,
+    notifications as never,
+    payments as never,
+    settlements as never,
+    capacity as never,
+    roundLifecycle as unknown as RoundOrderLifecycleService,
+  );
+  return { service, notifications, payments, settlements };
+}
+
+function seedClaimable(occ: Occ) {
+  occ.seed(ORDER_PATH, {
+    id: ORDER_ID,
+    storeId: 'store-1',
+    userId: 'consumer-1',
+    productId: 'product-1',
+    quantity: 2,
+    status: 'RECRUITING',
+    saleType: 'group',
+    deliveryMethod: 'direct',
+    totalAmount: 50000,
+  });
+  occ.seed(GC_PATH, {
+    productId: 'product-1',
+    currentQuantity: 5,
+    minQuantity: 2,
+    targetQuantity: 10,
+  });
+}
+
+function seedDone(occ: Occ) {
+  occ.seed(ORDER_PATH, {
+    id: ORDER_ID,
+    storeId: 'store-1',
+    userId: 'consumer-1',
+    productId: 'product-1',
+    quantity: 2,
+    status: 'CANCELLED',
+    saleType: 'group',
+    deliveryMethod: 'direct',
+    totalAmount: 50000,
+    cancellation: {
+      status: 'COMPLETED',
+      reason: '변심',
+      completedAt: '2026-08-27T00:00:00.000Z',
+      updatedAt: '2026-08-27T00:00:00.000Z',
+    },
+  });
+  occ.seed(GC_PATH, {
+    productId: 'product-1',
+    currentQuantity: 3,
+    minQuantity: 2,
+    targetQuantity: 10,
+  });
+}
+
+describe('legacy consumer cancellation OCC retry purity', () => {
+  it('L1. aborted done -> committed claim: caller consumes claimed, refund runs once', async () => {
+    const occ = createOccFirestore();
+    seedDone(occ);
+    const { service, payments, settlements, notifications } = makeService(occ);
+
+    const commits: Array<{ writeCount: number }> = [];
+    const arm = (): void => {
+      occ.setBeforeCommit((ctx) => {
+        commits.push({ writeCount: ctx.writes.length });
+        if (commits.length === 1) {
+          // Attempt 1 observed DONE (0 writes). Make the live order claimable
+          // before validation so attempt 1 aborts and the retry must claim.
+          occ.updateOutsideTransaction(ORDER_PATH, {
+            status: 'RECRUITING',
+            cancellation: null,
+          });
+        }
+        arm();
+      });
+    };
+    arm();
+
+    await expect(
+      service.cancelOrder('store-1', ORDER_ID, 'consumer-1', '변심'),
+    ).resolves.toEqual({ orderId: ORDER_ID, status: 'CANCELLED' });
+    occ.clearHooks();
+
+    // Attempt 1 (done, 0 writes, aborted) + attempt 2 (claim, 1 write,
+    // committed) + apply-local commit.
+    expect(commits.length).toBeGreaterThanOrEqual(2);
+    expect(commits[0].writeCount).toBe(0);
+    expect(commits[1].writeCount).toBe(1);
+    // Old outer-mutation code returned stale done here: provider 0 with an
+    // orphaned REFUNDING claim left behind. Committed-return must claim and
+    // drive the refund path.
+    expect(payments.processRefundByOrderId).toHaveBeenCalledTimes(1);
+    expect(payments.processRefundByOrderId).toHaveBeenCalledWith(ORDER_ID, '변심');
+    expect(settlements.cancelSettlement).toHaveBeenCalledTimes(1);
+    expect(notifications.sendToUser).toHaveBeenCalledTimes(1);
+    expect(occ.getData(ORDER_PATH)).toMatchObject({
+      status: 'CANCELLED',
+      cancellation: { status: 'COMPLETED', reason: '변심' },
+    });
+  });
+
+  it('L2. aborted in_progress -> committed claim: stale in_progress never escapes', async () => {
+    const occ = createOccFirestore();
+    seedClaimable(occ);
+    occ.updateOutsideTransaction(ORDER_PATH, {
+      cancellation: {
+        status: 'REFUNDING',
+        reason: 'foreign',
+        refundClaim: { token: 'foreign-token', expiresAt: Date.now() + 300000 },
+        updatedAt: new Date().toISOString(),
+      },
+    });
+    const { service, payments, settlements } = makeService(occ);
+
+    const commits: Array<{ writeCount: number }> = [];
+    const arm = (): void => {
+      occ.setBeforeCommit((ctx) => {
+        commits.push({ writeCount: ctx.writes.length });
+        if (commits.length === 1) {
+          // Attempt 1 observed the active foreign claim (in_progress).
+          // Expire it before validation so attempt 1 aborts and the retry
+          // must stage the owned claim.
+          occ.updateOutsideTransaction(ORDER_PATH, {
+            cancellation: {
+              status: 'REFUNDING',
+              reason: 'foreign',
+              refundClaim: { token: 'foreign-token', expiresAt: Date.now() - 1000 },
+              updatedAt: new Date().toISOString(),
+            },
+          });
+        }
+        arm();
+      });
+    };
+    arm();
+
+    await expect(
+      service.cancelOrder('store-1', ORDER_ID, 'consumer-1', '변심'),
+    ).resolves.toEqual({ orderId: ORDER_ID, status: 'CANCELLED' });
+    occ.clearHooks();
+
+    expect(commits.length).toBeGreaterThanOrEqual(2);
+    expect(commits[0].writeCount).toBe(0);
+    expect(commits[1].writeCount).toBe(1);
+    expect(payments.processRefundByOrderId).toHaveBeenCalledTimes(1);
+    expect(settlements.cancelSettlement).toHaveBeenCalledTimes(1);
+    expect(occ.getData(ORDER_PATH)).toMatchObject({
+      status: 'CANCELLED',
+      cancellation: { status: 'COMPLETED' },
+    });
+  });
+
+  it('L3. aborted claim -> committed foreign: aborted token never calls provider', async () => {
+    const occ = createOccFirestore();
+    seedClaimable(occ);
+    const { service, payments, settlements, notifications } = makeService(occ);
+
+    const commits: Array<{ writeCount: number }> = [];
+    const arm = (): void => {
+      occ.setBeforeCommit((ctx) => {
+        commits.push({ writeCount: ctx.writes.length });
+        if (commits.length === 1) {
+          // Attempt 1 staged the owned claim (1 write). A foreign active
+          // claim lands before validation, forcing an abort. The retry must
+          // observe the foreign claim and stage nothing.
+          occ.updateOutsideTransaction(ORDER_PATH, {
+            cancellation: {
+              status: 'REFUNDING',
+              reason: 'foreign',
+              refundClaim: { token: 'foreign-token', expiresAt: Date.now() + 300000 },
+              updatedAt: new Date().toISOString(),
+            },
+          });
+        }
+        arm();
+      });
+    };
+    arm();
+
+    await expect(
+      service.cancelOrder('store-1', ORDER_ID, 'consumer-1', '변심'),
+    ).rejects.toBeInstanceOf(ConflictException);
+    occ.clearHooks();
+
+    expect(commits.length).toBeGreaterThanOrEqual(2);
+    expect(commits[0].writeCount).toBe(1);
+    expect(commits[1].writeCount).toBe(0);
+    // The aborted owned claim must not reach the provider.
+    expect(payments.processRefundByOrderId).not.toHaveBeenCalled();
+    expect(settlements.cancelSettlement).not.toHaveBeenCalled();
+    expect(notifications.sendToUser).not.toHaveBeenCalled();
+    expect(occ.getData(ORDER_PATH)).toMatchObject({
+      status: 'RECRUITING',
+      cancellation: { status: 'REFUNDING', refundClaim: { token: 'foreign-token' } },
+    });
+    // Sequential retry still observes the foreign claim deterministically.
+    await expect(
+      service.cancelOrder('store-1', ORDER_ID, 'consumer-1', '변심'),
+    ).rejects.toBeInstanceOf(ConflictException);
+    expect(payments.processRefundByOrderId).not.toHaveBeenCalled();
+  });
+
+  it('L1b. sequential done idempotency keeps provider 0 without orphan claim', async () => {
+    const occ = createOccFirestore();
+    seedDone(occ);
+    const { service, payments, settlements } = makeService(occ);
+
+    await expect(
+      service.cancelOrder('store-1', ORDER_ID, 'consumer-1', '변심'),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+
+    expect(payments.processRefundByOrderId).not.toHaveBeenCalled();
+    expect(settlements.cancelSettlement).toHaveBeenCalledTimes(1);
+    expect(occ.getData(ORDER_PATH)).toMatchObject({
+      status: 'CANCELLED',
+      cancellation: { status: 'COMPLETED' },
+    });
+  });
+});

--- a/apps/api/src/orders/orders-lifecycle.service.ts
+++ b/apps/api/src/orders/orders-lifecycle.service.ts
@@ -479,9 +479,12 @@ export class OrdersLifecycleService {
     reason: string,
   ): Promise<LegacyConsumerCancelClaimResult> {
     const token = randomUUID();
-    let result: LegacyConsumerCancelClaimResult = { kind: 'claimed', token };
 
-    await this.firestore.runTransaction(async (tx) => {
+    // Retry purity: the post-transaction decision must come from the committed
+    // attempt's return value only. An outer `let result` mutated inside the
+    // callback would leak an aborted attempt's done/in_progress decision into
+    // a retried claim (or vice versa).
+    return this.firestore.runTransaction<LegacyConsumerCancelClaimResult>(async (tx) => {
       const orderRef = this.firestore.doc(`orders/${orderId}`);
       const orderSnap = await tx.get(orderRef);
       if (!orderSnap.exists || orderSnap.data()?.['storeId'] !== storeId) {
@@ -497,12 +500,10 @@ export class OrdersLifecycleService {
       const cancellationStatus = cancellation?.['status'] as string | undefined;
 
       if (order['status'] === 'CANCELLED' && cancellationStatus === 'COMPLETED') {
-        result = { kind: 'done' };
-        return;
+        return { kind: 'done' };
       }
       if (order['status'] === 'CANCELLED' && !cancellation) {
-        result = { kind: 'done' };
-        return;
+        return { kind: 'done' };
       }
 
       let expiredClaim = false;
@@ -516,12 +517,10 @@ export class OrdersLifecycleService {
           refundClaim.token.length === 0 ||
           typeof refundClaim.expiresAt !== 'number'
         ) {
-          result = { kind: 'in_progress' };
-          return;
+          return { kind: 'in_progress' };
         }
         if (refundClaim.expiresAt > Date.now()) {
-          result = { kind: 'in_progress' };
-          return;
+          return { kind: 'in_progress' };
         }
         expiredClaim = true;
       }
@@ -547,9 +546,8 @@ export class OrdersLifecycleService {
         },
         updatedAt: now,
       });
+      return { kind: 'claimed', token };
     });
-
-    return result;
   }
 
   private async applyLegacyConsumerLocalCancellation(

--- a/apps/api/src/orders/round-cancellation-occ-retry.spec.ts
+++ b/apps/api/src/orders/round-cancellation-occ-retry.spec.ts
@@ -1,0 +1,266 @@
+// Round cancellation OCC retry-purity proofs on the canonical harness.
+// Task: PILOT-CANCELLATION-TRANSACTION-RETRY-PURITY-27B
+//
+// Proves COMMITTED_CALLBACK_RETURN_ONLY for
+// RoundOrderLifecycleService.claimCancellation / applyLocalCancellation:
+//   R1. aborted done/needsRefund never pollutes committed LOCAL_PENDING retry
+//   R2. LOCAL_PENDING retry consumes only the committed needsRefund
+//   R3. happy cancellation semantics preserved
+//
+// Uses only the canonical harness at ../../test/helpers/firestore-occ-fake.
+// PortOne is mocked; no Firebase external calls.
+
+import { createOccFirestore } from '../../test/helpers/firestore-occ-fake';
+import { RoundOrderLifecycleService } from './round-order-lifecycle.service';
+
+type Occ = ReturnType<typeof createOccFirestore>;
+
+const ORDER_ID = 'order-1';
+const ORDER_PATH = `orders/${ORDER_ID}`;
+const PAYMENT_PATH = `payments/${ORDER_ID}`;
+
+function makeService(occ: Occ) {
+  let providerCalls = 0;
+  const payments = {
+    processRefundByOrderId: jest.fn(async (orderId: string) => {
+      providerCalls += 1;
+      // Simulate provider success converging the payment doc so the retry
+      // observes refunded state (paymentIsPaid === false afterwards).
+      const current = occ.getData(PAYMENT_PATH);
+      if (current) {
+        occ.updateOutsideTransaction(PAYMENT_PATH, {
+          refundedAt: new Date().toISOString(),
+        });
+      }
+    }),
+    refundOrderChargesByOrderId: jest.fn().mockResolvedValue(undefined),
+    __providerCalls: () => providerCalls,
+  };
+  const settlements = { cancelSettlement: jest.fn().mockResolvedValue(undefined) };
+  const capacity = {
+    releaseForOrderCancellationInTransaction: jest
+      .fn()
+      .mockResolvedValue({ reservation: { status: 'RELEASED' }, counters: null }),
+    adjustHeldOrderCountInTransaction: jest.fn().mockResolvedValue({}),
+  };
+  const service = new RoundOrderLifecycleService(
+    occ.firestore as never,
+    payments as never,
+    settlements as never,
+    capacity as never,
+  );
+  return { service, payments, settlements, capacity };
+}
+
+function seedOrder(
+  occ: Occ,
+  order: Record<string, unknown>,
+  payment?: Record<string, unknown> | null,
+) {
+  occ.seed(ORDER_PATH, {
+    id: ORDER_ID,
+    storeId: 'store-1',
+    userId: 'user-1',
+    ...order,
+  });
+  if (payment) {
+    occ.seed(PAYMENT_PATH, {
+      id: ORDER_ID,
+      orderId: ORDER_ID,
+      storeId: 'store-1',
+      ...payment,
+    });
+  }
+}
+
+describe('round cancellation OCC retry purity', () => {
+  it('R1. aborted done never pollutes committed LOCAL_FAILED retry', async () => {
+    const occ = createOccFirestore();
+    // Attempt 1 observes DONE (CANCELLED + COMPLETED, unpaid).
+    seedOrder(occ, {
+      status: 'CANCELLED',
+      cancellation: {
+        status: 'COMPLETED',
+        reason: '소비자 취소',
+        completedAt: '2026-08-27T00:00:00.000Z',
+        updatedAt: '2026-08-27T00:00:00.000Z',
+      },
+    });
+    const { service, payments, settlements } = makeService(occ);
+
+    const commits: Array<{ writeCount: number }> = [];
+    const arm = (): void => {
+      occ.setBeforeCommit((ctx) => {
+        commits.push({ writeCount: ctx.writes.length });
+        if (commits.length === 1) {
+          // Force attempt 1 (done, 0 writes) to abort. The retry observes
+          // LOCAL_FAILED, a path that stages no claim write in the old code
+          // and would have leaked stale done without committed-return.
+          occ.updateOutsideTransaction(ORDER_PATH, {
+            status: 'ACCEPTED',
+            cancellation: {
+              status: 'LOCAL_FAILED',
+              reason: '소비자 취소',
+              updatedAt: new Date().toISOString(),
+            },
+          });
+        }
+        arm();
+      });
+    };
+    arm();
+
+    await expect(
+      service.cancelForRound({
+        storeId: 'store-1',
+        orderId: ORDER_ID,
+        expectedStatus: 'ACCEPTED' as never,
+        reason: '소비자 취소',
+      }),
+    ).resolves.toEqual({ orderId: ORDER_ID, status: 'CANCELLED' });
+    occ.clearHooks();
+
+    expect(commits.length).toBeGreaterThanOrEqual(3);
+    expect(commits[0].writeCount).toBe(0);
+    // Stale done must not early-return: the committed LOCAL_FAILED retry
+    // drives applyLocal to convergence.
+    expect(payments.processRefundByOrderId).not.toHaveBeenCalled();
+    expect(settlements.cancelSettlement).toHaveBeenCalledTimes(1);
+    expect(occ.getData(ORDER_PATH)).toMatchObject({
+      status: 'CANCELLED',
+      cancellation: { status: 'COMPLETED' },
+    });
+  });
+
+  it('R2. LOCAL_PENDING retry consumes only the committed needsRefund (paid -> refund once)', async () => {
+    const occ = createOccFirestore();
+    seedOrder(
+      occ,
+      {
+        status: 'ACCEPTED',
+        cancellation: {
+          status: 'LOCAL_PENDING',
+          reason: '소비자 취소',
+          updatedAt: new Date().toISOString(),
+        },
+      },
+      { status: 'PAID', amount: { total: 100000 } },
+    );
+    const { service, payments, settlements } = makeService(occ);
+
+    const commits: Array<{ writeCount: number }> = [];
+    const arm = (): void => {
+      occ.setBeforeCommit((ctx) => {
+        commits.push({ writeCount: ctx.writes.length });
+        if (commits.length === 1) {
+          // Neutral version bump forces the claim attempt to abort without
+          // changing cancellation/payment semantics. The committed retry
+          // must supply needsRefund=false, then applyLocal observes PAID and
+          // supplies needsRefund=true exactly once.
+          occ.updateOutsideTransaction(ORDER_PATH, { probe: 1 });
+        }
+        arm();
+      });
+    };
+    arm();
+
+    await expect(
+      service.cancelForRound({
+        storeId: 'store-1',
+        orderId: ORDER_ID,
+        expectedStatus: 'ACCEPTED' as never,
+        reason: '소비자 취소',
+      }),
+    ).resolves.toEqual({ orderId: ORDER_ID, status: 'CANCELLED' });
+    occ.clearHooks();
+
+    expect(commits.length).toBeGreaterThanOrEqual(3);
+    // Exactly one provider refund despite the aborted claim attempt.
+    expect(payments.processRefundByOrderId).toHaveBeenCalledTimes(1);
+    expect(payments.__providerCalls()).toBe(1);
+    expect(settlements.cancelSettlement).toHaveBeenCalledTimes(1);
+    expect(occ.getData(ORDER_PATH)).toMatchObject({
+      status: 'CANCELLED',
+      cancellation: { status: 'COMPLETED' },
+    });
+  });
+
+  it('R2b. LOCAL_FAILED unpaid retry converges without refund', async () => {
+    const occ = createOccFirestore();
+    seedOrder(occ, {
+      status: 'ACCEPTED',
+      cancellation: {
+        status: 'LOCAL_FAILED',
+        reason: '소비자 취소',
+        updatedAt: new Date().toISOString(),
+      },
+    });
+    const { service, payments, settlements } = makeService(occ);
+
+    await expect(
+      service.cancelForRound({
+        storeId: 'store-1',
+        orderId: ORDER_ID,
+        expectedStatus: 'ACCEPTED' as never,
+        reason: '소비자 취소',
+      }),
+    ).resolves.toEqual({ orderId: ORDER_ID, status: 'CANCELLED' });
+
+    expect(payments.processRefundByOrderId).not.toHaveBeenCalled();
+    expect(settlements.cancelSettlement).toHaveBeenCalledTimes(1);
+    expect(occ.getData(ORDER_PATH)).toMatchObject({
+      status: 'CANCELLED',
+      cancellation: { status: 'COMPLETED' },
+    });
+  });
+
+  it('R3. happy cancellation preserved (PENDING unpaid -> no refund, direct complete)', async () => {
+    const occ = createOccFirestore();
+    seedOrder(occ, { status: 'PENDING' });
+    const { service, payments, settlements } = makeService(occ);
+
+    await expect(
+      service.cancelForRound({
+        storeId: 'store-1',
+        orderId: ORDER_ID,
+        expectedStatus: 'PENDING' as never,
+        reason: '소비자 취소',
+      }),
+    ).resolves.toEqual({ orderId: ORDER_ID, status: 'CANCELLED' });
+
+    expect(payments.processRefundByOrderId).not.toHaveBeenCalled();
+    expect(settlements.cancelSettlement).toHaveBeenCalledTimes(1);
+    expect(occ.getData(ORDER_PATH)).toMatchObject({
+      status: 'CANCELLED',
+      cancelReason: '소비자 취소',
+      cancellation: { status: 'COMPLETED', reason: '소비자 취소' },
+    });
+  });
+
+  it('R3b. happy cancellation preserved (ACCEPTED paid -> refund once then complete)', async () => {
+    const occ = createOccFirestore();
+    seedOrder(
+      occ,
+      { status: 'ACCEPTED' },
+      { status: 'PAID', amount: { total: 100000 } },
+    );
+    const { service, payments, settlements } = makeService(occ);
+
+    await expect(
+      service.cancelForRound({
+        storeId: 'store-1',
+        orderId: ORDER_ID,
+        expectedStatus: 'ACCEPTED' as never,
+        reason: '소비자 취소',
+      }),
+    ).resolves.toEqual({ orderId: ORDER_ID, status: 'CANCELLED' });
+
+    expect(payments.processRefundByOrderId).toHaveBeenCalledTimes(1);
+    expect(payments.__providerCalls()).toBe(1);
+    expect(settlements.cancelSettlement).toHaveBeenCalledTimes(1);
+    expect(occ.getData(ORDER_PATH)).toMatchObject({
+      status: 'CANCELLED',
+      cancellation: { status: 'COMPLETED' },
+    });
+  });
+});

--- a/apps/api/src/orders/round-order-lifecycle.service.ts
+++ b/apps/api/src/orders/round-order-lifecycle.service.ts
@@ -232,63 +232,66 @@ export class RoundOrderLifecycleService {
     requireOpenRound?: boolean;
     cancellationClaim?: SaleRoundCancellationClaim;
   }) {
-    let result = { done: false, needsRefund: false };
-    await this.firestore.runTransaction(async (tx) => {
-      const orderRef = this.firestore.doc(`orders/${input.orderId}`);
-      const paymentRef = this.firestore.doc(`payments/${input.orderId}`);
-      const orderSnap = await tx.get(orderRef);
-      if (!orderSnap.exists || orderSnap.data()?.['storeId'] !== input.storeId) {
-        throw new NotFoundException();
-      }
-      const order = orderSnap.data() as OrderRecord;
-      const paymentSnap = await tx.get(paymentRef);
-      const payment = paymentSnap.exists ? (paymentSnap.data() as OrderRecord) : null;
-      const paymentIsPaid = payment?.['status'] === 'PAID' && !payment['refundedAt'];
-      if (input.cancellationClaim) {
-        await this.assertRoundCancellationClaimInTransaction(tx, order, input.cancellationClaim);
-      }
-      if (order['status'] === 'CANCELLED') {
-        result = {
-          done: order['cancellation']?.['status'] === 'COMPLETED' && !paymentIsPaid,
-          needsRefund: paymentIsPaid,
-        };
-        return;
-      }
-      const cancellationStatus = order['cancellation']?.['status'] as string | undefined;
-      if (cancellationStatus === 'REFUNDING') {
-        result = { done: false, needsRefund: paymentIsPaid };
-        return;
-      }
-      if (!['LOCAL_PENDING', 'LOCAL_FAILED'].includes(cancellationStatus ?? '')) {
-        if (
-          ![
-            'PENDING',
-            'ACCEPTED',
-            'RECRUITING',
-            'CONFIRMED',
-            'PREPARING',
-            'DELIVERY_HELD',
-          ].includes(order['status'])
-        ) {
-          throw new ForbiddenException('취소할 수 없는 주문 상태입니다.');
+    // Retry purity: the post-transaction decision must come from the committed
+    // attempt's return value only. An outer `let result` mutated inside the
+    // callback would leak an aborted attempt's done/needsRefund decision into
+    // the committed retry.
+    return this.firestore.runTransaction<{ done: boolean; needsRefund: boolean }>(
+      async (tx) => {
+        const orderRef = this.firestore.doc(`orders/${input.orderId}`);
+        const paymentRef = this.firestore.doc(`payments/${input.orderId}`);
+        const orderSnap = await tx.get(orderRef);
+        if (!orderSnap.exists || orderSnap.data()?.['storeId'] !== input.storeId) {
+          throw new NotFoundException();
         }
-        if (input.requireOpenRound) await this.assertRoundOpen(tx, order, input.storeId);
+        const order = orderSnap.data() as OrderRecord;
+        const paymentSnap = await tx.get(paymentRef);
+        const payment = paymentSnap.exists ? (paymentSnap.data() as OrderRecord) : null;
+        const paymentIsPaid = payment?.['status'] === 'PAID' && !payment['refundedAt'];
+        if (input.cancellationClaim) {
+          await this.assertRoundCancellationClaimInTransaction(tx, order, input.cancellationClaim);
+        }
+        if (order['status'] === 'CANCELLED') {
+          return {
+            done: order['cancellation']?.['status'] === 'COMPLETED' && !paymentIsPaid,
+            needsRefund: paymentIsPaid,
+          };
+        }
+        const cancellationStatus = order['cancellation']?.['status'] as string | undefined;
         if (cancellationStatus === 'REFUNDING') {
-          throw new ConflictException('주문 취소가 이미 처리 중입니다.');
+          return { done: false, needsRefund: paymentIsPaid };
         }
-        const needsRefund = order['status'] !== 'PENDING' || paymentIsPaid;
-        tx.update(orderRef, {
-          cancellation: {
-            status: needsRefund ? 'REFUNDING' : 'LOCAL_PENDING',
-            reason: input.reason,
-            updatedAt: this.toIso(this.firestore.Timestamp.now()),
-          },
-          updatedAt: this.firestore.Timestamp.now(),
-        });
-        result = { done: false, needsRefund };
-      }
-    });
-    return result;
+        if (!['LOCAL_PENDING', 'LOCAL_FAILED'].includes(cancellationStatus ?? '')) {
+          if (
+            ![
+              'PENDING',
+              'ACCEPTED',
+              'RECRUITING',
+              'CONFIRMED',
+              'PREPARING',
+              'DELIVERY_HELD',
+            ].includes(order['status'])
+          ) {
+            throw new ForbiddenException('취소할 수 없는 주문 상태입니다.');
+          }
+          if (input.requireOpenRound) await this.assertRoundOpen(tx, order, input.storeId);
+          if (cancellationStatus === 'REFUNDING') {
+            throw new ConflictException('주문 취소가 이미 처리 중입니다.');
+          }
+          const needsRefund = order['status'] !== 'PENDING' || paymentIsPaid;
+          tx.update(orderRef, {
+            cancellation: {
+              status: needsRefund ? 'REFUNDING' : 'LOCAL_PENDING',
+              reason: input.reason,
+              updatedAt: this.toIso(this.firestore.Timestamp.now()),
+            },
+            updatedAt: this.firestore.Timestamp.now(),
+          });
+          return { done: false, needsRefund };
+        }
+        return { done: false, needsRefund: false };
+      },
+    );
   }
 
   private async applyLocalCancellation(input: {
@@ -298,22 +301,53 @@ export class RoundOrderLifecycleService {
     cancellationClaim?: SaleRoundCancellationClaim;
   }) {
     const now = this.firestore.Timestamp.now();
-    let result = { completed: false, needsRefund: false };
-    await this.firestore.runTransaction(async (tx) => {
-      const orderRef = this.firestore.doc(`orders/${input.orderId}`);
-      const paymentRef = this.firestore.doc(`payments/${input.orderId}`);
-      const orderSnap = await tx.get(orderRef);
-      if (!orderSnap.exists || orderSnap.data()?.['storeId'] !== input.storeId) {
-        throw new NotFoundException();
-      }
-      const order = orderSnap.data() as OrderRecord;
-      const paymentSnap = await tx.get(paymentRef);
-      const payment = paymentSnap.exists ? (paymentSnap.data() as OrderRecord) : null;
-      const paymentIsPaid = payment?.['status'] === 'PAID' && !payment['refundedAt'];
-      if (input.cancellationClaim) {
-        await this.assertRoundCancellationClaimInTransaction(tx, order, input.cancellationClaim);
-      }
-      if (order['status'] === 'CANCELLED') {
+    // Retry purity: same committed-callback-return-only principle as
+    // claimCancellation. Every non-throw path returns its decision; no outer
+    // mutable result may carry an aborted attempt's values into the caller.
+    return this.firestore.runTransaction<{ completed: boolean; needsRefund: boolean }>(
+      async (tx) => {
+        const orderRef = this.firestore.doc(`orders/${input.orderId}`);
+        const paymentRef = this.firestore.doc(`payments/${input.orderId}`);
+        const orderSnap = await tx.get(orderRef);
+        if (!orderSnap.exists || orderSnap.data()?.['storeId'] !== input.storeId) {
+          throw new NotFoundException();
+        }
+        const order = orderSnap.data() as OrderRecord;
+        const paymentSnap = await tx.get(paymentRef);
+        const payment = paymentSnap.exists ? (paymentSnap.data() as OrderRecord) : null;
+        const paymentIsPaid = payment?.['status'] === 'PAID' && !payment['refundedAt'];
+        if (input.cancellationClaim) {
+          await this.assertRoundCancellationClaimInTransaction(tx, order, input.cancellationClaim);
+        }
+        if (order['status'] === 'CANCELLED') {
+          if (paymentIsPaid) {
+            tx.update(orderRef, {
+              cancellation: {
+                status: 'REFUNDING',
+                reason: input.reason,
+                updatedAt: this.toIso(now),
+              },
+              updatedAt: now,
+            });
+            return { completed: false, needsRefund: true };
+          }
+          if (order['cancellation']?.['status'] !== 'COMPLETED') {
+            tx.update(orderRef, {
+              cancellation: {
+                status: 'COMPLETED',
+                reason: input.reason,
+                completedAt: this.toIso(now),
+                updatedAt: this.toIso(now),
+              },
+              updatedAt: now,
+            });
+          }
+          return { completed: true, needsRefund: false };
+        }
+        const cancellationStatus = order['cancellation']?.['status'];
+        if (!['LOCAL_PENDING', 'LOCAL_FAILED'].includes(cancellationStatus)) {
+          throw new ConflictException('주문 취소 재시도 상태가 아닙니다.');
+        }
         if (paymentIsPaid) {
           tx.update(orderRef, {
             cancellation: {
@@ -323,67 +357,36 @@ export class RoundOrderLifecycleService {
             },
             updatedAt: now,
           });
-          result = { completed: false, needsRefund: true };
-          return;
+          return { completed: false, needsRefund: true };
         }
-        if (order['cancellation']?.['status'] !== 'COMPLETED') {
-          tx.update(orderRef, {
-            cancellation: {
-              status: 'COMPLETED',
-              reason: input.reason,
-              completedAt: this.toIso(now),
-              updatedAt: this.toIso(now),
-            },
-            updatedAt: now,
+        // Single-owner cancellation convergence: reservation ordered
+        // projection and held projection move exactly once in one read phase
+        // (reservation + round + items) followed by one write phase. No direct
+        // FieldValue.increment outside OrderCapacityService.
+        const needsHeldExit = order['status'] === 'DELIVERY_HELD' && order['roundId'];
+        if (order['reservationId'] || needsHeldExit) {
+          await this.capacity.releaseForOrderCancellationInTransaction(tx, {
+            reservationId: order['reservationId'] ?? null,
+            storeId: input.storeId,
+            roundId: order['roundId'] ?? null,
+            decrementHeld: Boolean(needsHeldExit),
+            now,
           });
         }
-        result = { completed: true, needsRefund: false };
-        return;
-      }
-      const cancellationStatus = order['cancellation']?.['status'];
-      if (!['LOCAL_PENDING', 'LOCAL_FAILED'].includes(cancellationStatus)) {
-        throw new ConflictException('주문 취소 재시도 상태가 아닙니다.');
-      }
-      if (paymentIsPaid) {
         tx.update(orderRef, {
+          status: 'CANCELLED',
+          cancelReason: input.reason,
           cancellation: {
-            status: 'REFUNDING',
+            status: 'COMPLETED',
             reason: input.reason,
+            completedAt: this.toIso(now),
             updatedAt: this.toIso(now),
           },
           updatedAt: now,
         });
-        result = { completed: false, needsRefund: true };
-        return;
-      }
-      // Single-owner cancellation convergence: reservation ordered
-      // projection and held projection move exactly once in one read phase
-      // (reservation + round + items) followed by one write phase. No direct
-      // FieldValue.increment outside OrderCapacityService.
-      const needsHeldExit = order['status'] === 'DELIVERY_HELD' && order['roundId'];
-      if (order['reservationId'] || needsHeldExit) {
-        await this.capacity.releaseForOrderCancellationInTransaction(tx, {
-          reservationId: order['reservationId'] ?? null,
-          storeId: input.storeId,
-          roundId: order['roundId'] ?? null,
-          decrementHeld: Boolean(needsHeldExit),
-          now,
-        });
-      }
-      tx.update(orderRef, {
-        status: 'CANCELLED',
-        cancelReason: input.reason,
-        cancellation: {
-          status: 'COMPLETED',
-          reason: input.reason,
-          completedAt: this.toIso(now),
-          updatedAt: this.toIso(now),
-        },
-        updatedAt: now,
-      });
-      result = { completed: true, needsRefund: false };
-    });
-    return result;
+        return { completed: true, needsRefund: false };
+      },
+    );
   }
 
   private async processCancellationRefund(input: {


### PR DESCRIPTION
Closes Firestore transaction retry-purity gap in cancellation claim/apply (27B publication onto live main ba5916c7). No cancellation state-machine policy change. No refund/capacity/settlement policy change. Committed transaction return is the only authority; aborted attempt result/token cannot authorize provider/action. Focused OCC retry counterexamples added: legacy L1/L2/L3/L1b, round R1/R2/R2b/R3/R3b. Verified on current main: 9 retry-purity tests pass, 33 convergence tests pass, 21 suites / 225 tests in src/orders pass. PortOne mocked only; no Firebase/PortOne/ALIGO external mutation.