### PR TITLE
fix(payments): fence finalization refund ownership

### DIFF
--- a/apps/api/src/payments/payment-finalization-refund-ownership.spec.ts
+++ b/apps/api/src/payments/payment-finalization-refund-ownership.spec.ts
@@ -1,0 +1,349 @@
+// PILOT-PAYMENT-FINALIZATION-REFUND-OWNERSHIP-27C focused proofs.
+//
+// F1: uncommitted transaction attempts must not authorize finalization side
+//     effects (retry purity via committed return object).
+// F2: provider refund requires persisted ownership (order-level claim marker).
+// F3: duplicate PAID webhooks must not blindly refund twice.
+// F4: UNKNOWN results must reconcile provider state before retry.
+// F5: crash-after-success must not reissue cancel without readback.
+//
+// Real provider is never used; PortOne is fully mocked.
+
+import { LatePaymentCapacityError } from '../orders/order-capacity.service';
+import { createOccFirestore } from '../../test/helpers/firestore-occ-fake';
+import { PaymentFinalizationService } from './payment-finalization.service';
+
+type Occ = ReturnType<typeof createOccFirestore>;
+
+function makeOrder(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'order-1',
+    storeId: 'store-1',
+    userId: 'user-1',
+    status: 'PENDING',
+    saleType: 'normal',
+    schemaVersion: 2,
+    roundId: 'round-1',
+    reservationId: 'reservation-1',
+    deliveryAddress: { address: '경기도 이천시 중리천로 1' },
+    orderItems: [{ roundItemId: 'round-item-1', quantity: 2 }],
+    totalAmount: 100000,
+    ...overrides,
+  };
+}
+
+function paidPayment(total = 100000) {
+  return {
+    amount: { total },
+    status: 'PAID',
+    method: { type: 'CARD' },
+    transactionId: 'tx-1',
+  } as never;
+}
+
+function makeFixture(occ: Occ, orderOverrides: Record<string, unknown> = {}) {
+  occ.seed('orders/order-1', makeOrder(orderOverrides));
+  const portone = {
+    refund: jest.fn().mockResolvedValue(undefined),
+    getPayment: jest.fn(),
+  };
+  const service = new PaymentFinalizationService(
+    occ.firestore as never,
+    portone as never,
+    { sendToUser: jest.fn().mockResolvedValue(undefined) } as never,
+    { log: jest.fn().mockResolvedValue(undefined) } as never,
+    {
+      consumeReservationInTransaction: jest.fn().mockResolvedValue({ status: 'CONSUMED' }),
+      releaseReservationInTransaction: jest.fn().mockResolvedValue({ status: 'RELEASED' }),
+      reacquireAndConsumeLatePaymentInTransaction: jest
+        .fn()
+        .mockResolvedValue({ id: 'late-reservation-1', status: 'CONSUMED' }),
+    } as never,
+    { createOrMergeIssue: jest.fn().mockResolvedValue({ id: 'issue-1' }) } as never,
+    { saveRecord: jest.fn().mockResolvedValue({}) } as never,
+    { refundByOrderId: jest.fn().mockResolvedValue(undefined) } as never,
+  );
+  return { service, portone, occ };
+}
+
+function issueWriterOf(fixture: ReturnType<typeof makeFixture>) {
+  return (fixture.service as unknown as { issueWriter: { createOrMergeIssue: jest.Mock } })
+    .issueWriter;
+}
+
+describe('PILOT-PAYMENT-FINALIZATION-REFUND-OWNERSHIP-27C', () => {
+  it('P1a. aborted attempt refund decision must not leak: provider 0, already_processed', async () => {
+    const occ = createOccFirestore();
+    occ.seed('payments/order-1', {
+      id: 'order-1',
+      orderId: 'order-1',
+      storeId: 'store-1',
+      userId: 'user-1',
+      status: 'PAID',
+      amount: 100000,
+      portonePaymentId: 'order-1',
+    });
+    const fixture = makeFixture(occ, { status: 'CANCELLED', cancelReason: '소비자 취소' });
+    const refunds = { refundByOrderId: jest.fn().mockResolvedValue(undefined) };
+    (fixture.service as unknown as { refunds: unknown }).refunds = refunds;
+
+    occ.setBeforeCommit(() => {
+      occ.updateOutsideTransaction('payments/order-1', {
+        status: 'CANCELLED',
+        refundedAt: new Date('2026-09-01T00:00:00.000Z'),
+      });
+    });
+
+    await expect(fixture.service.finalizePaidOrder('order-1', paidPayment())).resolves.toEqual({
+      ok: true,
+      reason: 'already_processed',
+    });
+    occ.clearHooks();
+
+    expect(refunds.refundByOrderId).not.toHaveBeenCalled();
+    expect(fixture.portone.refund).not.toHaveBeenCalled();
+  });
+
+  it('P1b. aborted attempt staged PAID write is discarded: provider 0, seeded terminal doc intact', async () => {
+    const occ = createOccFirestore();
+    const fixture = makeFixture(occ, { status: 'CANCELLED', cancelReason: '소비자 취소' });
+
+    occ.setBeforeCommit(() => {
+      occ.updateOutsideTransaction('orders/order-1', { probe: 1 });
+      occ.seed('payments/order-1', {
+        id: 'order-1',
+        orderId: 'order-1',
+        storeId: 'store-1',
+        userId: 'user-1',
+        status: 'CANCELLED',
+        refundedAt: new Date('2026-09-01T00:00:00.000Z'),
+        refundClaim: null,
+      });
+    });
+
+    await expect(fixture.service.finalizePaidOrder('order-1', paidPayment())).resolves.toEqual({
+      ok: true,
+      reason: 'already_processed',
+    });
+    occ.clearHooks();
+
+    expect(fixture.portone.refund).not.toHaveBeenCalled();
+    expect(occ.getData('payments/order-1')).toMatchObject({ status: 'CANCELLED' });
+    expect(occ.getData('payments/order-1')).not.toMatchObject({ status: 'PAID' });
+  });
+
+  it('P2. duplicate amount-mismatch webhook refunds at most once with ownership marker', async () => {
+    const occ = createOccFirestore();
+    const fixture = makeFixture(occ);
+
+    await expect(
+      fixture.service.finalizePaidOrder('order-1', paidPayment(99999)),
+    ).resolves.toEqual({ ok: false, reason: 'amount_mismatch' });
+    await expect(
+      fixture.service.finalizePaidOrder('order-1', paidPayment(99999)),
+    ).resolves.toEqual({ ok: false, reason: 'amount_mismatch' });
+
+    expect(fixture.portone.refund).toHaveBeenCalledTimes(1);
+    expect(fixture.portone.refund).toHaveBeenCalledWith('order-1', 99999, '금액 위변조 감지');
+    expect(fixture.portone.getPayment).not.toHaveBeenCalled();
+    expect(occ.getData('orders/order-1')).toMatchObject({
+      status: 'CANCELLED',
+      cancelReason: 'amount_mismatch',
+    });
+    expect(occ.getData('orders/order-1')?.['finalizationRefund']).toMatchObject({
+      owner: 'payment-finalization',
+      reason: 'amount_mismatch',
+      status: 'REFUNDED',
+    });
+    expect(typeof occ.getData('orders/order-1')?.['finalizationRefund']?.['token']).toBe('string');
+    expect(typeof occ.getData('orders/order-1')?.['finalizationRefund']?.['expiresAt']).toBe(
+      'number',
+    );
+    expect(occ.getData('payments/order-1')).toBeUndefined();
+  });
+
+  it('P3. duplicate round late-payment PAID never blindly refunds twice', async () => {
+    const occ = createOccFirestore();
+    const fixture = makeFixture(occ, { status: 'CANCELLED', cancelReason: 'timeout' });
+    const capacity = (
+      fixture.service as unknown as {
+        capacity: { reacquireAndConsumeLatePaymentInTransaction: jest.Mock };
+      }
+    ).capacity;
+    capacity.reacquireAndConsumeLatePaymentInTransaction.mockRejectedValue(
+      new LatePaymentCapacityError('결제 만료 후 회차 한도 마감'),
+    );
+
+    await expect(fixture.service.finalizePaidOrder('order-1', paidPayment())).resolves.toEqual({
+      ok: false,
+      reason: 'late_payment_refunded',
+    });
+    await expect(fixture.service.finalizePaidOrder('order-1', paidPayment())).resolves.toEqual({
+      ok: true,
+      reason: 'already_processed',
+    });
+
+    expect(fixture.portone.refund).toHaveBeenCalledTimes(1);
+    expect(occ.getData('orders/order-1')?.['latePaymentRefundedAt']).toBeDefined();
+    expect(occ.getData('payments/order-1')).toMatchObject({
+      status: 'CANCELLED',
+      refundAmount: 100000,
+    });
+  });
+
+  it('P4. duplicate legacy late-payment PAID never blindly refunds twice', async () => {
+    const occ = createOccFirestore();
+    occ.seed('dailyCaps/store-1_2026-08-25', {
+      storeId: 'store-1',
+      date: '2026-08-25',
+      totalCap: 10,
+      usedSlots: 10,
+    });
+    const fixture = makeFixture(occ, {
+      schemaVersion: 1,
+      deliveryMethod: 'direct',
+      quantity: 2,
+      requestedDeliveryDate: '2026-08-25',
+      status: 'CANCELLED',
+      cancelReason: 'timeout',
+      legacyDailyCapacity: { status: 'RELEASED', date: '2026-08-25', quantity: 2 },
+    });
+
+    await expect(fixture.service.finalizePaidOrder('order-1', paidPayment())).resolves.toEqual({
+      ok: false,
+      reason: 'late_payment_refunded',
+    });
+    await expect(fixture.service.finalizePaidOrder('order-1', paidPayment())).resolves.toEqual({
+      ok: true,
+      reason: 'already_processed',
+    });
+
+    expect(fixture.portone.refund).toHaveBeenCalledTimes(1);
+    expect(fixture.portone.refund).toHaveBeenCalledWith(
+      'order-1',
+      100000,
+      '결제 만료 후 일일 배송 용량 재확보 실패',
+    );
+    expect(occ.getData('dailyCaps/store-1_2026-08-25')?.['usedSlots']).toBe(10);
+  });
+
+  it('P5. UNKNOWN cancel reconciles via readback: terminal proof issues no second POST', async () => {
+    const occ = createOccFirestore();
+    const fixture = makeFixture(occ);
+    fixture.portone.refund.mockRejectedValueOnce(new Error('provider timeout'));
+    fixture.portone.getPayment.mockResolvedValue({
+      id: 'order-1',
+      transactionId: 'tx-1',
+      amount: { total: 99999 },
+      status: 'CANCELLED',
+      method: { type: 'CARD' },
+    });
+
+    await expect(
+      fixture.service.finalizePaidOrder('order-1', paidPayment(99999)),
+    ).rejects.toThrow('provider timeout');
+    expect(fixture.portone.refund).toHaveBeenCalledTimes(1);
+    expect(issueWriterOf(fixture).createOrMergeIssue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'FINALIZATION_REFUND_FAILED',
+        idempotencyKey: 'finalization-refund-uncertain:order-1:amount_mismatch',
+        latestSnapshot: expect.objectContaining({ failureStage: 'provider_refund' }),
+      }),
+    );
+    expect(occ.getData('orders/order-1')?.['finalizationRefund']).toMatchObject({
+      status: 'UNKNOWN',
+    });
+
+    await expect(
+      fixture.service.finalizePaidOrder('order-1', paidPayment(99999)),
+    ).resolves.toEqual({ ok: false, reason: 'amount_mismatch' });
+
+    expect(fixture.portone.getPayment).toHaveBeenCalledWith('order-1');
+    expect(fixture.portone.refund).toHaveBeenCalledTimes(1);
+    expect(occ.getData('orders/order-1')).toMatchObject({
+      status: 'CANCELLED',
+      finalizationRefund: expect.objectContaining({ status: 'REFUNDED' }),
+    });
+  });
+
+  it('P6a. readback failure fails closed: no cancel POST, recovery issue recorded', async () => {
+    const occ = createOccFirestore();
+    const fixture = makeFixture(occ, {
+      finalizationRefund: {
+        token: 'prior-token',
+        owner: 'payment-finalization',
+        reason: 'amount_mismatch',
+        status: 'UNKNOWN',
+        claimedAt: new Date('2026-09-01T00:00:00.000Z'),
+        expiresAt: Date.now() + 300000,
+        updatedAt: new Date('2026-09-01T00:00:00.000Z'),
+      },
+    });
+    fixture.portone.getPayment.mockRejectedValue(new Error('readback down'));
+
+    await expect(
+      fixture.service.finalizePaidOrder('order-1', paidPayment(99999)),
+    ).rejects.toThrow('readback down');
+
+    expect(fixture.portone.refund).not.toHaveBeenCalled();
+    expect(issueWriterOf(fixture).createOrMergeIssue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'FINALIZATION_REFUND_FAILED',
+        latestSnapshot: expect.objectContaining({ failureStage: 'provider_readback' }),
+      }),
+    );
+    expect(occ.getData('orders/order-1')?.['finalizationRefund']).toMatchObject({
+      status: 'UNKNOWN',
+    });
+  });
+
+  it('P6b. ambiguous provider status fails closed: no cancel POST, recovery issue recorded', async () => {
+    const occ = createOccFirestore();
+    const fixture = makeFixture(occ, {
+      finalizationRefund: {
+        token: 'prior-token',
+        owner: 'payment-finalization',
+        reason: 'amount_mismatch',
+        status: 'UNKNOWN',
+        claimedAt: new Date('2026-09-01T00:00:00.000Z'),
+        expiresAt: Date.now() + 300000,
+        updatedAt: new Date('2026-09-01T00:00:00.000Z'),
+      },
+    });
+    fixture.portone.getPayment.mockResolvedValue({
+      id: 'order-1',
+      transactionId: 'tx-1',
+      amount: { total: 99999 },
+      status: 'PENDING',
+      method: { type: 'CARD' },
+    });
+
+    await expect(
+      fixture.service.finalizePaidOrder('order-1', paidPayment(99999)),
+    ).rejects.toThrow('PortOne 결제 상태를 확정할 수 없어 환불을 중단합니다.');
+
+    expect(fixture.portone.refund).not.toHaveBeenCalled();
+    expect(issueWriterOf(fixture).createOrMergeIssue).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'FINALIZATION_REFUND_FAILED' }),
+    );
+  });
+
+  it('P7. normal finalize happy path is preserved with zero provider calls', async () => {
+    const occ = createOccFirestore();
+    const fixture = makeFixture(occ);
+    const notifications = (
+      fixture.service as unknown as { notifications: { sendToUser: jest.Mock } }
+    ).notifications;
+
+    await expect(fixture.service.finalizePaidOrder('order-1', paidPayment())).resolves.toEqual({
+      ok: true,
+      status: 'ACCEPTED',
+    });
+
+    expect(occ.getData('orders/order-1')).toMatchObject({ status: 'ACCEPTED' });
+    expect(occ.getData('payments/order-1')).toMatchObject({ status: 'PAID' });
+    expect(fixture.portone.refund).not.toHaveBeenCalled();
+    expect(fixture.portone.getPayment).not.toHaveBeenCalled();
+    expect(notifications.sendToUser).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/api/src/payments/payment-finalization.service.ts
+++ b/apps/api/src/payments/payment-finalization.service.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import { forwardRef, Inject, Injectable } from '@nestjs/common';
 import { AuditService } from '../common/audit/audit.service';
 import { FirestoreService } from '../firestore/firestore.service';
@@ -20,6 +21,46 @@ import {
 type PaymentData = Awaited<ReturnType<PortoneClient['getPayment']>>;
 const LATE_PAYMENT_REFUND_REASON = '결제 만료 후 회차 한도 마감';
 const LEGACY_LATE_PAYMENT_REFUND_REASON = '결제 만료 후 일일 배송 용량 재확보 실패';
+
+// Payment-finalization-owned refund ownership (local to this service).
+// A direct provider cancel is authorized only by a persisted claim written
+// BEFORE the provider call. The claim lives on the order document because the
+// internal payment document may not exist yet on these paths (provider says
+// PAID, internal PAID commit never happened), so PaymentRefundService's
+// `status === PAID` claim condition cannot cover them.
+const FINALIZATION_REFUND_OWNER = 'payment-finalization';
+const FINALIZATION_REFUND_CLAIM_MS = 5 * 60 * 1000;
+
+type FinalizationRefundReasonClass =
+  | 'amount_mismatch'
+  | 'late_capacity_round'
+  | 'late_capacity_legacy';
+
+type FinalizationRefundMarkerStatus = 'CLAIMED' | 'UNKNOWN' | 'REFUNDED';
+
+type FinalizationRefundMarker = {
+  token: string;
+  owner: typeof FINALIZATION_REFUND_OWNER;
+  reason: FinalizationRefundReasonClass;
+  status: FinalizationRefundMarkerStatus;
+  claimedAt: unknown;
+  expiresAt: number;
+  updatedAt: unknown;
+};
+
+// Retry purity: the settle decision is the COMMITTED attempt's return value.
+// Outer `let` mutation inside the callback would leak an aborted attempt's
+// decision to the caller (F1).
+type FinalizeSettleDecision =
+  | { kind: 'applied' }
+  | { kind: 'refund_cancelled_order' }
+  | { kind: 'noop' };
+
+type FinalizationRefundClaimOutcome =
+  | { outcome: 'claimed_fresh'; token: string }
+  | { outcome: 'claimed_retry'; token: string }
+  | { outcome: 'already_handled' }
+  | { outcome: 'order_missing' };
 
 @Injectable()
 export class PaymentFinalizationService {
@@ -74,7 +115,14 @@ export class PaymentFinalizationService {
         userId: order['userId'] as string,
         detail: { orderId, expected: order['totalAmount'], actual: paymentData.amount.total },
       });
-      await this.portone.refund(orderId, paymentData.amount.total, '금액 위변조 감지');
+      const refundOutcome = await this.refundWithFinalizationOwnership(
+        orderId,
+        order,
+        paymentData,
+        'amount_mismatch',
+        '금액 위변조 감지',
+      );
+      if (refundOutcome === 'order_missing') return { ok: false, reason: 'order_not_found' };
       await this.cancelPendingOrder(orderId, 'amount_mismatch');
       return { ok: false, reason: 'amount_mismatch' };
     }
@@ -85,14 +133,13 @@ export class PaymentFinalizationService {
     // HELD leak is possible on crash between reserve and consume.
     const newStatus = order['saleType'] === 'group' ? 'RECRUITING' : 'ACCEPTED';
     const now = this.firestore.Timestamp.now();
-    let applied = false;
-    let cancellationOutcome: 'REFUND' | null = null;
+    let decision: FinalizeSettleDecision;
     try {
-      await this.firestore.runTransaction(async (tx) => {
+      decision = await this.firestore.runTransaction(async (tx): Promise<FinalizeSettleDecision> => {
         const orderRef = this.firestore.doc(`orders/${orderId}`);
         const paymentRef = this.firestore.doc(`payments/${orderId}`);
         const freshSnap = await tx.get(orderRef);
-        if (!freshSnap.exists) return;
+        if (!freshSnap.exists) return { kind: 'noop' };
         const freshOrder = freshSnap.data() as Record<string, any>;
         if (this.isCancellationSettlementCandidate(freshOrder)) {
           const paymentSnap = await tx.get(paymentRef);
@@ -108,11 +155,11 @@ export class PaymentFinalizationService {
                 freshOrder['status'],
               );
             }
-            cancellationOutcome = 'REFUND';
+            return { kind: 'refund_cancelled_order' };
           }
-          return;
+          return { kind: 'noop' };
         }
-        if (!this.canFinalize(freshOrder)) return;
+        if (!this.canFinalize(freshOrder)) return { kind: 'noop' };
 
         if (this.isLegacyTimeoutPaymentCandidate(freshOrder)) {
           await reacquireLegacyDailyCapacityInTransaction(this.firestore, tx, orderId, freshOrder);
@@ -166,31 +213,34 @@ export class PaymentFinalizationService {
           now,
           finalStatus,
         );
-        applied = true;
+        return { kind: 'applied' };
       });
     } catch (error) {
       if (error instanceof LatePaymentCapacityError) {
-        await this.portone.refund(orderId, paymentData.amount.total, LATE_PAYMENT_REFUND_REASON);
-        await this.recordLateRefund(orderId, order, paymentData);
-        return { ok: false, reason: 'late_payment_refunded' };
-      }
-      if (error instanceof LegacyDailyCapacityError) {
-        await this.portone.refund(
-          orderId,
-          paymentData.amount.total,
-          LEGACY_LATE_PAYMENT_REFUND_REASON,
-        );
-        await this.recordLateRefund(
+        const refundOutcome = await this.refundWithFinalizationOwnership(
           orderId,
           order,
           paymentData,
+          'late_capacity_round',
+          LATE_PAYMENT_REFUND_REASON,
+        );
+        if (refundOutcome === 'order_missing') return { ok: false, reason: 'order_not_found' };
+        return { ok: false, reason: 'late_payment_refunded' };
+      }
+      if (error instanceof LegacyDailyCapacityError) {
+        const refundOutcome = await this.refundWithFinalizationOwnership(
+          orderId,
+          order,
+          paymentData,
+          'late_capacity_legacy',
           LEGACY_LATE_PAYMENT_REFUND_REASON,
         );
+        if (refundOutcome === 'order_missing') return { ok: false, reason: 'order_not_found' };
         return { ok: false, reason: 'late_payment_refunded' };
       }
       throw error;
     }
-    if (cancellationOutcome === 'REFUND') {
+    if (decision.kind === 'refund_cancelled_order') {
       try {
         await this.refunds.refundByOrderId(
           orderId,
@@ -209,7 +259,7 @@ export class PaymentFinalizationService {
       }
       return { ok: false, reason: 'cancelled_paid_refunded' };
     }
-    if (!applied) return { ok: true, reason: 'already_processed' };
+    if (decision.kind !== 'applied') return { ok: true, reason: 'already_processed' };
 
     await this.notifications.sendToUser(
       order['userId'],
@@ -224,11 +274,10 @@ export class PaymentFinalizationService {
 
   async cancelPendingOrder(orderId: string, reason: string) {
     const now = this.firestore.Timestamp.now();
-    let applied = false;
-    await this.firestore.runTransaction(async (tx) => {
+    return this.firestore.runTransaction(async (tx): Promise<boolean> => {
       const orderRef = this.firestore.doc(`orders/${orderId}`);
       const orderSnap = await tx.get(orderRef);
-      if (!orderSnap.exists || orderSnap.data()?.['status'] !== 'PENDING') return;
+      if (!orderSnap.exists || orderSnap.data()?.['status'] !== 'PENDING') return false;
       const order = orderSnap.data() as Record<string, any>;
       if (order['schemaVersion'] === 2) {
         if (order['reservationId']) {
@@ -242,9 +291,298 @@ export class PaymentFinalizationService {
         await releaseLegacyDailyCapacityInTransaction(this.firestore, tx, orderId, reason);
       }
       tx.update(orderRef, { status: 'CANCELLED', cancelReason: reason, updatedAt: now });
-      applied = true;
+      return true;
     });
-    return applied;
+  }
+
+  /**
+   * Direct provider-cancel entry point shared by the three finalization refund
+   * paths (amount mismatch, round late-capacity, legacy late-capacity).
+   * F2: no provider cancel without persisted ownership recorded BEFORE the
+   * provider call. F4/F5: any attempt that follows an unclear provider result
+   * reconciles via getPayment readback before any cancel POST, and never
+   * blind-retries when the provider state cannot be confirmed.
+   */
+  private async refundWithFinalizationOwnership(
+    orderId: string,
+    order: Record<string, any>,
+    paymentData: PaymentData,
+    reason: FinalizationRefundReasonClass,
+    providerReason: string,
+  ): Promise<'refunded' | 'already_handled' | 'order_missing'> {
+    const claim = await this.claimFinalizationRefund(orderId, reason);
+    if (claim.outcome === 'already_handled' || claim.outcome === 'order_missing') {
+      return claim.outcome;
+    }
+    if (claim.outcome === 'claimed_retry') {
+      const reconciled = await this.reconcileUncertainFinalizationRefund(
+        orderId,
+        order,
+        paymentData,
+        reason,
+        providerReason,
+        claim.token,
+      );
+      if (reconciled !== 'proceed') return reconciled;
+    }
+    try {
+      await this.portone.refund(orderId, paymentData.amount.total, providerReason);
+    } catch (error) {
+      // The provider result is UNKNOWN (timeout included): the cancel may or
+      // may not have landed. Never blind-retry; persist the uncertainty and
+      // fail closed so the next attempt must read back provider state first.
+      await this.persistUncertainFinalizationRefund(
+        orderId,
+        claim.token,
+        reason,
+        error,
+        'provider_refund',
+      );
+      throw error;
+    }
+    await this.completeFinalizationRefund(
+      orderId,
+      order,
+      paymentData,
+      reason,
+      providerReason,
+      claim.token,
+    );
+    return 'refunded';
+  }
+
+  private async claimFinalizationRefund(
+    orderId: string,
+    reason: FinalizationRefundReasonClass,
+  ): Promise<FinalizationRefundClaimOutcome> {
+    const token = randomUUID();
+    const now = this.firestore.Timestamp.now();
+    const expiresAt = Date.now() + FINALIZATION_REFUND_CLAIM_MS;
+    return this.firestore.runTransaction(async (tx): Promise<FinalizationRefundClaimOutcome> => {
+      const orderRef = this.firestore.doc(`orders/${orderId}`);
+      const paymentRef = this.firestore.doc(`payments/${orderId}`);
+      const orderSnap = await tx.get(orderRef);
+      if (!orderSnap.exists) return { outcome: 'order_missing' };
+      const freshOrder = orderSnap.data() as Record<string, any>;
+      const marker = this.readFinalizationRefundMarker(freshOrder);
+      if (marker?.status === 'REFUNDED') return { outcome: 'already_handled' };
+      if (freshOrder['latePaymentRefundedAt']) return { outcome: 'already_handled' };
+      const paymentSnap = await tx.get(paymentRef);
+      const payment = paymentSnap.exists ? (paymentSnap.data() as Record<string, any>) : null;
+      if (payment && (payment['status'] === 'CANCELLED' || payment['refundedAt'])) {
+        return { outcome: 'already_handled' };
+      }
+      const paymentClaim = payment?.['refundClaim'] as { expiresAt?: unknown } | null | undefined;
+      if (
+        paymentClaim &&
+        typeof paymentClaim === 'object' &&
+        typeof paymentClaim['expiresAt'] === 'number' &&
+        paymentClaim['expiresAt'] > Date.now()
+      ) {
+        // A PaymentRefundService claim is in flight for the same money.
+        return { outcome: 'already_handled' };
+      }
+      if (!marker) {
+        tx.update(orderRef, {
+          finalizationRefund: {
+            token,
+            owner: FINALIZATION_REFUND_OWNER,
+            reason,
+            status: 'CLAIMED',
+            claimedAt: now,
+            expiresAt,
+            updatedAt: now,
+          },
+          updatedAt: now,
+        });
+        return { outcome: 'claimed_fresh', token };
+      }
+      if (marker.status === 'CLAIMED' && marker.expiresAt > Date.now()) {
+        return { outcome: 'already_handled' };
+      }
+      // Expired CLAIMED or any UNKNOWN: a prior attempt may already have
+      // reached the provider. Take over as uncertain so a getPayment
+      // readback is mandatory before any cancel POST.
+      tx.update(orderRef, {
+        finalizationRefund: {
+          token,
+          owner: FINALIZATION_REFUND_OWNER,
+          reason,
+          status: 'UNKNOWN',
+          claimedAt: now,
+          expiresAt,
+          updatedAt: now,
+        },
+        updatedAt: now,
+      });
+      return { outcome: 'claimed_retry', token };
+    });
+  }
+
+  private async reconcileUncertainFinalizationRefund(
+    orderId: string,
+    order: Record<string, any>,
+    paymentData: PaymentData,
+    reason: FinalizationRefundReasonClass,
+    providerReason: string,
+    token: string,
+  ): Promise<'proceed' | 'already_handled' | 'order_missing'> {
+    let providerState: Record<string, any>;
+    try {
+      providerState = (await this.portone.getPayment(orderId)) as Record<string, any>;
+    } catch (error) {
+      await this.persistUncertainFinalizationRefund(
+        orderId,
+        token,
+        reason,
+        error,
+        'provider_readback',
+      );
+      throw error;
+    }
+    if (providerState?.['status'] === 'CANCELLED') {
+      // Provider already terminal: converge locally, never re-POST.
+      await this.completeFinalizationRefund(
+        orderId,
+        order,
+        paymentData,
+        reason,
+        providerReason,
+        token,
+      );
+      return 'already_handled';
+    }
+    const providerTotal = (providerState?.['amount'] as { total?: unknown } | undefined)?.[
+      'total'
+    ];
+    if (providerState?.['status'] !== 'PAID' || providerTotal !== paymentData.amount.total) {
+      const error = new Error('PortOne 결제 상태를 확정할 수 없어 환불을 중단합니다.');
+      await this.persistUncertainFinalizationRefund(
+        orderId,
+        token,
+        reason,
+        error,
+        'provider_readback',
+      );
+      throw error;
+    }
+    const orderSnap = await this.firestore.doc(`orders/${orderId}`).get();
+    if (!orderSnap.exists) return 'order_missing';
+    const marker = this.readFinalizationRefundMarker(orderSnap.data() as Record<string, any>);
+    if (marker?.token !== token) return 'already_handled';
+    return 'proceed';
+  }
+
+  private async completeFinalizationRefund(
+    orderId: string,
+    order: Record<string, any>,
+    paymentData: PaymentData,
+    reason: FinalizationRefundReasonClass,
+    providerReason: string,
+    token: string,
+  ): Promise<void> {
+    if (reason === 'late_capacity_round' || reason === 'late_capacity_legacy') {
+      await this.recordLateRefund(orderId, order, paymentData, providerReason);
+    }
+    const now = this.firestore.Timestamp.now();
+    await this.firestore.runTransaction(async (tx) => {
+      const orderRef = this.firestore.doc(`orders/${orderId}`);
+      const snap = await tx.get(orderRef);
+      if (!snap.exists) return;
+      const marker = this.readFinalizationRefundMarker(snap.data() as Record<string, any>);
+      if (marker?.token !== token) return;
+      tx.update(orderRef, {
+        finalizationRefund: {
+          token: marker.token,
+          owner: FINALIZATION_REFUND_OWNER,
+          reason: marker.reason,
+          status: 'REFUNDED',
+          claimedAt: marker.claimedAt,
+          expiresAt: marker.expiresAt,
+          updatedAt: now,
+        },
+        updatedAt: now,
+      });
+    });
+  }
+
+  private async persistUncertainFinalizationRefund(
+    orderId: string,
+    token: string,
+    reason: FinalizationRefundReasonClass,
+    error: unknown,
+    failureStage: 'provider_refund' | 'provider_readback',
+  ): Promise<void> {
+    const now = this.firestore.Timestamp.now();
+    await this.firestore.runTransaction(async (tx) => {
+      const orderRef = this.firestore.doc(`orders/${orderId}`);
+      const snap = await tx.get(orderRef);
+      if (!snap.exists) return;
+      const marker = this.readFinalizationRefundMarker(snap.data() as Record<string, any>);
+      if (marker?.token !== token) return;
+      tx.update(orderRef, {
+        finalizationRefund: {
+          token,
+          owner: FINALIZATION_REFUND_OWNER,
+          reason,
+          status: 'UNKNOWN',
+          claimedAt: marker.claimedAt ?? now,
+          expiresAt: Date.now() + FINALIZATION_REFUND_CLAIM_MS,
+          updatedAt: now,
+        },
+        updatedAt: now,
+      });
+    });
+    const failure = this.safeLookupFailure(error);
+    const orderSnap = await this.firestore.doc(`orders/${orderId}`).get();
+    const freshOrder = orderSnap.exists ? (orderSnap.data() as Record<string, any>) : null;
+    await this.issueWriter.createOrMergeIssue({
+      storeId: String(freshOrder?.['storeId'] ?? ''),
+      orderId,
+      paymentId: orderId,
+      type: 'FINALIZATION_REFUND_FAILED',
+      severity: 'critical',
+      title: '확정 환불 결과 불명확',
+      message: '환불 요청 결과를 확정하지 못해 blind 재시도 없이 운영 확인이 필요합니다.',
+      idempotencyKey: `finalization-refund-uncertain:${orderId}:${reason}`,
+      latestSnapshot: {
+        orderStatus: freshOrder?.['status'] ?? null,
+        paymentStatus: 'UNKNOWN',
+        failureStage,
+        providerStatus: failure.status,
+        providerType: failure.type,
+      },
+    });
+  }
+
+  private readFinalizationRefundMarker(order: Record<string, any>): FinalizationRefundMarker | null {
+    const marker = order['finalizationRefund'] as Record<string, any> | null | undefined;
+    if (!marker || typeof marker !== 'object') return null;
+    if (marker['owner'] !== FINALIZATION_REFUND_OWNER) return null;
+    if (
+      marker['status'] !== 'CLAIMED' &&
+      marker['status'] !== 'UNKNOWN' &&
+      marker['status'] !== 'REFUNDED'
+    ) {
+      return null;
+    }
+    if (typeof marker['token'] !== 'string' || marker['token'].length === 0) return null;
+    if (
+      marker['reason'] !== 'amount_mismatch' &&
+      marker['reason'] !== 'late_capacity_round' &&
+      marker['reason'] !== 'late_capacity_legacy'
+    ) {
+      return null;
+    }
+    return {
+      token: marker['token'],
+      owner: FINALIZATION_REFUND_OWNER,
+      reason: marker['reason'],
+      status: marker['status'],
+      claimedAt: marker['claimedAt'] ?? null,
+      expiresAt: typeof marker['expiresAt'] === 'number' ? marker['expiresAt'] : 0,
+      updatedAt: marker['updatedAt'] ?? null,
+    };
   }
 
   private canFinalize(order: Record<string, any>) {


### PR DESCRIPTION
27C publication (PILOT-PAYMENT-FINALIZATION-REFUND-OWNERSHIP-PUBLICATION-27D).

What was found/fixed (27C, already implemented and verified, republished on live main d969cf19):
- Transaction retry purity: finalizePaidOrder settle decision is the COMMITTED attempt return object only; no outer mutable leaked from aborted attempts (P1a/P1b).
- cancelPendingOrder retry purity: committed boolean/result based, no aborted-attempt side-effect leakage.
- Direct PortOne refund 3 paths (amount_mismatch, late_capacity_round, late_capacity_legacy) converge on one service-local ownership helper refundWithFinalizationOwnership.
- Persisted finalizationRefund claim marker on order doc: token, owner=payment-finalization, reason, status CLAIMED/UNKNOWN/REFUNDED, claimedAt, expiresAt, updatedAt.
- claim-before-provider-call: no POST without persisted CLAIMED/UNKNOWN-takeover claim.
- Duplicate webhook protection: second identical webhook sees REFUNDED/latePaymentRefundedAt and issues no second POST (P2/P3/P4: provider refund total 1).
- UNKNOWN retry reconciles via getPayment readback: CANCELLED converges locally with 0 additional POST (P5); PAID plus ownership token recheck allows single POST; readback throw, ambiguous/non-PAID status, or amount drift fails closed with 0 POST and recovery issue (P6a/P6b).
- Normal ACCEPTED finalization issues zero refund provider calls (P7).

Not changed in this patch:
- PaymentRefundService is untouched.
- operations/orders/auth-probe areas untouched; PR diff is exactly 2 owned files.

Verification on live-main base (d969cf19, owned blobs identical on pre-push live 7d28a31a):
- npx jest src/payments/payment-finalization-refund-ownership.spec.ts: 9 passed
- npx jest src/payments: 11 suites / 123 passed, no new failures
- npx tsc --noEmit: 0 errors in owned files; 21 pre-existing foreign errors (admin-legacy-refund-occ-retry, orders-duplicate-contract)
- Admission gate PRE_PR vs live 7d28a31a: PUBLICATION_ALLOWED, remaining delta = 2 owned paths.

Provider calls:
- Real PortOne provider calls were NOT run; PortOne is fully mocked in tests.

Residual (not implemented here, follow-up candidates only):
- Provider-side refund idempotency-key contract does not exist yet.
- Cross-subsystem refund ownership convergence between PaymentRefundService claim and finalizationRefund marker is a separate follow-up.
- Provider terminal status vocabulary generalization is a separate follow-up.